### PR TITLE
Add more checking for vertex/joint indices.

### DIFF
--- a/momentum/character_solver/point_triangle_vertex_error_function.h
+++ b/momentum/character_solver/point_triangle_vertex_error_function.h
@@ -82,6 +82,9 @@ class PointTriangleVertexErrorFunctionT : public SkeletonErrorFunctionT<T> {
   static constexpr T kPlaneWeight = PlaneErrorFunctionT<T>::kLegacyWeight;
 
   size_t getNumVertices() const;
+  [[nodiscard]] const Character& getCharacter() const {
+    return character_;
+  }
 
  private:
   double calculatePositionJacobian(

--- a/momentum/character_solver/vertex_error_function.h
+++ b/momentum/character_solver/vertex_error_function.h
@@ -82,6 +82,10 @@ class VertexErrorFunctionT : public SkeletonErrorFunctionT<T> {
   static constexpr T kPositionWeight = PositionErrorFunctionT<T>::kLegacyWeight;
   static constexpr T kPlaneWeight = PlaneErrorFunctionT<T>::kLegacyWeight;
 
+  [[nodiscard]] const Character& getCharacter() const {
+    return character_;
+  }
+
  private:
   double calculatePositionJacobian(
       const ModelParametersT<T>& modelParameters,


### PR DESCRIPTION
Summary: My first couple error functions had pretty good bounds checking but I had let it slip, adding some utility functions to make this much simpler/cleaner and ensuring checks exist for all vertex and joint index arguments.

Reviewed By: jeongseok-meta

Differential Revision: D78068615


