### PR TITLE
Resolve pixi version string warning

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -380,19 +380,19 @@ test_py = { cmd = "pytest pymomentum/test/*.py -k 'not (TestFBXIO and (test_save
 [feature.py312-cuda126]
 platforms = ["linux-64", "win-64"]
 system-requirements = { cuda = "12" }
-build-dependencies = { cuda-toolkit = ">=12.6.3,<13", nvtx-c = ">=3.1.1", cuda-version = "12.8" }
+build-dependencies = { cuda-toolkit = ">=12.6.3,<13", nvtx-c = ">=3.1.1", cuda-version = "12.8.*" }
 dependencies = { python = "3.12.*", pytorch-gpu = ">=2.6.0,<3" }
 
 [feature.py311-cuda126]
 platforms = ["linux-64", "win-64"]
 system-requirements = { cuda = "12" }
-build-dependencies = { cuda-toolkit = ">=12.6.3,<13", nvtx-c = ">=3.1.1", cuda-version = "12.8" }
+build-dependencies = { cuda-toolkit = ">=12.6.3,<13", nvtx-c = ">=3.1.1", cuda-version = "12.8.*" }
 dependencies = { python = "3.11.*", pytorch-gpu = ">=2.6.0,<3" }
 
 [feature.py310-cuda126]
 platforms = ["linux-64", "win-64"]
 system-requirements = { cuda = "12" }
-build-dependencies = { cuda-toolkit = ">=12.6.3,<13", nvtx-c = ">=3.1.1", cuda-version = "12.8" }
+build-dependencies = { cuda-toolkit = ">=12.6.3,<13", nvtx-c = ">=3.1.1", cuda-version = "12.8.*" }
 dependencies = { python = "3.10.*", pytorch-gpu = ">=2.6.0,<3" }
 
 #==============


### PR DESCRIPTION
## Summary

To suppress:

```console
pixi r test_py  
 WARN Encountered ambiguous version specifier `12.8`, could be `12.8.*` but assuming you meant `==12.8`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `12.8`, could be `12.8.*` but assuming you meant `==12.8`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `12.8`, could be `12.8.*` but assuming you meant `==12.8`. In the future this will result in an error.
```

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

No warnings with `pixi run test_py`