### PR TITLE
Temporal smoothing option for the sequence solver

### DIFF
--- a/pymomentum/solver/solver_pybind.cpp
+++ b/pymomentum/solver/solver_pybind.cpp
@@ -74,14 +74,16 @@ PYBIND11_MODULE(solver, m) {
                         size_t minIter,
                         size_t maxIter,
                         float threshold,
-                        bool lineSearch) {
+                        bool lineSearch,
+                        float sequenceSmoothingWeight) {
             return SolverOptions{
                 linearSolverType,
                 levmar_lambda,
                 minIter,
                 maxIter,
                 threshold,
-                lineSearch
+                lineSearch,
+                sequenceSmoothingWeight
 
             };
           }),
@@ -90,7 +92,8 @@ PYBIND11_MODULE(solver, m) {
           py::arg("min_iter") = 4,
           py::arg("max_iter") = 50,
           py::arg("threshold") = 10.0f,
-          py::arg("line_search") = true)
+          py::arg("line_search") = true,
+          py::arg("sequence_smoothing_weight") = 0.0f)
       .def_readwrite(
           "linear_solver",
           &SolverOptions::linearSolverType,

--- a/pymomentum/tensor_ik/solver_options.h
+++ b/pymomentum/tensor_ik/solver_options.h
@@ -32,6 +32,8 @@ struct SolverOptions {
   size_t maxIter = 50;
   float threshold = 10.0f;
   bool lineSearch = true;
+  // Temporal smoothing of model parameters (only for the sequence solver)
+  float sequenceSmoothingWeight = 0.0f;
 
   bool operator==(const SolverOptions& rhs) const {
     return linearSolverType == rhs.linearSolverType &&

--- a/pymomentum/tensor_ik/tensor_ik.cpp
+++ b/pymomentum/tensor_ik/tensor_ik.cpp
@@ -13,6 +13,7 @@
 
 #include <dispenso/parallel_for.h> // @manual
 #include <momentum/character/skeleton_state.h>
+#include <momentum/character_sequence_solver/model_parameters_sequence_error_function.h>
 #include <momentum/character_sequence_solver/sequence_solver.h>
 #include <momentum/character_sequence_solver/sequence_solver_function.h>
 #include <momentum/character_solver/gauss_newton_solver_qr.h>
@@ -426,6 +427,15 @@ at::Tensor solveTensorSequenceIKProblem(
               errorFunctionWeights.select(0, iBatch),
               weightsMap,
               iBatch);
+
+      if (solverOptions.sequenceSmoothingWeight > 0.f) {
+        auto modelParamsSequenceSmoothingErrFunc = std::make_shared<
+            momentum::ModelParametersSequenceErrorFunctionT<T>>(character);
+        modelParamsSequenceSmoothingErrFunc->setWeight(
+            solverOptions.sequenceSmoothingWeight);
+        solverFunction->addSequenceErrorFunction(
+            momentum::kAllFrames, modelParamsSequenceSmoothingErrFunc);
+      }
 
       momentum::SequenceSolverT<T> solver(
           momentumSolverOptions, solverFunction.get());


### PR DESCRIPTION
Summary:
Adding temporal smoothing parameter to PyMomentum SolverOptions for the SequenceSolver to unblock several projects.

This parameters is used as a weight of ModelParametersSequenceErrorFunction added to the SequenceSolver when setting up the optimization problem.

While this solves our current issues, it does not expose all possible functionality. One may want to, for example, set different smoothing weights for different parameters. A proper solution would be to expose ModelParametersSequenceErrorFunction to PyMomentum. This will likely require implementing TensorSequenceErrorFunction and update interface of solveTensorSequenceIKProblem, buildSequenceSolverFunction functions and all corresponding bindings.

Reviewed By: jeongseok-meta

Differential Revision: D72410749


