### PR TITLE
fix flipped assignment for position constraints

### DIFF
--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -1392,8 +1392,8 @@ Uses a generalized loss function that support various forms of losses such as L1
              const std::string& name) {
             validateJointIndex(parent, "parent", errf.getSkeleton());
             errf.addConstraint(mm::PositionData(
-                target,
                 offset.value_or(Eigen::Vector3f::Zero()),
+                target,
                 parent,
                 weight,
                 name));
@@ -1418,6 +1418,10 @@ Uses a generalized loss function that support various forms of losses such as L1
             return self.getConstraints();
           },
           "Returns the list of position constraints.")
+      .def(
+          "clear_constraints",
+          [](mm::PositionErrorFunction& self) { self.clearConstraints(); },
+          "Clears all constraints from the error function.")
       .def(
           "add_constraints",
           [](mm::PositionErrorFunction& errf,

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -43,6 +43,24 @@ class TestSolver(unittest.TestCase):
         )
 
         pos_error = pym_solver2.PositionErrorFunction(character)
+
+        pos_error.add_constraint(
+            parent=0,
+            offset=np.array([1.0, 0.0, 0.0]),
+            target=np.array([10.0, 0.0, 0.0]),
+            weight=1.0,
+        )
+        self.assertTrue(len(pos_error.constraints) == 1)
+        self.assertTrue(
+            np.isclose(pos_error.constraints[0].offset, [1.0, 0.0, 0.0]).all()
+        )
+        self.assertTrue(
+            np.isclose(pos_error.constraints[0].target, [10.0, 0.0, 0.0]).all()
+        )
+
+        pos_error.clear_constraints()
+        self.assertTrue(len(pos_error.constraints) == 0)
+
         pos_error.add_constraints(
             parent=np.arange(n_joints), target=skel_state_target[:, :3].numpy()
         )


### PR DESCRIPTION
Summary:
The add_constraint function for the position error function in solver2 accidentally flipped the assignment of offset and target.

also added clear_constraints() function while at it.

Differential Revision: D79921053


