### PR TITLE
Add missing copyright headers to solver2

### DIFF
--- a/pymomentum/solver2/solver2_error_functions.h
+++ b/pymomentum/solver2/solver2_error_functions.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <pybind11/numpy.h>

--- a/pymomentum/solver2/solver2_sequence_error_functions.h
+++ b/pymomentum/solver2/solver2_sequence_error_functions.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <pybind11/numpy.h>

--- a/pymomentum/solver2/solver2_utility.h
+++ b/pymomentum/solver2/solver2_utility.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <momentum/character/character.h>


### PR DESCRIPTION
Summary:
To fix the Copyright Headers issue in https://www.internalfb.com/intern/opensource/github/repo/1177373580261769/checkup/:

{F1980844184}

Differential Revision: D79451243


