### PR TITLE
Remove unused exception parameter from arvr/libraries/mapping_data_contract/MapChunkGraphRecord.cpp

### DIFF
--- a/momentum/test/common/exception_test.cpp
+++ b/momentum/test/common/exception_test.cpp
@@ -26,7 +26,7 @@ TEST(ExceptionTest, ThrowImplNoArguments) {
   try {
     detail::throwImpl<std::bad_array_new_length>();
     FAIL() << "Expected std::bad_array_new_length";
-  } catch (const std::bad_array_new_length& e) {
+  } catch (const std::bad_array_new_length&) {
     EXPECT_TRUE(true) << "std::bad_array_new_length thrown as expected";
   } catch (...) {
     FAIL() << "Caught unexpected exception type";


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D79968933


