### PR TITLE
Fix solver verbosity.

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver.cpp
+++ b/momentum/character_sequence_solver/sequence_solver.cpp
@@ -486,7 +486,6 @@ void SequenceSolverT<T>::doIteration() {
   const Eigen::VectorX<T> searchDir = qrSolver.x_dense();
 
   const double error_orig = this->error_;
-  MT_LOGI_IF(this->verbose_, "Iteration: {}, error: {}", this->iteration_, error_orig);
   if (doLineSearch_) {
     const double innerProd = -qrSolver.At_times_b().dot(searchDir);
 

--- a/momentum/solver/solver.cpp
+++ b/momentum/solver/solver.cpp
@@ -8,6 +8,7 @@
 #include "momentum/solver/solver.h"
 
 #include "momentum/common/checks.h"
+#include "momentum/common/log.h"
 #include "momentum/common/profile.h"
 #include "momentum/solver/solver_function.h"
 
@@ -83,6 +84,8 @@ double SolverT<T>::solve(Eigen::VectorX<T>& params) {
   for (; iteration_ < maxIterations_; iteration_++) {
     // do actual iteration (iterations should update the error value)
     doIteration();
+
+    MT_LOGI_IF(this->verbose_, "Iteration: {}, error: {}", this->iteration_, error_);
 
     // check for convergence
     bool converged = false;

--- a/momentum/solver/solver.h
+++ b/momentum/solver/solver.h
@@ -27,7 +27,7 @@ struct SolverOptions {
   float threshold = 1.0f;
 
   /// Enable detailed logging during optimization
-  bool verbose = true;
+  bool verbose = false;
 
   /// Virtual destructor for polymorphic behavior
   virtual ~SolverOptions() = default;
@@ -132,7 +132,7 @@ class SolverT {
   std::unordered_map<std::string, Eigen::MatrixX<T>> iterationHistory_;
 
   /// Whether to output detailed progress information
-  bool verbose_;
+  bool verbose_ = false;
 
  private:
   /// Minimum iterations before checking convergence criteria

--- a/momentum/solver/solver.h
+++ b/momentum/solver/solver.h
@@ -82,6 +82,10 @@ class SolverT {
   /// Returns the maximum number of iterations before terminating
   [[nodiscard]] size_t getMaxIterations() const;
 
+  [[nodiscard]] size_t getNumParameters() const {
+    return numParameters_;
+  }
+
  protected:
   /// Initializes solver state before optimization begins
   virtual void initializeSolver() = 0;

--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -517,7 +517,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, TestSkinningErrorFunction) {
       std::vector<Vector3<T>> v = applySSD(bindpose, skin, mesh.vertices, bindState);
 
       // check position of skinning
-      EXPECT_LE((v[vi] - target).norm(), Eps<T>(1e-7f, 1e-7));
+      EXPECT_LE((v[vi] - target).norm(), Eps<T>(2e-7f, 2e-7));
 
       // check error
       gradient.setZero();


### PR DESCRIPTION
Summary:
I noticed a couple of things: (1) no solver except for the SequenceSolver actually uses the verbose flag to do anything (2) if we changed that it would break things because verbose defaults to true.  

My proposal is to make verbose actually print out a line for every iteration with the error value regardless of what solver you're using.  Then we should default verbose=false everywhere to make sure we don't break existing code.

Reviewed By: cstollmeta, jeongseok-meta

Differential Revision: D77639814


