### PR TITLE
Fix TORCH_CUDA_ARCH_LIST override for Windows

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -59,7 +59,7 @@ jobs:
         include:
           - pixi_env: "cpu"
           - pixi_env: "gpu"
-            cuda_version: "12.6.3"
+            cuda_version: "12.8.1"
     env:
       FULL_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -54,7 +54,7 @@ jobs:
         include:
           - pixi_env: "cpu"
           - pixi_env: "gpu"
-            cuda_version: "12.6.3"
+            cuda_version: "12.8.1"
     env:
       FULL_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:

--- a/pixi.toml
+++ b/pixi.toml
@@ -217,9 +217,8 @@ build_py = { cmd = "pip install . -vv", env = { FBXSDK_PATH = ".deps/fbxsdk", CM
     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
     -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
     -DMOMENTUM_USE_SYSTEM_PYBIND11=OFF \
-    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
-    -DTORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
-""", MOMENTUM_ENABLE_SIMD = "ON" }, depends-on = [
+    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+""", MOMENTUM_ENABLE_SIMD = "ON", TORCH_CUDA_ARCH_LIST = "5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX" }, depends-on = [
     "install_deps",
 ] }
 test_py = { cmd = "pytest pymomentum/test/*.py", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
@@ -360,9 +359,8 @@ build_py = { cmd = "pip install . -vv", env = { CMAKE_ARGS = """
     -DMOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
     -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
     -DMOMENTUM_USE_SYSTEM_PYBIND11=OFF \
-    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
-    -DTORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
-""", MOMENTUM_BUILD_WITH_FBXSDK = "OFF", MOMENTUM_ENABLE_SIMD = "ON" } }
+    -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON
+""", MOMENTUM_BUILD_WITH_FBXSDK = "OFF", MOMENTUM_ENABLE_SIMD = "ON", TORCH_CUDA_ARCH_LIST = "5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX" } }
 # TODO: Remove -k option, once this tests are disabled programmatically if momentum is not built with FBX support
 test_py = { cmd = "pytest pymomentum/test/*.py -k 'not (TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params))'", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",


### PR DESCRIPTION
## Summary

Second attempt to [fix pymomentum build](https://github.com/facebookresearch/momentum/actions/runs/14802073505/job/41567021500) with CUDA support from https://github.com/facebookresearch/momentum/pull/293. This involves switching from overriding `TORCH_CUDA_ARCH_LIST` using CMake options (which resulted in a syntax error for Windows) to setting it as an environment variable, and updating the CUDA version to the latest on CI (previously, 12.6.3 failed to be set up in CMake, resulting in a failed test program build).

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

CI
