### PR TITLE
Add tests for blend shape io

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -686,6 +686,15 @@ if(MOMENTUM_BUILD_TESTING)
   )
 
   mt_test(
+    NAME io_shape_test
+    SOURCES_VARS io_shape_test_sources
+    LINK_LIBRARIES
+      character
+      io_shape
+      io_test_helper
+  )
+
+  mt_test(
     NAME io_skeleton_test
     SOURCES_VARS io_skeleton_test_sources
     LINK_LIBRARIES

--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -393,6 +393,10 @@ io_shape_sources = [
     "io/shape/pose_shape_io.cpp",
 ]
 
+io_shape_test_sources = [
+    "test/io/blend_shape_io_test.cpp",
+]
+
 io_fbx_public_headers = [
     "io/fbx/fbx_io.h",
 ]

--- a/momentum/io/shape/blend_shape_io.h
+++ b/momentum/io/shape/blend_shape_io.h
@@ -14,49 +14,57 @@
 
 namespace momentum {
 
+/// Loads blend shape vectors from a file without base shape.
+///
+/// @param filename Path to the blend shape base data file
+/// @param expectedShapes Limits number of shape vectors loaded if > 0, otherwise loads all
+/// @param expectedVertices Limits number of vertices loaded if > 0, otherwise loads all
+/// @return BlendShapeBase object with loaded shape vectors
 BlendShapeBase loadBlendShapeBase(
     const filesystem::path& filename,
     int expectedShapes = -1,
     int expectedVertices = -1);
 
+/// Loads blend shape vectors from a stream without base shape.
+///
+/// @param data Input stream containing blend shape base data
+/// @param expectedShapes Limits number of shape vectors loaded if > 0, otherwise loads all
+/// @param expectedVertices Limits number of vertices loaded if > 0, otherwise loads all
+/// @return BlendShapeBase object with loaded shape vectors
 BlendShapeBase
 loadBlendShapeBase(std::istream& data, int expectedShapes = -1, int expectedVertices = -1);
 
-/// Loads a blend shape from a given filepath.
+/// Loads a blend shape from a file, including base shape and shape vectors.
 ///
-/// This function reads blend shape data from the provided file, including the mean shape and shape
-/// vectors. If `expectedShapes` or `expectedVertices` are provided, the function will attempt to
-/// limit the number of shape vectors or vertices read accordingly.
+/// @param filename Path to the blend shape data file
+/// @param expectedShapes Limits number of shape vectors loaded if > 0, otherwise loads all
+/// @param expectedVertices Limits number of vertices loaded if > 0, otherwise loads all
+/// @return BlendShape object with loaded data
 ///
-/// @param filename The file path containing the blend shape data.
-/// @param[in] expectedShapes The expected number of shape vectors to read. If this value is greater
-/// than 0, it will limit the number of shape vectors read. Defaults to 0, meaning all shape vectors
-/// will be read.
-/// @param[in] expectedVertices The expected number of vertices to read. If this value is greater
-/// than 0, it will limit the number of vertices read. Defaults to 0, meaning all vertices will be
-/// read.
-/// @return A BlendShape object containing the loaded data.
-///
-/// @note This function only supports parsing from a local file. If you want to parse from a
-/// non-local path, you may need to parse it using your favorite resource retriever into a stream
-/// buffer and use the buffer version of this function.
+/// @note Only supports local files. For non-local paths, use the stream version.
 BlendShape loadBlendShape(
     const filesystem::path& filename,
     int expectedShapes = -1,
     int expectedVertices = -1);
 
+/// Loads a blend shape from a stream, including base shape and shape vectors.
+///
+/// @param is Input stream containing blend shape data
+/// @param expectedShapes Limits number of shape vectors loaded if > 0, otherwise loads all
+/// @param expectedVertices Limits number of vertices loaded if > 0, otherwise loads all
+/// @return BlendShape object with loaded data
 BlendShape loadBlendShape(std::istream& is, int expectedShapes = -1, int expectedVertices = -1);
 
-void ReadShapeVectors(
-    std::istream& data,
-    MatrixXf& shapeVectors,
-    uint64_t numRows,
-    uint64_t numCols,
-    int expectedShapes,
-    int expectedVertices);
-
+/// Saves a blend shape to a file.
+///
+/// @param filename Output file path for the blend shape data
+/// @param blendShape BlendShape object to save
 void saveBlendShape(const filesystem::path& filename, const BlendShape& blendShape);
 
+/// Saves a blend shape to a stream.
+///
+/// @param os Output stream to write blend shape data
+/// @param blendShape BlendShape object to save
 void saveBlendShape(std::ostream& os, const BlendShape& blendShape);
 
 } // namespace momentum

--- a/momentum/test/io/blend_shape_io_test.cpp
+++ b/momentum/test/io/blend_shape_io_test.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/shape/blend_shape_io.h"
+
+#include "momentum/character/blend_shape.h"
+#include "momentum/character/blend_shape_base.h"
+#include "momentum/test/io/io_helpers.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+
+using namespace momentum;
+
+class BlendShapeIOTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    baseShape_ = {
+        Vector3f(1.0f, 2.0f, 3.0f), Vector3f(4.0f, 5.0f, 6.0f), Vector3f(7.0f, 8.0f, 9.0f)};
+    shapeVectors_.resize(9, 2);
+    shapeVectors_ << 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f,
+        1.4f, 1.5f, 1.6f, 1.7f, 1.8f;
+  }
+
+  std::string createBlendShapeBaseData() {
+    std::ostringstream oss(std::ios::binary);
+    uint64_t rows = 9, cols = 2;
+    oss.write(reinterpret_cast<const char*>(&rows), sizeof(rows));
+    oss.write(reinterpret_cast<const char*>(&cols), sizeof(cols));
+    oss.write(reinterpret_cast<const char*>(shapeVectors_.data()), sizeof(float) * 18);
+    return oss.str();
+  }
+
+  std::string createBlendShapeData() {
+    std::ostringstream oss(std::ios::binary);
+    uint64_t rows = 9, cols = 2;
+    oss.write(reinterpret_cast<const char*>(&rows), sizeof(rows));
+    oss.write(reinterpret_cast<const char*>(&cols), sizeof(cols));
+    oss.write(reinterpret_cast<const char*>(baseShape_.data()), sizeof(float) * 9);
+    oss.write(reinterpret_cast<const char*>(shapeVectors_.data()), sizeof(float) * 18);
+    return oss.str();
+  }
+
+  std::vector<Vector3f> baseShape_;
+  MatrixXf shapeVectors_;
+};
+
+TEST_F(BlendShapeIOTest, LoadBlendShapeBase) {
+  std::string data = createBlendShapeBaseData();
+  std::istringstream iss(data, std::ios::binary);
+  BlendShapeBase result = loadBlendShapeBase(iss);
+  EXPECT_EQ(result.modelSize(), 3);
+  EXPECT_EQ(result.shapeSize(), 2);
+  EXPECT_TRUE(result.getShapeVectors().isApprox(shapeVectors_));
+}
+
+TEST_F(BlendShapeIOTest, LoadBlendShapeBaseWithLimits) {
+  std::string data = createBlendShapeBaseData();
+  std::istringstream iss(data, std::ios::binary);
+  BlendShapeBase result = loadBlendShapeBase(iss, 1, 2);
+  EXPECT_EQ(result.modelSize(), 2);
+  EXPECT_EQ(result.shapeSize(), 1);
+}
+
+TEST_F(BlendShapeIOTest, LoadBlendShapeBaseFromFile) {
+  auto tempFile = temporaryFile("test", ".bin");
+  std::ofstream ofs(tempFile.path(), std::ios::binary);
+  std::string data = createBlendShapeBaseData();
+  ofs.write(data.data(), data.size());
+  ofs.close();
+
+  BlendShapeBase result = loadBlendShapeBase(tempFile.path());
+  EXPECT_EQ(result.modelSize(), 3);
+  EXPECT_EQ(result.shapeSize(), 2);
+}
+
+TEST_F(BlendShapeIOTest, LoadBlendShapeBaseFileNotFound) {
+  EXPECT_THROW(loadBlendShapeBase("nonexistent.bin"), std::runtime_error);
+}
+
+TEST_F(BlendShapeIOTest, LoadBlendShape) {
+  std::string data = createBlendShapeData();
+  std::istringstream iss(data, std::ios::binary);
+  BlendShape result = loadBlendShape(iss);
+  EXPECT_EQ(result.modelSize(), 3);
+  EXPECT_EQ(result.shapeSize(), 2);
+  EXPECT_EQ(result.getBaseShape().size(), 3);
+  EXPECT_TRUE(result.getShapeVectors().isApprox(shapeVectors_));
+}
+
+TEST_F(BlendShapeIOTest, LoadBlendShapeWithLimits) {
+  std::string data = createBlendShapeData();
+  std::istringstream iss(data, std::ios::binary);
+  BlendShape result = loadBlendShape(iss, 1, 2);
+  EXPECT_EQ(result.modelSize(), 2);
+  EXPECT_EQ(result.shapeSize(), 1);
+  EXPECT_EQ(result.getBaseShape().size(), 2);
+}
+
+TEST_F(BlendShapeIOTest, LoadBlendShapeFromFile) {
+  auto tempFile = temporaryFile("test", ".bin");
+  std::ofstream ofs(tempFile.path(), std::ios::binary);
+  std::string data = createBlendShapeData();
+  ofs.write(data.data(), data.size());
+  ofs.close();
+
+  BlendShape result = loadBlendShape(tempFile.path());
+  EXPECT_EQ(result.modelSize(), 3);
+  EXPECT_EQ(result.shapeSize(), 2);
+}
+
+TEST_F(BlendShapeIOTest, LoadBlendShapeFileNotFound) {
+  EXPECT_THROW(loadBlendShape("nonexistent.bin"), std::runtime_error);
+}
+
+TEST_F(BlendShapeIOTest, SaveAndLoadRoundTrip) {
+  BlendShape original(baseShape_, 2);
+  original.setShapeVectors(shapeVectors_);
+
+  auto tempFile = temporaryFile("test", ".bin");
+  saveBlendShape(tempFile.path(), original);
+  BlendShape loaded = loadBlendShape(tempFile.path());
+
+  EXPECT_TRUE(loaded.isApprox(original));
+}
+
+TEST_F(BlendShapeIOTest, SaveToStream) {
+  BlendShape blendShape(baseShape_, 2);
+  blendShape.setShapeVectors(shapeVectors_);
+
+  std::ostringstream oss(std::ios::binary);
+  saveBlendShape(oss, blendShape);
+
+  std::istringstream iss(oss.str(), std::ios::binary);
+  BlendShape loaded = loadBlendShape(iss);
+  EXPECT_TRUE(loaded.isApprox(blendShape));
+}
+
+TEST_F(BlendShapeIOTest, SaveToInvalidPath) {
+  BlendShape blendShape(baseShape_, 2);
+  EXPECT_NO_THROW(saveBlendShape("/invalid/path/file.bin", blendShape));
+}
+
+TEST_F(BlendShapeIOTest, EdgeCases) {
+  // Zero shapes
+  std::ostringstream oss(std::ios::binary);
+  uint64_t rows = 9, cols = 0;
+  oss.write(reinterpret_cast<const char*>(&rows), sizeof(rows));
+  oss.write(reinterpret_cast<const char*>(&cols), sizeof(cols));
+  oss.write(reinterpret_cast<const char*>(baseShape_.data()), sizeof(float) * 9);
+
+  std::istringstream iss(oss.str(), std::ios::binary);
+  BlendShape result = loadBlendShape(iss);
+  EXPECT_EQ(result.shapeSize(), 0);
+
+  // Large expected values
+  std::string data = createBlendShapeData();
+  std::istringstream iss2(data, std::ios::binary);
+  BlendShape result2 = loadBlendShape(iss2, 100, 100);
+  EXPECT_EQ(result2.modelSize(), 3);
+  EXPECT_EQ(result2.shapeSize(), 2);
+}


### PR DESCRIPTION
Summary:
- Add tests for blend shape io
- Move ReadShapeVectors() into source, as it's not used externally
- Rename ReadShapeVectors() to readShapeVectors() (camelCase) for consistency

Differential Revision: D76268756


