### PR TITLE
Add VertexErrorFunction to gen_fwd_input.toml.

### DIFF
--- a/momentum/character_solver/fwd.h
+++ b/momentum/character_solver/fwd.h
@@ -730,4 +730,28 @@ using VertexErrorFunctiond_const_p = ::std::shared_ptr<const VertexErrorFunction
 using VertexErrorFunctiond_const_u = ::std::unique_ptr<const VertexErrorFunctiond>;
 using VertexErrorFunctiond_const_w = ::std::weak_ptr<const VertexErrorFunctiond>;
 
+template <typename T>
+class VertexProjectionErrorFunctionT;
+using VertexProjectionErrorFunction = VertexProjectionErrorFunctionT<float>;
+using VertexProjectionErrorFunctiond = VertexProjectionErrorFunctionT<double>;
+
+using VertexProjectionErrorFunction_p = ::std::shared_ptr<VertexProjectionErrorFunction>;
+using VertexProjectionErrorFunction_u = ::std::unique_ptr<VertexProjectionErrorFunction>;
+using VertexProjectionErrorFunction_w = ::std::weak_ptr<VertexProjectionErrorFunction>;
+using VertexProjectionErrorFunction_const_p =
+    ::std::shared_ptr<const VertexProjectionErrorFunction>;
+using VertexProjectionErrorFunction_const_u =
+    ::std::unique_ptr<const VertexProjectionErrorFunction>;
+using VertexProjectionErrorFunction_const_w = ::std::weak_ptr<const VertexProjectionErrorFunction>;
+
+using VertexProjectionErrorFunctiond_p = ::std::shared_ptr<VertexProjectionErrorFunctiond>;
+using VertexProjectionErrorFunctiond_u = ::std::unique_ptr<VertexProjectionErrorFunctiond>;
+using VertexProjectionErrorFunctiond_w = ::std::weak_ptr<VertexProjectionErrorFunctiond>;
+using VertexProjectionErrorFunctiond_const_p =
+    ::std::shared_ptr<const VertexProjectionErrorFunctiond>;
+using VertexProjectionErrorFunctiond_const_u =
+    ::std::unique_ptr<const VertexProjectionErrorFunctiond>;
+using VertexProjectionErrorFunctiond_const_w =
+    ::std::weak_ptr<const VertexProjectionErrorFunctiond>;
+
 } // namespace momentum

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -54,6 +54,7 @@ template_structs = [
     "PlaneData",
     "PositionData",
     "VertexConstraint",
+    "VertexProjectionConstraint",
 ]
 classes = [
     "SimdNormalErrorFunction",
@@ -88,6 +89,7 @@ template_classes = [
     "StateErrorFunction",
     "TrustRegionQR",
     "VertexErrorFunction",
+    "VertexProjectionErrorFunction",
 ]
 
 [[fwd]]


### PR DESCRIPTION
Summary: I was adding another error function and when I ran gen_fwd it actually deleted the VertexProjectionErrorFunction, so I guess it got added manually.  Fixing to be generated automatically.

Reviewed By: jeongseok-meta

Differential Revision: D77404932


