### PR TITLE
Disable clang-tidy rule performance-enum-size under arvr/libraries/momentum/

### DIFF
--- a/momentum/.clang-tidy
+++ b/momentum/.clang-tidy
@@ -7,6 +7,7 @@
 InheritParentConfig: true
 Checks: '
 performance-*,
+-performance-enum-size,
 '
 
 CheckOptions:


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**This diff was generated by Racer AI agent on behalf of [Jeongseok Lee](https://www.internalfb.com/profile/view/100000682172784) for T233975338. If the diff quality is poor, consider contacting the user to provide clearer instructions on the task.**

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
This diff disables the clang-tidy rule `performance-enum-size` across multiple `.clang-tidy` files under the `arvr/` directory. The rule flags when the smallest possible datatype size is not used for enums, but reducing enum underlying types can lead to alignment issues, type safety concerns, and ABI compatibility problems.

The changes were made by updating `.clang-tidy` files that enable all performance rules (`performance-*`) to explicitly disable `performance-enum-size` by adding `-performance-enum-size,` to their checks configuration.

This addresses the review comment to rebase to master and ensures the clang-tidy configuration is properly updated across the arvr libraries including momentum, perception, vectorix, and other components.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=65713d6c-74bb-11f0-8c11-eaa9b4770ba7&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=65713d6c-74bb-11f0-8c11-eaa9b4770ba7&tab=Trace)

Differential Revision: D79901381


