### PR TITLE
Fix CUDA architecture mismatch in CI by restricting supported architectures

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -59,7 +59,7 @@ jobs:
         include:
           - pixi_env: "cpu"
           - pixi_env: "gpu"
-            cuda_version: "12.8.0"
+            cuda_version: "12.6.3"
     env:
       FULL_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
@@ -82,7 +82,7 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.23
         id: cuda-toolkit
         with:
-          # Available versions: https://github.com/Jimver/cuda-toolkit/blob/v0.2.21/src/links/linux-links.ts
+          # Available versions: https://github.com/Jimver/cuda-toolkit/blob/v0.2.23/src/links/linux-links.ts
           cuda: ${{ matrix.cuda_version }}
 
       - name: Check CUDA Version

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -54,7 +54,7 @@ jobs:
         include:
           - pixi_env: "cpu"
           - pixi_env: "gpu"
-            cuda_version: "12.8.0"
+            cuda_version: "12.6.3"
     env:
       FULL_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
@@ -66,7 +66,7 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.23
         id: cuda-toolkit
         with:
-          # Available versions: https://github.com/Jimver/cuda-toolkit/blob/v0.2.21/src/links/linux-links.ts
+          # Available versions: https://github.com/Jimver/cuda-toolkit/blob/v0.2.23/src/links/linux-links.ts
           cuda: ${{ matrix.cuda_version }}
 
       - name: Check CUDA Version

--- a/pixi.toml
+++ b/pixi.toml
@@ -217,7 +217,8 @@ build_py = { cmd = "pip install . -vv", env = { FBXSDK_PATH = ".deps/fbxsdk", CM
     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
     -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
     -DMOMENTUM_USE_SYSTEM_PYBIND11=OFF \
-    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
+    -DTORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
 """, MOMENTUM_ENABLE_SIMD = "ON" }, depends-on = [
     "install_deps",
 ] }
@@ -359,7 +360,8 @@ build_py = { cmd = "pip install . -vv", env = { CMAKE_ARGS = """
     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
     -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
     -DMOMENTUM_USE_SYSTEM_PYBIND11=OFF \
-    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
+    -DTORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
 """, MOMENTUM_BUILD_WITH_FBXSDK = "OFF", MOMENTUM_ENABLE_SIMD = "ON" } }
 # TODO: Remove -k option, once this tests are disabled programmatically if momentum is not built with FBX support
 test_py = { cmd = "pytest pymomentum/test/*.py -k 'not (TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params))'", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [


### PR DESCRIPTION
## Summary

The current GPU builds on CI ([py-gpu-ubuntu](https://github.com/facebookresearch/momentum/actions/runs/14799890711/job/41555959224) and [py-gpu-win](https://github.com/facebookresearch/momentum/actions/runs/14799890728/job/41555959184)) are broken because the auto-detected version 10.0 is not supported by the PyTorch conda package.

- Explicitly set `TORCH_CUDA_ARCH_LIST` to the [supported architectures](https://github.com/conda-forge/pytorch-cpu-feedstock/blob/71a445e6b5a73c4d0afd3ca1b235684bfcfa0bce/recipe/build.sh#L214)
- Set CI CUDA version to 12.6 to match [PyTorch's pre-built binaries](https://github.com/conda-forge/pytorch-cpu-feedstock/blob/71a445e6b5a73c4d0afd3ca1b235684bfcfa0bce/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml#L20)

## Checklist:

- [v] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [v] Codebase formatted by running `pixi run lint`

## Test Plan

CI
