### PR TITLE
Stable quaternion to xyz conversion

### DIFF
--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -98,7 +98,7 @@ def quaternion_to_xyz_euler(q: torch.Tensor) -> torch.Tensor:
     qz2 = torch.square(qz)
     ones = torch.ones_like(qw)
     rx = torch.atan2(2 * (qw * qx + qy * qz), ones - 2 * (qx2 + qy2))
-    ry = torch.asin(2 * (qw * qy - qz * qx))
+    ry = torch.asin(torch.clamp(2 * (qw * qy - qz * qx), -1, 1))
     rz = torch.atan2(2 * (qw * qz + qx * qy), ones - 2 * (qy2 + qz2))
     return torch.stack((rx, ry, rz), -1)
 

--- a/pymomentum/test/test_quaternion.py
+++ b/pymomentum/test/test_quaternion.py
@@ -51,6 +51,11 @@ class TestQuaternion(unittest.TestCase):
             "Expected rotation difference to be small.",
         )
 
+        # check corner case conversion
+        q_cornercase = torch.FloatTensor([0.4832, -0.5161, 0.4835, 0.5162])
+        euler_cornercase = quaternion.quaternion_to_xyz_euler(q_cornercase)
+        self.assertFalse(torch.isnan(euler_cornercase).any())
+
         # check the gradients:
         torch.autograd.gradcheck(
             quaternion.euler_xyz_to_quaternion,


### PR DESCRIPTION
Summary:
In edge cases the conversion from quaternion to xyz euler angles can be numerically unstable as 2 * (qw * qy - qz * qx) can be slightly smaller than -1 or bigger than 1, causing the asin operation to generate NaN.
By explicitly clamping to -1/1 we prevent this and can generate stable outputs without NaN

Reviewed By: jeongseok-meta

Differential Revision: D73521349


