### PR TITLE
use new logging sink signature

### DIFF
--- a/momentum/gui/rerun/logging_redirect.cpp
+++ b/momentum/gui/rerun/logging_redirect.cpp
@@ -31,6 +31,7 @@ arvr::logging::LogResult callback(
     size_t /* channelNameSizeInBytes */,
     const char* message,
     size_t /* messageSizeInBytes */,
+    bool /*isFatalLog*/,
     arvr::logging::CustomUserData userData) {
   const auto* rec = reinterpret_cast<const rerun::RecordingStream*>(userData);
 


### PR DESCRIPTION
Summary: There is a new signature for logging sinks that will be used to receive both 'regular' and fatal logs.

Differential Revision: D73936168


