### PR TITLE
Add missing weight arguments to constructors.

### DIFF
--- a/momentum/character_solver/gauss_newton_solver_qr.h
+++ b/momentum/character_solver/gauss_newton_solver_qr.h
@@ -19,7 +19,8 @@ namespace momentum {
 
 /// Gauss-Newton solver with QR decomposition specific options
 struct GaussNewtonSolverQROptions : SolverOptions {
-  /// Regularization parameter for QR decomposition.
+  /// Damping parameter added to Hessian diagonal for numerical stability; see
+  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
   float regularization = 0.05f;
 
   /// Flag to enable line search during optimization.

--- a/momentum/solver/gauss_newton_solver.h
+++ b/momentum/solver/gauss_newton_solver.h
@@ -14,7 +14,8 @@ namespace momentum {
 
 /// Extended options specific to the Gauss-Newton optimization algorithm
 struct GaussNewtonSolverOptions : SolverOptions {
-  /// Damping parameter added to Hessian diagonal for numerical stability
+  /// Damping parameter added to Hessian diagonal for numerical stability; see
+  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
   ///
   /// Higher values improve stability but may slow convergence
   float regularization = 0.05f;

--- a/momentum/solver/subset_gauss_newton_solver.h
+++ b/momentum/solver/subset_gauss_newton_solver.h
@@ -17,7 +17,8 @@ namespace momentum {
 /// Provides configuration specific to the subset-based Gauss-Newton solver
 /// that optimizes only a selected subset of parameters
 struct SubsetGaussNewtonSolverOptions : SolverOptions {
-  /// Damping parameter added to Hessian diagonal for numerical stability
+  /// Damping parameter added to Hessian diagonal for numerical stability; see
+  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
   ///
   /// Higher values improve stability but may slow convergence
   float regularization = 0.05f;

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -707,6 +707,27 @@ This is useful for camera-based constraints where you want to match a 3D point t
 }
 
 void defVertexProjectionErrorFunction(py::module_& m) {
+  py::class_<mm::VertexProjectionConstraint>(
+      m,
+      "VertexProjectionConstraint",
+      "Read-only access to a vertex projection constraint.")
+      .def_readonly(
+          "vertex_index",
+          &mm::VertexProjectionConstraint::vertexIndex,
+          "Returns the index of the vertex to project.")
+      .def_readonly(
+          "weight",
+          &mm::VertexProjectionConstraint::weight,
+          "Returns the weight of the constraint.")
+      .def_readonly(
+          "target_position",
+          &mm::VertexProjectionConstraint::targetPosition,
+          "Returns the target 2D position.")
+      .def_readonly(
+          "projection",
+          &mm::VertexProjectionConstraint::projection,
+          "Returns the 3x4 projection matrix.");
+
   py::class_<
       mm::VertexProjectionErrorFunctionT<float>,
       mm::SkeletonErrorFunction,
@@ -757,6 +778,13 @@ This is useful for camera-based constraints where you want to match a 3D vertex 
           "clear_constraints",
           &mm::VertexProjectionErrorFunctionT<float>::clearConstraints,
           "Clears all vertex projection constraints from the error function.")
+      .def_property_readonly(
+          "constraints",
+          [](const mm::VertexProjectionErrorFunctionT<float>& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of vertex projection constraints.",
+          py::return_value_policy::reference_internal)
       .def(
           "add_constraints",
           [](mm::VertexProjectionErrorFunctionT<float>& self,
@@ -1301,6 +1329,24 @@ avoid divide-by-zero. )");
           mm::VertexConstraintType::SymmetricNormal,
           "Point-to-plane using a 50/50 mix of source and target normal");
 
+  py::class_<mm::VertexConstraint>(m, "VertexConstraint")
+      .def_readonly(
+          "vertex_index",
+          &mm::VertexConstraint::vertexIndex,
+          "The index of the vertex to constrain.")
+      .def_readonly(
+          "weight",
+          &mm::VertexConstraint::weight,
+          "The weight of the constraint.")
+      .def_readonly(
+          "target_position",
+          &mm::VertexConstraint::targetPosition,
+          "The target position for the vertex.")
+      .def_readonly(
+          "target_normal",
+          &mm::VertexConstraint::targetNormal,
+          "The target normal for the vertex.");
+
   py::class_<
       mm::VertexErrorFunction,
       mm::SkeletonErrorFunction,
@@ -1405,7 +1451,13 @@ avoid divide-by-zero. )");
       .def(
           "clear_constraints",
           &mm::VertexErrorFunction::clearConstraints,
-          "Clears all vertex constraints from the error function.");
+          "Clears all vertex constraints from the error function.")
+      .def_property_readonly(
+          "constraints",
+          [](const mm::VertexErrorFunction& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of vertex constraints.");
 
   py::class_<
       mm::PointTriangleVertexErrorFunction,

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -738,12 +738,15 @@ void defVertexProjectionErrorFunction(py::module_& m) {
 This is useful for camera-based constraints where you want to match a 3D vertex to a 2D observation.)")
       .def(
           py::init<>(
-              [](const mm::Character& character, size_t maxThreads)
+              [](const mm::Character& character,
+                 size_t maxThreads,
+                 float weight)
                   -> std::shared_ptr<
                       mm::VertexProjectionErrorFunctionT<float>> {
                 auto result =
                     std::make_shared<mm::VertexProjectionErrorFunctionT<float>>(
                         character, maxThreads);
+                result->setWeight(weight);
                 return result;
               }),
           R"(Initialize a VertexProjectionErrorFunction.
@@ -752,7 +755,9 @@ This is useful for camera-based constraints where you want to match a 3D vertex 
             :param max_threads: The maximum number of threads to use for computation.)",
           py::keep_alive<1, 2>(),
           py::arg("character"),
-          py::arg("max_threads") = 0)
+          py::kw_only(),
+          py::arg("max_threads") = 0,
+          py::arg("weight") = 1.0f)
       .def(
           "add_constraint",
           [](mm::VertexProjectionErrorFunctionT<float>& self,
@@ -1562,16 +1567,22 @@ avoid divide-by-zero. )");
       std::shared_ptr<mm::PosePriorErrorFunction>>(m, "PosePriorErrorFunction")
       .def(
           py::init<>([](const mm::Character& character,
-                        std::shared_ptr<const mm::Mppca> posePrior) {
-            return std::make_shared<mm::PosePriorErrorFunction>(
+                        std::shared_ptr<const mm::Mppca> posePrior,
+                        float weight) {
+            auto result = std::make_shared<mm::PosePriorErrorFunction>(
                 character, posePrior);
+            result->setWeight(weight);
+            return result;
           }),
           R"(A skeleton error function that uses a mixture of PCA models pose prior to penalize deviations from expected poses.
 
   :param character: The character to use.
-  :param pose_prior: The pose prior model to use.)",
+  :param pose_prior: The pose prior model to use.
+  :param weight: The weight applied to the error function.)",
           py::arg("character"),
-          py::arg("pose_prior"))
+          py::arg("pose_prior"),
+          py::kw_only(),
+          py::arg("weight") = 1.0f)
       .def(
           "set_pose_prior",
           &mm::PosePriorErrorFunction::setPosePrior,
@@ -1726,13 +1737,19 @@ rotation matrix to a target rotation.)")
       mm::SkeletonErrorFunction,
       std::shared_ptr<mm::CollisionErrorFunction>>(m, "CollisionErrorFunction")
       .def(
-          py::init<>([](const mm::Character& character) {
-            return std::make_shared<mm::CollisionErrorFunction>(character);
+          py::init<>([](const mm::Character& character, float weight) {
+            auto result =
+                std::make_shared<mm::CollisionErrorFunction>(character);
+            result->setWeight(weight);
+            return result;
           }),
           R"(A skeleton error function that penalizes collisions between character parts.
 
-        :param character: The character to use.)",
-          py::arg("character"))
+        :param character: The character to use.
+        :param weight: The weight applied to the error function.)",
+          py::arg("character"),
+          py::kw_only(),
+          py::arg("weight") = 1.0f)
       .def(
           "get_collision_pairs",
           [](const mm::CollisionErrorFunction& self) {

--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -47,8 +47,8 @@ PYBIND11_MODULE(solver2, m) {
       std::shared_ptr<mm::SkeletonErrorFunction>>(m, "SkeletonErrorFunction")
       .def_property(
           "weight",
-          &mm::SkeletonErrorFunction::setWeight,
-          &mm::SkeletonErrorFunction::getWeight)
+          &mm::SkeletonErrorFunction::getWeight,
+          &mm::SkeletonErrorFunction::setWeight)
       .def(
           "get_error",
           [](mm::SkeletonErrorFunction& self,

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -507,6 +507,8 @@ class TestSolver(unittest.TestCase):
         vertex_error_function = pym_solver2.VertexErrorFunction(
             character, pym_solver2.VertexConstraintType.Position
         )
+        vertex_error_function.weight = 2.0
+        self.assertAlmostEqual(vertex_error_function.weight, 2.0)
 
         # Define a vertex and its target position
         vertex_index = 0

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -518,6 +518,7 @@ class TestSolver(unittest.TestCase):
         vertex_error_function.add_constraint(
             vertex_index, weight, target_position, target_normal
         )
+        self.assertEqual(len(vertex_error_function.constraints), 1)
 
         # Create solver function with the vertex error
         solver_function = pym_solver2.SkeletonSolverFunction(
@@ -1188,6 +1189,7 @@ class TestSolver(unittest.TestCase):
             target_position=target_2d,
             projection=projection,
         )
+        self.assertEqual(len(vertex_projection_error_function.constraints), 1)
 
         # Create solver function with the vertex projection error
         solver_function = pym_solver2.SkeletonSolverFunction(


### PR DESCRIPTION
Summary: We had a couple error functions that still didn't allow passing "weight=" in the constructor.

Reviewed By: jeongseok-meta

Differential Revision: D78304532


