### PR TITLE
Fix flaky USD test by improving plugin initialization and error handling

### DIFF
--- a/momentum/io/usd/usd_io.cpp
+++ b/momentum/io/usd/usd_io.cpp
@@ -41,6 +41,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -101,8 +102,23 @@ void initializeUsdWithSuppressedWarnings() {
   g_suppressor = std::make_unique<ResolverWarningsSuppressor>();
   TfDiagnosticMgr::GetInstance().AddDelegate(g_suppressor.get());
 
-  g_usdPluginInit =
-      std::make_unique<UsdPluginInit>(filesystem::temp_directory_path() / "usd_plugin");
+  // Create a unique temporary directory for USD plugins to avoid conflicts
+  // Use thread ID and timestamp to ensure uniqueness across concurrent tests
+  auto tempDir = filesystem::temp_directory_path();
+  auto uniqueDir = tempDir /
+      ("usd_plugin_" + std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id())) +
+       "_" + std::to_string(std::time(nullptr)));
+
+  // Ensure the directory exists and is writable
+  std::error_code ec;
+  filesystem::create_directories(uniqueDir, ec);
+  if (ec) {
+    // If we can't create the directory, fall back to default temp directory
+    // This allows USD to handle its own plugin initialization
+    g_usdPluginInit = std::make_unique<UsdPluginInit>();
+  } else {
+    g_usdPluginInit = std::make_unique<UsdPluginInit>(uniqueDir);
+  }
 
   g_usdInitialized = true;
 }

--- a/momentum/test/io/io_usd_test.cpp
+++ b/momentum/test/io/io_usd_test.cpp
@@ -104,23 +104,31 @@ TEST_F(UsdIoTest, LoadCharacterWithMaterials) {
 }
 
 TEST_F(UsdIoTest, SaveAndLoadRoundTrip) {
-  // Create a temporary file for testing
-  auto tempFile = temporaryFile("test_usd", ".usda");
+  // Create a temporary file for testing with a more unique name
+  auto tempFile = temporaryFile("momentum_usd_roundtrip", ".usda");
 
-  // Save the test character
-  saveUsd(tempFile.path(), testCharacter);
+  try {
+    // Save the test character
+    saveUsd(tempFile.path(), testCharacter);
 
-  // Load it back
-  const auto loadedCharacter = loadUsdCharacter(tempFile.path());
+    // Verify the file was created
+    ASSERT_TRUE(filesystem::exists(tempFile.path()))
+        << "USD file was not created at: " << tempFile.path();
 
-  // Verify the loaded character matches the original
-  EXPECT_EQ(loadedCharacter.skeleton.joints.size(), testCharacter.skeleton.joints.size());
-  EXPECT_EQ(loadedCharacter.mesh->vertices.size(), testCharacter.mesh->vertices.size());
-  EXPECT_EQ(loadedCharacter.mesh->faces.size(), testCharacter.mesh->faces.size());
+    // Load it back
+    const auto loadedCharacter = loadUsdCharacter(tempFile.path());
 
-  // Verify joint names are preserved
-  for (size_t i = 0; i < testCharacter.skeleton.joints.size(); ++i) {
-    EXPECT_EQ(loadedCharacter.skeleton.joints[i].name, testCharacter.skeleton.joints[i].name);
+    // Verify the loaded character matches the original
+    EXPECT_EQ(loadedCharacter.skeleton.joints.size(), testCharacter.skeleton.joints.size());
+    EXPECT_EQ(loadedCharacter.mesh->vertices.size(), testCharacter.mesh->vertices.size());
+    EXPECT_EQ(loadedCharacter.mesh->faces.size(), testCharacter.mesh->faces.size());
+
+    // Verify joint names are preserved
+    for (size_t i = 0; i < testCharacter.skeleton.joints.size(); ++i) {
+      EXPECT_EQ(loadedCharacter.skeleton.joints[i].name, testCharacter.skeleton.joints[i].name);
+    }
+  } catch (const std::exception& e) {
+    FAIL() << "USD save/load round trip failed with exception: " << e.what();
   }
 }
 


### PR DESCRIPTION
Summary:
* USD Plugin Initialization (`usd_io.cpp`): Create unique temp directories using thread ID and timestamp to avoid conflicts, add proper error handling for directory creation with a fallback to default USD initialization.
* Test Robustness (`io_usd_test.cpp`): Use descriptive temporary file names, add exception handling with detailed error messages, and verify file existence before loading USD files.

Differential Revision: D79490808


