### PR TITLE
Use alignmend memory for DrJit error functions

### DIFF
--- a/momentum/character_solver/simd_plane_error_function.cpp
+++ b/momentum/character_solver/simd_plane_error_function.cpp
@@ -283,15 +283,17 @@ __vectorcall DRJIT_INLINE void jacobian_jointParams_to_modelParams(
     const Eigen::Index iJointParam,
     const ParameterTransform& parameterTransform_,
     Eigen::Ref<Eigen::MatrixX<float>> jacobian) {
+  checkAlignment<kSimdAlignment>(jacobian);
+
   // explicitly multiply with the parameter transform to generate parameter space gradients
   for (auto index = parameterTransform_.transform.outerIndexPtr()[iJointParam];
        index < parameterTransform_.transform.outerIndexPtr()[iJointParam + 1];
        ++index) {
     const auto modelParamIdx = parameterTransform_.transform.innerIndexPtr()[index];
     float* jacPtr = jacobian.col(modelParamIdx).data();
-    drjit::store(
+    drjit::store_aligned(
         jacPtr,
-        drjit::load<FloatP>(jacPtr) +
+        drjit::load_aligned<FloatP>(jacPtr) +
             parameterTransform_.transform.valuePtr()[index] * jacobian_jointParams);
   }
 }
@@ -314,6 +316,11 @@ double SimdPlaneErrorFunction::getJacobian(
   // Storage for joint errors
   std::vector<double> jointErrors(constraints_->numJoints);
 
+  // Need to make sure we're actually at a kSimdAlignment byte data offset at the first offset for
+  // SIMD access
+  const size_t addressOffset = computeOffset<kSimdAlignment>(jacobian);
+  checkAlignment<kSimdAlignment>(jacobian, addressOffset);
+
   // Loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
   dispensoOptions.maxThreads = maxThreads_;
@@ -330,7 +337,7 @@ double SimdPlaneErrorFunction::getJacobian(
         for (uint32_t index = 0; index < constraintCount; index += kSimdPacketSize) {
           const auto constraintOffsetIndex =
               jointId * SimdPlaneConstraints::kMaxConstraints + index;
-          const auto jacobianOffsetCur = jacobianOffset_[jointId] + index;
+          const auto jacobianOffsetCur = jacobianOffset_[jointId] + index + addressOffset;
 
           // Transform offset by joint transform: pos = transform * offset
           const Vector3fP offset{
@@ -357,7 +364,8 @@ double SimdPlaneErrorFunction::getJacobian(
           const FloatP wgt = drjit::sqrt(kPlaneWeight * weight_ * constraintWeight);
 
           // Calculate residual: res = wgt * dist
-          drjit::store(residual.segment(jacobianOffsetCur, kSimdPacketSize).data(), dist * wgt);
+          drjit::store_aligned(
+              residual.segment(jacobianOffsetCur, kSimdPacketSize).data(), dist * wgt);
 
           // Loop over all joints the constraint is attached to and calculate gradient
           size_t jointIndex = jointId;

--- a/momentum/character_solver/simd_position_error_function.cpp
+++ b/momentum/character_solver/simd_position_error_function.cpp
@@ -160,10 +160,6 @@ double SimdPositionErrorFunction::getGradient(
   // Storage for joint errors
   std::vector<double> jointErrors(constraints_->numJoints);
 
-  // Need to make sure we're actually at a kSimdAlignment byte data offset at the first offset for
-  // SIMD access
-  checkAlignment<kSimdAlignment>(gradient);
-
   // Loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
   dispensoOptions.maxThreads = maxThreads_;
@@ -311,10 +307,6 @@ double SimdPositionErrorFunction::getJacobian(
 
   // Storage for joint errors
   std::vector<double> jointErrors(constraints_->numJoints);
-
-  // Need to make sure we're actually at a kSimdAlignment byte data offset at the first offset for
-  // SIMD access
-  checkAlignment<kSimdAlignment>(jacobian);
 
   // Loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
@@ -802,7 +794,8 @@ double SimdPositionErrorFunctionAVX::getJacobian(
   std::vector<double> ets_error;
 
   // need to make sure we're actually at a 32 byte data offset at the first offset for AVX access
-  checkAlignment<kAvxAlignment>(jacobian);
+  const size_t addressOffset = computeOffset<kAvxAlignment>(jacobian);
+  checkAlignment<kAvxAlignment>(jacobian, addressOffset);
 
   // loop over all joints, as these are our base units
   auto dispensoOptions = dispenso::ParForOptions();
@@ -814,7 +807,7 @@ double SimdPositionErrorFunctionAVX::getJacobian(
       constraints_->numJoints,
       [&](double& error_local, const size_t jointId) {
         // get initial offset
-        const auto offset = jacobianOffset_[jointId];
+        const auto offset = jacobianOffset_[jointId] + addressOffset;
 
         // pre-load some joint specific values
         const auto& transformation = state.jointState[jointId].transformation;

--- a/momentum/simd/simd.h
+++ b/momentum/simd/simd.h
@@ -49,11 +49,26 @@ using Vector3fP = Vector3P<float>;
 using Vector2dP = Vector2P<double>;
 using Vector3dP = Vector3P<double>;
 
+/// Computes the offset required for the matrix data to meet the alignment requirement.
+template <size_t Alignment>
+[[nodiscard]] size_t computeOffset(const Eigen::Ref<Eigen::MatrixXf>& mat) {
+  constexpr size_t sizeOfScalar = sizeof(typename Eigen::MatrixXf::Scalar);
+  const size_t addressOffset =
+      Alignment / sizeOfScalar - (((size_t)mat.data() % Alignment) / sizeOfScalar);
+
+  // If the current alignment already meets the requirement, no offset is needed.
+  if (addressOffset == Alignment / sizeOfScalar) {
+    return 0;
+  }
+
+  return addressOffset;
+}
+
 /// Checks if the data of the matrix is aligned correctly.
 template <size_t Alignment>
-void checkAlignment(const Eigen::Ref<Eigen::MatrixXf>& mat) {
+void checkAlignment(const Eigen::Ref<Eigen::MatrixXf>& mat, size_t offset = 0) {
   MT_THROW_IF(
-      (uintptr_t(mat.data())) % Alignment != 0,
+      (uintptr_t(mat.data() + offset)) % Alignment != 0,
       "Matrix ({}x{}, ptr: {}) is not aligned ({}) correctly.",
       mat.rows(),
       mat.cols(),


### PR DESCRIPTION
Summary: This diff updates the DrJit implementation of the SIMD error functions to utilize the aligned memory versions of DrJit by correctly offsetting the Jacobian pointer to the aligned memory, similar to the AVX implementations.

Differential Revision: D64133416


