### PR TITLE
Add parser for legacy json format.

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -473,6 +473,18 @@ io_urdf_test_sources = [
     "test/io/io_urdf_test.cpp",
 ]
 
+io_legacy_json_public_headers = [
+    "io/legacy_json/legacy_json_io.h",
+]
+
+io_legacy_json_sources = [
+    "io/legacy_json/legacy_json_io.cpp",
+]
+
+io_legacy_json_test_sources = [
+    "test/io/io_legacy_json_test.cpp",
+]
+
 io_motion_public_headers = [
     "io/motion/mmo_io.h",
 ]

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -23,7 +23,8 @@ structs = [
     "BlendShape",
     "BlendShapeBase",
     "PoseShape",
-    "SkinWeights"
+    "SkinWeights",
+    "Locator",
 ]
 template_structs = [
     "Character",

--- a/momentum/io/legacy_json/legacy_json_io.cpp
+++ b/momentum/io/legacy_json/legacy_json_io.cpp
@@ -1,0 +1,560 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/legacy_json/legacy_json_io.h"
+
+#include <momentum/character/character.h>
+#include <momentum/character/collision_geometry.h>
+#include <momentum/character/joint.h>
+#include <momentum/character/locator.h>
+#include <momentum/character/parameter_transform.h>
+#include <momentum/character/skeleton.h>
+#include <momentum/character/skin_weights.h>
+#include <momentum/character/types.h>
+#include <momentum/common/exception.h>
+#include <momentum/io/common/stream_utils.h>
+#include <momentum/math/mesh.h>
+#include <momentum/math/transform.h>
+#include <momentum/math/types.h>
+
+#include <fstream>
+#include <sstream>
+
+namespace momentum {
+
+namespace {
+
+/// Helper function to convert Vector3 to JSON array
+template <typename T>
+nlohmann::json eigenToJsonArray(const Eigen::Matrix<T, 3, 1>& vec) {
+  return nlohmann::json::array({vec.x(), vec.y(), vec.z()});
+}
+
+/// Helper function to convert Vector2 to JSON array
+template <typename T>
+nlohmann::json eigenToJsonArray(const Eigen::Matrix<T, 2, 1>& vec) {
+  return nlohmann::json::array({vec.x(), vec.y()});
+}
+
+/// Helper function to convert Quaternion to JSON array (w, x, y, z)
+template <typename T>
+nlohmann::json eigenToJsonArray(const Eigen::Quaternion<T>& quat) {
+  return nlohmann::json::array({quat.x(), quat.y(), quat.z(), quat.w()});
+}
+
+/// Helper function to convert Transform to JSON object
+template <typename T>
+nlohmann::json transformToJson(const TransformT<T>& transform) {
+  nlohmann::json j;
+
+  // Extract translation
+  j["Translation"] = eigenToJsonArray(transform.translation);
+
+  // Extract rotation as quaternion
+  j["Rotation"] = eigenToJsonArray(transform.rotation);
+
+  // Extract scale
+  j["Scale"] = transform.scale;
+
+  return j;
+}
+
+/// Helper function to convert JSON array to Vector3
+template <typename T>
+Eigen::Matrix<T, 3, 1> jsonArrayToEigenVector3(const nlohmann::json& j) {
+  MT_THROW_IF(j.size() != 3, "Expected array of size 3 for Vector3");
+  return Eigen::Matrix<T, 3, 1>(j[0].get<T>(), j[1].get<T>(), j[2].get<T>());
+}
+
+/// Helper function to convert JSON array to Vector2
+template <typename T>
+Eigen::Matrix<T, 2, 1> jsonArrayToEigenVector2(const nlohmann::json& j) {
+  MT_THROW_IF(j.size() != 2, "Expected array of size 2 for Vector2");
+  return Eigen::Matrix<T, 2, 1>(j[0].get<T>(), j[1].get<T>());
+}
+
+/// Helper function to convert JSON array to Quaternion (w, x, y, z)
+template <typename T>
+Eigen::Quaternion<T> jsonArrayToEigenQuaternion(const nlohmann::json& j) {
+  MT_THROW_IF(j.size() != 4, "Expected array of size 4 for Quaternion");
+  // Eigen constructor takes (w, x, y, z); json storage is (x, y, z, w)
+  return Eigen::Quaternion<T>(j[3].get<T>(), j[0].get<T>(), j[1].get<T>(), j[2].get<T>());
+}
+
+/// Helper function to convert JSON object to Transform
+template <typename T>
+TransformT<T> jsonToTransform(const nlohmann::json& j) {
+  TransformT<T> transform; // Identity by default
+
+  if (j.contains("Translation")) {
+    transform.translation = jsonArrayToEigenVector3<T>(j["Translation"]);
+  }
+
+  if (j.contains("Rotation")) {
+    transform.rotation = jsonArrayToEigenQuaternion<T>(j["Rotation"]);
+  }
+
+  if (j.contains("Scale")) {
+    transform.scale = j["Scale"].get<T>();
+  }
+
+  return transform;
+}
+
+Skeleton legacySkeletonToMomentum(const nlohmann::json& legacySkeleton) {
+  MT_THROW_IF(!legacySkeleton.contains("Bones"), "Legacy skeleton JSON missing 'Bones' field");
+
+  const auto& bones = legacySkeleton["Bones"];
+  JointList joints;
+  joints.reserve(bones.size());
+
+  for (const auto& boneJson : bones) {
+    Joint joint;
+
+    // Extract joint name
+    joint.name = boneJson["Name"].get<std::string>();
+
+    // Extract parent index
+    joint.parent = boneJson["Parent"].get<size_t>();
+
+    // Extract pre-rotation quaternion
+    if (boneJson.contains("PreRotation")) {
+      joint.preRotation = jsonArrayToEigenQuaternion<float>(boneJson["PreRotation"]);
+    } else {
+      joint.preRotation = Eigen::Quaternionf::Identity();
+    }
+
+    // Extract translation offset
+    if (boneJson.contains("TranslationOffset")) {
+      joint.translationOffset = jsonArrayToEigenVector3<float>(boneJson["TranslationOffset"]);
+    } else {
+      joint.translationOffset = Eigen::Vector3f::Zero();
+    }
+
+    joints.push_back(joint);
+  }
+
+  return Skeleton(joints);
+}
+
+nlohmann::json momentumSkeletonToLegacy(const Skeleton& skeleton) {
+  nlohmann::json legacySkeleton;
+  nlohmann::json bones = nlohmann::json::array();
+
+  for (const auto& joint : skeleton.joints) {
+    nlohmann::json boneJson;
+
+    boneJson["Name"] = joint.name;
+    boneJson["Parent"] = joint.parent;
+    boneJson["PreRotation"] = eigenToJsonArray(joint.preRotation);
+    boneJson["TranslationOffset"] = eigenToJsonArray(joint.translationOffset);
+
+    // Add default values for legacy compatibility
+    boneJson["RestState"] = nlohmann::json{
+        {"Rot", nlohmann::json::array({0.0, 0.0, 0.0})},
+        {"Trans", nlohmann::json::array({0.0, 0.0, 0.0})},
+        {"Scale", 0.0}};
+
+    // Determine joint type
+    if (joint.parent == kInvalidIndex) {
+      boneJson["JointType"] = "Root";
+    } else {
+      boneJson["JointType"] = "Limb";
+    }
+
+    boneJson["RotationOrder"] = "XYZ";
+
+    bones.push_back(boneJson);
+  }
+
+  legacySkeleton["Bones"] = bones;
+  return legacySkeleton;
+}
+
+std::pair<Mesh, SkinWeights> legacySkinnedModelToMomentum(
+    const nlohmann::json& legacySkinnedModel) {
+  Mesh mesh;
+  SkinWeights skinWeights;
+
+  // Extract vertices
+  if (legacySkinnedModel.contains("vertices")) {
+    const auto& vertices = legacySkinnedModel["vertices"];
+    mesh.vertices.reserve(vertices.size());
+    for (const auto& vertex : vertices) {
+      mesh.vertices.push_back(jsonArrayToEigenVector3<float>(vertex));
+    }
+  }
+
+  // Extract normals
+  if (legacySkinnedModel.contains("normals")) {
+    const auto& normals = legacySkinnedModel["normals"];
+    mesh.normals.reserve(normals.size());
+    for (const auto& normal : normals) {
+      mesh.normals.push_back(jsonArrayToEigenVector3<float>(normal));
+    }
+  }
+
+  // Extract faces
+  if (legacySkinnedModel.contains("faces")) {
+    const auto& faces = legacySkinnedModel["faces"];
+    mesh.faces.reserve(faces.size());
+    for (const auto& face : faces) {
+      MT_THROW_IF(face.size() != 3, "Expected triangular faces");
+      mesh.faces.emplace_back(face[0].get<int>(), face[1].get<int>(), face[2].get<int>());
+    }
+  }
+
+  // Extract texture coordinates
+  if (legacySkinnedModel.contains("texcoords")) {
+    const auto& texcoords = legacySkinnedModel["texcoords"];
+    mesh.texcoords.reserve(texcoords.size());
+    for (const auto& texcoord : texcoords) {
+      mesh.texcoords.push_back(jsonArrayToEigenVector2<float>(texcoord));
+    }
+  }
+
+  // Extract texture coordinate faces
+  if (legacySkinnedModel.contains("texcoord_faces")) {
+    const auto& texcoordFaces = legacySkinnedModel["texcoord_faces"];
+    mesh.texcoord_faces.reserve(texcoordFaces.size());
+    for (const auto& face : texcoordFaces) {
+      MT_THROW_IF(face.size() != 3, "Expected triangular texture coordinate faces");
+      mesh.texcoord_faces.emplace_back(face[0].get<int>(), face[1].get<int>(), face[2].get<int>());
+    }
+  }
+
+  // Extract skin weights
+  if (legacySkinnedModel.contains("skinWeights")) {
+    const auto& skinWeightsJson = legacySkinnedModel["skinWeights"];
+
+    if (skinWeightsJson.contains("indices") && skinWeightsJson.contains("weights")) {
+      const auto& indices = skinWeightsJson["indices"];
+      const auto& weights = skinWeightsJson["weights"];
+
+      const size_t numVertices = indices.size();
+      skinWeights.index = IndexMatrix::Zero(numVertices, kMaxSkinJoints);
+      skinWeights.weight = WeightMatrix::Zero(numVertices, kMaxSkinJoints);
+
+      for (size_t i = 0; i < numVertices; ++i) {
+        const auto& vertexIndices = indices[i];
+        const auto& vertexWeights = weights[i];
+
+        const size_t numInfluences =
+            std::min(vertexIndices.size(), static_cast<size_t>(kMaxSkinJoints));
+        for (size_t j = 0; j < numInfluences; ++j) {
+          skinWeights.index(i, j) = vertexIndices[j].get<uint32_t>();
+          skinWeights.weight(i, j) = vertexWeights[j].get<float>();
+        }
+      }
+    }
+  }
+
+  return std::make_pair(std::move(mesh), std::move(skinWeights));
+}
+
+nlohmann::json momentumSkinnedModelToLegacy(const Mesh& mesh, const SkinWeights& skinWeights) {
+  nlohmann::json legacySkinnedModel;
+
+  // Convert vertices
+  nlohmann::json vertices = nlohmann::json::array();
+  for (const auto& vertex : mesh.vertices) {
+    vertices.push_back(eigenToJsonArray(vertex));
+  }
+  legacySkinnedModel["vertices"] = vertices;
+
+  // Convert normals
+  if (!mesh.normals.empty()) {
+    nlohmann::json normals = nlohmann::json::array();
+    for (const auto& normal : mesh.normals) {
+      normals.push_back(eigenToJsonArray(normal));
+    }
+    legacySkinnedModel["normals"] = normals;
+  }
+
+  // Convert faces
+  nlohmann::json faces = nlohmann::json::array();
+  for (const auto& face : mesh.faces) {
+    faces.push_back(nlohmann::json::array({face.x(), face.y(), face.z()}));
+  }
+  legacySkinnedModel["faces"] = faces;
+
+  // Convert texture coordinates
+  if (!mesh.texcoords.empty()) {
+    nlohmann::json texcoords = nlohmann::json::array();
+    for (const auto& texcoord : mesh.texcoords) {
+      texcoords.push_back(eigenToJsonArray(texcoord));
+    }
+    legacySkinnedModel["texcoords"] = texcoords;
+  }
+
+  // Convert texture coordinate faces
+  if (!mesh.texcoord_faces.empty()) {
+    nlohmann::json texcoordFaces = nlohmann::json::array();
+    for (const auto& face : mesh.texcoord_faces) {
+      texcoordFaces.push_back(nlohmann::json::array({face.x(), face.y(), face.z()}));
+    }
+    legacySkinnedModel["texcoord_faces"] = texcoordFaces;
+  }
+
+  // Convert skin weights
+  nlohmann::json skinWeightsJson;
+  nlohmann::json indices = nlohmann::json::array();
+  nlohmann::json weights = nlohmann::json::array();
+
+  for (int i = 0; i < skinWeights.index.rows(); ++i) {
+    nlohmann::json vertexIndices = nlohmann::json::array();
+    nlohmann::json vertexWeights = nlohmann::json::array();
+
+    for (int j = 0; j < skinWeights.index.cols(); ++j) {
+      if (skinWeights.weight(i, j) > 0.0f) {
+        vertexIndices.push_back(skinWeights.index(i, j));
+        vertexWeights.push_back(skinWeights.weight(i, j));
+      }
+    }
+
+    indices.push_back(vertexIndices);
+    weights.push_back(vertexWeights);
+  }
+
+  skinWeightsJson["indices"] = indices;
+  skinWeightsJson["weights"] = weights;
+  legacySkinnedModel["skinWeights"] = skinWeightsJson;
+
+  return legacySkinnedModel;
+}
+
+CollisionGeometry legacyCollisionToMomentum(const nlohmann::json& legacyCollision) {
+  CollisionGeometry collision;
+
+  if (legacyCollision.is_array()) {
+    collision.reserve(legacyCollision.size());
+
+    for (const auto& capsuleJson : legacyCollision) {
+      TaperedCapsule capsule;
+
+      if (capsuleJson.contains("transformation")) {
+        TransformT<float> transform = jsonToTransform<float>(capsuleJson["transformation"]);
+        capsule.transformation = transform.toAffine3();
+      }
+
+      if (capsuleJson.contains("radius")) {
+        capsule.radius = jsonArrayToEigenVector2<float>(capsuleJson["radius"]);
+      }
+
+      if (capsuleJson.contains("parent")) {
+        capsule.parent = capsuleJson["parent"].get<size_t>();
+      }
+
+      if (capsuleJson.contains("length")) {
+        capsule.length = capsuleJson["length"].get<float>();
+      }
+
+      collision.push_back(capsule);
+    }
+  }
+
+  return collision;
+}
+
+nlohmann::json momentumCollisionToLegacy(const CollisionGeometry& collision) {
+  nlohmann::json legacyCollision = nlohmann::json::array();
+
+  for (const auto& capsule : collision) {
+    nlohmann::json capsuleJson;
+
+    TransformT<float> transform = TransformT<float>::fromAffine3(capsule.transformation);
+    capsuleJson["transformation"] = transformToJson(transform);
+    capsuleJson["radius"] = eigenToJsonArray(capsule.radius);
+    capsuleJson["parent"] = capsule.parent;
+    capsuleJson["length"] = capsule.length;
+
+    legacyCollision.push_back(capsuleJson);
+  }
+
+  return legacyCollision;
+}
+
+LocatorList legacyLocatorsToMomentum(const nlohmann::json& legacyLocators) {
+  LocatorList locators;
+
+  if (legacyLocators.is_array()) {
+    locators.reserve(legacyLocators.size());
+
+    for (const auto& locatorJson : legacyLocators) {
+      Locator locator;
+
+      if (locatorJson.contains("name")) {
+        locator.name = locatorJson["name"].get<std::string>();
+      }
+
+      if (locatorJson.contains("parent")) {
+        locator.parent = locatorJson["parent"].get<size_t>();
+      }
+
+      if (locatorJson.contains("offset")) {
+        locator.offset = jsonArrayToEigenVector3<float>(locatorJson["offset"]);
+      } else if (
+          locatorJson.contains("offsetX") && locatorJson.contains("offsetY") &&
+          locatorJson.contains("offsetZ")) {
+        // Legacy format with separate X, Y, Z fields
+        locator.offset = Eigen::Vector3f(
+            locatorJson["offsetX"].get<float>(),
+            locatorJson["offsetY"].get<float>(),
+            locatorJson["offsetZ"].get<float>());
+      }
+
+      // Set default values for other fields
+      locator.locked = Eigen::Vector3i::Zero();
+      locator.weight = 1.0f;
+      locator.limitOrigin = locator.offset;
+      locator.limitWeight = Eigen::Vector3f::Zero();
+
+      locators.push_back(locator);
+    }
+  }
+
+  return locators;
+}
+
+nlohmann::json momentumLocatorsToLegacy(const LocatorList& locators) {
+  nlohmann::json legacyLocators = nlohmann::json::array();
+
+  for (const auto& locator : locators) {
+    nlohmann::json locatorJson;
+
+    locatorJson["name"] = locator.name;
+    locatorJson["parent"] = locator.parent;
+    locatorJson["offsetX"] = locator.offset.x();
+    locatorJson["offsetY"] = locator.offset.y();
+    locatorJson["offsetZ"] = locator.offset.z();
+
+    legacyLocators.push_back(locatorJson);
+  }
+
+  return legacyLocators;
+}
+
+/// Helper function to find field names with multiple possible variants
+nlohmann::json::const_iterator findFieldNames(
+    const nlohmann::json& json,
+    const std::initializer_list<const char*>& names) {
+  for (const auto& name : names) {
+    auto itr = json.find(name);
+    if (itr != json.end()) {
+      return itr;
+    }
+  }
+  return json.end();
+}
+
+} // namespace
+
+Character loadCharacterFromLegacyJson(const std::string& jsonPath) {
+  std::ifstream file(jsonPath);
+  MT_THROW_IF(!file.is_open(), "Failed to open legacy JSON file: {}", jsonPath);
+
+  nlohmann::json j;
+  file >> j;
+
+  return loadCharacterFromLegacyJsonString(j.dump());
+}
+
+Character loadCharacterFromLegacyJsonBuffer(gsl::span<const std::byte> jsonBuffer) {
+  std::string jsonString(reinterpret_cast<const char*>(jsonBuffer.data()), jsonBuffer.size());
+  return loadCharacterFromLegacyJsonString(jsonString);
+}
+
+Character loadCharacterFromLegacyJsonString(const std::string& jsonString) {
+  nlohmann::json j = nlohmann::json::parse(jsonString);
+
+  // Extract skeleton - support multiple naming variants for backward compatibility
+  auto skeletonItr = findFieldNames(j, {"Skeleton", "BodySkeleton", "skeleton"});
+  MT_THROW_IF(skeletonItr == j.end(), "Legacy JSON missing skeleton field");
+  Skeleton skeleton = legacySkeletonToMomentum(*skeletonItr);
+
+  // Create default parameter transform
+  ParameterTransform parameterTransform =
+      ParameterTransform::empty(skeleton.joints.size() * kParametersPerJoint);
+
+  // Extract mesh and skin weights if present - support multiple naming variants
+  std::unique_ptr<Mesh> mesh;
+  std::unique_ptr<SkinWeights> skinWeights;
+
+  auto skinnedModelItr = findFieldNames(j, {"SkinnedModel", "BodySkinnedModel", "skinnedmodel"});
+  if (skinnedModelItr != j.end()) {
+    auto [meshData, skinWeightsData] = legacySkinnedModelToMomentum(*skinnedModelItr);
+    mesh = std::make_unique<Mesh>(std::move(meshData));
+    skinWeights = std::make_unique<SkinWeights>(std::move(skinWeightsData));
+  }
+
+  // Extract collision geometry if present - support multiple naming variants
+  std::unique_ptr<CollisionGeometry> collision;
+  auto collisionItr = findFieldNames(j, {"Collision", "collision"});
+  if (collisionItr != j.end()) {
+    CollisionGeometry collisionData = legacyCollisionToMomentum(*collisionItr);
+    if (!collisionData.empty()) {
+      collision = std::make_unique<CollisionGeometry>(std::move(collisionData));
+    }
+  }
+
+  // Extract locators if present - support multiple naming variants
+  LocatorList locators;
+  auto locatorsItr = findFieldNames(j, {"Locators", "locators"});
+  if (locatorsItr != j.end()) {
+    locators = legacyLocatorsToMomentum(*locatorsItr);
+  }
+
+  // Create and return the character
+  return {
+      skeleton,
+      parameterTransform,
+      ParameterLimits(), // Default parameter limits
+      locators,
+      mesh.get(),
+      skinWeights.get(),
+      collision.get()};
+}
+
+void saveCharacterToLegacyJson(const Character& character, const std::string& jsonPath) {
+  nlohmann::json j = characterToLegacyJson(character);
+
+  std::ofstream file(jsonPath);
+  MT_THROW_IF(!file.is_open(), "Failed to open file for writing: {}", jsonPath);
+
+  file << j.dump(2); // Pretty print with 2-space indentation
+}
+
+std::string characterToLegacyJsonString(const Character& character) {
+  nlohmann::json j = characterToLegacyJson(character);
+  return j.dump(2);
+}
+
+nlohmann::json characterToLegacyJson(const Character& character) {
+  nlohmann::json j;
+
+  // Convert skeleton - use capitalized naming to match BasicBodyProfile
+  j["Skeleton"] = momentumSkeletonToLegacy(character.skeleton);
+
+  // Convert mesh and skin weights if present - use capitalized naming to match BasicBodyProfile
+  if (character.mesh && character.skinWeights) {
+    j["SkinnedModel"] = momentumSkinnedModelToLegacy(*character.mesh, *character.skinWeights);
+  }
+
+  // Convert collision geometry if present
+  if (character.collision && !character.collision->empty()) {
+    j["Collision"] = momentumCollisionToLegacy(*character.collision);
+  }
+
+  // Convert locators if present
+  if (!character.locators.empty()) {
+    j["Locators"] = momentumLocatorsToLegacy(character.locators);
+  }
+
+  return j;
+}
+
+} // namespace momentum

--- a/momentum/io/legacy_json/legacy_json_io.h
+++ b/momentum/io/legacy_json/legacy_json_io.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/character/collision_geometry.h>
+#include <momentum/character/fwd.h>
+#include <momentum/character/locator.h>
+#include <momentum/math/fwd.h>
+
+#include <nlohmann/json.hpp>
+#include <gsl/span>
+#include <string>
+
+namespace momentum {
+
+/// Loads a Character from a legacy JSON format that was previously used by mopy (and some
+/// other tools).
+///
+/// The legacy JSON format contains:
+/// - "skeleton": FBX skeleton structure with joints, hierarchy, and transforms
+/// - "skinnedmodel": Mesh data with skinning weights
+/// - "collision": Optional collision geometry (tapered capsules)
+///
+/// @param[in] jsonPath Path to the legacy JSON file
+/// @return The loaded Character object
+/// @throws std::runtime_error if the file cannot be loaded or parsed
+[[nodiscard]] Character loadCharacterFromLegacyJson(const std::string& jsonPath);
+
+/// Loads a Character from a legacy JSON buffer.
+///
+/// @param[in] jsonBuffer Buffer containing the legacy JSON data
+/// @return The loaded Character object
+/// @throws std::runtime_error if the buffer cannot be parsed
+[[nodiscard]] Character loadCharacterFromLegacyJsonBuffer(gsl::span<const std::byte> jsonBuffer);
+
+/// Loads a Character from a legacy JSON string.
+///
+/// @param[in] jsonString String containing the legacy JSON data
+/// @return The loaded Character object
+/// @throws std::runtime_error if the string cannot be parsed
+[[nodiscard]] Character loadCharacterFromLegacyJsonString(const std::string& jsonString);
+
+/// Saves a Character to legacy JSON format.
+///
+/// This function converts a momentum::Character back to the legacy JSON format
+/// for compatibility with existing tools and workflows.
+///
+/// @param[in] character The Character to save
+/// @param[in] jsonPath Path where to save the legacy JSON file
+/// @throws std::runtime_error if the file cannot be written
+void saveCharacterToLegacyJson(const Character& character, const std::string& jsonPath);
+
+/// Converts a Character to legacy JSON string.
+///
+/// @param[in] character The Character to convert
+/// @return String containing the legacy JSON representation
+[[nodiscard]] std::string characterToLegacyJsonString(const Character& character);
+
+/// Converts a Character to legacy JSON object.
+///
+/// @param[in] character The Character to convert
+/// @return nlohmann::json object containing the legacy JSON representation
+[[nodiscard]] nlohmann::json characterToLegacyJson(const Character& character);
+
+} // namespace momentum

--- a/momentum/test/io/io_legacy_json_test.cpp
+++ b/momentum/test/io/io_legacy_json_test.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/legacy_json/legacy_json_io.h"
+
+#include "momentum/character/character.h"
+#include "momentum/character/collision_geometry.h"
+#include "momentum/character/locator.h"
+#include "momentum/character/skeleton.h"
+#include "momentum/character/skin_weights.h"
+#include "momentum/math/mesh.h"
+#include "momentum/test/character/character_helpers_gtest.h"
+#include "momentum/test/io/io_helpers.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace momentum;
+
+class LegacyJsonIOTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a simple test character
+    testCharacter_ = createTestCharacter();
+  }
+
+  static Character createTestCharacter() {
+    // Create a simple skeleton with 3 joints
+    JointList joints;
+
+    // Root joint
+    Joint root;
+    root.name = "root";
+    root.parent = kInvalidIndex;
+    root.preRotation = Eigen::Quaternionf::Identity();
+    root.translationOffset = Eigen::Vector3f(0.0f, 0.0f, 0.0f);
+    joints.push_back(root);
+
+    // Child joint 1
+    Joint child1;
+    child1.name = "child1";
+    child1.parent = 0;
+    child1.preRotation = Eigen::Quaternionf::Identity();
+    child1.translationOffset = Eigen::Vector3f(1.0f, 0.0f, 0.0f);
+    joints.push_back(child1);
+
+    // Child joint 2
+    Joint child2;
+    child2.name = "child2";
+    child2.parent = 1;
+    child2.preRotation = Eigen::Quaternionf::Identity();
+    child2.translationOffset = Eigen::Vector3f(0.0f, 1.0f, 0.0f);
+    joints.push_back(child2);
+
+    Skeleton skeleton(joints);
+
+    // Create a simple mesh
+    auto mesh = std::make_unique<Mesh>();
+    mesh->vertices = {
+        Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+        Eigen::Vector3f(1.0f, 0.0f, 0.0f),
+        Eigen::Vector3f(0.0f, 1.0f, 0.0f)};
+    mesh->faces = {Eigen::Vector3i(0, 1, 2)};
+    mesh->normals = {
+        Eigen::Vector3f(0.0f, 0.0f, 1.0f),
+        Eigen::Vector3f(0.0f, 0.0f, 1.0f),
+        Eigen::Vector3f(0.0f, 0.0f, 1.0f)};
+
+    // Create skin weights
+    auto skinWeights = std::make_unique<SkinWeights>();
+    skinWeights->index = IndexMatrix::Zero(3, kMaxSkinJoints);
+    skinWeights->weight = WeightMatrix::Zero(3, kMaxSkinJoints);
+
+    // Simple skinning: each vertex influenced by one joint
+    skinWeights->index(0, 0) = 0;
+    skinWeights->weight(0, 0) = 1.0f;
+    skinWeights->index(1, 0) = 1;
+    skinWeights->weight(1, 0) = 1.0f;
+    skinWeights->index(2, 0) = 2;
+    skinWeights->weight(2, 0) = 1.0f;
+
+    // Create locators
+    LocatorList locators;
+    Locator locator;
+    locator.name = "test_locator";
+    locator.parent = 0;
+    locator.offset = Eigen::Vector3f(0.5f, 0.5f, 0.5f);
+    locator.locked = Eigen::Vector3i::Zero();
+    locator.weight = 1.0f;
+    locator.limitOrigin = locator.offset;
+    locator.limitWeight = Eigen::Vector3f::Zero();
+    locators.push_back(locator);
+
+    // Create collision geometry
+    auto collision = std::make_unique<CollisionGeometry>();
+    TaperedCapsule capsule;
+    capsule.transformation = Eigen::Affine3f::Identity();
+    capsule.radius = Eigen::Vector2f(0.1f, 0.05f);
+    capsule.parent = 0;
+    capsule.length = 1.0f;
+    collision->push_back(capsule);
+
+    // Create parameter transform
+    ParameterTransform parameterTransform =
+        ParameterTransform::empty(skeleton.joints.size() * kParametersPerJoint);
+
+    return {
+        skeleton,
+        parameterTransform,
+        ParameterLimits(),
+        locators,
+        mesh.get(),
+        skinWeights.get(),
+        collision.get()};
+  }
+
+  Character testCharacter_;
+};
+
+TEST_F(LegacyJsonIOTest, RoundTripConversion) {
+  // Convert character to legacy JSON
+  nlohmann::json legacyJson = characterToLegacyJson(testCharacter_);
+
+  // Verify the JSON structure
+  EXPECT_TRUE(legacyJson.contains("Skeleton"));
+  EXPECT_TRUE(legacyJson.contains("SkinnedModel"));
+  EXPECT_TRUE(legacyJson.contains("Collision"));
+  EXPECT_TRUE(legacyJson.contains("Locators"));
+
+  // Convert back to character
+  Character roundTripCharacter = loadCharacterFromLegacyJsonString(legacyJson.dump());
+
+  // Verify skeleton structure
+  EXPECT_EQ(roundTripCharacter.skeleton.joints.size(), testCharacter_.skeleton.joints.size());
+
+  for (size_t i = 0; i < testCharacter_.skeleton.joints.size(); ++i) {
+    const auto& originalJoint = testCharacter_.skeleton.joints[i];
+    const auto& roundTripJoint = roundTripCharacter.skeleton.joints[i];
+
+    EXPECT_EQ(originalJoint.name, roundTripJoint.name);
+    EXPECT_EQ(originalJoint.parent, roundTripJoint.parent);
+    EXPECT_TRUE(originalJoint.preRotation.isApprox(roundTripJoint.preRotation, 1e-5f));
+    EXPECT_TRUE(originalJoint.translationOffset.isApprox(roundTripJoint.translationOffset, 1e-5f));
+  }
+
+  // Verify mesh data
+  ASSERT_NE(roundTripCharacter.mesh, nullptr);
+  EXPECT_EQ(roundTripCharacter.mesh->vertices.size(), testCharacter_.mesh->vertices.size());
+  EXPECT_EQ(roundTripCharacter.mesh->faces.size(), testCharacter_.mesh->faces.size());
+
+  // Verify locators
+  EXPECT_EQ(roundTripCharacter.locators.size(), testCharacter_.locators.size());
+  if (!roundTripCharacter.locators.empty()) {
+    const auto& originalLocator = testCharacter_.locators[0];
+    const auto& roundTripLocator = roundTripCharacter.locators[0];
+
+    EXPECT_EQ(originalLocator.name, roundTripLocator.name);
+    EXPECT_EQ(originalLocator.parent, roundTripLocator.parent);
+    EXPECT_TRUE(originalLocator.offset.isApprox(roundTripLocator.offset, 1e-5f));
+  }
+
+  // Verify collision geometry
+  ASSERT_NE(roundTripCharacter.collision, nullptr);
+  EXPECT_EQ(roundTripCharacter.collision->size(), testCharacter_.collision->size());
+}
+
+TEST_F(LegacyJsonIOTest, SkeletonOnlyConversion) {
+  // Create a character with only skeleton data
+  Character skeletonOnlyCharacter(
+      testCharacter_.skeleton,
+      testCharacter_.parameterTransform,
+      testCharacter_.parameterLimits,
+      LocatorList(),
+      nullptr,
+      nullptr,
+      nullptr);
+
+  // Convert to legacy JSON
+  nlohmann::json legacyJson = characterToLegacyJson(skeletonOnlyCharacter);
+
+  // Should only contain skeleton
+  EXPECT_TRUE(legacyJson.contains("Skeleton"));
+  EXPECT_FALSE(legacyJson.contains("SkinnedModel"));
+  EXPECT_FALSE(legacyJson.contains("Collision"));
+  EXPECT_FALSE(legacyJson.contains("Locators"));
+
+  // Convert back
+  Character roundTripCharacter = loadCharacterFromLegacyJsonString(legacyJson.dump());
+
+  // Verify skeleton is preserved
+  EXPECT_EQ(
+      roundTripCharacter.skeleton.joints.size(), skeletonOnlyCharacter.skeleton.joints.size());
+  EXPECT_EQ(roundTripCharacter.mesh, nullptr);
+  EXPECT_EQ(roundTripCharacter.skinWeights, nullptr);
+  EXPECT_EQ(roundTripCharacter.collision, nullptr);
+  EXPECT_TRUE(roundTripCharacter.locators.empty());
+}
+
+TEST_F(LegacyJsonIOTest, InvalidJsonHandling) {
+  // Test with invalid JSON
+  EXPECT_THROW((void)loadCharacterFromLegacyJsonString("invalid json"), std::exception);
+
+  // Test with JSON missing required fields
+  nlohmann::json invalidJson;
+  invalidJson["not_skeleton"] = "invalid";
+  EXPECT_THROW((void)loadCharacterFromLegacyJsonString(invalidJson.dump()), std::runtime_error);
+}
+
+TEST_F(LegacyJsonIOTest, StringConversion) {
+  // Convert to string
+  std::string jsonString = characterToLegacyJsonString(testCharacter_);
+
+  // Verify it's valid JSON
+  nlohmann::json parsedJson;
+  EXPECT_NO_THROW(parsedJson = nlohmann::json::parse(jsonString));
+
+  // Convert back from string
+  Character roundTripCharacter = loadCharacterFromLegacyJsonString(jsonString);
+
+  // Verify structure is preserved
+  EXPECT_EQ(roundTripCharacter.skeleton.joints.size(), testCharacter_.skeleton.joints.size());
+}
+
+TEST_F(LegacyJsonIOTest, BufferOperations) {
+  // Convert to string first
+  std::string jsonString = characterToLegacyJsonString(testCharacter_);
+
+  // Create buffer
+  std::vector<std::byte> buffer(jsonString.size());
+  std::memcpy(buffer.data(), jsonString.data(), jsonString.size());
+
+  // Load from buffer
+  Character loadedCharacter = loadCharacterFromLegacyJsonBuffer(gsl::span<const std::byte>(buffer));
+
+  // Verify loaded character
+  EXPECT_EQ(loadedCharacter.skeleton.joints.size(), testCharacter_.skeleton.joints.size());
+}
+
+TEST_F(LegacyJsonIOTest, LegacyLocatorFormat) {
+  // Test legacy locator format with separate X, Y, Z fields
+  nlohmann::json legacyJson;
+  legacyJson["skeleton"]["Bones"] = nlohmann::json::array();
+
+  // Add a simple bone
+  nlohmann::json bone;
+  bone["Name"] = "root";
+  bone["Parent"] = SIZE_MAX;
+  bone["PreRotation"] = nlohmann::json::array({1.0, 0.0, 0.0, 0.0}); // w, x, y, z
+  bone["TranslationOffset"] = nlohmann::json::array({0.0, 0.0, 0.0});
+  bone["RestState"] = nlohmann::json{
+      {"Rot", nlohmann::json::array({0.0, 0.0, 0.0})},
+      {"Trans", nlohmann::json::array({0.0, 0.0, 0.0})},
+      {"Scale", 0.0}};
+  bone["JointType"] = "Root";
+  bone["RotationOrder"] = "XYZ";
+  legacyJson["skeleton"]["Bones"].push_back(bone);
+
+  // Add legacy format locator
+  legacyJson["locators"] = nlohmann::json::array();
+  nlohmann::json locator;
+  locator["name"] = "legacy_locator";
+  locator["parent"] = 0;
+  locator["offsetX"] = 1.0f;
+  locator["offsetY"] = 2.0f;
+  locator["offsetZ"] = 3.0f;
+  legacyJson["locators"].push_back(locator);
+
+  // Load character
+  Character character = loadCharacterFromLegacyJsonString(legacyJson.dump());
+
+  // Verify locator was loaded correctly
+  EXPECT_EQ(character.locators.size(), 1);
+  const auto& loadedLocator = character.locators[0];
+  EXPECT_EQ(loadedLocator.name, "legacy_locator");
+  EXPECT_EQ(loadedLocator.parent, 0);
+  EXPECT_FLOAT_EQ(loadedLocator.offset.x(), 1.0f);
+  EXPECT_FLOAT_EQ(loadedLocator.offset.y(), 2.0f);
+  EXPECT_FLOAT_EQ(loadedLocator.offset.z(), 3.0f);
+}


### PR DESCRIPTION
Summary: This format dates back to the early days of mopy, when there was no support for either fbx or GLTF.  It's been deprecated for a while but a lot of people are still using the old format, and to facilitate their ability to transition over to pymomentum we'd like to support reading it.

Reviewed By: jeongseok-meta

Differential Revision: D80818717


