### PR TITLE
Fix mesh colors

### DIFF
--- a/momentum/gui/rerun/logger.cpp
+++ b/momentum/gui/rerun/logger.cpp
@@ -53,7 +53,7 @@ void logMesh(
     std::optional<rerun::Color> color) {
   auto rerunMesh = rerun::Mesh3D(mesh.vertices).with_triangle_indices(mesh.faces);
   if (color.has_value()) {
-    rerunMesh = std::move(rerunMesh).with_vertex_colors(color.value());
+    rerunMesh = std::move(rerunMesh).with_albedo_factor(rerun::AlbedoFactor(color.value()));
   } else if (mesh.colors.size() == mesh.vertices.size()) {
     rerunMesh = std::move(rerunMesh).with_vertex_colors(mesh.colors);
   }

--- a/momentum/gui/rerun/logger.h
+++ b/momentum/gui/rerun/logger.h
@@ -17,7 +17,6 @@
 
 #include <map>
 #include <string>
-#include <vector>
 
 namespace momentum {
 


### PR DESCRIPTION
Summary: Fixes issue that cropped up after move to Rerun v0.22 where mesh colors were only being applied to the first vertex, instead of the entire mesh.

Reviewed By: jeongseok-meta

Differential Revision: D76844670


