### PR TITLE
Always store the history of errors in the solver.

### DIFF
--- a/momentum/solver/solver.cpp
+++ b/momentum/solver/solver.cpp
@@ -69,6 +69,9 @@ double SolverT<T>::solve(Eigen::VectorX<T>& params) {
     iterationCount.setZero();
   }
 
+  errorHistory_.clear();
+  errorHistory_.reserve(maxIterations_);
+
   MT_CHECK(params.size() == gsl::narrow<Eigen::DenseIndex>(numParameters_));
   parameters_ = params;
 
@@ -84,6 +87,7 @@ double SolverT<T>::solve(Eigen::VectorX<T>& params) {
   for (; iteration_ < maxIterations_; iteration_++) {
     // do actual iteration (iterations should update the error value)
     doIteration();
+    errorHistory_.push_back(error_);
 
     MT_LOGI_IF(this->verbose_, "Iteration: {}, error: {}", this->iteration_, error_);
 

--- a/momentum/solver/solver.h
+++ b/momentum/solver/solver.h
@@ -86,6 +86,11 @@ class SolverT {
     return numParameters_;
   }
 
+  /// Returns the history of objective function values over the iterations of the solve
+  [[nodiscard]] const std::vector<double>& getErrorHistory() const {
+    return errorHistory_;
+  }
+
  protected:
   /// Initializes solver state before optimization begins
   virtual void initializeSolver() = 0;
@@ -130,6 +135,8 @@ class SolverT {
   ///
   /// Contains matrices for parameters, errors, and other solver-specific data
   std::unordered_map<std::string, Eigen::MatrixX<T>> iterationHistory_;
+  /// History of objective function values over the iterations
+  std::vector<double> errorHistory_;
 
   /// Whether to output detailed progress information
   bool verbose_ = false;

--- a/pymomentum/tensor_ik/tensor_ik.cpp
+++ b/pymomentum/tensor_ik/tensor_ik.cpp
@@ -166,21 +166,14 @@ at::Tensor solveTensorIKProblem(
             derivedSolverOptions, &solverFunction);
       }
       solver->setEnabledParameters(activeParams);
-      // To record model params and errors at each iteration, and the
-      // iteration count.
-      solver->setStoreHistory(true);
 
       Eigen::VectorX<T> parameters_opt =
           toEigenMap<T>(modelParameters_init_cur);
       solver->solve(parameters_opt);
 
       // Record iteration count.
-      const std::unordered_map<std::string, Eigen::MatrixX<T>>& iterHistory =
-          solver->getHistory();
-      const auto iterCountIterator = iterHistory.find("iterations");
-      assert(iterCountIterator != iterHistory.end());
-      size_t iterCount = size_t(iterCountIterator->second(0, 0) + 0.5);
-      nTotalSolveIKIter += iterCount;
+      const std::vector<double>& iterHistory = solver->getErrorHistory();
+      nTotalSolveIKIter += iterHistory.size();
 
       if (parameters_opt.array().isNaN().any() ||
           parameters_opt.array().isInf().any()) {


### PR DESCRIPTION
Summary:
The two things people often want to know when running the solver is (1) how many iterations did it take and (2) did it converge?  For the latter you only really know if you look at the full history of error values, if you just know that the error is 100 it's not very informative but if you know the error is (1000, 600, 200, 101, 100.1, 100) it's a much better hint.

However currently the only way to know the history of errors is to set setStoreHistory to True.  This is extremely heavyweight because not only does it store the history of errors it also stores all the Jacobians, JtJs, etc. It's really unfortunate that the only way to know how many iterations you ran or the history of error values is to store the Jacobians, so let's fix that by always storing the history of error values.  This is very cheap so shouldn't affect the runtime of solvers (a vector of length 100 is a lot smaller than even computing the residual once).

Reviewed By: cstollmeta

Differential Revision: D77819293


