### PR TITLE
Use PAT to bypass branch-protection for website deployment

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -79,6 +79,6 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: JamesIves/github-pages-deploy-action@releases/v4
       with:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.BYPASS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: momentum/website/build


### PR DESCRIPTION
Summary:
Update the GitHub Pages deployment action's token from `GITHUB_TOKEN` to `BYPASS_TOKEN` in the publish_website.yml workflow. This enables the website deployment to bypass branch protection rules on the `gh-pages` branch, similar to the fix applied in D79453122 for the update-pixi workflow.

The `BYPASS_TOKEN` has "bypass required status checks" permission, which prevents deployment failures when branch protection rules are enforced on the target branch.

Differential Revision: D79460052
