### PR TITLE
Introspection for all constraint error functions.

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver_function.h
+++ b/momentum/character_sequence_solver/sequence_solver_function.h
@@ -85,6 +85,14 @@ class SequenceSolverFunctionT : public SolverFunctionT<T> {
     return parameterTransform_;
   }
 
+  [[nodiscard]] const auto& getErrorFunctions(size_t iFrame) const {
+    return perFrameErrorFunctions_.at(iFrame);
+  }
+
+  [[nodiscard]] const auto& getSequenceErrorFunctions(size_t iFrame) const {
+    return sequenceErrorFunctions_.at(iFrame);
+  }
+
  private:
   void setFrameParametersFromJoinedParameterVector(const Eigen::VectorX<T>& parameters);
 

--- a/momentum/character_solver/distance_error_function.h
+++ b/momentum/character_solver/distance_error_function.h
@@ -60,6 +60,10 @@ class DistanceErrorFunctionT : public momentum::SkeletonErrorFunctionT<T> {
     return constraints_.size();
   }
 
+  [[nodiscard]] const std::vector<DistanceConstraintDataT<T>>& getConstraints() const {
+    return constraints_;
+  }
+
  protected:
   // TODO: what should we use here?
   const T kDistanceWeight = 1.0f;

--- a/momentum/character_solver/projection_error_function.h
+++ b/momentum/character_solver/projection_error_function.h
@@ -71,6 +71,10 @@ class ProjectionErrorFunctionT : public momentum::SkeletonErrorFunctionT<T> {
     constraints_ = std::move(constraints);
   }
 
+  [[nodiscard]] const std::vector<ProjectionConstraintDataT<T>>& getConstraints() const {
+    return constraints_;
+  }
+
  protected:
   std::vector<ProjectionConstraintDataT<T>> constraints_;
 

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -81,6 +81,10 @@ void defAimErrorFunction(
           py::arg("alpha") = 2.0f,
           py::arg("c") = 1.0f,
           py::arg("weight") = 1.0f)
+      .def_property_readonly(
+          "constraints",
+          [](const AimErrorFunctionT& self) { return self.getConstraints(); },
+          "Returns the list of aim constraints.")
       .def(
           "add_constraint",
           [](AimErrorFunctionT& self,
@@ -248,6 +252,12 @@ void defFixedAxisError(
           py::arg("parent"),
           py::arg("weight") = 1.0f,
           py::arg("name") = std::string{})
+      .def_property_readonly(
+          "constraints",
+          [](const FixedAxisErrorFunctionT& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of fixed axis constraints.")
       .def(
           "add_constraints",
           [](FixedAxisErrorFunctionT& self,
@@ -310,6 +320,42 @@ void defFixedAxisError(
 }
 
 void defNormalErrorFunction(py::module_& m) {
+  py::class_<mm::NormalDataT<float>>(m, "NormalData")
+      .def(
+          "__repr__",
+          [](const mm::NormalDataT<float>& self) {
+            return fmt::format(
+                "NormalData(parent={}, weight={}, local_point=[{:.3f}, {:.3f}, {:.3f}], local_normal=[{:.3f}, {:.3f}, {:.3f}], global_point=[{:.3f}, {:.3f}, {:.3f}])",
+                self.parent,
+                self.weight,
+                self.localPoint.x(),
+                self.localPoint.y(),
+                self.localPoint.z(),
+                self.localNormal.x(),
+                self.localNormal.y(),
+                self.localNormal.z(),
+                self.globalPoint.x(),
+                self.globalPoint.y(),
+                self.globalPoint.z());
+          })
+      .def_readonly(
+          "parent", &mm::NormalDataT<float>::parent, "The parent joint index")
+      .def_readonly(
+          "weight",
+          &mm::NormalDataT<float>::weight,
+          "The weight of the constraint")
+      .def_readonly(
+          "local_point",
+          &mm::NormalDataT<float>::localPoint,
+          "The local point in parent space")
+      .def_readonly(
+          "local_normal",
+          &mm::NormalDataT<float>::localNormal,
+          "The local normal in parent space")
+      .def_readonly(
+          "global_point",
+          &mm::NormalDataT<float>::globalPoint,
+          "The global point");
   py::class_<
       mm::NormalErrorFunctionT<float>,
       mm::SkeletonErrorFunction,
@@ -382,6 +428,12 @@ plane defined by a local point and a local normal vector.)")
           py::arg("local_point") = std::nullopt,
           py::arg("weight") = 1.0f,
           py::arg("name") = std::string{})
+      .def_property_readonly(
+          "constraints",
+          [](const mm::NormalErrorFunctionT<float>& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of normal constraints.")
       .def(
           "add_constraints",
           [](mm::NormalErrorFunctionT<float>& self,
@@ -457,6 +509,43 @@ plane defined by a local point and a local normal vector.)")
 }
 
 void defDistanceErrorFunction(py::module_& m) {
+  py::class_<mm::DistanceConstraintDataT<float>>(m, "DistanceData")
+      .def(
+          "__repr__",
+          [](const mm::DistanceConstraintDataT<float>& self) {
+            return fmt::format(
+                "DistanceData(parent={}, weight={}, offset=[{:.3f}, {:.3f}, {:.3f}], origin=[{:.3f}, {:.3f}, {:.3f}], target={:.3f})",
+                self.parent,
+                self.weight,
+                self.offset.x(),
+                self.offset.y(),
+                self.offset.z(),
+                self.origin.x(),
+                self.origin.y(),
+                self.origin.z(),
+                self.target);
+          })
+      .def_readonly(
+          "parent",
+          &mm::DistanceConstraintDataT<float>::parent,
+          "The parent joint index")
+      .def_readonly(
+          "weight",
+          &mm::DistanceConstraintDataT<float>::weight,
+          "The weight of the constraint")
+      .def_readonly(
+          "offset",
+          &mm::DistanceConstraintDataT<float>::offset,
+          "The offset in parent space")
+      .def_readonly(
+          "origin",
+          &mm::DistanceConstraintDataT<float>::origin,
+          "The origin point in world space")
+      .def_readonly(
+          "target",
+          &mm::DistanceConstraintDataT<float>::target,
+          "The target distance");
+
   py::class_<
       mm::DistanceErrorFunctionT<float>,
       mm::SkeletonErrorFunction,
@@ -585,10 +674,48 @@ and a target distance. The constraint is defined as ||(p_joint - origin)^2 - tar
       .def(
           "num_constraints",
           &mm::DistanceErrorFunctionT<float>::numConstraints,
-          "Returns the number of constraints.");
+          "Returns the number of constraints.")
+      .def_property_readonly(
+          "constraints",
+          &mm::DistanceErrorFunctionT<float>::getConstraints,
+          "Returns the list of distance constraints.");
 }
 
 void defProjectionErrorFunction(py::module_& m) {
+  py::class_<mm::ProjectionConstraintDataT<float>>(m, "ProjectionConstraint")
+      .def(
+          "__repr__",
+          [](const mm::ProjectionConstraintDataT<float>& self) {
+            return fmt::format(
+                "ProjectionConstraint(parent={}, weight={}, offset=[{:.3f}, {:.3f}, {:.3f}], target=[{:.3f}, {:.3f}])",
+                self.parent,
+                self.weight,
+                self.offset.x(),
+                self.offset.y(),
+                self.offset.z(),
+                self.target.x(),
+                self.target.y());
+          })
+      .def_readonly(
+          "parent",
+          &mm::ProjectionConstraintDataT<float>::parent,
+          "The parent joint index")
+      .def_readonly(
+          "weight",
+          &mm::ProjectionConstraintDataT<float>::weight,
+          "The weight of the constraint")
+      .def_readonly(
+          "offset",
+          &mm::ProjectionConstraintDataT<float>::offset,
+          "The offset in parent space")
+      .def_readonly(
+          "target",
+          &mm::ProjectionConstraintDataT<float>::target,
+          "The target 2D position")
+      .def_readonly(
+          "projection",
+          &mm::ProjectionConstraintDataT<float>::projection,
+          "The 3x4 projection matrix");
   py::class_<
       mm::ProjectionErrorFunctionT<float>,
       mm::SkeletonErrorFunction,
@@ -748,7 +875,11 @@ This is useful for camera-based constraints where you want to match a 3D point t
       .def(
           "num_constraints",
           &mm::ProjectionErrorFunctionT<float>::numConstraints,
-          "Returns the number of constraints.");
+          "Returns the number of constraints.")
+      .def_property_readonly(
+          "constraints",
+          &mm::ProjectionErrorFunctionT<float>::getConstraints,
+          "Returns the list of projection constraints.");
 }
 
 void defVertexProjectionErrorFunction(py::module_& m) {
@@ -914,6 +1045,39 @@ This is useful for camera-based constraints where you want to match a 3D vertex 
 }
 
 void defPlaneErrorFunction(py::module_& m) {
+  py::class_<mm::PlaneDataT<float>>(m, "PlaneData")
+      .def(
+          "__repr__",
+          [](const mm::PlaneDataT<float>& self) {
+            return fmt::format(
+                "PlaneData(parent={}, weight={}, offset=[{:.3f}, {:.3f}, {:.3f}], normal=[{:.3f}, {:.3f}, {:.3f}], d={:.3f})",
+                self.parent,
+                self.weight,
+                self.offset.x(),
+                self.offset.y(),
+                self.offset.z(),
+                self.normal.x(),
+                self.normal.y(),
+                self.normal.z(),
+                self.d);
+          })
+      .def_readonly(
+          "parent", &mm::PlaneDataT<float>::parent, "The parent joint index")
+      .def_readonly(
+          "weight",
+          &mm::PlaneDataT<float>::weight,
+          "The weight of the constraint")
+      .def_readonly(
+          "offset",
+          &mm::PlaneDataT<float>::offset,
+          "The offset in parent space")
+      .def_readonly(
+          "normal", &mm::PlaneDataT<float>::normal, "The normal of the plane")
+      .def_readonly(
+          "d",
+          &mm::PlaneDataT<float>::d,
+          "The d parameter in the plane equation");
+
   py::class_<
       mm::PlaneErrorFunction,
       mm::SkeletonErrorFunction,
@@ -985,6 +1149,12 @@ distance is greater than zero (ie. the point being above).)")
           py::arg("parent"),
           py::arg("weight") = 1.0f,
           py::arg("name") = std::string{})
+      .def_property_readonly(
+          "constraints",
+          [](const mm::PlaneErrorFunction& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of plane constraints.")
       .def(
           "add_constraints",
           [](mm::PlaneErrorFunction& self,
@@ -1144,6 +1314,34 @@ void addErrorFunctions(py::module_& m) {
           py::arg("target_parameters"),
           py::arg("weights") = std::optional<py::array_t<float>>{});
 
+  py::class_<mm::PositionDataT<float>>(m, "PositionData")
+      .def(
+          "__repr__",
+          [](const mm::PositionDataT<float>& self) {
+            return fmt::format(
+                "PositionData(parent={}, weight={}, offset=[{:.3f}, {:.3f}, {:.3f}], target=[{:.3f}, {:.3f}, {:.3f}])",
+                self.parent,
+                self.weight,
+                self.offset.x(),
+                self.offset.y(),
+                self.offset.z(),
+                self.target.x(),
+                self.target.y(),
+                self.target.z());
+          })
+      .def_readonly(
+          "parent", &mm::PositionDataT<float>::parent, "The parent joint index")
+      .def_readonly(
+          "weight",
+          &mm::PositionDataT<float>::weight,
+          "The weight of the constraint")
+      .def_readonly(
+          "offset",
+          &mm::PositionDataT<float>::offset,
+          "The offset in parent space")
+      .def_readonly(
+          "target", &mm::PositionDataT<float>::target, "The target position");
+
   py::class_<
       mm::PositionErrorFunction,
       mm::SkeletonErrorFunction,
@@ -1215,6 +1413,12 @@ Uses a generalized loss function that support various forms of losses such as L1
           py::arg("offset") = std::nullopt,
           py::arg("weight") = 1.0f,
           py::arg("name") = std::string{})
+      .def_property_readonly(
+          "constraints",
+          [](const mm::PositionErrorFunction& self) {
+            return self.getConstraints();
+          },
+          "Returns the list of position constraints.")
       .def(
           "add_constraints",
           [](mm::PositionErrorFunction& errf,
@@ -1281,6 +1485,43 @@ Uses a generalized loss function that support various forms of losses such as L1
           py::arg("name") = std::optional<std::vector<std::string>>{});
 
   // Aim error functions
+  py::class_<mm::AimDataT<float>>(m, "AimData")
+      .def(
+          "__repr__",
+          [](const mm::AimDataT<float>& self) {
+            return fmt::format(
+                "AimData(parent={}, weight={}, local_point=[{:.3f}, {:.3f}, {:.3f}], local_dir=[{:.3f}, {:.3f}, {:.3f}], global_target=[{:.3f}, {:.3f}, {:.3f}])",
+                self.parent,
+                self.weight,
+                self.localPoint.x(),
+                self.localPoint.y(),
+                self.localPoint.z(),
+                self.localDir.x(),
+                self.localDir.y(),
+                self.localDir.z(),
+                self.globalTarget.x(),
+                self.globalTarget.y(),
+                self.globalTarget.z());
+          })
+      .def_readonly(
+          "parent", &mm::AimDataT<float>::parent, "The parent joint index")
+      .def_readonly(
+          "weight",
+          &mm::AimDataT<float>::weight,
+          "The weight of the constraint")
+      .def_readonly(
+          "local_point",
+          &mm::AimDataT<float>::localPoint,
+          "The origin of the local ray")
+      .def_readonly(
+          "local_dir",
+          &mm::AimDataT<float>::localDir,
+          "The direction of the local ray")
+      .def_readonly(
+          "global_target",
+          &mm::AimDataT<float>::globalTarget,
+          "The global aim target");
+
   defAimErrorFunction<mm::AimDistErrorFunctionT<float>>(
       m,
       "AimDistErrorFunction",
@@ -1298,6 +1539,38 @@ world-space target point.  If the vector has near-zero length, the residual is s
 avoid divide-by-zero. )");
 
   // Fixed axis error functions.
+  py::class_<mm::FixedAxisDataT<float>>(m, "FixedAxisData")
+      .def(
+          "__repr__",
+          [](const mm::FixedAxisDataT<float>& self) {
+            return fmt::format(
+                "FixedAxisData(parent={}, weight={}, local_axis=[{:.3f}, {:.3f}, {:.3f}], global_axis=[{:.3f}, {:.3f}, {:.3f}])",
+                self.parent,
+                self.weight,
+                self.localAxis.x(),
+                self.localAxis.y(),
+                self.localAxis.z(),
+                self.globalAxis.x(),
+                self.globalAxis.y(),
+                self.globalAxis.z());
+          })
+      .def_readonly(
+          "parent",
+          &mm::FixedAxisDataT<float>::parent,
+          "The parent joint index")
+      .def_readonly(
+          "weight",
+          &mm::FixedAxisDataT<float>::weight,
+          "The weight of the constraint")
+      .def_readonly(
+          "local_axis",
+          &mm::FixedAxisDataT<float>::localAxis,
+          "The local axis in parent space")
+      .def_readonly(
+          "global_axis",
+          &mm::FixedAxisDataT<float>::globalAxis,
+          "The global axis");
+
   defFixedAxisError<mm::FixedAxisDiffErrorFunctionT<float>>(
       m,
       "FixedAxisDiffErrorFunction",

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -756,6 +756,16 @@ void defVertexProjectionErrorFunction(py::module_& m) {
       m,
       "VertexProjectionConstraint",
       "Read-only access to a vertex projection constraint.")
+      .def(
+          "__repr__",
+          [](const mm::VertexProjectionConstraint& self) {
+            return fmt::format(
+                "VertexProjectionConstraint(vertex_index={}, weight={}, target_position=[{:.3f}, {:.3f}])",
+                self.vertexIndex,
+                self.weight,
+                self.targetPosition.x(),
+                self.targetPosition.y());
+          })
       .def_readonly(
           "vertex_index",
           &mm::VertexProjectionConstraint::vertexIndex,
@@ -841,8 +851,7 @@ This is useful for camera-based constraints where you want to match a 3D vertex 
           [](const mm::VertexProjectionErrorFunctionT<float>& self) {
             return self.getConstraints();
           },
-          "Returns the list of vertex projection constraints.",
-          py::return_value_policy::reference_internal)
+          "Returns the list of vertex projection constraints.")
       .def(
           "add_constraints",
           [](mm::VertexProjectionErrorFunctionT<float>& self,
@@ -1423,6 +1432,17 @@ avoid divide-by-zero. )");
           "Point-to-plane using a 50/50 mix of source and target normal");
 
   py::class_<mm::VertexConstraint>(m, "VertexConstraint")
+      .def(
+          "__repr__",
+          [](const mm::VertexConstraint& self) {
+            return fmt::format(
+                "VertexConstraint(vertex_index={}, weight={}, target_position=[{:.3f}, {:.3f}, {:.3f}])",
+                self.vertexIndex,
+                self.weight,
+                self.targetPosition.x(),
+                self.targetPosition.y(),
+                self.targetPosition.z());
+          })
       .def_readonly(
           "vertex_index",
           &mm::VertexConstraint::vertexIndex,

--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -288,6 +288,10 @@ Note that if you're trying to actually solve a problem using SGD, you should con
           [](mm::SequenceSolverFunction& self,
              int iFrame,
              std::shared_ptr<mm::SkeletonErrorFunction> errorFunction) {
+            if (iFrame < 0 || iFrame >= self.getNumFrames()) {
+              throw py::index_error(
+                  fmt::format("Invalid frame index {}", iFrame));
+            }
             self.addErrorFunction(iFrame, errorFunction);
           },
           R"(Adds an error function that applies to a single frame to the solver.
@@ -313,6 +317,10 @@ Note that if you're trying to actually solve a problem using SGD, you should con
           [](mm::SequenceSolverFunction& self,
              int iFrame,
              std::shared_ptr<mm::SequenceErrorFunction> errorFunction) {
+            if (iFrame < 0 || iFrame >= self.getNumFrames()) {
+              throw py::index_error(
+                  fmt::format("Invalid frame index {}", iFrame));
+            }
             self.addSequenceErrorFunction(iFrame, errorFunction);
           },
           R"(Adds an error function that spans multiple frames in the solver.
@@ -341,7 +349,35 @@ Note that if you're trying to actually solve a problem using SGD, you should con
           R"(Sets the active model parameters for the solver.  The array should be of size `character.parameter_transform.size()` and applies to every frame of the solve.
 
 :param active_parameters: Numpy array of length num of model params.)",
-          py::arg("active_parameters"));
+          py::arg("active_parameters"))
+      .def(
+          "get_error_functions",
+          [](const mm::SequenceSolverFunction& self, int frameIdx) {
+            if (frameIdx < 0 || frameIdx >= self.getNumFrames()) {
+              throw py::index_error(
+                  fmt::format("Invalid frame index {}", frameIdx));
+            }
+            return self.getErrorFunctions(frameIdx);
+          },
+          R"(Returns the per-frame error functions for a given frame.
+          
+          Note that this is read-only; appending to this list will not affect the SequenceErrorFunction,
+          use :func:`add_error_function` instead.)",
+          py::arg("frame_idx"))
+      .def(
+          "get_sequence_error_functions",
+          [](const mm::SequenceSolverFunction& self, int frameIdx) {
+            if (frameIdx < 0 || frameIdx >= self.getNumFrames()) {
+              throw py::index_error(
+                  fmt::format("Invalid frame index {}", frameIdx));
+            }
+            return self.getSequenceErrorFunctions(frameIdx);
+          },
+          R"(Returns the sequence error functions.
+          
+          Note that this is read-only; appending to this list will not affect the SequenceErrorFunction,
+          use :func:`add_sequence_error_function` instead.)",
+          py::arg("frame_idx"));
 
   // Solver options:
   py::class_<mm::SolverOptions, std::shared_ptr<mm::SolverOptions>>(


### PR DESCRIPTION
Summary: For debugging it's sometimes useful to be able to look at the constraints and see what's stored in there, so add read-only access through a "constraints" property.

Differential Revision: D78503690


