### PR TITLE
Add feature of baking scales into mesh

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -179,6 +179,7 @@ character_test_sources = [
     "test/character/parameter_transform_test.cpp",
     "test/character/simplify_test.cpp",
     "test/character/skeleton_test.cpp",
+    "test/character/skeleton_bake_test.cpp",
 ]
 
 character_solver_public_headers = [

--- a/momentum/character/character.h
+++ b/momentum/character/character.h
@@ -152,6 +152,21 @@ struct CharacterT {
   // and strip the blend shapes out of the parameter transform:
   CharacterT bakeBlendShape(const ModelParameters& modelParams) const;
   CharacterT bakeBlendShape(const BlendWeights& blendWeights) const;
+
+  /// Generic "bake-out" for turning a character into self-contained geometry.
+  ///
+  /// @param[in] modelParams Current pose/scale/blend-shape parameters.
+  /// @param[in] bakeBlendShapes Set true (default) to apply blend-shape deltas and remove their
+  /// parameters from the character.
+  /// @param[in] bakeScales Set true (default) to evaluate the posed skeleton, run
+  /// Linear-Blend-Skinning once, and remove all scaling parameters from the character.
+  ///
+  /// The returned character contains a static mesh with all requested deformations baked in, while
+  /// still supporting any parameters you elected to keep.
+  CharacterT bake(
+      const ModelParameters& modelParams,
+      bool bakeBlendShapes = true,
+      bool bakeScales = true) const;
 };
 
 } // namespace momentum

--- a/momentum/test/character/skeleton_bake_test.cpp
+++ b/momentum/test/character/skeleton_bake_test.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <momentum/character/blend_shape_skinning.h>
+#include <momentum/character/character.h>
+#include <momentum/character/skeleton.h>
+#include <momentum/character/skeleton_state.h>
+#include <momentum/math/mesh.h>
+#include <momentum/math/random.h>
+#include <momentum/test/character/character_helpers.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace momentum;
+
+using Types = testing::Types<float, double>;
+
+template <typename T>
+struct BakeTest : testing::Test {
+  using Type = T;
+};
+
+TYPED_TEST_SUITE(BakeTest, Types);
+
+// Helper: ensure at least one scaling & one blend-shape parameter != 0
+template <typename T>
+void activateSomeBakeableParams(const Character& c, ModelParametersT<T>& mp) {
+  // Set the first scaling parameter we can find.
+  for (size_t i = 0; i < mp.size(); ++i) {
+    if (c.parameterTransform.getScalingParameters().test(i)) {
+      mp[i] = T(0.07); // 7 % scale tweak
+      break;
+    }
+  }
+  // And the first blend-shape parameter.
+  for (size_t i = 0; i < mp.size(); ++i) {
+    if (c.parameterTransform.getBlendShapeParameters().test(i)) {
+      mp[i] = T(0.25); // 25 % weight
+      break;
+    }
+  }
+}
+
+TYPED_TEST(BakeTest, Geometry) {
+  using T = typename TestFixture::Type;
+
+  // Build a character with both scale & blend-shape capabilities
+  const Character characterBlend = withTestBlendShapes(createTestCharacter());
+  ASSERT_TRUE(characterBlend.mesh);
+  ASSERT_TRUE(characterBlend.blendShape);
+  ASSERT_TRUE(characterBlend.skinWeights);
+
+  const ParameterTransformT<T> paramX = characterBlend.parameterTransform.cast<T>();
+
+  // Random (but reproducible) model parameters
+  ModelParametersT<T> modelParams = uniform<VectorX<T>>(paramX.numAllModelParameters(), 0, 1);
+
+  activateSomeBakeableParams(characterBlend, modelParams);
+
+  // Runtime path: skinning with blend shapes
+  SkeletonStateT<T> skelState(paramX.apply(modelParams), characterBlend.skeleton);
+
+  MeshT<T> posedMesh = characterBlend.mesh->cast<T>();
+  skinWithBlendShapes(characterBlend, skelState, modelParams, posedMesh);
+
+  // Bake-time path
+  Character baked = characterBlend.bake(modelParams.template cast<float>());
+  ASSERT_TRUE(baked.mesh); // sanity
+
+  MeshT<T> bakedMesh = baked.mesh->cast<T>(); // convert verts to current precision
+
+  // Compare vertex positions
+  ASSERT_EQ(posedMesh.vertices.size(), bakedMesh.vertices.size());
+  for (size_t i = 0; i < posedMesh.vertices.size(); ++i) {
+    const Eigen::Vector3<T> vRun = posedMesh.vertices[i];
+    const Eigen::Vector3<T> vBake = bakedMesh.vertices[i];
+    EXPECT_LE((vRun - vBake).norm(), Eps<T>(1e-5f, 5e-6)) << "Vertex " << i << " mismatch";
+  }
+}
+
+TYPED_TEST(BakeTest, ParameterStripping) {
+  using T = typename TestFixture::Type;
+
+  const Character characterBlend = withTestBlendShapes(createTestCharacter());
+  const ParameterTransformT<T> paramX = characterBlend.parameterTransform.cast<T>();
+
+  ModelParametersT<T> modelParams = VectorX<T>::Zero(paramX.numAllModelParameters());
+  activateSomeBakeableParams(characterBlend, modelParams);
+
+  Character baked = characterBlend.bake(modelParams.template cast<float>());
+
+  // Blend-shape and scale parameter sets are gone
+  EXPECT_EQ(baked.parameterTransform.getBlendShapeParameters().count(), 0);
+  EXPECT_EQ(baked.parameterTransform.getScalingParameters().count(), 0);
+
+  // Overall DOF count strictly smaller (unless the original had none to strip)
+  EXPECT_LT(
+      baked.parameterTransform.numAllModelParameters(),
+      characterBlend.parameterTransform.numAllModelParameters());
+}
+
+} // namespace


### PR DESCRIPTION
Summary: Add `CharacterT::bake()` that bakes blend-shapes and scale/LBS skinning into the mesh, then removes those parameters, which is handy when exporting a fully static FBX/GLTF asset

Differential Revision: D74661362


