### PR TITLE
Add vertex projection error function to pymomentum

### DIFF
--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -798,7 +798,9 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexProjectionErrorFunction) {
     applySSD(ibp, skin, mesh, skelState, targetMesh);
 
     Eigen::Matrix<T, 3, 4> projection = Eigen::Matrix<T, 3, 4>::Identity();
-    projection(2, 3) = 10;
+    projection(0, 0) = 10.0;
+    projection(1, 1) = 10.0;
+    projection(2, 3) = 10.0;
 
     const T errorTol = Eps<T>(5e-2f, 1e-5);
 
@@ -806,7 +808,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, VertexProjectionErrorFunction) {
     for (size_t iCons = 0; iCons < nConstraints; ++iCons) {
       const int index = uniform<int>(0, character_orig.mesh->vertices.size() - 1);
       const Eigen::Vector3<T> target = projection * targetMesh.vertices[index].homogeneous();
-      const Eigen::Vector2<T> target2d = target.hnormalized();
+      const Eigen::Vector2<T> target2d = target.hnormalized() + Eigen::Vector2<T>::Random() * 0.1;
       errorFunction.addConstraint(index, uniform<float>(0, 1e-2), target2d, projection);
     }
 

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -67,6 +67,7 @@ tensor_ik_public_headers = [
     "tensor_ik/tensor_projection_error_function.h",
     "tensor_ik/tensor_residual.h",
     "tensor_ik/tensor_vertex_error_function.h",
+    "tensor_ik/tensor_vertex_projection_error_function.h",
 ]
 
 tensor_ik_sources = [
@@ -84,6 +85,7 @@ tensor_ik_sources = [
     "tensor_ik/tensor_projection_error_function.cpp",
     "tensor_ik/tensor_residual.cpp",
     "tensor_ik/tensor_vertex_error_function.cpp",
+    "tensor_ik/tensor_vertex_projection_error_function.cpp",
 ]
 
 tensor_ik_test_sources = [

--- a/pymomentum/solver/momentum_ik.h
+++ b/pymomentum/solver/momentum_ik.h
@@ -34,6 +34,7 @@ enum class ErrorFunctionType {
   Projection,
   Distance,
   Vertex,
+  VertexProjection,
   NumTypes
 };
 
@@ -69,7 +70,11 @@ at::Tensor solveBodyIKProblem(
     std::optional<at::Tensor> vertexCons_weights,
     std::optional<at::Tensor> vertexCons_target_positions,
     std::optional<at::Tensor> vertexCons_target_normals,
-    momentum::VertexConstraintType vertexCons_type);
+    momentum::VertexConstraintType vertexCons_type,
+    std::optional<at::Tensor> vertexProjCons_vertices,
+    std::optional<at::Tensor> vertexProjCons_weights,
+    std::optional<at::Tensor> vertexProjCons_target_positions,
+    std::optional<at::Tensor> vertexProjCons_projections);
 
 at::Tensor computeGradient(
     pybind11::object characters,
@@ -101,7 +106,11 @@ at::Tensor computeGradient(
     std::optional<at::Tensor> vertexCons_weights,
     std::optional<at::Tensor> vertexCons_target_positions,
     std::optional<at::Tensor> vertexCons_target_normals,
-    momentum::VertexConstraintType vertexCons_type);
+    momentum::VertexConstraintType vertexCons_type,
+    std::optional<at::Tensor> vertexProjCons_vertices,
+    std::optional<at::Tensor> vertexProjCons_weights,
+    std::optional<at::Tensor> vertexProjCons_target_positions,
+    std::optional<at::Tensor> vertexProjCons_projections);
 
 at::Tensor computeResidual(
     pybind11::object characters,
@@ -133,7 +142,11 @@ at::Tensor computeResidual(
     std::optional<at::Tensor> vertexCons_weights,
     std::optional<at::Tensor> vertexCons_target_positions,
     std::optional<at::Tensor> vertexCons_target_normals,
-    momentum::VertexConstraintType vertexCons_type);
+    momentum::VertexConstraintType vertexCons_type,
+    std::optional<at::Tensor> vertexProjCons_vertices,
+    std::optional<at::Tensor> vertexProjCons_weights,
+    std::optional<at::Tensor> vertexProjCons_target_positions,
+    std::optional<at::Tensor> vertexProjCons_projections);
 
 std::tuple<at::Tensor, at::Tensor> computeJacobian(
     pybind11::object characters,
@@ -165,7 +178,11 @@ std::tuple<at::Tensor, at::Tensor> computeJacobian(
     std::optional<at::Tensor> vertexCons_weights,
     std::optional<at::Tensor> vertexCons_target_positions,
     std::optional<at::Tensor> vertexCons_target_normals,
-    momentum::VertexConstraintType vertexCons_type);
+    momentum::VertexConstraintType vertexCons_type,
+    std::optional<at::Tensor> vertexProjCons_vertices,
+    std::optional<at::Tensor> vertexProjCons_weights,
+    std::optional<at::Tensor> vertexProjCons_target_positions,
+    std::optional<at::Tensor> vertexProjCons_projections);
 
 at::Tensor solveBodySequenceIKProblem(
     pybind11::object characters,
@@ -200,7 +217,11 @@ at::Tensor solveBodySequenceIKProblem(
     std::optional<at::Tensor> vertexCons_weights,
     std::optional<at::Tensor> vertexCons_target_positions,
     std::optional<at::Tensor> vertexCons_target_normals,
-    momentum::VertexConstraintType vertexCons_type);
+    momentum::VertexConstraintType vertexCons_type,
+    std::optional<at::Tensor> vertexProjCons_vertices,
+    std::optional<at::Tensor> vertexProjCons_weights,
+    std::optional<at::Tensor> vertexProjCons_target_positions,
+    std::optional<at::Tensor> vertexProjCons_projections);
 
 at::Tensor transformPose(
     const momentum::Character& character,

--- a/pymomentum/solver/solver_pybind.cpp
+++ b/pymomentum/solver/solver_pybind.cpp
@@ -44,6 +44,7 @@ PYBIND11_MODULE(solver, m) {
       .value("Projection", ErrorFunctionType::Projection)
       .value("Distance", ErrorFunctionType::Distance)
       .value("Vertex", ErrorFunctionType::Vertex)
+      .value("VertexProjection", ErrorFunctionType::VertexProjection)
       .export_values();
 
   py::enum_<LinearSolverType>(
@@ -215,6 +216,12 @@ All quaternion parameters use the quaternion order [x, y, z, w], where :math:`q 
 :param vertex_cons_target_positions: float-valued torch.Tensor of dimension (nBatch x nConstraints x 3); contains the target position.
 :param vertex_cons_target_normals: float-valued torch.Tensor of dimension (nBatch x nConstraints x 3); contains the target normal.  Not used if the vertex constraint type is POSITION.
 :param vertex_cons_type: Type of vertex constraint.  POSITION is a position constraint, while PLANE, NORMAL, and SYMMETRIC_NORMAL are variants on point-to-plane (PLANE uses the target normal, NORMAL uses the source normal, and SYMMETRIC_NORMAL uses a blend of the two normals).
+:param vertex_proj_cons_vertices: int-valued torch.Tensor of dimension (nBatch x nConstraints); contains the vertex index for each constraint.
+:param vertex_proj_cons_weights: float-valued torch.Tensor of dimension (nBatch x nConstraints); contains the per-constraint weight for each constraint.
+:param vertex_proj_cons_target_positions: float-valued torch.Tensor of dimension (nBatch x nConstraints x 2); contains the target position.
+:param vertex_proj_cons_target_projections: float-valued torch.Tensor of dimension (nBatch x nConstraints x 4 x 3); containing a 4x3 projection matrix for each constraint.  Note
+    that while you can use a standard pinhole model matrix as the projection matrix, we actually recommend constructing a separate local projection matrix
+    for each constraint centered around the camera ray, which is more robust for e.g. fisheye cameras.
 )",
       py::arg("character"),
       py::arg("active_parameters"),
@@ -247,7 +254,12 @@ All quaternion parameters use the quaternion order [x, y, z, w], where :math:`q 
       py::arg("vertex_cons_weights") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_positions") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_normals") = std::optional<at::Tensor>{},
-      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position);
+      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position,
+      py::arg("vertex_proj_cons_vertices") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_weights") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_target_positions") =
+          std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_projections") = std::optional<at::Tensor>{});
 
   m.def(
       "gradient",
@@ -293,7 +305,12 @@ For details on the arguments, see :py:func:`solve_ik`.
       py::arg("vertex_cons_weights") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_positions") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_normals") = std::optional<at::Tensor>{},
-      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position);
+      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position,
+      py::arg("vertex_proj_cons_vertices") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_weights") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_target_positions") =
+          std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_projections") = std::optional<at::Tensor>{});
 
   m.def(
       "residual",
@@ -336,7 +353,12 @@ For details on the arguments, see :py:func:`solve_ik`.
       py::arg("vertex_cons_weights") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_positions") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_normals") = std::optional<at::Tensor>{},
-      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position);
+      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position,
+      py::arg("vertex_proj_cons_vertices") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_weights") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_target_positions") =
+          std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_projections") = std::optional<at::Tensor>{});
 
   m.def(
       "jacobian",
@@ -392,7 +414,12 @@ For details on the arguments, see :py:func:`solve_ik`.
       py::arg("vertex_cons_weights") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_positions") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_normals") = std::optional<at::Tensor>{},
-      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position);
+      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position,
+      py::arg("vertex_proj_cons_vertices") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_weights") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_target_positions") =
+          std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_projections") = std::optional<at::Tensor>{});
 
   // -------------------------------------------------------------
   //                    solveBodyIKProblem
@@ -448,7 +475,12 @@ This is to prevent confusing ambiguities in whether you meant sharing across the
       py::arg("vertex_cons_weights") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_positions") = std::optional<at::Tensor>{},
       py::arg("vertex_cons_target_normals") = std::optional<at::Tensor>{},
-      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position);
+      py::arg("vertex_cons_type") = momentum::VertexConstraintType::Position,
+      py::arg("vertex_proj_cons_vertices") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_weights") = std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_target_positions") =
+          std::optional<at::Tensor>{},
+      py::arg("vertex_proj_cons_projections") = std::optional<at::Tensor>{});
 
   m.def(
       "get_solve_ik_statistics",

--- a/pymomentum/tensor_ik/tensor_vertex_projection_error_function.cpp
+++ b/pymomentum/tensor_ik/tensor_vertex_projection_error_function.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "tensor_vertex_projection_error_function.h"
+
+#include "tensor_error_function_utility.h"
+
+#include <momentum/character/character.h>
+#include <momentum/character_solver/vertex_projection_error_function.h>
+
+namespace pymomentum {
+
+namespace {
+
+const static int NCONS_IDX = -1;
+static constexpr const char* kVerticesName = "vertices";
+static constexpr const char* kWeightsName = "weights";
+static constexpr const char* kTargetPositionsName = "target_positions";
+static constexpr const char* kProjectionsName = "projections";
+
+template <typename T>
+class TensorVertexProjectionErrorFunction : public TensorErrorFunction<T> {
+ public:
+  TensorVertexProjectionErrorFunction(
+      size_t batchSize,
+      size_t nFrames,
+      at::Tensor vertexIndex,
+      at::Tensor weights,
+      at::Tensor target_positions,
+      at::Tensor projections);
+
+ protected:
+  std::shared_ptr<momentum::SkeletonErrorFunctionT<T>> createErrorFunctionImp(
+      const momentum::Character& character,
+      size_t iBatch,
+      size_t jFrame) const override;
+};
+
+template <typename T>
+TensorVertexProjectionErrorFunction<T>::TensorVertexProjectionErrorFunction(
+    size_t batchSize,
+    size_t nFrames,
+    at::Tensor vertexIndex,
+    at::Tensor weights,
+    at::Tensor target_positions,
+    at::Tensor projections)
+    : TensorErrorFunction<T>(
+          "VertexProjection",
+          "vertex_projection_cons",
+          batchSize,
+          nFrames,
+          std::initializer_list<TensorInput>{
+              {kVerticesName,
+               vertexIndex,
+               {NCONS_IDX},
+               TensorType::TYPE_INT,
+               TensorInput::NON_DIFFERENTIABLE,
+               TensorInput::REQUIRED},
+              {kWeightsName,
+               weights,
+               {NCONS_IDX},
+               TensorType::TYPE_FLOAT,
+               TensorInput::NON_DIFFERENTIABLE,
+               TensorInput::OPTIONAL},
+              {kTargetPositionsName,
+               target_positions,
+               {NCONS_IDX, 2},
+               TensorType::TYPE_FLOAT,
+               TensorInput::NON_DIFFERENTIABLE,
+               TensorInput::REQUIRED},
+              {kProjectionsName,
+               projections,
+               {NCONS_IDX, 3, 4},
+               TensorType::TYPE_FLOAT,
+               TensorInput::NON_DIFFERENTIABLE,
+               TensorInput::REQUIRED}},
+          {{NCONS_IDX, "nConstraints"}}) {}
+
+template <typename T>
+std::shared_ptr<momentum::SkeletonErrorFunctionT<T>>
+TensorVertexProjectionErrorFunction<T>::createErrorFunctionImp(
+    const momentum::Character& character,
+    size_t iBatch,
+    size_t jFrame) const {
+  auto result =
+      std::make_unique<momentum::VertexProjectionErrorFunctionT<T>>(character);
+
+  const auto weights =
+      this->getTensorInput(kWeightsName).template toEigenMap<T>(iBatch, jFrame);
+  const auto vertices = this->getTensorInput(kVerticesName)
+                            .template toEigenMap<int>(iBatch, jFrame);
+  const auto target_positions = this->getTensorInput(kTargetPositionsName)
+                                    .template toEigenMap<T>(iBatch, jFrame);
+  const auto projections = this->getTensorInput(kProjectionsName)
+                               .template toEigenMap<T>(iBatch, jFrame);
+
+  const auto nCons = this->sharedSize(NCONS_IDX);
+  for (Eigen::Index i = 0; i < nCons; ++i) {
+    result->addConstraint(
+        extractScalar<int>(vertices, i),
+        extractScalar<T>(weights, i, T(1)),
+        extractVector<T, 2>(target_positions, i),
+        extractMatrix<T, 3, 4>(projections, i));
+  }
+
+  return result;
+}
+
+template class TensorVertexProjectionErrorFunction<float>;
+template class TensorVertexProjectionErrorFunction<double>;
+
+} // namespace
+
+template <typename T>
+std::unique_ptr<TensorErrorFunction<T>> createVertexProjectionErrorFunction(
+    size_t batchSize,
+    size_t nFrames,
+    at::Tensor vertexIndex,
+    at::Tensor weights,
+    at::Tensor target_positions,
+    at::Tensor projections) {
+  return std::make_unique<TensorVertexProjectionErrorFunction<T>>(
+      batchSize, nFrames, vertexIndex, weights, target_positions, projections);
+}
+
+template std::unique_ptr<TensorErrorFunction<float>>
+createVertexProjectionErrorFunction(
+    size_t batchSize,
+    size_t nFrames,
+    at::Tensor vertexIndex,
+    at::Tensor weights,
+    at::Tensor target_positions,
+    at::Tensor projections);
+
+template std::unique_ptr<TensorErrorFunction<double>>
+createVertexProjectionErrorFunction(
+    size_t batchSize,
+    size_t nFrames,
+    at::Tensor vertexIndex,
+    at::Tensor weights,
+    at::Tensor target_positions,
+    at::Tensor projections);
+
+} // namespace pymomentum

--- a/pymomentum/tensor_ik/tensor_vertex_projection_error_function.h
+++ b/pymomentum/tensor_ik/tensor_vertex_projection_error_function.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "pymomentum/tensor_ik/tensor_error_function.h"
+
+#include <momentum/character_solver/vertex_projection_error_function.h>
+
+#include <ATen/ATen.h>
+
+namespace pymomentum {
+
+template <typename T>
+std::unique_ptr<TensorErrorFunction<T>> createVertexProjectionErrorFunction(
+    size_t batchSize,
+    size_t nFrames,
+    at::Tensor vertexIndex,
+    at::Tensor weights,
+    at::Tensor target_positions,
+    at::Tensor projections);
+
+} // namespace pymomentum


### PR DESCRIPTION
Summary:
Added tensor_vertex_projection_error_function
Extended solveIK and solveSequenceIK to take necessary data as input

Differential Revision: D74899487


