### PR TITLE
add pose priors and first frame floor constraints back into marker solver

### DIFF
--- a/momentum/io/skeleton/locator_io.cpp
+++ b/momentum/io/skeleton/locator_io.cpp
@@ -12,6 +12,7 @@
 #include "momentum/character/skeleton.h"
 #include "momentum/character/skeleton_state.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/log.h"
 #include "momentum/common/string.h"
 #include "momentum/math/utility.h"
 
@@ -184,8 +185,10 @@ LocatorList loadLocatorsFromBuffer(
     } while (line < lines.size() - 1 && (current != "}," || current != "}"));
 
     // do we have a valid locator
-    if (l.parent == kInvalidIndex)
+    if (l.parent == kInvalidIndex) {
+      MT_LOGW("Could not find parent for locator {}", l.name);
       continue;
+    }
 
     if (haveGlobal)
       l.offset = state.jointState[l.parent].transformation.inverse() * (global);

--- a/momentum/marker_tracking/app_utils.cpp
+++ b/momentum/marker_tracking/app_utils.cpp
@@ -83,6 +83,18 @@ void addCalibrationOptions(CLI::App& app, std::shared_ptr<CalibrationConfig> con
       config->greedySampling,
       "Use greedy sampling to select calibration frames");
   greedySamplingOption->default_val(config->greedySampling)->check(CLI::NonNegativeNumber);
+
+  auto* firstFrameFloorContactOption = app.add_flag(
+      "--init-floor-contact",
+      config->enforceFloorInFirstFrame,
+      "Enforce floor contact constraints in first frame");
+  firstFrameFloorContactOption->default_val(config->enforceFloorInFirstFrame);
+
+  auto* poseOption = app.add_option(
+      "--init-pose",
+      config->firstFramePoseConstraintSet,
+      "Enforce pose constraints from named pose constraint set in first frame");
+  poseOption->default_val(config->firstFramePoseConstraintSet);
 }
 
 void addTrackingOptions(CLI::App& app, std::shared_ptr<TrackingConfig> config) {

--- a/momentum/marker_tracking/app_utils.cpp
+++ b/momentum/marker_tracking/app_utils.cpp
@@ -77,6 +77,12 @@ void addCalibrationOptions(CLI::App& app, std::shared_ptr<CalibrationConfig> con
   auto* locatorsOnlyOption =
       app.add_option("--locators-only", config->locatorsOnly, "Calibrate only the locator offsets");
   locatorsOnlyOption->default_val(config->locatorsOnly);
+
+  auto* greedySamplingOption = app.add_option(
+      "--greedy-sampling",
+      config->greedySampling,
+      "Use greedy sampling to select calibration frames");
+  greedySamplingOption->default_val(config->greedySampling)->check(CLI::NonNegativeNumber);
 }
 
 void addTrackingOptions(CLI::App& app, std::shared_ptr<TrackingConfig> config) {

--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -28,6 +28,120 @@ using namespace momentum;
 
 namespace marker_tracking {
 
+std::vector<size_t> sampleFrames(
+    momentum::Character& character,
+    const MatrixXf& initialMotion,
+    gsl::span<const std::vector<momentum::Marker>> markerData,
+    const ParameterSet& parameters,
+    const size_t frameStride,
+    const size_t numSamples) {
+  // sample frames so that we get the most variance from the initial input
+  const auto numFrames = static_cast<size_t>(initialMotion.cols());
+  size_t solvedFrames = (numFrames - 1) / frameStride + 1;
+
+  std::vector<size_t> frameIndices;
+  if (solvedFrames == 0) {
+    return frameIndices;
+  }
+  const size_t numActualSamples = std::min(numSamples, solvedFrames);
+
+  // get the indices of the parameters to be used
+  std::vector<size_t> usedParameters;
+  for (size_t i = 0; i < static_cast<size_t>(initialMotion.rows()); ++i) {
+    if (parameters.test(i)) {
+      usedParameters.push_back(i);
+    }
+  }
+
+  // calculate per frame error
+  const ParameterTransform& pt = character.parameterTransform;
+
+  // map locator name to its index
+  std::map<std::string, size_t> locatorLookup;
+  for (size_t i = 0; i < character.locators.size(); i++) {
+    locatorLookup[character.locators[i].name] = i;
+  }
+
+  std::vector<double> frameErrors(solvedFrames, 0.0f);
+  SkeletonState state;
+  for (size_t iFrame = 0, fi = 0; iFrame < numFrames; iFrame += frameStride, fi++) {
+    const auto jointParams = pt.apply(initialMotion.col(iFrame));
+    state.set(jointParams, character.skeleton, false);
+
+    const auto& markerList = markerData[iFrame];
+    for (const auto& jMarker : markerList) {
+      if (jMarker.occluded) {
+        continue;
+      }
+      auto query = locatorLookup.find(jMarker.name);
+      if (query == locatorLookup.end()) {
+        continue;
+      }
+      size_t locatorIdx = query->second;
+
+      const auto& locator = character.locators[locatorIdx];
+      const Vector3f locatorPos = state.jointState[locator.parent].transform * locator.offset;
+      const Vector3f diff = locatorPos - jMarker.pos.cast<float>();
+      const float markerError = diff.norm();
+      frameErrors[fi] += markerError;
+    }
+  }
+  std::vector<double> sortedErrors = frameErrors;
+  std::sort(sortedErrors.begin(), sortedErrors.end());
+
+  // do not use the worst 1/4 of the fitted errors, there's likely to be some outliers and
+  // errors due to the initialization
+  const double threshold = sortedErrors[(sortedErrors.size() * 3) / 4];
+
+  // get the motion of only the used parameters and then normalize
+  // by the mean and variance
+  MatrixXf normalized;
+  {
+    const MatrixXf subMotion =
+        initialMotion(usedParameters, Eigen::seq(0, numFrames - 1, frameStride));
+    const VectorXf mean = subMotion.rowwise().mean();
+    const MatrixXf centered = subMotion.colwise() - mean;
+    const VectorXf std = centered.array().square().rowwise().sum() / (numFrames - 1);
+
+    // normalize the motion by the sqrt of the variance, i.e. leave a little bit of scale in
+    normalized = centered.array().colwise() / (std.array().sqrt().sqrt().cwiseMax(1e-5f));
+  }
+
+  for (size_t i = 0; i < frameErrors.size(); ++i) {
+    if (frameErrors[i] > threshold) {
+      normalized.col(i) = VectorXf::Ones(normalized.rows()) * 1000.0f;
+    }
+  }
+
+  // calculate the distances from each frame to the already selected indices
+  frameIndices.push_back(0);
+  VectorXf distances = VectorXf::Zero(solvedFrames);
+  for (size_t fi = 0; fi < solvedFrames; fi++) {
+    distances[fi] = (normalized.col(frameIndices[0]) - normalized.col(fi)).norm();
+  }
+
+  // finally add additional samples with the largest distance
+  for (size_t i = frameIndices.size(); i < numActualSamples; ++i) {
+    size_t maxFrame = 0;
+    const float maxval = distances.maxCoeff(&maxFrame);
+    if (maxval < 1e-5f) {
+      break;
+    }
+    frameIndices.push_back(maxFrame);
+
+    for (size_t fi = 0; fi < solvedFrames; fi++) {
+      const float dist = (normalized.col(maxFrame) - normalized.col(fi)).cwiseAbs().maxCoeff();
+      distances[fi] = std::min(distances[fi], dist);
+    }
+  }
+
+  for (auto&& fi : frameIndices) {
+    fi *= frameStride;
+  }
+
+  return frameIndices;
+}
+
 Eigen::MatrixXf trackSequence(
     const gsl::span<const std::vector<Marker>> markerData,
     const Character& character,
@@ -180,6 +294,151 @@ Eigen::MatrixXf trackSequence(
     for (size_t jDelta = 0; jDelta < frameStride && iFrame + jDelta < numFrames; ++jDelta) {
       outMotion.col(iFrame + jDelta) = solverFunc.getFrameParameters(solverFrame).v;
     }
+  }
+  return outMotion;
+}
+
+Eigen::MatrixXf trackSequence(
+    const gsl::span<const std::vector<Marker>> markerData,
+    const Character& character,
+    const ParameterSet& globalParams,
+    const MatrixXf& initialMotion,
+    const TrackingConfig& config,
+    const std::vector<size_t>& frames,
+    float regularizer) {
+  // sanity checks
+  const size_t numFrames = markerData.size();
+  MT_CHECK(numFrames > 0, "Input data is empty.");
+  MT_CHECK(
+      initialMotion.cols() >= numFrames,
+      "Number of frames in data {} doesn't match that of input motion {}",
+      numFrames,
+      initialMotion.cols());
+  MT_CHECK(
+      initialMotion.rows() == character.parameterTransform.numAllModelParameters(),
+      "Input motion parameters {} do not match character model parameters {}",
+      initialMotion.rows(),
+      character.parameterTransform.numAllModelParameters());
+
+  const ParameterTransform& pt = character.parameterTransform;
+  const size_t numMarkers = markerData[0].size();
+
+  // universal parameters include "scaling" and "locators" (if exists); pose parameters need to
+  // exclude "locators". universalParams is to indicate to the solver which parameters are "global"
+  // (ie. not time varying). The input globalParams indicate which parameters within universalParams
+  // we want to solve for. globalParams is either a subset or all of universalParams.
+  ParameterSet poseParams = pt.getPoseParameters();
+  ParameterSet universalParams = pt.getScalingParameters();
+  const auto locatorSet = pt.parameterSets.find("locators");
+  if (locatorSet != pt.parameterSets.end()) {
+    poseParams &= ~locatorSet->second;
+    universalParams |= locatorSet->second;
+  }
+
+  // set up the solver function
+  std::vector<size_t> sortedFrames = frames;
+  std::sort(sortedFrames.begin(), sortedFrames.end());
+  size_t solvedFrames = sortedFrames.size();
+  auto solverFunc = SequenceSolverFunction(
+      &character.skeleton, &character.parameterTransform, universalParams, solvedFrames);
+
+  // floor penetration constraints; we assume the world is y-up and floor is y=0 for mocap data.
+  const auto& floorConstraints = createFloorConstraints<float>(
+      "Floor_",
+      character.locators,
+      Vector3f::UnitY(),
+      /* y offset */ 0.0f,
+      /* weight */ 5.0f);
+
+  // marker constraints
+  const auto constrData = createConstraintData(markerData, character.locators);
+
+  // add per-frame constraint data to the solver
+  for (size_t solverFrame = 0; solverFrame < solvedFrames; ++solverFrame) {
+    const size_t& iFrame = sortedFrames[solverFrame];
+    if (constrData.at(iFrame).size() > numMarkers * config.minVisPercent) {
+      // prepare positional constraints
+      auto posConstrFunc = std::make_shared<PositionErrorFunction>(character, config.lossAlpha);
+      posConstrFunc->setConstraints(constrData.at(iFrame));
+      posConstrFunc->setWeight(PositionErrorFunction::kLegacyWeight);
+      solverFunc.addErrorFunction(solverFrame, posConstrFunc);
+
+      // prepare floor constraints
+      if (!floorConstraints.empty()) {
+        auto halfPlaneConstrFunc =
+            std::make_shared<PlaneErrorFunction>(character, /*half plane*/ true);
+        halfPlaneConstrFunc->setConstraints(floorConstraints);
+        halfPlaneConstrFunc->setWeight(PlaneErrorFunction::kLegacyWeight);
+        solverFunc.addErrorFunction(solverFrame, halfPlaneConstrFunc);
+      }
+    }
+    // Set per-frame initial value
+    solverFunc.setFrameParameters(solverFrame, initialMotion.col(iFrame));
+  }
+
+  // add parameter limits
+  auto limitConstrFunc = std::make_shared<LimitErrorFunction>(character);
+  limitConstrFunc->setWeight(0.1);
+  solverFunc.addErrorFunction(kAllFrames, limitConstrFunc);
+
+  // add collision error
+  if (config.collisionErrorWeight != 0 && character.collision != nullptr) {
+    auto collisionConstrFunc = std::make_shared<CollisionErrorFunctionStateless>(character);
+    collisionConstrFunc->setWeight(config.collisionErrorWeight);
+    solverFunc.addErrorFunction(kAllFrames, collisionConstrFunc);
+  }
+
+  // add a smoothness constraint in parameter space
+  if (config.smoothing != 0) {
+    auto smoothConstrFunc = std::make_shared<ModelParametersSequenceErrorFunction>(character);
+    smoothConstrFunc->setWeight(config.smoothing);
+    solverFunc.addSequenceErrorFunction(kAllFrames, smoothConstrFunc);
+  }
+
+  // minimize the change to global params
+  if (globalParams.count() > 0 && regularizer != 0) {
+    auto regularizerFunc = std::make_shared<ModelParametersErrorFunction>(character);
+    Eigen::VectorXf universalMask(pt.numAllModelParameters());
+    for (size_t i = 0; i < universalMask.size(); ++i) {
+      if (globalParams.test(i)) {
+        universalMask[i] = regularizer;
+      } else {
+        universalMask[i] = 0.0;
+      }
+    }
+    regularizerFunc->setTargetParameters(initialMotion.col(0), universalMask);
+    // Sufficient to add to the first frame since it won't change.
+    solverFunc.addErrorFunction(0, regularizerFunc);
+  }
+
+  // solver configration
+  SequenceSolverOptions solverOptions;
+  solverOptions.maxIterations = config.maxIter;
+  solverOptions.minIterations = 2;
+  solverOptions.progressBar = config.debug;
+  solverOptions.doLineSearch = false;
+  solverOptions.multithreaded = true;
+  solverOptions.verbose = config.debug;
+  solverOptions.threshold = 1.f;
+  solverOptions.regularization = 0.05f;
+
+  // solve the problem
+  SequenceSolver solver = SequenceSolver(solverOptions, &solverFunc);
+  solver.setEnabledParameters(poseParams | globalParams);
+  // returns all the dofs with initial values nicely packed into a vector
+  VectorXf dofs = solverFunc.getJoinedParameterVector();
+  solver.solve(dofs);
+  double error = solverFunc.getError(dofs);
+  MT_LOGI_IF(config.debug, "Solver residual: {}", error);
+
+  // set results to output
+  size_t sortedIndex = 0;
+  MatrixXf outMotion(pt.numAllModelParameters(), numFrames);
+  for (size_t fi = 0; fi < numFrames; fi++) {
+    if (sortedIndex < sortedFrames.size() - 1 && fi == sortedFrames[sortedIndex + 1]) {
+      sortedIndex++;
+    }
+    outMotion.col(fi) = solverFunc.getFrameParameters(sortedIndex).v;
   }
   return outMotion;
 }
@@ -345,6 +604,141 @@ Eigen::MatrixXf trackPosesPerframe(
   return motion;
 }
 
+Eigen::MatrixXf trackPosesForFrames(
+    const gsl::span<const std::vector<Marker>> markerData,
+    const Character& character,
+    const MatrixXf& initialMotion,
+    const TrackingConfig& config,
+    const std::vector<size_t>& frameIndices) {
+  const size_t numFrames = markerData.size();
+  MT_CHECK(numFrames > 0, "Input data is empty.");
+  MT_CHECK(
+      initialMotion.rows() == character.parameterTransform.numAllModelParameters(),
+      "Input motion parameters {} do not match character model parameters {}",
+      initialMotion.rows(),
+      character.parameterTransform.numAllModelParameters());
+
+  const ParameterTransform& pt = character.parameterTransform;
+  const size_t numMarkers = markerData[0].size();
+
+  std::vector<size_t> sortedFrames = frameIndices;
+  std::sort(sortedFrames.begin(), sortedFrames.end());
+
+  // pose parameters need to exclude "locators"
+  ParameterSet poseParams = pt.getPoseParameters();
+  const auto& locatorSet = pt.parameterSets.find("locators");
+  if (locatorSet != pt.parameterSets.end()) {
+    poseParams &= ~locatorSet->second;
+  }
+
+  // set up the solver
+  auto solverFunc = SkeletonSolverFunction(&character.skeleton, &pt);
+  GaussNewtonSolverOptions solverOptions;
+  solverOptions.maxIterations = config.maxIter;
+  solverOptions.minIterations = 2;
+  solverOptions.doLineSearch = false;
+  solverOptions.verbose = config.debug;
+  solverOptions.threshold = 1.f;
+  solverOptions.regularization = 0.05f;
+  auto solver = GaussNewtonSolver(solverOptions, &solverFunc);
+  solver.setEnabledParameters(poseParams);
+
+  // parameter limits constraint
+  auto limitConstrFunc = std::make_shared<LimitErrorFunction>(character);
+  limitConstrFunc->setWeight(0.1);
+  solverFunc.addErrorFunction(limitConstrFunc);
+
+  // positional constraint function for markers
+  auto posConstrFunc = std::make_shared<PositionErrorFunction>(character, config.lossAlpha);
+  posConstrFunc->setWeight(PositionErrorFunction::kLegacyWeight);
+  solverFunc.addErrorFunction(posConstrFunc);
+
+  // floor penetration constraint data; we assume the world is y-up and floor is y=0 for mocap data.
+  const auto& floorConstraints = createFloorConstraints<float>(
+      "Floor_",
+      character.locators,
+      Vector3f::UnitY(),
+      /* y offset */ 0.0f,
+      /* weight */ 5.0f);
+  auto halfPlaneConstrFunc = std::make_shared<PlaneErrorFunction>(character, /*half plane*/ true);
+  halfPlaneConstrFunc->setConstraints(floorConstraints);
+  halfPlaneConstrFunc->setWeight(PlaneErrorFunction::kLegacyWeight);
+  solverFunc.addErrorFunction(halfPlaneConstrFunc);
+
+  // marker constraint data
+  auto constrData = createConstraintData(markerData, character.locators);
+
+  // add collision error
+  std::shared_ptr<CollisionErrorFunction> collisionErrorFunction;
+  if (config.collisionErrorWeight != 0 && character.collision != nullptr) {
+    collisionErrorFunction = std::make_shared<CollisionErrorFunction>(character);
+    collisionErrorFunction->setWeight(config.collisionErrorWeight);
+    solverFunc.addErrorFunction(collisionErrorFunction);
+  }
+
+  // initialize parameters to contain identity information
+  // the identity fields will be used but untouched during optimization
+  // globalParams could also be repurposed to pass in initial pose value
+  std::vector<Eigen::VectorXf> poses(frameIndices.size());
+  Eigen::VectorXf dof = initialMotion.col(sortedFrames[0]);
+  size_t solverFrame = 0;
+  double priorError = 0.0;
+  double error = 0.0;
+
+  MatrixXf outMotion(pt.numAllModelParameters(), numFrames);
+  { // scope the ProgressBar so it returns
+    ProgressBar progress("", sortedFrames.size());
+    for (size_t fi = 0; fi < sortedFrames.size(); fi++) {
+      const size_t& iFrame = sortedFrames[fi];
+      dof = initialMotion.col(iFrame);
+
+      if (constrData.at(iFrame).size() > numMarkers * config.minVisPercent) {
+        // add positional constraints
+        posConstrFunc->clearConstraints(); // clear constraint data from the previous frame
+        posConstrFunc->setConstraints(constrData.at(iFrame));
+
+        // initialization
+        solverOptions.maxIterations = 50; // make sure it converges
+        solver.setOptions(solverOptions);
+        solver.setEnabledParameters(pt.getRigidParameters());
+
+        solver.solve(dof);
+
+        // Recover solver config
+        solverOptions.maxIterations = config.maxIter;
+        solver.setOptions(solverOptions);
+        solver.setEnabledParameters(poseParams);
+
+        priorError += solverFunc.getError(dof);
+        error += solver.solve(dof);
+        ++solverFrame;
+      }
+
+      // store result
+      poses[fi] = dof;
+      progress.increment();
+    }
+
+    // set results to output
+    size_t sortedIndex = 0;
+    for (size_t fi = 0; fi < numFrames; fi++) {
+      if (sortedIndex < sortedFrames.size() - 1 && fi == sortedFrames[sortedIndex + 1]) {
+        sortedIndex++;
+      }
+      outMotion.col(fi) = poses[sortedIndex];
+    }
+  }
+  if (config.debug) {
+    if (solverFrame > 0) {
+      MT_LOGI("Pre optimization residual: {}", priorError / solverFrame);
+      MT_LOGI("Average per-frame residual: {}", error / solverFrame);
+    } else {
+      MT_LOGW("no valid frames to solve");
+    }
+  }
+  return outMotion;
+}
+
 void calibrateModel(
     const gsl::span<const std::vector<Marker>> markerData,
     const CalibrationConfig& config,
@@ -388,40 +782,106 @@ void calibrateModel(
   // identity information will be initialized and updated in the motion matrix throughout all the
   // solves.
   MatrixXf motion = MatrixXf::Zero(transformExtended.numAllModelParameters(), numFrames);
+  std::vector<size_t> frameIndices;
 
   { // Initialization
     MT_LOGI_IF(config.debug, "Solving for an initial pose and skeleton");
 
     // first solve for initial tracking poses with fixed identity and locators to default
     // Because we are solving for poses only, use character to save compute.
-    motion.topRows(transform.numAllModelParameters()) =
-        trackPosesPerframe(markerData, character, identity, trackingConfig, frameStride);
+    if (config.greedySampling > 0) {
+      // first only track the first frame
+      MT_LOGI_IF(config.debug, "Pre-solving for the first frame");
+      std::vector<size_t> firstFrame;
+      firstFrame.push_back(0);
+      motion.topRows(transform.numAllModelParameters()) = trackPosesForFrames(
+          markerData,
+          character,
+          motion.topRows(transform.numAllModelParameters()),
+          trackingConfig,
+          firstFrame);
+      motion.topRows(transform.numAllModelParameters()) = trackSequence(
+          markerData,
+          character,
+          calibBodySet,
+          motion.topRows(transform.numAllModelParameters()),
+          trackingConfig,
+          firstFrame,
+          0.0); // still solving a subset
+      std::tie(identity.v, character.locators) =
+          extractIdAndLocatorsFromParams(motion.col(0), solvingCharacter, character);
 
-    // then solve for identity and poses with fixed locators, initialized with solved poses
-    // this works using "character" because additional parameters for the locators are appended at
-    // the end, so the indices work out using topRows() without special treatment.
-    motion.topRows(transform.numAllModelParameters()) = trackSequence(
-        markerData,
-        character,
-        calibBodySet, // only solve for identity and not markers
-        motion.topRows(transform.numAllModelParameters()),
-        trackingConfig,
-        0.0 /*regularizer*/, // allow large change at initialization without any regularization
-        frameStride);
+      // track sequence with selected stride. we need to sample at least config.calibFrames frames
+      // so make sure we have a stride that allows that
+      size_t sampleStride = std::min(numFrames / config.calibFrames, config.greedySampling);
+
+      motion.topRows(transform.numAllModelParameters()) =
+          trackPosesPerframe(markerData, character, identity, trackingConfig, sampleStride);
+
+      const ParameterSet ps = transformExtended.getPoseParameters() &
+          ~transformExtended.getRigidParameters() & ~locatorSet;
+      frameIndices = sampleFrames(
+          character,
+          motion.topRows(transform.numAllModelParameters()),
+          markerData,
+          ps,
+          100,
+          sampleStride);
+
+      // then solve for identity and poses with fixed locators, initialized with solved poses
+      // this works using "character" because additional parameters for the locators are appended at
+      // the end, so the indices work out using topRows() without special treatment.
+      motion.topRows(transform.numAllModelParameters()) = trackSequence(
+          markerData,
+          character,
+          calibBodySet, // only solve for identity and not markers
+          motion.topRows(transform.numAllModelParameters()),
+          trackingConfig,
+          frameIndices,
+          0.0 /*regularizer*/ // allow large change at initialization without any regularization
+      );
+    } else {
+      motion.topRows(transform.numAllModelParameters()) =
+          trackPosesPerframe(markerData, character, identity, trackingConfig, frameStride);
+
+      // then solve for identity and poses with fixed locators, initialized with solved poses
+      // this works using "character" because additional parameters for the locators are appended at
+      // the end, so the indices work out using topRows() without special treatment.
+      motion.topRows(transform.numAllModelParameters()) = trackSequence(
+          markerData,
+          character,
+          calibBodySet, // only solve for identity and not markers
+          motion.topRows(transform.numAllModelParameters()),
+          trackingConfig,
+          0.0 /*regularizer*/, // allow large change at initialization without any regularization
+          frameStride);
+    }
   }
 
   // Solve everything together for a few iterations
   for (size_t iIter = 0; iIter < config.majorIter; ++iIter) {
     MT_LOGI_IF(config.debug, "Iteration {} of calibration", iIter);
 
-    motion = trackSequence(
-        markerData,
-        solvingCharacter,
-        locatorSet | calibBodySetExtended,
-        motion,
-        trackingConfig,
-        0.0, // TODO: use a small regularization to prevent too large a change
-        frameStride); // still solving a subset
+    if (config.greedySampling > 0) {
+      motion = trackSequence(
+          markerData,
+          solvingCharacter,
+          locatorSet | calibBodySetExtended,
+          motion,
+          trackingConfig,
+          frameIndices,
+          0.0 // TODO: use a small regularization to prevent too large a change
+      ); // still solving a subset
+    } else {
+      motion = trackSequence(
+          markerData,
+          solvingCharacter,
+          locatorSet | calibBodySetExtended,
+          motion,
+          trackingConfig,
+          0.0, // TODO: use a small regularization to prevent too large a change
+          frameStride); // still solving a subset
+    }
     // extract solving results to identity and character so we can pass them to trackPosesPerframe
     // below.
     std::tie(identity.v, character.locators) =
@@ -430,17 +890,31 @@ void calibrateModel(
     // The sequence solve above could get stuck with euler singularity but per-frame solve could get
     // it out. Pass in the first frame from previous solve as a better initial guess than the zero
     // pose.
-    const VectorXf initPose = motion.col(0).head(transform.numAllModelParameters());
-    motion.topRows(transform.numAllModelParameters()) =
-        trackPosesPerframe(markerData, character, initPose, trackingConfig, frameStride);
+    if (config.greedySampling > 0) {
+      motion.topRows(transform.numAllModelParameters()) = trackPosesForFrames(
+          markerData,
+          character,
+          motion.topRows(transform.numAllModelParameters()),
+          trackingConfig,
+          frameIndices);
+    } else {
+      const VectorXf initPose = motion.col(0).head(transform.numAllModelParameters());
+      motion.topRows(transform.numAllModelParameters()) =
+          trackPosesPerframe(markerData, character, initPose, trackingConfig, frameStride);
+    }
   }
 
   // Finally, fine tune marker offsets with fix identity.
   MT_LOGI_IF(config.debug, "Fine-tune marker offsets");
 
   // TODO: use a larger regularizer to prevent too large a change.
-  motion = trackSequence(
-      markerData, solvingCharacter, locatorSet, motion, trackingConfig, 0.0, frameStride);
+  if (config.greedySampling > 0) {
+    motion = trackSequence(
+        markerData, solvingCharacter, locatorSet, motion, trackingConfig, frameIndices, 0.0);
+  } else {
+    motion = trackSequence(
+        markerData, solvingCharacter, locatorSet, motion, trackingConfig, 0.0, frameStride);
+  }
   std::tie(identity.v, character.locators) =
       extractIdAndLocatorsFromParams(motion.col(0), solvingCharacter, character);
 
@@ -549,6 +1023,65 @@ MatrixXf refineMotion(
   }
 
   return newMotion;
+}
+
+std::pair<float, float> getLocatorError(
+    gsl::span<const std::vector<momentum::Marker>> markerData,
+    const MatrixXf& motion,
+    momentum::Character& character) {
+  const size_t numFrames = markerData.size();
+  MT_CHECK(numFrames > 0, "Input data is empty.");
+  MT_CHECK(
+      motion.rows() == character.parameterTransform.numAllModelParameters(),
+      "Input motion parameters {} do not match character model parameters {}",
+      motion.rows(),
+      character.parameterTransform.numAllModelParameters());
+
+  const ParameterTransform& pt = character.parameterTransform;
+
+  // map locator name to its index
+  std::map<std::string, size_t> locatorLookup;
+  for (size_t i = 0; i < character.locators.size(); i++) {
+    locatorLookup[character.locators[i].name] = i;
+  }
+
+  SkeletonState state;
+
+  // go over all frames and pose the locators and compute the error
+  double error = 0.0;
+  double maxError = 0.0;
+  for (size_t iFrame = 0; iFrame < numFrames; ++iFrame) {
+    const auto jointParams = pt.apply(motion.col(iFrame));
+    state.set(jointParams, character.skeleton, false);
+
+    double frameError = 0.0;
+
+    const auto& markerList = markerData[iFrame];
+    size_t validMarkers = 0;
+    for (const auto& jMarker : markerList) {
+      if (jMarker.occluded) {
+        continue;
+      }
+      auto query = locatorLookup.find(jMarker.name);
+      if (query == locatorLookup.end()) {
+        continue;
+      }
+      size_t locatorIdx = query->second;
+
+      const auto& locator = character.locators[locatorIdx];
+      const Vector3f locatorPos = state.jointState[locator.parent].transform * locator.offset;
+      const Vector3f diff = locatorPos - jMarker.pos.cast<float>();
+      const float markerError = diff.norm();
+      frameError += markerError;
+      maxError = std::max(maxError, static_cast<double>(markerError));
+      validMarkers++;
+    }
+
+    if (validMarkers > 0) {
+      error += frameError / validMarkers;
+    }
+  }
+  return {error / numFrames, maxError};
 }
 
 } // namespace marker_tracking

--- a/momentum/marker_tracking/marker_tracker.h
+++ b/momentum/marker_tracking/marker_tracker.h
@@ -39,6 +39,10 @@ struct CalibrationConfig : public BaseConfig {
   bool locatorsOnly = false;
   /// Sample uniformly or do a greedy importance sampling
   size_t greedySampling = 0;
+  /// True to lock the floor constraints to the floor in the first frame
+  bool enforceFloorInFirstFrame = false;
+  /// Name of a pose constraint set to use for the first frame
+  std::string firstFramePoseConstraintSet = "";
 };
 
 /// Configuration for pose tracking given a calibrated body and locators
@@ -77,6 +81,8 @@ struct RefineConfig : public TrackingConfig {
 /// Number of parameters should be the same as defined in character.
 /// @param[in] config Solving options.
 /// @param[in] frameStride Frame stride to select solver frames (ie. uniform sample).
+/// @param[in] enforceFloorInFirstFrame Flag to enforce the floor contact constraints in first frame
+/// @param[in] firstFramePoseConstraintSet Name of a pose constraint set to use for the first frame
 ///
 /// @return The solved motion. It has the same length as markerData. It repeats the same solved pose
 /// within a frame stride.
@@ -87,7 +93,9 @@ Eigen::MatrixXf trackSequence(
     const Eigen::MatrixXf& initialMotion,
     const TrackingConfig& config,
     float regularizer = 0.0,
-    size_t frameStride = 1);
+    size_t frameStride = 1,
+    bool enforceFloorInFirstFrame = false,
+    const std::string& firstFramePoseConstraintSet = "");
 
 /// Use multiple frames to solve for global parameters such as body proportions and/or marker
 /// offsets together with the motion.
@@ -100,7 +108,9 @@ Eigen::MatrixXf trackSequence(
 /// markerData, but only frames used in solving are used. Values in unused frames do not matter.
 /// Number of parameters should be the same as defined in character.
 /// @param[in] config Solving options.
-/// @param[in] frameStride Frame stride to select solver frames (ie. uniform sample).
+/// @param[in] frames List of frames to solve for.
+/// @param[in] enforceFloorInFirstFrame Flag to enforce the floor contact constraints in first frame
+/// @param[in] firstFramePoseConstraintSet Name of a pose constraint set to use for the first frame
 ///
 /// @return The solved motion. It has the same length as markerData. It repeats the same solved pose
 /// within a frame stride.
@@ -111,7 +121,9 @@ Eigen::MatrixXf trackSequence(
     const Eigen::MatrixXf& initialMotion,
     const TrackingConfig& config,
     const std::vector<size_t>& frames,
-    float regularizer = 0.0);
+    float regularizer = 0.0,
+    bool enforceFloorInFirstFrame = false,
+    const std::string& firstFramePoseConstraintSet = "");
 
 /// Track poses per-frame given a calibrated character.
 ///

--- a/momentum/marker_tracking/process_markers.cpp
+++ b/momentum/marker_tracking/process_markers.cpp
@@ -56,6 +56,10 @@ Eigen::MatrixXf processMarkers(
 
   // track motion; identity parameters will be repeated for every frame in finalMotion.
   Eigen::MatrixXf finalMotion = trackPosesPerframe(inputData, character, identity, trackingConfig);
+
+  if (trackingConfig.debug) {
+    getLocatorError(markerData, finalMotion, character);
+  }
   return finalMotion;
 }
 

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -102,7 +102,15 @@ PYBIND11_MODULE(marker_tracking, m) {
       .def_readwrite(
           "locators_only",
           &marker_tracking::CalibrationConfig::locatorsOnly,
-          "Calibrate only the locator offsets");
+          "Calibrate only the locator offsets")
+      .def_readwrite(
+          "enforce_floor_in_first_frame",
+          &marker_tracking::CalibrationConfig::enforceFloorInFirstFrame,
+          "Force floor contact in first frame")
+      .def_readwrite(
+          "first_frame_pose_constraint_set",
+          &marker_tracking::CalibrationConfig::firstFramePoseConstraintSet,
+          "Name of pose constraint set to use in first frame");
 
   auto trackingConfig =
       py::class_<marker_tracking::TrackingConfig, marker_tracking::BaseConfig>(

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -64,7 +64,16 @@ PYBIND11_MODULE(marker_tracking, m) {
   // Default values are set from the configured values in marker_tracker.h
   calibrationConfig.def(py::init<>())
       .def(
-          py::init<float, float, size_t, bool, size_t, size_t, bool, bool>(),
+          py::init<
+              float,
+              float,
+              size_t,
+              bool,
+              size_t,
+              size_t,
+              size_t,
+              bool,
+              bool>(),
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
@@ -72,11 +81,16 @@ PYBIND11_MODULE(marker_tracking, m) {
           py::arg("calib_frames") = 100,
           py::arg("major_iter") = 3,
           py::arg("global_scale_only") = false,
-          py::arg("locators_only") = false)
+          py::arg("locators_only") = false,
+          py::arg("greedy_sampling") = 0)
       .def_readwrite(
           "calib_frames",
           &marker_tracking::CalibrationConfig::calibFrames,
           "Number of frames used for model calibration")
+      .def_readwrite(
+          "greedy_sampling",
+          &marker_tracking::CalibrationConfig::greedySampling,
+          "Enable greedy frame sampling with the given stride")
       .def_readwrite(
           "major_iter",
           &marker_tracking::CalibrationConfig::majorIter,


### PR DESCRIPTION
Summary:
Added functionality to allow locking the floor contact locators to y=0 in the first frame for better foot calibration.
Added functionality to add pose constraints for first frame in calibration (i.e. to enforce straigh arms/legs/spine in case it is known the sequence starts with a t-pose)
This will lead to better calibration results.

Reviewed By: jeongseok-meta

Differential Revision: D74821953
