### PR TITLE
Convert keepLocators boolean to enum

### DIFF
--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -145,7 +145,8 @@ int main(int argc, char** argv) {
       } else if (motionExt == ".fbx") {
         MT_LOGI("Loading motion from fbx...");
         int motionIndex = -1;
-        auto [c, motions, framerate] = loadFbxCharacterWithMotion(motionPath, true, false);
+        auto [c, motions, framerate] =
+            loadFbxCharacterWithMotion(motionPath, KeepLocators::Yes, false);
         // Validate the motion
         if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
           MT_LOGW("No motion loaded from file");

--- a/momentum/examples/fbx_viewer/fbx_viewer.cpp
+++ b/momentum/examples/fbx_viewer/fbx_viewer.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[]) {
     rec.log_static("world", ViewCoordinates(::components::ViewCoordinates::RUB)); // Set an up-axis
 
     const auto [character, motions, fps] =
-        loadFbxCharacterWithMotion(options->fbxFile, true /*keepLocators*/, options->permissive);
+        loadFbxCharacterWithMotion(options->fbxFile, KeepLocators::Yes, options->permissive);
     // Validate the loaded motion
     if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
       MT_LOGW("No motion loaded from file");

--- a/momentum/io/character_io.cpp
+++ b/momentum/io/character_io.cpp
@@ -50,7 +50,7 @@ namespace {
   if (format == CharacterFormat::Gltf) {
     return loadGltfCharacter(filepath);
   } else if (format == CharacterFormat::Fbx) {
-    return loadFbxCharacter(filepath, true);
+    return loadFbxCharacter(filepath, KeepLocators::Yes);
   } else {
     return {};
   }
@@ -62,7 +62,7 @@ namespace {
   if (format == CharacterFormat::Gltf) {
     return loadGltfCharacter(fileBuffer);
   } else if (format == CharacterFormat::Fbx) {
-    return loadFbxCharacter(fileBuffer, true);
+    return loadFbxCharacter(fileBuffer, KeepLocators::Yes);
   } else {
     return {};
   }

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -553,23 +553,26 @@ void saveFbxCommon(
 
 } // namespace
 
-Character loadFbxCharacter(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+Character
+loadFbxCharacter(const filesystem::path& inputPath, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
 }
 
 Character
-loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool keepLocators, bool permissive) {
+loadFbxCharacter(gsl::span<const std::byte> inputSpan, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
 }
 
-std::tuple<Character, std::vector<MatrixXf>, float>
-loadFbxCharacterWithMotion(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    const filesystem::path& inputPath,
+    KeepLocators keepLocators,
+    bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
 }

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -31,6 +31,9 @@ enum class FBXFrontVector { ParityEven = 1, ParityOdd = 2 };
 // Maps to fbxsdk::FbxAxisSystem::ECoordSystem
 enum class FBXCoordSystem { RightHanded, LeftHanded };
 
+// KeepLocators Specifies whether Nulls in the transform hierarchy should be turned into Locators.
+enum class KeepLocators { No, Yes };
+
 // A struct containing the up, front vectors and coordinate system
 struct FBXCoordSystemInfo {
   // Default to the same orientations as FbxAxisSystem::eMayaYUp
@@ -44,7 +47,7 @@ struct FBXCoordSystemInfo {
 // Permissive mode allows loading  mesh-only characters (without skin weights).
 Character loadFbxCharacter(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Using keepLocators means the Nulls in the transform hierarchy will be turned into Locators.
@@ -52,19 +55,19 @@ Character loadFbxCharacter(
 // Permissive mode allows loading  mesh-only characters (without skin weights).
 Character loadFbxCharacter(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows saving mesh-only characters (without skin weights).

--- a/momentum/io/fbx/fbx_io_unsupported.cpp
+++ b/momentum/io/fbx/fbx_io_unsupported.cpp
@@ -13,23 +13,26 @@
 
 namespace momentum {
 
-Character loadFbxCharacter(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+Character
+loadFbxCharacter(const filesystem::path& inputPath, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
 }
 
 Character
-loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool keepLocators, bool permissive) {
+loadFbxCharacter(gsl::span<const std::byte> inputSpan, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
 }
 
-std::tuple<Character, std::vector<MatrixXf>, float>
-loadFbxCharacterWithMotion(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    const filesystem::path& inputPath,
+    KeepLocators keepLocators,
+    bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
 }

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -949,7 +949,7 @@ std::tuple<std::unique_ptr<ofbx::u8[]>, size_t> readFileToBuffer(const filesyste
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbx(
     const gsl::span<const std::byte> fbxDataRaw,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool loadAnim,
     bool permissive) {
   auto fbxCharDataRaw = cast_span<const unsigned char>(fbxDataRaw);
@@ -1011,7 +1011,7 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbx(
       skeleton,
       ParameterTransform::empty(skeleton.joints.size() * kParametersPerJoint),
       ParameterLimits(),
-      keepLocators ? locators : LocatorList(),
+      keepLocators == KeepLocators::Yes ? locators : LocatorList(),
       &mesh,
       skinWeights.get(),
       collision.empty() ? nullptr : &collision);
@@ -1025,13 +1025,14 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbx(
 
 Character loadOpenFbxCharacter(
     const gsl::span<const std::byte> fbxDataRaw,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   auto [character, motion, fps] = loadOpenFbx(fbxDataRaw, keepLocators, false, permissive);
   return character;
 }
 
-Character loadOpenFbxCharacter(const filesystem::path& path, bool keepLocators, bool permissive) {
+Character
+loadOpenFbxCharacter(const filesystem::path& path, KeepLocators keepLocators, bool permissive) {
   auto [buffer, length] = readFileToBuffer(path);
   return loadOpenFbxCharacter(
       gsl::as_bytes(gsl::make_span(buffer.get(), length)), keepLocators, permissive);
@@ -1039,14 +1040,14 @@ Character loadOpenFbxCharacter(const filesystem::path& path, bool keepLocators, 
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   return loadOpenFbx(inputSpan, keepLocators, true, permissive);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     const filesystem::path& inputPath,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   auto [buffer, length] = readFileToBuffer(inputPath);
   return loadOpenFbxCharacterWithMotion(

--- a/momentum/io/fbx/openfbx_loader.h
+++ b/momentum/io/fbx/openfbx_loader.h
@@ -9,6 +9,7 @@
 
 #include <momentum/character/fwd.h>
 #include <momentum/common/filesystem.h>
+#include <momentum/io/fbx/fbx_io.h>
 #include <momentum/math/types.h>
 
 #include <gsl/span>
@@ -20,25 +21,25 @@ namespace momentum {
 // Permissive mode allows loading mesh-only characters (without skin weights).
 Character loadOpenFbxCharacter(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 Character loadOpenFbxCharacter(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 } // namespace momentum

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -174,7 +174,7 @@ at::Tensor mapJointParameters(
   return result;
 }
 
-constexpr bool keepLocators = true;
+constexpr momentum::KeepLocators keepLocators = momentum::KeepLocators::Yes;
 
 momentum::Character loadFBXCharacterFromFile(
     const std::string& fbxPath,


### PR DESCRIPTION
Summary:
- Converted `bool keepLocators` to `enum class KeepLocators { No, Yes }` across FBX loading functions because the boolean had domain-specific, non-obvious semantics (`loadFbx(path, true)` -> `loadFbx(path, KeepLocators::Yes)` is self-documenting)

- Only convert booleans with domain-specific meaning to enums, as blanket conversion creates unnecessary complexity for universally understood concepts (e.g., `bool permissive` remains boolean since strict/permissive mode is clear and unlikely to need extension)

Differential Revision: D76563757


