### PR TITLE
Update code style guide for momentum header include

### DIFF
--- a/momentum/diff_ik/fully_differentiable_projection_error_function.cpp
+++ b/momentum/diff_ik/fully_differentiable_projection_error_function.cpp
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <momentum/character_solver/projection_error_function.h>
-#include <momentum/diff_ik/fully_differentiable_projection_error_function.h>
+#include "momentum/diff_ik/fully_differentiable_projection_error_function.h"
+#include "momentum/character_solver/projection_error_function.h"
 
-#include <momentum/character/character.h>
-#include <momentum/character/skeleton.h>
-#include <momentum/character/skeleton_state.h>
-#include <momentum/diff_ik/ceres_utility.h>
+#include "momentum/character/character.h"
+#include "momentum/character/skeleton.h"
+#include "momentum/character/skeleton_state.h"
+#include "momentum/diff_ik/ceres_utility.h"
 
 namespace momentum {
 

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -145,7 +145,8 @@ int main(int argc, char** argv) {
       } else if (motionExt == ".fbx") {
         MT_LOGI("Loading motion from fbx...");
         int motionIndex = -1;
-        auto [c, motions, framerate] = loadFbxCharacterWithMotion(motionPath, true, false);
+        auto [c, motions, framerate] =
+            loadFbxCharacterWithMotion(motionPath, KeepLocators::Yes, false);
         // Validate the motion
         if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
           MT_LOGW("No motion loaded from file");

--- a/momentum/examples/fbx_viewer/fbx_viewer.cpp
+++ b/momentum/examples/fbx_viewer/fbx_viewer.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[]) {
     rec.log_static("world", ViewCoordinates(::components::ViewCoordinates::RUB)); // Set an up-axis
 
     const auto [character, motions, fps] =
-        loadFbxCharacterWithMotion(options->fbxFile, true /*keepLocators*/, options->permissive);
+        loadFbxCharacterWithMotion(options->fbxFile, KeepLocators::Yes, options->permissive);
     // Validate the loaded motion
     if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
       MT_LOGW("No motion loaded from file");

--- a/momentum/io/character_io.cpp
+++ b/momentum/io/character_io.cpp
@@ -50,7 +50,7 @@ namespace {
   if (format == CharacterFormat::Gltf) {
     return loadGltfCharacter(filepath);
   } else if (format == CharacterFormat::Fbx) {
-    return loadFbxCharacter(filepath, true);
+    return loadFbxCharacter(filepath, KeepLocators::Yes);
   } else {
     return {};
   }
@@ -62,7 +62,7 @@ namespace {
   if (format == CharacterFormat::Gltf) {
     return loadGltfCharacter(fileBuffer);
   } else if (format == CharacterFormat::Fbx) {
-    return loadFbxCharacter(fileBuffer, true);
+    return loadFbxCharacter(fileBuffer, KeepLocators::Yes);
   } else {
     return {};
   }

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -553,23 +553,26 @@ void saveFbxCommon(
 
 } // namespace
 
-Character loadFbxCharacter(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+Character
+loadFbxCharacter(const filesystem::path& inputPath, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
 }
 
 Character
-loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool keepLocators, bool permissive) {
+loadFbxCharacter(gsl::span<const std::byte> inputSpan, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
 }
 
-std::tuple<Character, std::vector<MatrixXf>, float>
-loadFbxCharacterWithMotion(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    const filesystem::path& inputPath,
+    KeepLocators keepLocators,
+    bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
 }

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -31,6 +31,9 @@ enum class FBXFrontVector { ParityEven = 1, ParityOdd = 2 };
 // Maps to fbxsdk::FbxAxisSystem::ECoordSystem
 enum class FBXCoordSystem { RightHanded, LeftHanded };
 
+// KeepLocators Specifies whether Nulls in the transform hierarchy should be turned into Locators.
+enum class KeepLocators { No, Yes };
+
 // A struct containing the up, front vectors and coordinate system
 struct FBXCoordSystemInfo {
   // Default to the same orientations as FbxAxisSystem::eMayaYUp
@@ -44,7 +47,7 @@ struct FBXCoordSystemInfo {
 // Permissive mode allows loading  mesh-only characters (without skin weights).
 Character loadFbxCharacter(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Using keepLocators means the Nulls in the transform hierarchy will be turned into Locators.
@@ -52,19 +55,19 @@ Character loadFbxCharacter(
 // Permissive mode allows loading  mesh-only characters (without skin weights).
 Character loadFbxCharacter(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows saving mesh-only characters (without skin weights).

--- a/momentum/io/fbx/fbx_io_unsupported.cpp
+++ b/momentum/io/fbx/fbx_io_unsupported.cpp
@@ -13,23 +13,26 @@
 
 namespace momentum {
 
-Character loadFbxCharacter(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+Character
+loadFbxCharacter(const filesystem::path& inputPath, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
 }
 
 Character
-loadFbxCharacter(gsl::span<const std::byte> inputSpan, bool keepLocators, bool permissive) {
+loadFbxCharacter(gsl::span<const std::byte> inputSpan, KeepLocators keepLocators, bool permissive) {
   return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
 }
 
-std::tuple<Character, std::vector<MatrixXf>, float>
-loadFbxCharacterWithMotion(const filesystem::path& inputPath, bool keepLocators, bool permissive) {
+std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
+    const filesystem::path& inputPath,
+    KeepLocators keepLocators,
+    bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
 }

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -949,7 +949,7 @@ std::tuple<std::unique_ptr<ofbx::u8[]>, size_t> readFileToBuffer(const filesyste
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbx(
     const gsl::span<const std::byte> fbxDataRaw,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool loadAnim,
     bool permissive) {
   auto fbxCharDataRaw = cast_span<const unsigned char>(fbxDataRaw);
@@ -1011,7 +1011,7 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbx(
       skeleton,
       ParameterTransform::empty(skeleton.joints.size() * kParametersPerJoint),
       ParameterLimits(),
-      keepLocators ? locators : LocatorList(),
+      keepLocators == KeepLocators::Yes ? locators : LocatorList(),
       &mesh,
       skinWeights.get(),
       collision.empty() ? nullptr : &collision);
@@ -1025,13 +1025,14 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbx(
 
 Character loadOpenFbxCharacter(
     const gsl::span<const std::byte> fbxDataRaw,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   auto [character, motion, fps] = loadOpenFbx(fbxDataRaw, keepLocators, false, permissive);
   return character;
 }
 
-Character loadOpenFbxCharacter(const filesystem::path& path, bool keepLocators, bool permissive) {
+Character
+loadOpenFbxCharacter(const filesystem::path& path, KeepLocators keepLocators, bool permissive) {
   auto [buffer, length] = readFileToBuffer(path);
   return loadOpenFbxCharacter(
       gsl::as_bytes(gsl::make_span(buffer.get(), length)), keepLocators, permissive);
@@ -1039,14 +1040,14 @@ Character loadOpenFbxCharacter(const filesystem::path& path, bool keepLocators, 
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   return loadOpenFbx(inputSpan, keepLocators, true, permissive);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     const filesystem::path& inputPath,
-    bool keepLocators,
+    KeepLocators keepLocators,
     bool permissive) {
   auto [buffer, length] = readFileToBuffer(inputPath);
   return loadOpenFbxCharacterWithMotion(

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -11,6 +11,7 @@
 #include "momentum/character/collision_geometry_state.h"
 #include "momentum/character/skin_weights.h"
 #include "momentum/character/types.h"
+#include "momentum/common/filesystem.h"
 #include "momentum/common/log.h"
 #include "momentum/io/common/gsl_utils.h"
 #include "momentum/io/fbx/polygon_data.h"
@@ -22,7 +23,6 @@
 #include "momentum/math/mesh.h"
 #include "momentum/math/utility.h"
 
-#include <momentum/common/filesystem.h>
 #include <ofbx.h>
 #include <gsl/span_ext>
 

--- a/momentum/io/fbx/openfbx_loader.h
+++ b/momentum/io/fbx/openfbx_loader.h
@@ -9,6 +9,7 @@
 
 #include <momentum/character/fwd.h>
 #include <momentum/common/filesystem.h>
+#include <momentum/io/fbx/fbx_io.h>
 #include <momentum/math/types.h>
 
 #include <gsl/span>
@@ -20,25 +21,25 @@ namespace momentum {
 // Permissive mode allows loading mesh-only characters (without skin weights).
 Character loadOpenFbxCharacter(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 Character loadOpenFbxCharacter(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     const filesystem::path& inputPath,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    bool keepLocators = false,
+    KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false);
 
 } // namespace momentum

--- a/momentum/test/io/io_parameter_limits_test.cpp
+++ b/momentum/test/io/io_parameter_limits_test.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 #include <momentum/character/parameter_limits.h>
 #include <momentum/io/skeleton/parameter_limits_io.h>
-#include "momentum/test/character/character_helpers.h"
+#include <momentum/test/character/character_helpers.h>
 
 using namespace momentum;
 

--- a/momentum/test/solver/solver_test.cpp
+++ b/momentum/test/solver/solver_test.cpp
@@ -8,7 +8,7 @@
 #include <momentum/math/types.h>
 #include <momentum/solver/solver.h>
 #include <momentum/solver/solver_function.h>
-#include "momentum/test/helpers/expect_throw.h"
+#include <momentum/test/helpers/expect_throw.h>
 
 #include <gtest/gtest.h>
 

--- a/momentum/website/docs/04_developer_guide/02_style_guide.md
+++ b/momentum/website/docs/04_developer_guide/02_style_guide.md
@@ -44,6 +44,46 @@ When accessing elements within arrays, the Momentum codebase employs two methods
 
 ## Design Decisions
 
-### Prefer `gsl::span` over typed container like `std::vector`` as function argument
+### Prefer `gsl::span` over typed container like `std::vector` as function argument
 
 Using `std::vector<T>` as a function argument requires the call site to create an `std::vector<T>` instance even when the data is already stored in a compatible memory layout, such as contiguous memory. By switching to `gsl::span<T>`, call sites can avoid creating an additional `std::vector<T>` object and benefit from improved performance by not requiring an unnecessary data copy.
+
+### Header Include Style
+
+Momentum follows standard C++ conventions for header includes, using different syntax depending on the context:
+
+#### Public Headers (Use Angle Brackets `<>`)
+
+In **public Momentum headers** that are installed for users, use angle brackets:
+
+```cpp
+// In public header files (e.g., momentum/character/character.h)
+#include <momentum/common/checks.h>
+#include <momentum/math/mesh.h>
+```
+
+**Rationale**: Angle brackets instruct the compiler to search in system/standard include paths. When Momentum is installed as a library, downstream users and build systems will treat these as system headers and look for them in the appropriate system locations (e.g., `/usr/local/include`, `/opt/include`).
+
+#### Library Implementation Source Files (Use Quotes `""`)
+
+In **library implementation source files** (`.cpp` files in core library directories), use quotes:
+
+```cpp
+// In library implementation .cpp files
+#include "momentum/character/character.h"
+#include "momentum/common/checks.h"
+```
+
+**Rationale**: Quotes instruct the compiler to first search in local/relative directories before falling back to system paths. This ensures that during Momentum's own build process, the compiler finds the local development headers rather than any previously installed system versions.
+
+#### Tests, Tutorials, and Examples (Use Angle Brackets `<>`)
+
+In **tests, tutorials, and example code**, use angle brackets:
+
+```cpp
+// In test files, tutorials, and examples
+#include <momentum/character/character.h>
+#include <momentum/common/checks.h>
+```
+
+**Rationale**: Tests, tutorials, and examples represent user-facing code that demonstrates how external developers should consume the Momentum library. They should mirror the external user experience by using angle brackets as users would when the library is installed as a system library. This also serves as documentation showing the correct way to include headers.

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -174,7 +174,7 @@ at::Tensor mapJointParameters(
   return result;
 }
 
-constexpr bool keepLocators = true;
+constexpr momentum::KeepLocators keepLocators = momentum::KeepLocators::Yes;
 
 momentum::Character loadFBXCharacterFromFile(
     const std::string& fbxPath,


### PR DESCRIPTION
Summary:
- Add momentum header include convention to the style guide page, as discussed in D75662923
- Update the codebase by applying the convention

Reviewed By: juliencbmeta

Differential Revision: D76563448


