### PR TITLE
Disable dev mode builds for ubuntu

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         simd: ["ON", "OFF"]
-        mode: ["", "_dev"]
+        mode: [""]
     env:
       MOMENTUM_ENABLE_SIMD: ${{ matrix.simd }}
     steps:


### PR DESCRIPTION
Summary: to reduce GitHub CI cost to meet the budget (see: T226633151)

Differential Revision: D76235803
