### PR TITLE
Make SkeletonT and CharacterT movable

### DIFF
--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -105,6 +105,9 @@ CharacterT<T>::CharacterT(const CharacterT& c)
 }
 
 template <typename T>
+CharacterT<T>::CharacterT(CharacterT&& c) noexcept = default;
+
+template <typename T>
 CharacterT<T>::CharacterT() = default;
 
 template <typename T>
@@ -132,6 +135,9 @@ CharacterT<T>& CharacterT<T>::operator=(const CharacterT& rhs) {
 
   return *this;
 }
+
+template <typename T>
+CharacterT<T>& CharacterT<T>::operator=(CharacterT&& rhs) noexcept = default;
 
 template <typename T>
 std::vector<bool> CharacterT<T>::parametersToActiveJoints(const ParameterSet& parameterSet) const {

--- a/momentum/character/character.h
+++ b/momentum/character/character.h
@@ -105,8 +105,14 @@ struct CharacterT {
   /// Copy constructor
   CharacterT(const CharacterT& c);
 
-  /// Assignment operator
+  /// Move constructor
+  CharacterT(CharacterT&& c) noexcept;
+
+  /// Copy assignment operator
   CharacterT& operator=(const CharacterT& rhs);
+
+  /// Move assignment operator
+  CharacterT& operator=(CharacterT&& rhs) noexcept;
 
   /// Creates a simplified character with only joints affected by the specified parameters
   ///

--- a/momentum/character/skeleton.h
+++ b/momentum/character/skeleton.h
@@ -23,10 +23,24 @@ struct SkeletonT {
   /// The list of joints in this skeleton.
   JointList joints;
 
+  /// Default constructor
+  SkeletonT() = default;
+
   /// Constructor that validates joint hierarchy.
   /// Ensures parent indices are valid (parent < child index or kInvalidIndex).
   explicit SkeletonT(JointList joints);
-  SkeletonT() = default;
+
+  /// Copy constructor
+  SkeletonT(const SkeletonT& other) = default;
+
+  /// Move constructor
+  SkeletonT(SkeletonT&& other) noexcept = default;
+
+  /// Copy assignment operator
+  SkeletonT& operator=(const SkeletonT& other) = default;
+
+  /// Move assignment operator
+  SkeletonT& operator=(SkeletonT&& other) noexcept = default;
 
   /// Returns the index of a joint with the given name, or kInvalidIndex if not found.
   [[nodiscard]] size_t getJointIdByName(std::string_view name) const;

--- a/momentum/test/character/skeleton_test.cpp
+++ b/momentum/test/character/skeleton_test.cpp
@@ -347,6 +347,95 @@ TYPED_TEST(SkeletonTest, Cast) {
   }
 }
 
+// Test move constructor
+TYPED_TEST(SkeletonTest, MoveConstructor) {
+  using SkeletonType = typename TestFixture::SkeletonType;
+
+  // Create a skeleton with the test joints
+  SkeletonType originalSkeleton(this->joints);
+
+  // Store original data for comparison
+  const size_t originalJointCount = originalSkeleton.joints.size();
+  const std::string originalFirstJointName =
+      originalSkeleton.joints.empty() ? "" : originalSkeleton.joints[0].name;
+
+  // Move construct a new skeleton
+  SkeletonType movedSkeleton = std::move(originalSkeleton);
+
+  // Verify the moved skeleton has the expected data
+  EXPECT_EQ(movedSkeleton.joints.size(), originalJointCount);
+  if (!movedSkeleton.joints.empty()) {
+    EXPECT_EQ(movedSkeleton.joints[0].name, originalFirstJointName);
+  }
+
+  // Verify that the moved skeleton is functional
+  if (movedSkeleton.joints.size() > 1) {
+    EXPECT_NE(movedSkeleton.getJointIdByName(originalFirstJointName), kInvalidIndex);
+  }
+}
+
+// Test move assignment operator
+TYPED_TEST(SkeletonTest, MoveAssignment) {
+  using SkeletonType = typename TestFixture::SkeletonType;
+
+  // Create two skeletons with different joint configurations
+  SkeletonType originalSkeleton(this->joints);
+
+  // Create a different skeleton for the target
+  JointList otherJoints;
+  otherJoints.resize(2);
+  otherJoints[0].name = "other_root";
+  otherJoints[0].parent = kInvalidIndex;
+  otherJoints[0].translationOffset = Vector3<float>(0, 0, 0);
+  otherJoints[0].preRotation = Quaternion<float>::Identity();
+  otherJoints[1].name = "other_joint";
+  otherJoints[1].parent = 0;
+  otherJoints[1].translationOffset = Vector3<float>(2, 0, 0);
+  otherJoints[1].preRotation = Quaternion<float>::Identity();
+
+  SkeletonType targetSkeleton(otherJoints);
+
+  // Store original data for comparison
+  const size_t originalJointCount = originalSkeleton.joints.size();
+  const std::string originalFirstJointName =
+      originalSkeleton.joints.empty() ? "" : originalSkeleton.joints[0].name;
+
+  // Move assign
+  targetSkeleton = std::move(originalSkeleton);
+
+  // Verify the target skeleton has the expected data
+  EXPECT_EQ(targetSkeleton.joints.size(), originalJointCount);
+  if (!targetSkeleton.joints.empty()) {
+    EXPECT_EQ(targetSkeleton.joints[0].name, originalFirstJointName);
+  }
+
+  // Verify that the moved skeleton is functional
+  if (targetSkeleton.joints.size() > 1) {
+    EXPECT_NE(targetSkeleton.getJointIdByName(originalFirstJointName), kInvalidIndex);
+  }
+}
+
+// Test that moved-from objects are in a valid but unspecified state
+TYPED_TEST(SkeletonTest, MovedFromObjectState) {
+  using SkeletonType = typename TestFixture::SkeletonType;
+
+  // Create a skeleton with the test joints
+  SkeletonType originalSkeleton(this->joints);
+
+  // Move construct
+  SkeletonType movedSkeleton = std::move(originalSkeleton);
+
+  // The moved-from object should be in a valid but unspecified state
+  // We can't make strong assertions about its state, but it should not crash
+  // when accessing basic properties
+  EXPECT_NO_THROW({
+    auto jointCount = originalSkeleton.joints.size();
+    auto jointNames = originalSkeleton.getJointNames();
+    (void)jointCount;
+    (void)jointNames; // Suppress unused variable warnings
+  });
+}
+
 // Test error cases
 TYPED_TEST(SkeletonTest, ErrorCases) {
   using SkeletonType = typename TestFixture::SkeletonType;


### PR DESCRIPTION
Summary: Enables easier passing around without copying or wrapping in smart pointers.

Differential Revision: D77617567


