### PR TITLE
Add gtest annotations for vertex constraint error function tests

### DIFF
--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -577,6 +577,8 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexErrorFunctionSerial) {
 
   // Test WITHOUT blend shapes:
   {
+    SCOPED_TRACE("Without blend shapes");
+
     const Character character_orig = createTestCharacter();
     const ModelParametersT<T> modelParams =
         0.25 * VectorX<T>::Random(character_orig.parameterTransform.numAllModelParameters());
@@ -586,6 +588,8 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexErrorFunctionSerial) {
           VertexConstraintType::Plane,
           VertexConstraintType::Normal,
           VertexConstraintType::SymmetricNormal}) {
+      SCOPED_TRACE(fmt::format("Constraint type: {}", toString(type)));
+
       const T errorTol = [&]() {
         switch (type) {
           case VertexConstraintType::Position:
@@ -628,6 +632,8 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexErrorFunctionSerial) {
 
   // Test WITH blend shapes:
   {
+    SCOPED_TRACE("With blend shapes");
+
     const Character character_blend = withTestBlendShapes(createTestCharacter());
     const ModelParametersT<T> modelParams =
         0.25 * VectorX<T>::Random(character_blend.parameterTransform.numAllModelParameters());
@@ -638,6 +644,8 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexErrorFunctionSerial) {
     // model.
     for (VertexConstraintType type :
          {VertexConstraintType::Position, VertexConstraintType::Plane}) {
+      SCOPED_TRACE(fmt::format("Constraint type: {}", toString(type)));
+
       VertexErrorFunctionT<T> errorFunction(character_blend, type);
       for (size_t iCons = 0; iCons < nConstraints; ++iCons) {
         errorFunction.addConstraint(
@@ -677,6 +685,8 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexErrorFunctionParallel) {
         VertexConstraintType::Plane,
         VertexConstraintType::Normal,
         VertexConstraintType::SymmetricNormal}) {
+    SCOPED_TRACE(fmt::format("Constraint type: {}", toString(type)));
+
     const T errorTol = [&]() {
       switch (type) {
         case VertexConstraintType::Position:


### PR DESCRIPTION
Summary:
To fix CI failure on GitHub (https://github.com/facebookresearch/momentum/actions/runs/14341120842/job/40200319361):

```
/Users/runner/work/momentum/momentum/momentum/test/character_solver/error_function_helpers.cpp:147: Failure
Expected: ((numGradient - anaGradient).norm() / ((numGradient + anaGradient).norm() + Momentum_ErrorFunctionsTest<T>::getEps())) <= (numThreshold), actual: 0.0520811118 vs 0.05
Google Test trace:
/Users/runner/work/momentum/momentum/momentum/test/character_solver/error_function_helpers.cpp:142: Checking Numerical Gradient
/Users/runner/work/momentum/momentum/momentum/test/character_solver/error_function_helpers.cpp:36: Called from file: /Users/runner/work/momentum/momentum/momentum/test/character_solver/error_functions_test.cpp, line: 716
```

Differential Revision: D72660464


