### PR TITLE
fixing incorrect blendshape transform

### DIFF
--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -32,10 +32,12 @@ class CharacterUtilityTest : public ::testing::Test {
     // Create test characters with different numbers of joints
     character = createTestCharacter<float>(5);
     smallCharacter = createTestCharacter<float>(3);
+    characterWithBlendShapes = withTestBlendShapes(character);
   }
 
   Character character;
   Character smallCharacter;
+  Character characterWithBlendShapes;
 };
 
 // Test scaleCharacter function
@@ -182,7 +184,11 @@ void testTransformCharacter(const Character& character) {
 
 // Test transformCharacter function
 TEST_F(CharacterUtilityTest, TransformCharacter) {
+  // test a character without blend shapes
   testTransformCharacter(this->character);
+
+  // test a character with blend shapes
+  testTransformCharacter(this->characterWithBlendShapes);
 }
 
 // Test removeJoints function


### PR DESCRIPTION
Summary: Fixing a bug in Charachter::transformCharacter that didn't apply the correct transform to blendshapes that resulted in wrong posed meshes.

Reviewed By: jeongseok-meta

Differential Revision: D77695220


