### PR TITLE
Add sequence error functions to solver2.

### DIFF
--- a/momentum/character_sequence_solver/state_sequence_error_function.cpp
+++ b/momentum/character_sequence_solver/state_sequence_error_function.cpp
@@ -40,10 +40,19 @@ template <typename T>
 void StateSequenceErrorFunctionT<T>::setTargetWeights(
     const Eigen::VectorX<T>& posWeight,
     const Eigen::VectorX<T>& rotWeight) {
-  MT_CHECK(posWeight.size() == static_cast<Eigen::Index>(this->skeleton_.joints.size()));
-  MT_CHECK(rotWeight.size() == static_cast<Eigen::Index>(this->skeleton_.joints.size()));
+  setPositionTargetWeights(posWeight);
+  setRotationTargetWeights(rotWeight);
+}
 
+template <typename T>
+void StateSequenceErrorFunctionT<T>::setPositionTargetWeights(const Eigen::VectorX<T>& posWeight) {
+  MT_CHECK(posWeight.size() == static_cast<Eigen::Index>(this->skeleton_.joints.size()));
   targetPositionWeights_ = posWeight;
+}
+
+template <typename T>
+void StateSequenceErrorFunctionT<T>::setRotationTargetWeights(const Eigen::VectorX<T>& rotWeight) {
+  MT_CHECK(rotWeight.size() == static_cast<Eigen::Index>(this->skeleton_.joints.size()));
   targetRotationWeights_ = rotWeight;
 }
 

--- a/momentum/character_sequence_solver/state_sequence_error_function.h
+++ b/momentum/character_sequence_solver/state_sequence_error_function.h
@@ -45,6 +45,8 @@ class StateSequenceErrorFunctionT : public SequenceErrorFunctionT<T> {
   [[nodiscard]] size_t getJacobianSize() const final;
 
   void setTargetWeights(const Eigen::VectorX<T>& posWeight, const Eigen::VectorX<T>& rotWeight);
+  void setPositionTargetWeights(const Eigen::VectorX<T>& posWeight);
+  void setRotationTargetWeights(const Eigen::VectorX<T>& rotWeight);
   void setWeights(const float posWeight, const float rotationWeight) {
     posWgt_ = posWeight;
     rotWgt_ = rotationWeight;


### PR DESCRIPTION
Summary: We want to support smoothness constraints in the sequence solver.

Reviewed By: cstollmeta

Differential Revision: D77251620


