### PR TITLE
Adding basic slerp functionality to skel_state and quaternion.

### DIFF
--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -365,6 +365,41 @@ def blend(
     return result
 
 
+def slerp(q0: torch.Tensor, q1: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+    """
+    Perform spherical linear interpolation (slerp) between two quaternions.
+
+    :parameter q0: The starting quaternion.
+    :parameter q1: The ending quaternion.
+    :parameter t: The interpolation parameter, where 0 <= t <= 1.  t=0 corresponds to q0, t=1 corresponds to q1.
+    :return: The interpolated quaternion.
+    """
+    check(q0)
+    check(q1)
+
+    # Compute the cosine of the angle between the two quaternions
+    cos_theta = torch.einsum("...x,...x", q0, q1)[..., None]
+
+    # If the dot product is negative, the quaternions have opposite handed-ness
+    # and slerp won't take the shorter path. Fix by reversing one quaternion.
+    q1 = torch.where(cos_theta < 0, -q1, q1)
+    cos_theta = torch.abs(cos_theta)
+
+    # Use linear interpolation for very close quaternions to avoid division by zero
+    lerp_result = normalize(q1 + t * (q1 - q0))
+
+    # Calculate the angle and the sin of the angle
+    eps = 1e-4
+    theta = torch.acos(torch.clamp(cos_theta, 0, 1.0 - eps))
+    inv_sin_theta = torch.reciprocal(torch.sin(theta))
+    c0 = torch.sin((1 - t) * theta) * inv_sin_theta
+    c1 = torch.sin(t * theta) * inv_sin_theta
+
+    slerp_result = normalize(c0 * q0 + c1 * q1)
+
+    return torch.where(cos_theta > 0.9995, lerp_result, slerp_result)
+
+
 def from_two_vectors(v1: torch.Tensor, v2: torch.Tensor) -> torch.Tensor:
     """
     Construct a quaternion that rotates one vector into another.

--- a/pymomentum/skel_state.py
+++ b/pymomentum/skel_state.py
@@ -274,6 +274,28 @@ def blend(
     return torch.cat((t_blend, q_blend, s_blend), -1)
 
 
+def slerp(s0: torch.Tensor, s1: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+    """
+    Spherical linear interpolation between two skeleton states.
+
+    :parameter s0: The first skeleton state.
+    :parameter s1: The second skeleton state.
+    :parameter t: The interpolation factor, where 0 <= t <= 1.  t=0 corresponds to s0, t=1 corresponds to s1.
+    :return: The interpolated skeleton state.
+    """
+    check(s0)
+    check(s1)
+
+    t = match_leading_dimensions(t, s0)
+    t0, q0, s0 = split(s0)
+    t1, q1, s1 = split(s1)
+
+    s = (1 - t) * s0 + t * s1
+    q = quaternion.slerp(q0, q1, t)
+    t = (1 - t) * t0 + t * t1
+    return torch.cat((t, q, s), -1)
+
+
 def from_matrix(matrices: torch.Tensor) -> torch.Tensor:
     """
     Convert 4x4 matrices to skeleton states.  Assumes that the scale is uniform.


### PR DESCRIPTION
Summary: We have this blending functionality that lets you blend an arbitrary number of quaternions/skel_states.  However, it gets annoying in the most common case where you only have two: (1) the API is annoying because you have to torch.stack them into a single tensor (2) back propagation gets riskier because torch eigenvalue decomposition often produces NaNs in the gradients.  It would be nice to have a really basic slerp functionality that we can easily use to blend two quaternions/skel_states.

Reviewed By: jeongseok-meta

Differential Revision: D78105310


