### PR TITLE
Use fully qualified name to suppress -Wchanges-meaning warning

### DIFF
--- a/axel/axel/TriBvh.h
+++ b/axel/axel/TriBvh.h
@@ -25,7 +25,7 @@ class TriBvh {
  public:
   using Scalar = S;
   using QueryBuffer = typename BvhBase<S>::QueryBuffer;
-  using ClosestSurfacePointResult = ClosestSurfacePointResult<S>;
+  using ClosestSurfacePointResult = ::axel::ClosestSurfacePointResult<S>;
 
   TriBvh() = default;
 


### PR DESCRIPTION
Summary:
This is to suppress warnings when [building on GitHub](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1221839&view=logs&j=d818e662-7181-5ce9-b265-50d03742b7af&t=49931598-d7ad-5685-e176-ee07d6380434):

```
/home/conda/feedstock_root/build_artifacts/momentum_1744310620753/work/axel/axel/TriBvh.h:28:9: warning: declaration of 'using axel::TriBvh<S, LeafCapacity>::ClosestSurfacePointResult = struct axel::ClosestSurfacePointResult<S>' changes meaning of 'ClosestSurfacePointResult' [-Wchanges-meaning]
   28 |   using ClosestSurfacePointResult = ClosestSurfacePointResult<S>;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/conda/feedstock_root/build_artifacts/momentum_1744310620753/work/axel/axel/TriBvh.h:28:37: note: used here to mean 'struct axel::ClosestSurfacePointResult<S>'
   28 |   using ClosestSurfacePointResult = ClosestSurfacePointResult<S>;
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/conda/feedstock_root/build_artifacts/momentum_1744310620753/work/axel/axel/Bvh.h:28,
                 from /home/conda/feedstock_root/build_artifacts/momentum_1744310620753/work/axel/axel/TriBvh.h:16:
/home/conda/feedstock_root/build_artifacts/momentum_1744310620753/work/axel/axel/BvhCommon.h:32:8: note: declared here
   32 | struct ClosestSurfacePointResult {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Differential Revision: D72808449


