### PR TITLE
Add descriptions to pixi tasks

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -55,8 +55,9 @@ clean = { cmd = """
     rm -rf build \
     && rm -rf .pixi \
     && rm pixi.lock
-    """ }
-lint = { cmd = "clang-format -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp" }
+    """, description = "Clean all build artifacts and pixi cache" }
+lint = { cmd = "clang-format -i axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp", description = "Format C++ code using clang-format" }
+check-format = { cmd = "clang-format --dry-run --Werror axel/**/*.h axel/**/*.cpp momentum/**/*.h momentum/**/*.cpp pymomentum/**/*.h pymomentum/**/*.cpp", description = "Check if code is properly formatted without modifying files" }
 config = { cmd = """
     cmake \
         -S . \
@@ -75,7 +76,7 @@ config = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
         -DMOMENTUM_USE_SYSTEM_TRACY=ON
-    """, env = { MOMENTUM_BUILD_WITH_FBXSDK = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
+    """, env = { MOMENTUM_BUILD_WITH_FBXSDK = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, description = "Configure CMake for Release build" }
 config_dev = { cmd = """
     cmake \
         -S . \
@@ -94,56 +95,65 @@ config_dev = { cmd = """
         -DMOMENTUM_USE_SYSTEM_PYBIND11=ON \
         -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
         -DMOMENTUM_USE_SYSTEM_TRACY=ON
-    """, env = { MOMENTUM_BUILD_WITH_FBXSDK = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" } }
+    """, env = { MOMENTUM_BUILD_WITH_FBXSDK = "OFF", MOMENTUM_ENABLE_SIMD = "ON", MOMENTUM_BUILD_PYMOMENTUM = "ON" }, description = "Configure CMake for Debug build" }
 build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target all", depends-on = [
     "config",
-] }
+], description = "Build Release version" }
 build_dev = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/debug -j --target all", depends-on = [
     "config_dev",
-] }
+], description = "Build Debug version" }
+build_fast = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j4 --target all", depends-on = [
+    "config",
+], description = "Build Release version with limited parallelism" }
 test = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/release --output-on-failure", depends-on = [
     "build",
-] }
+], description = "Run C++ tests (Release)" }
 test_dev = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/debug --output-on-failure", depends-on = [
     "build_dev",
-] }
+], description = "Run C++ tests (Debug)" }
+test_verbose = { cmd = "ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/release --output-on-failure --verbose", depends-on = [
+    "build",
+], description = "Run C++ tests with verbose output" }
 hello_world = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/hello_world", depends-on = [
     "build",
-] }
+], description = "Run hello world example" }
 convert_model = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/convert_model", depends-on = [
     "build",
-] }
+], description = "Run model conversion tool" }
 c3d_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/c3d_viewer", depends-on = [
     "build",
-] }
+], description = "Run C3D file viewer" }
 fbx_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/fbx_viewer", depends-on = [
     "build",
-] }
+], description = "Run FBX file viewer" }
 glb_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/glb_viewer", depends-on = [
     "build",
-] }
+], description = "Run GLB file viewer" }
 urdf_viewer = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/urdf_viewer", depends-on = [
     "build",
-] }
+], description = "Run URDF file viewer" }
 process_markers = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/process_markers_app", depends-on = [
     "build",
-] }
+], description = "Run marker processing application" }
 refine_motion = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/refine_motion", depends-on = [
     "build",
-] }
+], description = "Run motion refinement tool" }
 install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target install", depends-on = [
     "build",
-] }
-tracy = { cmd = "tracy-profiler" }
+], description = "Install built libraries and executables" }
+tracy = { cmd = "tracy-profiler", description = "Launch Tracy profiler GUI" }
 test_py = { cmd = "pytest pymomentum/test/*.py", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
-] }
+], description = "Run Python tests" }
+test_py_verbose = { cmd = "pytest pymomentum/test/*.py -v", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
+    "build_py",
+], description = "Run Python tests with verbose output" }
 doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
     "build_py",
-] }
+], description = "Build Python API documentation" }
 open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = [
     "doc_py",
-] }
+], description = "Open Python documentation in browser" }
 
 #===========
 # linux-64


### PR DESCRIPTION
## Summary

Before:

```
❯ pixi task list
Tasks that can run on this machine:
-----------------------------------
build, build_dev, build_py, c3d_viewer, clean, config, config_dev, convert_model, doc_py, fbx_viewer, glb_viewer, hello_world, install, lint, open_doc_py, process_markers, refine_motion, test, test_dev, test_py, tracy, urdf_viewer
Task  Description
```

After:

```
❯ pixi task list      
Tasks that can run on this machine:
-----------------------------------
build, build_dev, build_fast, build_py, c3d_viewer, check-format, clean, config, config_dev, convert_model, doc_py, fbx_viewer, glb_viewer, hello_world, install, lint, open_doc_py, process_markers, refine_motion, test, test_dev, test_py, test_py_verbose, test_verbose, tracy, urdf_viewer
Task             Description
build            Build Release version
build_dev        Build Debug version
build_fast       Build Release version with limited parallelism
c3d_viewer       Run C3D file viewer
check-format     Check if code is properly formatted without modifying files
clean            Clean all build artifacts and pixi cache
config           Configure CMake for Release build
config_dev       Configure CMake for Debug build
convert_model    Run model conversion tool
fbx_viewer       Run FBX file viewer
glb_viewer       Run GLB file viewer
hello_world      Run hello world example
install          Install built libraries and executables
lint             Format C++ code using clang-format
process_markers  Run marker processing application
refine_motion    Run motion refinement tool
test             Run C++ tests (Release)
test_dev         Run C++ tests (Debug)
test_py_verbose  Run Python tests with verbose output
test_verbose     Run C++ tests with verbose output
tracy            Launch Tracy profiler GUI
urdf_viewer      Run URDF file viewer
```

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

```
pixi task list 
```
