### PR TITLE
allow adding sequence error function to all frames

### DIFF
--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -322,6 +322,16 @@ Note that if you're trying to actually solve a problem using SGD, you should con
           py::arg("frame_idx"),
           py::arg("error_function"))
       .def(
+          "add_sequence_error_function_all_frames",
+          [](mm::SequenceSolverFunction& self,
+             std::shared_ptr<mm::SequenceErrorFunction> errorFunction) {
+            self.addSequenceErrorFunction(mm::kAllFrames, errorFunction);
+          },
+          R"(Adds an error function that spans all frames in the solver.
+
+:param error_function: The error function to add.)",
+          py::arg("error_function"))
+      .def(
           "set_enabled_parameters",
           [](mm::SequenceSolverFunction& self,
              const py::array_t<bool>& activeParams) {

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -295,7 +295,7 @@ class TestSolver(unittest.TestCase):
 
         # Add StateSequenceErrorFunction for smoothness across frames
         smoothness_error = pym_solver2.StateSequenceErrorFunction(character, weight=1.0)
-        solver_function.add_sequence_error_function(0, smoothness_error)
+        solver_function.add_sequence_error_function_all_frames(smoothness_error)
 
         # Set solver options
         solver_options = pym_solver2.SequenceSolverOptions()


### PR DESCRIPTION
Summary: Added "add_sequence_error_function_all_frames" to SequenceSolverFunction so we don't have to pass a SIZE_MAX through the python interface.

Differential Revision: D78434994


