### PR TITLE
Add tests for ProgressBar

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -29,6 +29,7 @@ common_sources = [
 common_test_sources = [
     "test/common/aligned_allocator_test.cpp",
     "test/common/exception_test.cpp",
+    "test/common/progress_bar_test.cpp",
 ]
 
 simd_public_headers = [

--- a/momentum/common/progress_bar.cpp
+++ b/momentum/common/progress_bar.cpp
@@ -9,27 +9,31 @@
 
 namespace momentum {
 
-ProgressBar::ProgressBar(const std::string& name, const int64_t numOperations) {
+ProgressBar::ProgressBar(const std::string& prefix, const size_t numOperations) {
   using namespace indicators;
 
-  bar_.set_option(option::BarWidth(kMaxWidth - name.size() - 9));
+  bar_.set_option(option::BarWidth(kMaxWidth - prefix.size() - 9));
   bar_.set_option(option::MaxProgress(numOperations));
   bar_.set_option(option::Start{"["});
   bar_.set_option(option::Fill{"="});
   bar_.set_option(option::Lead{">"});
   bar_.set_option(option::Remainder{" "});
   bar_.set_option(option::End{"]"});
-  bar_.set_option(option::PrefixText{name});
+  bar_.set_option(option::PrefixText{prefix});
   bar_.set_option(option::ShowPercentage{true});
   bar_.set_option(option::FontStyles{std::vector<FontStyle>{FontStyle::bold}});
 }
 
-void ProgressBar::increment(int64_t count) {
+void ProgressBar::increment(size_t count) {
   bar_.set_progress(bar_.current() + count);
 }
 
-void ProgressBar::set(int64_t count) {
+void ProgressBar::set(size_t count) {
   bar_.set_progress(count);
+}
+
+size_t ProgressBar::getCurrentProgress() {
+  return bar_.current();
 }
 
 } // namespace momentum

--- a/momentum/common/progress_bar.h
+++ b/momentum/common/progress_bar.h
@@ -15,16 +15,22 @@ namespace momentum {
 
 // A simple progress bar that prints hash marks (e.g., "Name [===>  ] 60%")
 class ProgressBar {
-  static constexpr int64_t kMaxWidth = 80;
-
  public:
-  /// @param name Displayed prefix (visible=true only)
+  /// @param prefix Displayed prefix
   /// @param numOperations Total operations (determines progress ratio)
-  ProgressBar(const std::string& name, int64_t numOperations);
-  void increment(int64_t count = 1);
-  void set(int64_t count);
+  ProgressBar(const std::string& prefix, size_t numOperations);
+
+  /// Increments the progress by the given count (default 1)
+  void increment(size_t count = 1);
+
+  /// Sets the progress to the given count
+  void set(size_t count);
+
+  /// Returns the current progress in the range [0, 100]
+  [[nodiscard]] size_t getCurrentProgress();
 
  private:
+  static constexpr size_t kMaxWidth = 80;
   indicators::ProgressBar bar_;
 };
 

--- a/momentum/test/common/progress_bar_test.cpp
+++ b/momentum/test/common/progress_bar_test.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/common/progress_bar.h"
+
+#include <gtest/gtest.h>
+
+using namespace momentum;
+
+TEST(ProgressBarTest, Constructor) {
+  // Test with different prefixes and operation counts
+  ProgressBar bar1("Test Bar", 100);
+  EXPECT_EQ(bar1.getCurrentProgress(), 0);
+
+  ProgressBar bar2("", 50);
+  EXPECT_EQ(bar2.getCurrentProgress(), 0);
+
+  ProgressBar bar3("Very Long Prefix That Might Exceed Buffer Limits", 1000);
+  EXPECT_EQ(bar3.getCurrentProgress(), 0);
+
+  // Test with edge cases
+  ProgressBar bar4("Zero Operations", 0);
+  EXPECT_EQ(bar4.getCurrentProgress(), 0);
+
+  // Note: We don't test with negative operations since size_t is unsigned
+  // and the underlying indicators library uses size_t
+}
+
+TEST(ProgressBarTest, Increment) {
+  ProgressBar bar("Increment Test", 100);
+  EXPECT_EQ(bar.getCurrentProgress(), 0);
+
+  // Test default increment (1)
+  bar.increment();
+  EXPECT_EQ(bar.getCurrentProgress(), 1);
+
+  // Test increment with specific values
+  bar.increment(5);
+  EXPECT_EQ(bar.getCurrentProgress(), 6);
+
+  bar.increment(10);
+  EXPECT_EQ(bar.getCurrentProgress(), 16);
+
+  // Test increment with zero
+  bar.increment(0);
+  EXPECT_EQ(bar.getCurrentProgress(), 16); // Should remain unchanged
+
+  // Note: We don't test with negative increments since size_t is unsigned
+  // and the underlying indicators library uses size_t
+
+  // Test increment beyond max
+  int64_t currentProgress = bar.getCurrentProgress();
+  bar.increment(200); // Should handle gracefully
+  // Progress should be clamped to max or at least not decrease
+  EXPECT_GE(bar.getCurrentProgress(), currentProgress);
+}
+
+TEST(ProgressBarTest, Set) {
+  ProgressBar bar("Set Test", 100);
+  EXPECT_EQ(bar.getCurrentProgress(), 0);
+
+  // Test setting to specific values
+  bar.set(0);
+  EXPECT_EQ(bar.getCurrentProgress(), 0);
+
+  bar.set(50);
+  EXPECT_EQ(bar.getCurrentProgress(), 50);
+
+  bar.set(100);
+  EXPECT_EQ(bar.getCurrentProgress(), 100);
+
+  // Test setting to values outside the range
+  // Note: We don't test with negative values since size_t is unsigned
+  // and the underlying indicators library uses size_t
+
+  bar.set(150); // Should handle gracefully
+
+  // Test setting to the same value multiple times
+  bar.set(75);
+  EXPECT_EQ(bar.getCurrentProgress(), 75);
+
+  bar.set(75);
+  EXPECT_EQ(bar.getCurrentProgress(), 75);
+}
+
+TEST(ProgressBarTest, MixedOperations) {
+  ProgressBar bar("Mixed Test", 100);
+  EXPECT_EQ(bar.getCurrentProgress(), 0);
+
+  // Mix increment and set operations
+  bar.set(10);
+  EXPECT_EQ(bar.getCurrentProgress(), 10);
+
+  bar.increment(5);
+  EXPECT_EQ(bar.getCurrentProgress(), 15);
+
+  bar.set(0);
+  EXPECT_EQ(bar.getCurrentProgress(), 0);
+
+  bar.increment(20);
+  EXPECT_EQ(bar.getCurrentProgress(), 20);
+
+  bar.set(100);
+  EXPECT_EQ(bar.getCurrentProgress(), 100);
+
+  bar.increment(); // Beyond max
+  // Progress should be clamped to max or at least not decrease
+  EXPECT_GE(bar.getCurrentProgress(), 100);
+}
+
+TEST(ProgressBarTest, LargeValues) {
+  // Test with large operation counts
+  ProgressBar bar("Large Values", 1000000);
+  EXPECT_EQ(bar.getCurrentProgress(), 0);
+
+  bar.increment(10000);
+  EXPECT_EQ(bar.getCurrentProgress(), 10000);
+
+  bar.set(500000);
+  EXPECT_EQ(bar.getCurrentProgress(), 500000);
+
+  bar.increment(500000);
+  EXPECT_EQ(bar.getCurrentProgress(), 1000000);
+}


### PR DESCRIPTION
Summary:
*   Added a `getCurrentProgress()` method to the ProgressBar class to enable verification of the internal state in tests
*   Renamed the constructor parameter from "name" to "prefix" to better reflect its actual purpose
*   Updated the test file with comprehensive test cases that verify the functionality of the ProgressBar class

Differential Revision: D75532009


