### PR TITLE
Add read-only access to the constraints.

### DIFF
--- a/momentum/character_solver/gauss_newton_solver_qr.h
+++ b/momentum/character_solver/gauss_newton_solver_qr.h
@@ -19,7 +19,8 @@ namespace momentum {
 
 /// Gauss-Newton solver with QR decomposition specific options
 struct GaussNewtonSolverQROptions : SolverOptions {
-  /// Regularization parameter for QR decomposition.
+  /// Damping parameter added to Hessian diagonal for numerical stability; see
+  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
   float regularization = 0.05f;
 
   /// Flag to enable line search during optimization.

--- a/momentum/solver/gauss_newton_solver.h
+++ b/momentum/solver/gauss_newton_solver.h
@@ -14,7 +14,8 @@ namespace momentum {
 
 /// Extended options specific to the Gauss-Newton optimization algorithm
 struct GaussNewtonSolverOptions : SolverOptions {
-  /// Damping parameter added to Hessian diagonal for numerical stability
+  /// Damping parameter added to Hessian diagonal for numerical stability; see
+  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
   ///
   /// Higher values improve stability but may slow convergence
   float regularization = 0.05f;

--- a/momentum/solver/subset_gauss_newton_solver.h
+++ b/momentum/solver/subset_gauss_newton_solver.h
@@ -17,7 +17,8 @@ namespace momentum {
 /// Provides configuration specific to the subset-based Gauss-Newton solver
 /// that optimizes only a selected subset of parameters
 struct SubsetGaussNewtonSolverOptions : SolverOptions {
-  /// Damping parameter added to Hessian diagonal for numerical stability
+  /// Damping parameter added to Hessian diagonal for numerical stability; see
+  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
   ///
   /// Higher values improve stability but may slow convergence
   float regularization = 0.05f;

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -707,6 +707,27 @@ This is useful for camera-based constraints where you want to match a 3D point t
 }
 
 void defVertexProjectionErrorFunction(py::module_& m) {
+  py::class_<mm::VertexProjectionConstraint>(
+      m,
+      "VertexProjectionConstraint",
+      "Read-only access to a vertex projection constraint.")
+      .def_readonly(
+          "vertex_index",
+          &mm::VertexProjectionConstraint::vertexIndex,
+          "Returns the index of the vertex to project.")
+      .def_readonly(
+          "weight",
+          &mm::VertexProjectionConstraint::weight,
+          "Returns the weight of the constraint.")
+      .def_readonly(
+          "target_position",
+          &mm::VertexProjectionConstraint::targetPosition,
+          "Returns the target 2D position.")
+      .def_readonly(
+          "projection",
+          &mm::VertexProjectionConstraint::projection,
+          "Returns the 3x4 projection matrix.");
+
   py::class_<
       mm::VertexProjectionErrorFunctionT<float>,
       mm::SkeletonErrorFunction,
@@ -757,6 +778,13 @@ This is useful for camera-based constraints where you want to match a 3D vertex 
           "clear_constraints",
           &mm::VertexProjectionErrorFunctionT<float>::clearConstraints,
           "Clears all vertex projection constraints from the error function.")
+      .def_property_readonly(
+          "constraints",
+          [](const mm::VertexProjectionErrorFunctionT<float>& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of vertex projection constraints.",
+          py::return_value_policy::reference_internal)
       .def(
           "add_constraints",
           [](mm::VertexProjectionErrorFunctionT<float>& self,
@@ -1301,6 +1329,24 @@ avoid divide-by-zero. )");
           mm::VertexConstraintType::SymmetricNormal,
           "Point-to-plane using a 50/50 mix of source and target normal");
 
+  py::class_<mm::VertexConstraint>(m, "VertexConstraint")
+      .def_readonly(
+          "vertex_index",
+          &mm::VertexConstraint::vertexIndex,
+          "The index of the vertex to constrain.")
+      .def_readonly(
+          "weight",
+          &mm::VertexConstraint::weight,
+          "The weight of the constraint.")
+      .def_readonly(
+          "target_position",
+          &mm::VertexConstraint::targetPosition,
+          "The target position for the vertex.")
+      .def_readonly(
+          "target_normal",
+          &mm::VertexConstraint::targetNormal,
+          "The target normal for the vertex.");
+
   py::class_<
       mm::VertexErrorFunction,
       mm::SkeletonErrorFunction,
@@ -1405,7 +1451,13 @@ avoid divide-by-zero. )");
       .def(
           "clear_constraints",
           &mm::VertexErrorFunction::clearConstraints,
-          "Clears all vertex constraints from the error function.");
+          "Clears all vertex constraints from the error function.")
+      .def_property_readonly(
+          "constraints",
+          [](const mm::VertexErrorFunction& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of vertex constraints.");
 
   py::class_<
       mm::PointTriangleVertexErrorFunction,

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -518,6 +518,7 @@ class TestSolver(unittest.TestCase):
         vertex_error_function.add_constraint(
             vertex_index, weight, target_position, target_normal
         )
+        self.assertEqual(len(vertex_error_function.constraints), 1)
 
         # Create solver function with the vertex error
         solver_function = pym_solver2.SkeletonSolverFunction(
@@ -1188,6 +1189,7 @@ class TestSolver(unittest.TestCase):
             target_position=target_2d,
             projection=projection,
         )
+        self.assertEqual(len(vertex_projection_error_function.constraints), 1)
 
         # Create solver function with the vertex projection error
         solver_function = pym_solver2.SkeletonSolverFunction(


### PR DESCRIPTION
Summary: This is purely utility functionality in case someone wants to introspect a VertexErrorFunction.

Reviewed By: jeongseok-meta

Differential Revision: D78290388


