### PR TITLE
Use PAT to bypass branch-protection for update-pixi PR

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BYPASS_TOKEN }}
           commit-message: Update pixi lockfile
           title: Update pixi lockfile
           body-path: diff.md


### PR DESCRIPTION
Summary: Update the create-pull-request action's token input from `GITHUB_TOKEN` to `BYPASS_TOKEN`, which has "bypass required status checks" permission. This enables auto-generated `update-pixi` branch pushes without waiting for "Meta CLA Check". See https://github.com/facebookresearch/momentum/actions/runs/16666841667.

Differential Revision: D79453122
