### PR TITLE
Add skinned locators to parameter transform.

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -167,6 +167,7 @@ character_public_headers = [
     "character/locator.h",
     "character/marker.h",
     "character/pose_shape.h",
+    "character/skinned_locator.h",
     "character/skin_weights.h",
 ]
 

--- a/momentum/character/character.h
+++ b/momentum/character/character.h
@@ -13,6 +13,7 @@
 #include <momentum/character/parameter_limits.h>
 #include <momentum/character/parameter_transform.h>
 #include <momentum/character/skeleton.h>
+#include <momentum/character/skinned_locator.h>
 #include <momentum/character/types.h>
 #include <momentum/math/fwd.h>
 
@@ -38,6 +39,9 @@ struct CharacterT {
 
   /// Points of interest attached to joints
   LocatorList locators;
+
+  /// Points of interest attached to joints, with skinning weights
+  SkinnedLocatorList skinnedLocators;
 
   /// 3D mesh representing the character's surface
   Mesh_u mesh;
@@ -100,7 +104,8 @@ struct CharacterT {
       BlendShape_const_p blendShapes = {},
       BlendShapeBase_const_p faceExpressionBlendShapes = {},
       const std::string& nameIn = "",
-      const momentum::TransformationList& inverseBindPose = {});
+      const momentum::TransformationList& inverseBindPose = {},
+      const SkinnedLocatorList& skinnedLocators = {});
 
   /// Copy constructor
   CharacterT(const CharacterT& c);
@@ -157,6 +162,10 @@ struct CharacterT {
   /// @return Remapped locators for the simplified character
   [[nodiscard]] LocatorList remapLocators(
       const LocatorList& locs,
+      const CharacterT& originalCharacter) const;
+
+  [[nodiscard]] SkinnedLocatorList remapSkinnedLocators(
+      const SkinnedLocatorList& locs,
       const CharacterT& originalCharacter) const;
 
   /// Determines which joints are affected by the specified parameters

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -51,6 +51,15 @@ using SkinWeights_const_p = ::std::shared_ptr<const SkinWeights>;
 using SkinWeights_const_u = ::std::unique_ptr<const SkinWeights>;
 using SkinWeights_const_w = ::std::weak_ptr<const SkinWeights>;
 
+struct SkinnedLocator;
+
+using SkinnedLocator_p = ::std::shared_ptr<SkinnedLocator>;
+using SkinnedLocator_u = ::std::unique_ptr<SkinnedLocator>;
+using SkinnedLocator_w = ::std::weak_ptr<SkinnedLocator>;
+using SkinnedLocator_const_p = ::std::shared_ptr<const SkinnedLocator>;
+using SkinnedLocator_const_u = ::std::unique_ptr<const SkinnedLocator>;
+using SkinnedLocator_const_w = ::std::weak_ptr<const SkinnedLocator>;
+
 template <typename T>
 struct CharacterT;
 using Character = CharacterT<float>;

--- a/momentum/character/locator.h
+++ b/momentum/character/locator.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <momentum/character/parameter_transform.h>
+#include <momentum/character/types.h>
 #include <momentum/math/utility.h>
 
 namespace momentum {

--- a/momentum/character/skinned_locator.h
+++ b/momentum/character/skinned_locator.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/character/skin_weights.h>
+#include <momentum/character/types.h>
+#include <momentum/math/utility.h>
+
+namespace momentum {
+
+/// A skinned locator is a locator which can be attached to multiple bones.
+/// The locator's position is defined relative to the rest pose of the character (and not
+/// local to a single parent bone as with a regular Locator) and its position at runtime is
+/// determined by blending the skinning transforms (using LBS).
+///
+/// The purpose of the SkinnedLocator is to model mocap markers attached to the actor's skin:
+/// the location of points on e.g. the shoulder is more accurately modeled by blending
+/// multiple transforms.  In addition, the locator can be constrained to slide along the
+/// surface of the mesh using e.g. the SkinnedLocatorTriangleErrorFunction.
+///
+/// Locators can be used for various purposes such as tracking specific points
+/// on a character, defining constraints, or serving as targets for inverse kinematics.
+struct SkinnedLocator {
+  /// Name identifier for the locator
+  std::string name;
+
+  /// Index of the parent joints in the skeleton.  The final position of the locator
+  /// is determined by blending the transforms from each (valid) parent.
+  Eigen::Matrix<uint32_t, kMaxSkinJoints, 1> parents;
+
+  /// Skinning weight for each parent joint.
+  Eigen::Matrix<float, kMaxSkinJoints, 1> skinWeights;
+
+  /// Position relative to rest pose of the character
+  Vector3f position;
+
+  /// Influence weight of this locator when used in constraints
+  float weight;
+
+  /// Creates a locator with the specified properties
+  ///
+  /// @param name Identifier for the locator
+  /// @param parents Indices of the parent joints
+  /// @param weights Skinning weights for the parent joints
+  /// @param weight Influence weight in constraints
+  SkinnedLocator(
+      const std::string& name = "uninitialized",
+      const Eigen::Matrix<uint32_t, kMaxSkinJoints, 1>& parents =
+          Eigen::Matrix<uint32_t, kMaxSkinJoints, 1>::Zero(),
+      const Eigen::Matrix<float, kMaxSkinJoints, 1>& skinWeights =
+          Eigen::Matrix<float, kMaxSkinJoints, 1>::Zero(),
+      const Vector3f& position = Vector3f::Zero(),
+      const float weight = 1.0f)
+      : name(name),
+        parents(parents),
+        skinWeights(skinWeights),
+        position(position),
+        weight(weight) {}
+
+  /// Compares two locators for equality, using approximate comparison for floating-point values
+  ///
+  /// @param locator The locator to compare with
+  /// @return True if all properties are equal (or approximately equal for floating-point values)
+  inline bool operator==(const SkinnedLocator& locator) const {
+    return (
+        (name == locator.name) && (parents == locator.parents) &&
+        skinWeights.isApprox(locator.skinWeights) && position.isApprox(locator.position) &&
+        isApprox(weight, locator.weight));
+  }
+};
+
+/// A collection of locators attached to a skeleton
+using SkinnedLocatorList = std::vector<SkinnedLocator>;
+
+} // namespace momentum

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -22,9 +22,10 @@ subdirectory = "character"
 structs = [
     "BlendShape",
     "BlendShapeBase",
+    "Locator",
     "PoseShape",
     "SkinWeights",
-    "Locator",
+    "SkinnedLocator"
 ]
 template_structs = [
     "Character",

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -230,7 +230,8 @@ PYBIND11_MODULE(geometry, m) {
                 character.blendShape,
                 character.faceExpressionBlendShape,
                 character.name,
-                character.inverseBindPose);
+                character.inverseBindPose,
+                character.skinnedLocators);
           },
           "Adds mesh and skin weight to the character and return a new character instance",
           py::arg("mesh"),
@@ -283,7 +284,8 @@ PYBIND11_MODULE(geometry, m) {
                 character.blendShape,
                 character.faceExpressionBlendShape,
                 character.name,
-                character.inverseBindPose);
+                character.inverseBindPose,
+                character.skinnedLocators);
           },
           R"(Returns a new character with the passed-in locators.  If 'replace' is true, the existing locators are replaced, otherwise (the default) the new locators are appended to the existing ones.
 

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -259,7 +259,8 @@ momentum::Character loadConfigFromFile(
       character.blendShape,
       character.faceExpressionBlendShape,
       character.name,
-      character.inverseBindPose);
+      character.inverseBindPose,
+      character.skinnedLocators);
 }
 
 momentum::Character loadFBXCharacterFromBytes(
@@ -288,7 +289,8 @@ momentum::Character loadConfigFromBytes(
       character.blendShape,
       character.faceExpressionBlendShape,
       character.name,
-      character.inverseBindPose);
+      character.inverseBindPose,
+      character.skinnedLocators);
 }
 
 momentum::Character loadLocatorsFromBytes(
@@ -457,7 +459,9 @@ momentum::Character replaceRestMesh(
       character.poseShapes.get(),
       character.blendShape,
       character.faceExpressionBlendShape,
-      character.name);
+      character.name,
+      character.inverseBindPose,
+      character.skinnedLocators);
 }
 
 at::Tensor uniformRandomToModelParameters(


### PR DESCRIPTION
Summary: We want to be able to solve for the skinned locator locations, so we need to make them available through the parameter transform.  This is similar to how we handle e.g. blend shape parameters except that there are 3 parameters (x/y/z) for each skinned locator.

Reviewed By: cstollmeta

Differential Revision: D78220115


