### PR TITLE
Fix glb output of identity

### DIFF
--- a/momentum/marker_tracking/app_utils.h
+++ b/momentum/marker_tracking/app_utils.h
@@ -57,7 +57,6 @@ void saveMotion(
     Eigen::MatrixXf& finalMotion,
     gsl::span<const std::vector<momentum::Marker>> markerData,
     double fps,
-    bool saveMarkerMesh = true,
-    bool saveScaleToMotion = true);
+    bool saveMarkerMesh = true);
 
 } // namespace momentum

--- a/momentum/marker_tracking/tracker_utils.h
+++ b/momentum/marker_tracking/tracker_utils.h
@@ -47,6 +47,12 @@ void fillIdentity(
     const momentum::ModelParameters& identity,
     Eigen::MatrixXf& motion);
 
+// convert from joint to model parameters using only the parameters active in idSet
+ModelParameters jointIdentityToModelIdentity(
+    const Character& c,
+    const ParameterSet& idSet,
+    const JointParameters& jointIdentity);
+
 void removeIdentity(
     const momentum::ParameterSet& idSet,
     const momentum::ModelParameters& identity,


### PR DESCRIPTION
Summary:
This reverts some changes made in a prior commit to store the identity in the motion vector of GLBs. This could cause problems in cases where no motion is stored but only an identity.

Instead when loading a GLB we now ensure to only map the identity back to scaling parameters to ensure there's no inconsistency.

Reviewed By: jeongseok-meta

Differential Revision: D79733284


