### PR TITLE
Remove redundant verbose member variable from TrustRegionQRT

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver.cpp
+++ b/momentum/character_sequence_solver/sequence_solver.cpp
@@ -486,7 +486,7 @@ void SequenceSolverT<T>::doIteration() {
   const Eigen::VectorX<T> searchDir = qrSolver.x_dense();
 
   const double error_orig = this->error_;
-  MT_LOGD("error {}", error_orig);
+  MT_LOGI_IF(this->verbose_, "Iteration: {}, error: {}", this->iteration_, error_orig);
   if (doLineSearch_) {
     const double innerProd = -qrSolver.At_times_b().dot(searchDir);
 

--- a/momentum/character_solver/trust_region_qr.cpp
+++ b/momentum/character_solver/trust_region_qr.cpp
@@ -236,7 +236,7 @@ void TrustRegionQRT<T>::doIteration() {
     const T quadraticModelEval = evalQuadraticModel(searchDir_sub);
     const T rho = (this->error_ - error_new) / (this->error_ - quadraticModelEval);
     MT_LOGI_IF(
-        verbose_,
+        this->verbose_,
         "Error orig: {}; error new: {}; quadratic model: {}; rho: {}",
         this->error_,
         error_new,

--- a/momentum/character_solver/trust_region_qr.h
+++ b/momentum/character_solver/trust_region_qr.h
@@ -73,7 +73,6 @@ class TrustRegionQRT : public SolverT<T> {
   T maxTrustRegionRadius_ = 10.0;
   T curTrustRegionRadius_ = 1.0;
   Eigen::MatrixX<T> Rmatrix_;
-  bool verbose_ = false;
 };
 
 } // namespace momentum

--- a/momentum/solver/solver.h
+++ b/momentum/solver/solver.h
@@ -107,6 +107,7 @@ class SolverT {
   /// Iteration history data.
   std::unordered_map<std::string, Eigen::MatrixX<T>> iterationHistory_;
 
+  /// Flag to enable verbose logging during the solver's execution.
   bool verbose_;
 
  private:


### PR DESCRIPTION
Summary: The `verbose_` is already declared in the base solver class, and `TrustRegionQRT` was mixing the use of two separate verbose members, which causes confusion.

Differential Revision: D75084243


