### PR TITLE
save glb will save scaling parameters to motion

### DIFF
--- a/momentum/marker_tracking/app_utils.cpp
+++ b/momentum/marker_tracking/app_utils.cpp
@@ -188,15 +188,21 @@ void saveMotion(
     Eigen::MatrixXf& finalMotion,
     gsl::span<const std::vector<momentum::Marker>> markerData,
     const double fps,
-    const bool saveMarkerMesh) {
+    const bool saveMarkerMesh,
+    const bool saveScaleToMotion) {
+  const filesystem::path output(outFile);
+  const auto ext = output.extension();
+
   ModelParameters id =
       extractParameters(identity, character.parameterTransform.getScalingParameters());
+
+  if (saveScaleToMotion) {
+    id = ModelParameters::Zero(character.parameterTransform.numAllModelParameters());
+  }
   // gltf io assumes the identity info is removed from the motion matrix
   removeIdentity(character.parameterTransform.getScalingParameters(), id, finalMotion);
   const VectorXf idVec = character.parameterTransform.apply(id).v;
 
-  const filesystem::path output(outFile);
-  const auto ext = output.extension();
   if (ext == ".fbx") {
     saveFbx(output, character, finalMotion, idVec, fps, saveMarkerMesh);
   } else if (ext == ".glb" || ext == ".gltf") {

--- a/momentum/marker_tracking/app_utils.h
+++ b/momentum/marker_tracking/app_utils.h
@@ -38,6 +38,18 @@ std::tuple<momentum::Character, momentum::ModelParameters> loadCalibratedModel(
 std::tuple<momentum::Character, momentum::ModelParameters> loadCharacterWithIdentity(
     const ModelOptions& modelFiles);
 
+/// Save the given character and motion to a GLB or FBX file.
+///
+/// @param[in] outFile The GLB/FBX file to save to
+/// @param[in] character The GLB/FBX file to save to
+/// @param[in] identity The identity parameters used for the character
+/// @param[in] finalMotion The motion save to the file. (Note: this may be modified to remove
+/// scaling parameters if saveScaleToMotion is false)
+/// @param[in] markerData Marker data to save to the file
+/// @param[in] fps Framerate of the motion
+/// @param[in] saveMarkerMesh (optional) Whether to save a visible cube mesh for the markers
+/// @param[in] saveScaleToMotion (optional) Whether to save the scale parameters to the motion or
+/// identity parameter vectors (saving to motion is preferred)
 void saveMotion(
     const std::string& outFile,
     const momentum::Character& character,
@@ -45,6 +57,7 @@ void saveMotion(
     Eigen::MatrixXf& finalMotion,
     gsl::span<const std::vector<momentum::Marker>> markerData,
     double fps,
-    bool saveMarkerMesh = true);
+    bool saveMarkerMesh = true,
+    bool saveScaleToMotion = true);
 
 } // namespace momentum


### PR DESCRIPTION
Summary:
The previous saveMotion for the marker tools still saved the identity as joint parameters in the identity vector. This breaks with in some models where we have two model parameters that influence the same things and the inverse transform from joint parameter identity to model parameters can't correctly split the values up again, thus putting some identity values into pose parameters, which breaks tracking afterwards.

This added a flag to the saveModel function to allow either storing things the old way or (as default) store the scaling parameters in the modelparameter vector directly.

Differential Revision: D79284000


