### PR TITLE
Update to 0.22.1

### DIFF
--- a/momentum/examples/c3d_viewer/c3d_viewer.cpp
+++ b/momentum/examples/c3d_viewer/c3d_viewer.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
     rec.spawn().exit_on_failure();
     redirectLogsToRerun(rec);
 
-    rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
+    rec.log_static("world", ViewCoordinates(::components::ViewCoordinates::RUB)); // Set an up-axis
 
     for (const auto& actor : sequences) {
       if (actor.frames.empty()) {

--- a/momentum/examples/fbx_viewer/fbx_viewer.cpp
+++ b/momentum/examples/fbx_viewer/fbx_viewer.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[]) {
 
     redirectLogsToRerun(rec);
 
-    rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
+    rec.log_static("world", ViewCoordinates(::components::ViewCoordinates::RUB)); // Set an up-axis
 
     const auto [character, motions, fps] =
         loadFbxCharacterWithMotion(options->fbxFile, true /*keepLocators*/, options->permissive);

--- a/momentum/examples/glb_viewer/glb_viewer.cpp
+++ b/momentum/examples/glb_viewer/glb_viewer.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
 
     redirectLogsToRerun(rec);
 
-    rec.log_static("world", ViewCoordinates::RUB); // Set an up-axis
+    rec.log_static("world", ViewCoordinates(::components::ViewCoordinates::RUB)); // Set an up-axis
 
     const auto [character, motion, offsets, cFps] = loadCharacterWithMotion(options->glbFile);
     const size_t nFrames = motion.cols();

--- a/momentum/examples/urdf_viewer/urdf_viewer.cpp
+++ b/momentum/examples/urdf_viewer/urdf_viewer.cpp
@@ -91,7 +91,8 @@ int main(int argc, char* argv[]) {
 
     redirectLogsToRerun(rec);
 
-    rec.log_static("world", ViewCoordinates::RIGHT_HAND_Z_UP); // Set an up-axis
+    rec.log_static(
+        "world", ViewCoordinates(components::ViewCoordinates::RIGHT_HAND_Z_UP)); // Set an up-axis
 
     CharacterState charState;
     CharacterParameters charParams;

--- a/momentum/gui/rerun/logger.cpp
+++ b/momentum/gui/rerun/logger.cpp
@@ -51,17 +51,15 @@ void logMesh(
     const std::string& streamName,
     const Mesh& mesh,
     std::optional<rerun::Color> color) {
-  rerun::Mesh3D rerunMesh;
-  rerunMesh.vertex_positions = mesh.vertices;
-  rerunMesh.triangle_indices = mesh.faces;
+  auto rerunMesh = rerun::Mesh3D(mesh.vertices).with_triangle_indices(mesh.faces);
   if (color.has_value()) {
-    rerunMesh.vertex_colors = color.value();
+    rerunMesh = std::move(rerunMesh).with_vertex_colors(color.value());
   } else if (mesh.colors.size() == mesh.vertices.size()) {
-    rerunMesh.vertex_colors = mesh.colors;
+    rerunMesh = std::move(rerunMesh).with_vertex_colors(mesh.colors);
   }
 
   if (mesh.normals.size() == mesh.vertices.size()) {
-    rerunMesh.vertex_normals = mesh.normals;
+    rerunMesh = std::move(rerunMesh).with_vertex_normals(mesh.normals);
   }
 
   rec.log(streamName, rerunMesh);


### PR DESCRIPTION
Summary:
Update rerun_cpp_sdk to 0.22.1 and fix corresponding API call
- disconnected space does not longer exists
- some archetypes have now function to edit properties so we use std::move(OBJ).with_X().with_Y()

In this release we got multiple issue with error in asan mode:
- we have reported the issue https://github.com/rerun-io/rerun/issues/9503
- we have identified that the two archetype with the issue are ViewCoordinates and Clear (two archetype that are passed by using a static const value -> replacing with a value created on stack is solving the issue)

Reviewed By: jeongseok-meta

Differential Revision: D71758158
