### PR TITLE
Stop overwriting the mean shape in a blend shape basis.

### DIFF
--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -600,21 +600,24 @@ CharacterParameters CharacterT<T>::splitParameters(
 
 template <typename T>
 CharacterT<T> CharacterT<T>::withBlendShape(
-    BlendShape_p blendShape_in,
-    Eigen::Index maxBlendShapes,
-    const bool overwriteBaseShape) const {
+    BlendShape_const_p blendShape_in,
+    Eigen::Index maxBlendShapes) const {
   CharacterT<T> result = *this;
-  result.addBlendShape(blendShape_in, maxBlendShapes, overwriteBaseShape);
+  result.addBlendShape(blendShape_in, maxBlendShapes);
   return result;
 }
 
 template <typename T>
 void CharacterT<T>::addBlendShape(
-    const BlendShape_p& blendShape_in,
-    Eigen::Index maxBlendShapes,
-    const bool overwriteBaseShape) {
+    const BlendShape_const_p& blendShape_in,
+    Eigen::Index maxBlendShapes) {
   MT_CHECK(this->mesh);
-  MT_CHECK(blendShape_in);
+  if (!blendShape_in) {
+    std::tie(parameterTransform, parameterLimits) =
+        addBlendShapeParameters(parameterTransform, parameterLimits, 0);
+    this->blendShape.reset();
+    return;
+  }
 
   // TODO should we accommodate passing in a BlendShape with "extra" vertices (for the
   // higher subdivision levels)?
@@ -623,12 +626,6 @@ void CharacterT<T>::addBlendShape(
       "{} is not {}",
       blendShape_in->modelSize(),
       this->mesh->vertices.size());
-
-  if (overwriteBaseShape) {
-    // We need to use the base shape from the mesh rather than the one that's stored in the file.
-    // TODO (fbogo): Check if this operation is actually meaningful.
-    blendShape_in->setBaseShape(this->mesh->vertices);
-  }
 
   blendShape = blendShape_in;
 

--- a/momentum/character/character.h
+++ b/momentum/character/character.h
@@ -204,12 +204,10 @@ struct CharacterT {
   ///
   /// @param blendShape_in Blend shapes to add to the character
   /// @param maxBlendShapes Maximum number of blend shape parameters to add (use all if <= 0)
-  /// @param overwriteBaseShape Whether to set the blend shape base to the character's mesh
   /// @return A new character with the specified blend shapes
   [[nodiscard]] CharacterT withBlendShape(
-      BlendShape_p blendShape_in,
-      Eigen::Index maxBlendShapes,
-      bool overwriteBaseShape = true) const;
+      BlendShape_const_p blendShape_in,
+      Eigen::Index maxBlendShapes) const;
 
   /// Creates a new character with the specified face expression blend shapes
   ///
@@ -224,11 +222,7 @@ struct CharacterT {
   ///
   /// @param blendShape_in Blend shapes to add to the character
   /// @param maxBlendShapes Maximum number of blend shape parameters to add (use all if <= 0)
-  /// @param overwriteBaseShape Whether to set the blend shape base to the character's mesh
-  void addBlendShape(
-      const BlendShape_p& blendShape_in,
-      Eigen::Index maxBlendShapes,
-      bool overwriteBaseShape = true);
+  void addBlendShape(const BlendShape_const_p& blendShape_in, Eigen::Index maxBlendShapes);
 
   /// Adds face expression blend shapes to this character
   ///

--- a/momentum/test/character/character_test.cpp
+++ b/momentum/test/character/character_test.cpp
@@ -884,8 +884,7 @@ TYPED_TEST(CharacterTest, WithBlendShape) {
   // Note: The implementation doesn't set the second parameter to -1, it's still 0
   // EXPECT_EQ(characterWithLimitedBlendShape.parameterTransform.blendShapeParameters(1), -1);
 
-  // Test with overwriteBaseShape = false
-  CharacterType characterWithoutOverwrite = this->character.withBlendShape(blendShape, 2, false);
+  CharacterType characterWithoutOverwrite = this->character.withBlendShape(blendShape, 2);
 
   // Check that the blend shape was set correctly
   EXPECT_TRUE(characterWithoutOverwrite.blendShape);
@@ -950,9 +949,8 @@ TYPED_TEST(CharacterTest, AddBlendShape) {
   // Note: The implementation doesn't set the second parameter to -1, it's still 0
   // EXPECT_EQ(modifiedCharacter2.parameterTransform.blendShapeParameters(1), -1);
 
-  // Test with overwriteBaseShape = false
   CharacterType modifiedCharacter3 = this->character;
-  modifiedCharacter3.addBlendShape(blendShape, 2, false);
+  modifiedCharacter3.addBlendShape(blendShape, 2);
 
   // Check that the blend shape was set correctly
   EXPECT_TRUE(modifiedCharacter3.blendShape);

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -135,7 +135,7 @@ PYBIND11_MODULE(geometry, m) {
   // - joint_parameter_limits
   // - [constructor](name, skeleton, parameter_transform, locators)
   // - with_mesh_and_skin_weights(mesh, skin_weights)
-  // - with_blend_shape(blend_shape, n_shapes, overwrite_base_shape)
+  // - with_blend_shape(blend_shape, n_shapes)
   //
   // [memeber methods]
   // - pose_mesh(jointParams)
@@ -350,24 +350,20 @@ PYBIND11_MODULE(geometry, m) {
       .def(
           "with_blend_shape",
           [](const mm::Character& c,
-             std::shared_ptr<mm::BlendShape> blendShape,
-             int nShapes,
-             bool overwriteBaseShape) {
+             const std::optional<mm::BlendShape_const_p>& blendShape,
+             int nShapes) {
             return c.withBlendShape(
-                blendShape,
-                nShapes < 0 ? INT_MAX : nShapes,
-                overwriteBaseShape);
+                blendShape.value_or(mm::BlendShape_const_p{}),
+                nShapes < 0 ? INT_MAX : nShapes);
           },
           R"(Returns a character that uses the parameter transform to control the passed-in blend shape basis.
 It can be used to solve for shapes and pose simultaneously.
 
 :param blend_shape: Blend shape basis.
 :param n_shapes: Max blend shapes to retain.  Pass -1 to keep all of them (but warning: the default allgender basis is quite large with hundreds of shapes).
-:param overwrite_base_shape: Whether to overwrite the base shape with the rest mesh of the character.
 )",
           py::arg("blend_shape"),
-          py::arg("n_shapes") = -1,
-          py::arg("overwrite_base_shape") = true)
+          py::arg("n_shapes") = -1)
       .def(
           "with_collision_geometry",
           [](const mm::Character& c,

--- a/pymomentum/test/test_blend_shape.py
+++ b/pymomentum/test/test_blend_shape.py
@@ -20,10 +20,10 @@ from pymomentum.solver import ErrorFunctionType
 def _build_blend_shape_basis(
     c: pym_geometry.Character,
 ) -> pym_geometry.BlendShape:
-    base_shape = c.mesh.vertices
-    n_pts = base_shape.shape[0]
-    n_blend = 4
     np.random.seed(0)
+    n_pts = c.mesh.n_vertices
+    base_shape = np.random.rand(n_pts, 3)
+    n_blend = 4
     shape_vectors = np.random.rand(n_blend, n_pts, 3)
     blend_shape = pym_geometry.BlendShape.from_tensors(base_shape, shape_vectors)
     return blend_shape
@@ -75,6 +75,17 @@ class TestBlendShape(unittest.TestCase):
         bp1 = params[c2.parameter_transform.blend_shape_parameters]
         bp2 = pym_geometry.model_parameters_to_blend_shape_coefficients(c2, params)
         self.assertTrue(bp1.allclose(bp2))
+
+        blend_shape_2 = c2.blend_shape
+        self.assertTrue(blend_shape_2 is not None)
+        self.assertTrue(
+            np.allclose(blend_shape_2.shape_vectors, blend_shape.shape_vectors)
+        )
+        self.assertTrue(np.allclose(blend_shape_2.base_shape, blend_shape.base_shape))
+
+        c3 = c.with_blend_shape(None)
+        self.assertTrue(c3.blend_shape is None)
+        self.assertTrue(torch.sum(c3.parameter_transform.blend_shape_parameters) == 0)
 
     def test_save_and_load(self) -> None:
         torch.manual_seed(0)  # ensure repeatability


### PR DESCRIPTION
Summary:
Apparently it was my idea to add this, but I now think it's a terrible idea: having the blend shape basis change when you pass it in violates the principle of least astonishment and is almost certainly never what you want.

This allows us to fix these functions to be const-correct.

Also support removing the blend shape from a character (by passing in None).

Reviewed By: jeongseok-meta, fbogo

Differential Revision: D78744907


