### PR TITLE
Add verbose iteration logging to sequence solver

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver.cpp
+++ b/momentum/character_sequence_solver/sequence_solver.cpp
@@ -486,7 +486,7 @@ void SequenceSolverT<T>::doIteration() {
   const Eigen::VectorX<T> searchDir = qrSolver.x_dense();
 
   const double error_orig = this->error_;
-  MT_LOGD("error {}", error_orig);
+  MT_LOGI_IF(this->verbose_, "Iteration: {}, error: {}", this->iteration_, error_orig);
   if (doLineSearch_) {
     const double innerProd = -qrSolver.At_times_b().dot(searchDir);
 


### PR DESCRIPTION
Summary:
When the user enables the `verbose` option in the sequence solver, for every iteration log the current iteration count & error.

(FYI this mimics per-iteration logging behavior already implemented in `character_solver/trust_region_qr.cpp`)

Reviewed By: jeongseok-meta

Differential Revision: D75083006


