### PR TITLE
Consolidate FBX loading API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,6 @@ mt_library(
     io_gltf
     io_motion
     io_marker
-    io_openfbx
     io_shape
     io_skeleton
 )
@@ -740,7 +739,7 @@ if(MOMENTUM_BUILD_EXAMPLES)
     NAME fbx_viewer
     SOURCES_VARS fbx_viewer_sources
     LINK_LIBRARIES
-      io_openfbx
+      io_fbx
       rerun
       CLI11::CLI11
       rerun_sdk

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -14,7 +14,6 @@
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
 #include <momentum/io/motion/mmo_io.h>
-#include <momentum/io/openfbx/openfbx_io.h>
 #include <momentum/io/skeleton/locator_io.h>
 #include <momentum/io/skeleton/parameter_transform_io.h>
 #include <momentum/io/skeleton/parameters_io.h>
@@ -146,7 +145,7 @@ int main(int argc, char** argv) {
       } else if (motionExt == ".fbx") {
         MT_LOGI("Loading motion from fbx...");
         int motionIndex = -1;
-        auto [c, motions, framerate] = loadOpenFbxCharacterWithMotion(motionPath, true, false);
+        auto [c, motions, framerate] = loadFbxCharacterWithMotion(motionPath, true, false);
         // Validate the motion
         if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
           MT_LOGW("No motion loaded from file");

--- a/momentum/examples/fbx_viewer/fbx_viewer.cpp
+++ b/momentum/examples/fbx_viewer/fbx_viewer.cpp
@@ -11,7 +11,7 @@
 #include <momentum/common/log.h>
 #include <momentum/gui/rerun/logger.h>
 #include <momentum/gui/rerun/logging_redirect.h>
-#include <momentum/io/openfbx/openfbx_io.h>
+#include <momentum/io/fbx/fbx_io.h>
 
 #include <CLI/CLI.hpp>
 #include <rerun.hpp>
@@ -70,8 +70,8 @@ int main(int argc, char* argv[]) {
 
     rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
 
-    const auto [character, motions, fps] = loadOpenFbxCharacterWithMotion(
-        options->fbxFile, true /*keepLocators*/, options->permissive);
+    const auto [character, motions, fps] =
+        loadFbxCharacterWithMotion(options->fbxFile, true /*keepLocators*/, options->permissive);
     // Validate the loaded motion
     if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
       MT_LOGW("No motion loaded from file");

--- a/momentum/io/character_io.cpp
+++ b/momentum/io/character_io.cpp
@@ -8,8 +8,8 @@
 #include "momentum/io/character_io.h"
 
 #include "momentum/character/character.h"
+#include "momentum/io/fbx/fbx_io.h"
 #include "momentum/io/gltf/gltf_io.h"
-#include "momentum/io/openfbx/openfbx_io.h"
 #include "momentum/io/shape/pose_shape_io.h"
 #include "momentum/io/skeleton/locator_io.h"
 #include "momentum/io/skeleton/mppca_io.h"
@@ -50,7 +50,7 @@ namespace {
   if (format == CharacterFormat::Gltf) {
     return loadGltfCharacter(filepath);
   } else if (format == CharacterFormat::Fbx) {
-    return loadOpenFbxCharacter(filepath, true);
+    return loadFbxCharacter(filepath, true);
   } else {
     return {};
   }
@@ -62,7 +62,7 @@ namespace {
   if (format == CharacterFormat::Gltf) {
     return loadGltfCharacter(fileBuffer);
   } else if (format == CharacterFormat::Fbx) {
-    return loadOpenFbxCharacter(fileBuffer, true);
+    return loadFbxCharacter(fileBuffer, true);
   } else {
     return {};
   }

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -547,12 +547,25 @@ void saveFbxCommon(
 
 } // namespace
 
-Character loadFbxCharacter(const filesystem::path& inputPath, bool permissive) {
-  return loadOpenFbxCharacter(inputPath, false, permissive);
+Character loadFbxCharacter(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+  return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
 }
 
-Character loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool permissive) {
-  return loadOpenFbxCharacter(inputSpan, false, permissive);
+Character
+loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool keepLocators, bool permissive) {
+  return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
+}
+
+std::tuple<Character, std::vector<MatrixXf>, float>
+loadFbxCharacterWithMotion(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+  return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
+}
+
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    gsl::span<const std::byte> inputSpan,
+    bool keepLocators,
+    bool permissive) {
+  return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
 }
 
 void saveFbx(

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -39,11 +39,33 @@ struct FBXCoordSystemInfo {
   FBXCoordSystem coordSystem = FBXCoordSystem::RightHanded;
 };
 
+// Using keepLocators means the Nulls in the transform hierarchy will be turned into Locators.
+// This is different from historical momentum behavior so it's off by default.
 // Permissive mode allows loading  mesh-only characters (without skin weights).
-Character loadFbxCharacter(const filesystem::path& inputPath, bool permissive = false);
+Character loadFbxCharacter(
+    const filesystem::path& inputPath,
+    bool keepLocators = false,
+    bool permissive = false);
 
+// Using keepLocators means the Nulls in the transform hierarchy will be turned into Locators.
+// This is different from historical momentum behavior so it's off by default.
 // Permissive mode allows loading  mesh-only characters (without skin weights).
-Character loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool permissive = false);
+Character loadFbxCharacter(
+    gsl::span<const std::byte> inputSpan,
+    bool keepLocators = false,
+    bool permissive = false);
+
+// Permissive mode allows loading mesh-only characters (without skin weights).
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    const filesystem::path& inputPath,
+    bool keepLocators = false,
+    bool permissive = false);
+
+// Permissive mode allows loading mesh-only characters (without skin weights).
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    gsl::span<const std::byte> inputSpan,
+    bool keepLocators = false,
+    bool permissive = false);
 
 // Permissive mode allows saving mesh-only characters (without skin weights).
 void saveFbx(

--- a/momentum/io/fbx/fbx_io_unsupported.cpp
+++ b/momentum/io/fbx/fbx_io_unsupported.cpp
@@ -9,17 +9,29 @@
 
 #include "momentum/character/character.h"
 #include "momentum/common/exception.h"
+#include "momentum/io/openfbx/openfbx_io.h"
 
 namespace momentum {
 
-Character loadFbxCharacter(const filesystem::path& inputPath, bool permissive) {
-  MT_THROW("FbxSDK is not supported on your platform. Please use loadOpenFbxCharacter instead.");
-  return Character();
+Character loadFbxCharacter(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+  return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
 }
 
-Character loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool permissive) {
-  MT_THROW("FbxSDK is not supported on your platform. Please use loadOpenFbxCharacter instead.");
-  return Character();
+Character
+loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool keepLocators, bool permissive) {
+  return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
+}
+
+std::tuple<Character, std::vector<MatrixXf>, float>
+loadFbxCharacterWithMotion(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+  return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
+}
+
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    gsl::span<const std::byte> inputSpan,
+    bool keepLocators,
+    bool permissive) {
+  return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
 }
 
 void saveFbx(

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -155,7 +155,6 @@ mt_python_binding(
     io_fbx
     io_gltf
     io_marker
-    io_openfbx
     io_shape
     io_skeleton
     io_urdf

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -19,8 +19,8 @@
 #include <momentum/character/skeleton_state.h>
 #include <momentum/character/skin_weights.h>
 #include <momentum/common/checks.h>
+#include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
-#include <momentum/io/openfbx/openfbx_io.h>
 #include <momentum/io/shape/blend_shape_io.h>
 #include <momentum/io/skeleton/locator_io.h>
 #include <momentum/io/skeleton/mppca_io.h>
@@ -192,7 +192,7 @@ momentum::Character loadFBXCharacterFromFile(
     const std::optional<std::string>& configPath,
     const std::optional<std::string>& locatorsPath,
     bool permissive) {
-  momentum::Character result = momentum::loadOpenFbxCharacter(
+  momentum::Character result = momentum::loadFbxCharacter(
       filesystem::path(fbxPath), keepLocators, permissive);
   if (configPath && !configPath->empty()) {
     result = loadConfigFromFile(result, *configPath);
@@ -219,7 +219,7 @@ std::tuple<momentum::Character, std::vector<Eigen::MatrixXf>, float>
 loadFBXCharacterWithMotionFromFile(
     const std::string& fbxPath,
     bool permissive) {
-  auto [character, motion, fps] = momentum::loadOpenFbxCharacterWithMotion(
+  auto [character, motion, fps] = momentum::loadFbxCharacterWithMotion(
       filesystem::path(fbxPath), keepLocators, permissive);
   transposeMotionInPlace(motion);
   return {character, motion, fps};
@@ -229,7 +229,7 @@ std::tuple<momentum::Character, std::vector<Eigen::MatrixXf>, float>
 loadFBXCharacterWithMotionFromBytes(
     const py::bytes& fbxBytes,
     bool permissive) {
-  auto [character, motion, fps] = momentum::loadOpenFbxCharacterWithMotion(
+  auto [character, motion, fps] = momentum::loadFbxCharacterWithMotion(
       toSpan<std::byte>(fbxBytes), keepLocators, permissive);
   transposeMotionInPlace(motion);
   return {character, motion, fps};
@@ -276,7 +276,7 @@ momentum::Character loadConfigFromFile(
 momentum::Character loadFBXCharacterFromBytes(
     const pybind11::bytes& bytes,
     bool permissive) {
-  return momentum::loadOpenFbxCharacter(
+  return momentum::loadFbxCharacter(
       toSpan<std::byte>(bytes), keepLocators, permissive);
 }
 


### PR DESCRIPTION
Summary:
## Context

Now that (I believe) the FBX loaders in Momentum with OpenFBX and FBXSDK are identical for what we want to achieve (we have tests for this), it would be good to consolidate them into one.

Eventually, in the upper stack of this Diff, we merge io_openfbx into io_fbx, where we use OpenFBX for loading and FBXSDK for saving. This way the users no longer need to know which one to use with different API.

## This Diff

Update downstream to always use `io_fbx` for loading

Differential Revision: D72579404


