### PR TITLE
Update API to fit 0.23.3 deprecation

### DIFF
--- a/momentum/examples/c3d_viewer/c3d_viewer.cpp
+++ b/momentum/examples/c3d_viewer/c3d_viewer.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
 
       for (size_t iFrame = 0; iFrame < nFrames; ++iFrame) {
         rec.set_time_sequence("frame_index", iFrame);
-        rec.set_time_seconds("log_time", (float)iFrame / actor.fps);
+        rec.set_time_duration_secs("log_time", (float)iFrame / actor.fps);
         logMarkers(rec, "world/" + streamName, actor.frames.at(iFrame));
 
         if (options->plot) {

--- a/momentum/examples/fbx_viewer/fbx_viewer.cpp
+++ b/momentum/examples/fbx_viewer/fbx_viewer.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[]) {
       for (size_t iFrame = 0; iFrame < nFrames; ++iFrame) {
         // log timeline
         rec.set_time_sequence("frame_index", iFrame);
-        rec.set_time_seconds("log_time", (float)iFrame / fps);
+        rec.set_time_duration_secs("log_time", (float)iFrame / fps);
 
         // log character info
         if (iFrame < nFrames) {

--- a/momentum/examples/glb_viewer/glb_viewer.cpp
+++ b/momentum/examples/glb_viewer/glb_viewer.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) {
     for (size_t iFrame = firstFrame; iFrame < lastFrame; iFrame += options->stride) {
       // log timeline
       rec.set_time_sequence("frame_index", iFrame);
-      rec.set_time_seconds("log_time", (float)iFrame / fps);
+      rec.set_time_duration_secs("log_time", (float)iFrame / fps);
 
       // log character info
       if (iFrame < nFrames) {

--- a/momentum/examples/urdf_viewer/urdf_viewer.cpp
+++ b/momentum/examples/urdf_viewer/urdf_viewer.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
     for (auto i = 0; i < kNumFrames; ++i) {
       // log timeline
       rec.set_time_sequence("frame_index", i);
-      rec.set_time_seconds("log_time", (float)i / fps);
+      rec.set_time_duration_secs("log_time", (float)i / fps);
 
       charParams.pose = motion.col(i);
       charState.set(


### PR DESCRIPTION
Summary:
C++:
set_time -> set_time_duration
set_time_seconds  -> set_time_duration_secs
set_time_nanos -> set_time_duration_nanos

Python/C++
connect -> connect_grpc

Python:
serve -> serve_web

https://rerun.io/docs/reference/migration/migration-0-23

Differential Revision: D76273230


