### PR TITLE
Fix flaky tests by adding missing random seeds

### DIFF
--- a/pymomentum/test/test_blend_shape.py
+++ b/pymomentum/test/test_blend_shape.py
@@ -23,6 +23,7 @@ def _build_blend_shape_basis(
     base_shape = c.mesh.vertices
     n_pts = base_shape.shape[0]
     n_blend = 4
+    np.random.seed(0)
     shape_vectors = np.random.rand(n_blend, n_pts, 3)
     blend_shape = pym_geometry.BlendShape.from_tensors(base_shape, shape_vectors)
     return blend_shape

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -670,6 +670,7 @@ class TestSolver(unittest.TestCase):
 
         # Ensure repeatability in the rng:
         torch.manual_seed(0)
+        np.random.seed(0)
         model_params_init = torch.zeros(n_params, dtype=torch.float32)
 
         def _normalize_vec(vec: npt.NDArray) -> npt.NDArray:
@@ -735,6 +736,7 @@ class TestSolver(unittest.TestCase):
 
         # Ensure repeatability in the rng:
         torch.manual_seed(0)
+        np.random.seed(0)
         model_params_init = torch.zeros(n_params, dtype=torch.float32)
 
         # Define local and global axes
@@ -940,6 +942,7 @@ class TestSolver(unittest.TestCase):
 
         # Ensure repeatability in the rng:
         torch.manual_seed(0)
+        np.random.seed(0)
         model_params_init = torch.zeros(n_params, dtype=torch.float32)
 
         # Define offset and target quaternions


### PR DESCRIPTION
Summary:
Fix flaky test failures in pymomentum by adding consistent random seeding to tests that use np.random but don't set seeds.

The main issue was in test_save_load_gltf_character_with_motion_from_skel_states which used np.random.random() to generate test data without a fixed seed, causing occasional numerical precision issues with torch.allclose() assertions.

Changes:
- Added np.random.seed(0) to test methods in test_gltf.py that use random data generation
- Added missing np.random.seed(0) to three test functions in test_solver2.py that were using torch.manual_seed(0) but missing np.random seeding
- Added np.random.seed(0) to _build_blend_shape_basis helper function in test_blend_shape.py
- Used seed value 0 consistently to match existing codebase patterns

All tests now have deterministic, reproducible behavior and the flaky test failures are resolved.

Differential Revision: D80203404


