### PR TITLE
Add multi-thread version of normal update to mesh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ mt_library(
     common
     fmt_eigen
     online_qr
+    Dispenso::dispenso
     Eigen3::Eigen
     Microsoft.GSL::GSL
 )

--- a/momentum/math/mesh.h
+++ b/momentum/math/mesh.h
@@ -36,8 +36,33 @@ struct MeshT {
   std::vector<Eigen::Vector3i> texcoord_faces; // list of texture coordinate indices per face
   std::vector<std::vector<int32_t>> texcoord_lines; // list of texture coordinate indices per line
 
+  MeshT(
+      const std::vector<Eigen::Vector3<T>>& vertices = {},
+      const std::vector<Eigen::Vector3<T>>& normals = {},
+      const std::vector<Eigen::Vector3i>& faces = {},
+      const std::vector<std::vector<int32_t>>& lines = {},
+      const std::vector<Eigen::Vector3b>& colors = {},
+      const std::vector<T>& confidence = {},
+      const std::vector<Eigen::Vector2f>& texcoords = {},
+      const std::vector<Eigen::Vector3i>& texcoord_faces = {},
+      const std::vector<std::vector<int32_t>>& texcoord_lines = {})
+      : vertices(vertices),
+        normals(normals),
+        faces(faces),
+        lines(lines),
+        colors(colors),
+        confidence(confidence),
+        texcoords(texcoords),
+        texcoord_faces(texcoord_faces),
+        texcoord_lines(texcoord_lines) {
+    // Empty
+  }
+
   /// Compute vertex normals (by averaging connected face normals)
   void updateNormals();
+
+  /// Compute vertex normals (by averaging connected face normals) in multi-threaded fashion
+  void updateNormalsMt(size_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   /// Cast data type of mesh vertices, normals and confidence
   template <typename T2>
@@ -45,6 +70,11 @@ struct MeshT {
 
   /// Reset mesh
   void reset();
+
+ private:
+  // Cache for updateNormalsMt()
+  std::vector<std::vector<size_t>> facePerVertex_; // for each vertex, list of faces it belongs to
+  std::vector<Vector3<T>> faceNormals_;
 };
 
 } // namespace momentum

--- a/momentum/test/math/mesh_test.cpp
+++ b/momentum/test/math/mesh_test.cpp
@@ -43,6 +43,25 @@ TEST(Momentum_Mesh, UpdateNormals) {
   }
 }
 
+TEST(Momentum_Mesh, UpdateNormalsMt) {
+  // Construct simple mesh with 3 vertices and 1 face
+  Mesh m;
+  m.vertices = {{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}};
+  m.faces = {{0, 1, 2}};
+
+  // Compute mesh normals
+  m.updateNormalsMt();
+  EXPECT_EQ(m.normals.size(), 3);
+
+  // Ensure all normals are (0, 0, 1)
+  const float eps = 1e-5;
+  for (int i = 0; i < m.normals.size(); ++i) {
+    EXPECT_NEAR(m.normals[i][0], 0.f, eps);
+    EXPECT_NEAR(m.normals[i][1], 0.f, eps);
+    EXPECT_NEAR(m.normals[i][2], 1.f, eps);
+  }
+}
+
 TEST(Momentum_Mesh, Reset) {
   // Construct non-empty mesh
   Mesh m = {


### PR DESCRIPTION
Summary:
Inspired by D63747584, adding a multi-threaded version of normal update in mesh.

Additional Changes:

- Clear `facePerVertex_` before updating
- Utilize Eigen::Vector::normalize() to potentially optimize SIMD (if available) while maintaining the same behavior (i.e., leaving the vector unchanged when the norm is too small)
- Use .noalias() for improved performance.
- Prefer using member functions over assignment (e.g., setZero() instead of m = Eigen::Vector3f::Zero()) for better performance.

Differential Revision: D63765102


