### PR TITLE
Fix USD plugin directory conflicts in parallel tests

### DIFF
--- a/momentum/io/usd/usd_io.cpp
+++ b/momentum/io/usd/usd_io.cpp
@@ -110,8 +110,8 @@ void initializeUsdWithSuppressedWarnings() {
   for (const auto& pathName : fixedPaths) {
     pluginDir = tempDir / pathName;
     std::error_code ec;
-    filesystem::create_directories(pluginDir, ec);
-    if (!ec) {
+    // Use create_directory (not create_directories) to fail if directory exists
+    if (filesystem::create_directory(pluginDir, ec) && !ec) {
       pluginDirCreated = true;
       break;
     }


### PR DESCRIPTION
Summary: Fix USD plugin initialization failures that occurred during parallel test execution. The issue was caused by multiple processes trying to initialize the same plugin directory simultaneously, leading to corrupted plugin JSON files and "Failed to find plugin for ArDefaultResolver" errors.

Differential Revision: D80023433


