### PR TITLE
Add support for loading gltf characters with motion from bytes.

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -458,6 +458,16 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
 :return: a valid Character.
       )",
           py::arg("gltf_bytes"))
+      .def_static(
+          "from_gltf_bytes_with_motion",
+          &loadGLTFCharacterWithMotionFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Load a character from a gltf byte array.
+  
+  :parameter gltf_bytes: A :class:`bytes` containing the GLTF JSON/messagepack data.
+  :return: a valid Character.
+        )",
+          py::arg("gltf_bytes"))
       // toGLTF(character, fps, motion)
       .def_static(
           "to_gltf",
@@ -569,7 +579,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
       // loadCharacterWithMotion(gltfFilename)
       .def_static(
           "load_gltf_with_motion",
-          &loadCharacterWithMotion,
+          &loadGLTFCharacterWithMotion,
           py::call_guard<py::gil_scoped_release>(),
           R"(Load a character and a motion sequence from a gltf file.
 

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -52,17 +52,6 @@ gsl::span<const T> toSpan(const pybind11::bytes& bytes) {
   return gsl::make_span<const T>(data, length);
 }
 
-momentum::Character loadGLTFCharacterFromBytes(const pybind11::bytes& bytes) {
-  py::buffer_info info(py::buffer(bytes).request());
-  const std::byte* data = reinterpret_cast<const std::byte*>(info.ptr);
-  const size_t length = static_cast<size_t>(info.size);
-
-  MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.");
-
-  return momentum::loadGltfCharacter(
-      gsl::make_span<const std::byte>(data, length));
-}
-
 // Use tensor.index_select() and tensor.index_copy() to copy data from srcTensor
 // to form a new tensor. The dimension the mapping is applied on is `dimension`.
 // The mapping is created by matching `srcNames` to `tgtNames`. The target slice

--- a/pymomentum/geometry/momentum_geometry.h
+++ b/pymomentum/geometry/momentum_geometry.h
@@ -27,8 +27,6 @@ using RowMatrixi =
 using RowMatrixb =
     Eigen::Matrix<uint8_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
-momentum::Character loadGLTFCharacterFromBytes(const pybind11::bytes& bytes);
-
 at::Tensor mapModelParameters_names(
     at::Tensor motion_in,
     const std::vector<std::string>& srcParameterNames,

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -30,6 +30,7 @@ using RowMatrixf =
     Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
 momentum::Character loadGLTFCharacterFromFile(const std::string& path);
+momentum::Character loadGLTFCharacterFromBytes(const pybind11::bytes& bytes);
 
 void saveGLTFCharacterToFile(
     const std::string& path,
@@ -62,7 +63,10 @@ void saveFBXCharacterToFileWithJointParams(
     std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo);
 
 std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float>
-loadCharacterWithMotion(const std::string& gltfFilename);
+loadGLTFCharacterWithMotion(const std::string& gltfFilename);
+
+std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float>
+loadGLTFCharacterWithMotionFromBytes(const pybind11::bytes& bytes);
 
 std::string toGLTF(const momentum::Character& character);
 


### PR DESCRIPTION
Summary:
It's annoyed me twice in the last week that I can't load motion directly from GLB bytes, I have to save to a temporary file first. So let's fix that by adding a from_gltf_bytes_with_motion() function.  

Naming is a bit clumsy, since there is a from_gltf_bytes() function I wanted to match it but "with_motion_from_gltf_bytes" is theoretically just as valid as or "from_gltf_bytes_with_motion" but I think the latter is a bit better?

Reviewed By: jeongseok-meta

Differential Revision: D74682162


