### PR TITLE
Add permissive flags to FBX loaders

### DIFF
--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -39,10 +39,13 @@ struct FBXCoordSystemInfo {
   FBXCoordSystem coordSystem = FBXCoordSystem::RightHanded;
 };
 
-Character loadFbxCharacter(const filesystem::path& inputPath);
+// Permissive mode allows loading  mesh-only characters (without skin weights).
+Character loadFbxCharacter(const filesystem::path& inputPath, bool permissive = false);
 
-Character loadFbxCharacter(gsl::span<const std::byte> inputSpan);
+// Permissive mode allows loading  mesh-only characters (without skin weights).
+Character loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool permissive = false);
 
+// Permissive mode allows saving mesh-only characters (without skin weights).
 void saveFbx(
     const filesystem::path& filename,
     const Character& character,
@@ -50,20 +53,25 @@ void saveFbx(
     const VectorXf& identity = VectorXf(),
     double framerate = 120.0,
     bool saveMesh = false,
-    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo());
+    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    bool permissive = false);
 
+// Permissive mode allows saving mesh-only characters (without skin weights).
 void saveFbxWithJointParams(
     const filesystem::path& filename,
     const Character& character,
     const MatrixXf& jointParams = MatrixXf(),
     double framerate = 120.0,
     bool saveMesh = false,
-    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo());
+    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    bool permissive = false);
 
 // A shorthand of saveFbx() to save both the skeleton and mesh as a model but without any animation
+// Permissive mode allows saving mesh-only characters (without skin weights).
 void saveFbxModel(
     const filesystem::path& filename,
     const Character& character,
-    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo());
+    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    bool permissive = false);
 
 } // namespace momentum

--- a/momentum/io/fbx/fbx_io_unsupported.cpp
+++ b/momentum/io/fbx/fbx_io_unsupported.cpp
@@ -9,17 +9,15 @@
 
 #include "momentum/character/character.h"
 #include "momentum/common/exception.h"
-#include "momentum/io/skeleton/locator_io.h"
-#include "momentum/io/skeleton/parameter_transform_io.h"
 
 namespace momentum {
 
-Character loadFbxCharacter(const filesystem::path& inputPath) {
+Character loadFbxCharacter(const filesystem::path& inputPath, bool permissive) {
   MT_THROW("FbxSDK is not supported on your platform. Please use loadOpenFbxCharacter instead.");
   return Character();
 }
 
-Character loadFbxCharacter(gsl::span<const std::byte> inputSpan) {
+Character loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool permissive) {
   MT_THROW("FbxSDK is not supported on your platform. Please use loadOpenFbxCharacter instead.");
   return Character();
 }
@@ -31,7 +29,8 @@ void saveFbx(
     const VectorXf& identity,
     double framerate,
     bool saveMesh,
-    const FBXCoordSystemInfo& coordSystemInfo) {
+    const FBXCoordSystemInfo& coordSystemInfo,
+    bool permissive) {
   MT_THROW("FbxSDK is not supported on your platform.");
 }
 
@@ -41,14 +40,16 @@ void saveFbxWithJointParams(
     const MatrixXf& jointParams,
     double framerate,
     bool saveMesh,
-    const FBXCoordSystemInfo& coordSystemInfo) {
+    const FBXCoordSystemInfo& coordSystemInfo,
+    bool permissive) {
   MT_THROW("FbxSDK is not supported on your platform.");
 }
 
 void saveFbxModel(
     const filesystem::path& filename,
     const Character& character,
-    const FBXCoordSystemInfo& coordSystemInfo) {
+    const FBXCoordSystemInfo& coordSystemInfo,
+    bool permissive) {
   MT_THROW("FbxSDK is not supported on your platform.");
 }
 

--- a/momentum/io/openfbx/openfbx_io.h
+++ b/momentum/io/openfbx/openfbx_io.h
@@ -17,21 +17,25 @@ namespace momentum {
 
 // Using keepLocators means the Nulls in the transform hierarchy will be turned into Locators.
 // This is different from historical momentum behavior so it's off by default.
+// Permissive mode allows loading mesh-only characters (without skin weights).
 Character loadOpenFbxCharacter(
     const filesystem::path& inputPath,
     bool keepLocators = false,
     bool permissive = false);
 
+// Permissive mode allows loading mesh-only characters (without skin weights).
 Character loadOpenFbxCharacter(
     gsl::span<const std::byte> inputSpan,
     bool keepLocators = false,
     bool permissive = false);
 
+// Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     bool keepLocators = false,
     bool permissive = false);
 
+// Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
     bool keepLocators = false,


### PR DESCRIPTION
Summary: Modify the behavior to only allow mesh-only characters when permissive mode is enabled.

Differential Revision: D72569719


