### PR TITLE
Adding VertexSequenceErrorFunction.

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -304,6 +304,7 @@ character_sequence_solver_public_headers = [
     "character_sequence_solver/sequence_solver_function.h",
     "character_sequence_solver/sequence_solver.h",
     "character_sequence_solver/state_sequence_error_function.h",
+    "character_sequence_solver/vertex_sequence_error_function.h",
 ]
 
 character_sequence_solver_sources = [
@@ -313,6 +314,7 @@ character_sequence_solver_sources = [
     "character_sequence_solver/sequence_solver_function.cpp",
     "character_sequence_solver/sequence_solver.cpp",
     "character_sequence_solver/state_sequence_error_function.cpp",
+    "character_sequence_solver/vertex_sequence_error_function.cpp",
 ]
 
 character_sequence_solver_test_sources = [

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -33,6 +33,15 @@ using BlendShapeBase_const_p = ::std::shared_ptr<const BlendShapeBase>;
 using BlendShapeBase_const_u = ::std::unique_ptr<const BlendShapeBase>;
 using BlendShapeBase_const_w = ::std::weak_ptr<const BlendShapeBase>;
 
+struct Locator;
+
+using Locator_p = ::std::shared_ptr<Locator>;
+using Locator_u = ::std::unique_ptr<Locator>;
+using Locator_w = ::std::weak_ptr<Locator>;
+using Locator_const_p = ::std::shared_ptr<const Locator>;
+using Locator_const_u = ::std::unique_ptr<const Locator>;
+using Locator_const_w = ::std::weak_ptr<const Locator>;
+
 struct PoseShape;
 
 using PoseShape_p = ::std::shared_ptr<PoseShape>;

--- a/momentum/character_sequence_solver/fwd.h
+++ b/momentum/character_sequence_solver/fwd.h
@@ -178,4 +178,23 @@ using StateSequenceErrorFunctiond_const_p = ::std::shared_ptr<const StateSequenc
 using StateSequenceErrorFunctiond_const_u = ::std::unique_ptr<const StateSequenceErrorFunctiond>;
 using StateSequenceErrorFunctiond_const_w = ::std::weak_ptr<const StateSequenceErrorFunctiond>;
 
+template <typename T>
+class VertexSequenceErrorFunctionT;
+using VertexSequenceErrorFunction = VertexSequenceErrorFunctionT<float>;
+using VertexSequenceErrorFunctiond = VertexSequenceErrorFunctionT<double>;
+
+using VertexSequenceErrorFunction_p = ::std::shared_ptr<VertexSequenceErrorFunction>;
+using VertexSequenceErrorFunction_u = ::std::unique_ptr<VertexSequenceErrorFunction>;
+using VertexSequenceErrorFunction_w = ::std::weak_ptr<VertexSequenceErrorFunction>;
+using VertexSequenceErrorFunction_const_p = ::std::shared_ptr<const VertexSequenceErrorFunction>;
+using VertexSequenceErrorFunction_const_u = ::std::unique_ptr<const VertexSequenceErrorFunction>;
+using VertexSequenceErrorFunction_const_w = ::std::weak_ptr<const VertexSequenceErrorFunction>;
+
+using VertexSequenceErrorFunctiond_p = ::std::shared_ptr<VertexSequenceErrorFunctiond>;
+using VertexSequenceErrorFunctiond_u = ::std::unique_ptr<VertexSequenceErrorFunctiond>;
+using VertexSequenceErrorFunctiond_w = ::std::weak_ptr<VertexSequenceErrorFunctiond>;
+using VertexSequenceErrorFunctiond_const_p = ::std::shared_ptr<const VertexSequenceErrorFunctiond>;
+using VertexSequenceErrorFunctiond_const_u = ::std::unique_ptr<const VertexSequenceErrorFunctiond>;
+using VertexSequenceErrorFunctiond_const_w = ::std::weak_ptr<const VertexSequenceErrorFunctiond>;
+
 } // namespace momentum

--- a/momentum/character_sequence_solver/vertex_sequence_error_function.cpp
+++ b/momentum/character_sequence_solver/vertex_sequence_error_function.cpp
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/character_sequence_solver/vertex_sequence_error_function.h"
+
+#include "momentum/character/blend_shape.h"
+#include "momentum/character/blend_shape_skinning.h"
+#include "momentum/character/character.h"
+#include "momentum/character/linear_skinning.h"
+#include "momentum/character/skeleton.h"
+#include "momentum/character/skeleton_state.h"
+#include "momentum/character/skin_weights.h"
+#include "momentum/character_solver/error_function_utils.h"
+#include "momentum/character_solver/skinning_weight_iterator.h"
+#include "momentum/common/checks.h"
+#include "momentum/common/profile.h"
+#include "momentum/math/mesh.h"
+
+#include <numeric>
+
+namespace momentum {
+
+template <typename T>
+VertexSequenceErrorFunctionT<T>::VertexSequenceErrorFunctionT(const Character& character)
+    : SequenceErrorFunctionT<T>(character.skeleton, character.parameterTransform),
+      character_(character) {
+  MT_CHECK(static_cast<bool>(character_.mesh));
+  MT_CHECK(static_cast<bool>(character_.skinWeights));
+
+  neutralMesh_ = std::make_unique<MeshT<T>>(character_.mesh->template cast<T>());
+  restMesh_ = std::make_unique<MeshT<T>>(character_.mesh->template cast<T>());
+  posedMesh0_ = std::make_unique<MeshT<T>>(character_.mesh->template cast<T>());
+  posedMesh1_ = std::make_unique<MeshT<T>>(character_.mesh->template cast<T>());
+}
+
+template <typename T>
+void VertexSequenceErrorFunctionT<T>::clearConstraints() {
+  constraints_.clear();
+}
+
+template <typename T>
+void VertexSequenceErrorFunctionT<T>::addConstraint(
+    int vertexIndex,
+    T weight,
+    const Eigen::Vector3<T>& targetVelocity) {
+  MT_CHECK(vertexIndex >= 0 && ((size_t)vertexIndex) < character_.mesh->vertices.size());
+  constraints_.push_back(VertexVelocityConstraintT<T>{vertexIndex, weight, targetVelocity});
+}
+
+template <typename T>
+void VertexSequenceErrorFunctionT<T>::updateMeshes(
+    gsl::span<const ModelParametersT<T>> modelParameters,
+    gsl::span<const SkeletonStateT<T>> skelStates) const {
+  MT_PROFILE_FUNCTION();
+  MT_CHECK(modelParameters.size() == 2);
+  MT_CHECK(skelStates.size() == 2);
+
+  // Since the rest mesh is the same for both frames, we only need to update it once
+  // We'll use the blend shape parameters from frame 0 (could be either frame)
+  bool doUpdateNormals = false;
+  if (character_.blendShape) {
+    const BlendWeightsT<T> blendWeights =
+        extractBlendWeights(this->parameterTransform_, modelParameters[0]);
+    character_.blendShape->computeShape(blendWeights, restMesh_->vertices);
+    doUpdateNormals = true;
+  }
+  if (character_.faceExpressionBlendShape) {
+    if (!character_.blendShape) {
+      Eigen::Map<Eigen::VectorX<T>> outputVec(
+          &restMesh_->vertices[0][0], restMesh_->vertices.size() * 3);
+      const Eigen::Map<Eigen::VectorX<T>> baseVec(
+          &neutralMesh_->vertices[0][0], neutralMesh_->vertices.size() * 3);
+      outputVec = baseVec.template cast<T>();
+    }
+    const BlendWeightsT<T> faceExpressionBlendWeights =
+        extractFaceExpressionBlendWeights(this->parameterTransform_, modelParameters[0]);
+    character_.faceExpressionBlendShape->applyDeltas(
+        faceExpressionBlendWeights, restMesh_->vertices);
+    doUpdateNormals = true;
+  }
+  if (doUpdateNormals) {
+    restMesh_->updateNormals();
+  }
+
+  // Apply skinning for both frames using the same rest mesh
+  applySSD(
+      cast<T>(character_.inverseBindPose),
+      *character_.skinWeights,
+      *restMesh_,
+      skelStates[0],
+      *posedMesh0_);
+
+  applySSD(
+      cast<T>(character_.inverseBindPose),
+      *character_.skinWeights,
+      *restMesh_,
+      skelStates[1],
+      *posedMesh1_);
+}
+
+template <typename T>
+double VertexSequenceErrorFunctionT<T>::getError(
+    gsl::span<const ModelParametersT<T>> modelParameters,
+    gsl::span<const SkeletonStateT<T>> skelStates) const {
+  MT_PROFILE_FUNCTION();
+  MT_CHECK(modelParameters.size() == 2);
+  MT_CHECK(skelStates.size() == 2);
+
+  updateMeshes(modelParameters, skelStates);
+
+  double error = 0.0;
+
+  // Calculate vertex velocities and compare with target velocities
+  for (const auto& constraint : constraints_) {
+    const Eigen::Vector3<T>& vertex0 = posedMesh0_->vertices[constraint.vertexIndex];
+    const Eigen::Vector3<T>& vertex1 = posedMesh1_->vertices[constraint.vertexIndex];
+
+    // Compute actual velocity (difference between frames)
+    const Eigen::Vector3<T> actualVelocity = vertex1 - vertex0;
+
+    // Compute velocity difference
+    const Eigen::Vector3<T> velocityDiff = actualVelocity - constraint.targetVelocity;
+
+    error += constraint.weight * velocityDiff.squaredNorm() * kVelocityWeight;
+  }
+
+  return error * this->weight_;
+}
+
+template <typename T>
+double VertexSequenceErrorFunctionT<T>::calculateVelocityGradient(
+    gsl::span<const SkeletonStateT<T>> skelStates,
+    const VertexVelocityConstraintT<T>& constraint,
+    Eigen::Ref<Eigen::VectorX<T>> gradient) const {
+  const Eigen::Vector3<T>& vertex0 = posedMesh0_->vertices[constraint.vertexIndex];
+  const Eigen::Vector3<T>& vertex1 = posedMesh1_->vertices[constraint.vertexIndex];
+
+  const Eigen::Vector3<T> actualVelocity = vertex1 - vertex0;
+  const Eigen::Vector3<T> velocityDiff = actualVelocity - constraint.targetVelocity;
+
+  const T wgt = constraint.weight * 2.0f * kVelocityWeight * this->weight_;
+
+  const Eigen::Index nParam = this->parameterTransform_.numAllModelParameters();
+
+  Eigen::Ref<Eigen::VectorX<T>> grad0 = gradient.segment(0, nParam);
+  Eigen::Ref<Eigen::VectorX<T>> grad1 = gradient.segment(nParam, nParam);
+
+  // Gradient with respect to frame 0 (negative contribution to velocity)
+  {
+    SkinningWeightIteratorT<T> skinningIter(
+        character_, *restMesh_, skelStates[0], constraint.vertexIndex);
+
+    while (!skinningIter.finished()) {
+      size_t jointIndex = 0;
+      T boneWeight;
+      Eigen::Vector3<T> pos;
+      std::tie(jointIndex, boneWeight, pos) = skinningIter.next();
+
+      MT_CHECK(jointIndex < this->skeleton_.joints.size());
+
+      const auto& jointState = skelStates[0].jointState[jointIndex];
+      const size_t paramIndex = jointIndex * kParametersPerJoint;
+      const Eigen::Vector3<T> posd = pos - jointState.translation();
+
+      for (size_t d = 0; d < 3; d++) {
+        if (this->activeJointParams_[paramIndex + d]) {
+          // Create a temporary gradient vector for frame 0
+          gradient_jointParams_to_modelParams(
+              -boneWeight * velocityDiff.dot(jointState.getTranslationDerivative(d)) * wgt,
+              paramIndex + d,
+              this->parameterTransform_,
+              grad0);
+        }
+        if (this->activeJointParams_[paramIndex + 3 + d]) {
+          gradient_jointParams_to_modelParams(
+              -boneWeight * velocityDiff.dot(jointState.getRotationDerivative(d, posd)) * wgt,
+              paramIndex + 3 + d,
+              this->parameterTransform_,
+              grad0);
+        }
+      }
+      if (this->activeJointParams_[paramIndex + 6]) {
+        gradient_jointParams_to_modelParams(
+            -boneWeight * velocityDiff.dot(jointState.getScaleDerivative(posd)) * wgt,
+            paramIndex + 6,
+            this->parameterTransform_,
+            grad0);
+      }
+    }
+  }
+
+  // Gradient with respect to frame 1 (positive contribution to velocity)
+  {
+    SkinningWeightIteratorT<T> skinningIter(
+        character_, *restMesh_, skelStates[1], constraint.vertexIndex);
+
+    while (!skinningIter.finished()) {
+      size_t jointIndex = 0;
+      T boneWeight;
+      Eigen::Vector3<T> pos;
+      std::tie(jointIndex, boneWeight, pos) = skinningIter.next();
+
+      MT_CHECK(jointIndex < this->skeleton_.joints.size());
+
+      const auto& jointState = skelStates[1].jointState[jointIndex];
+      const size_t paramIndex = jointIndex * kParametersPerJoint;
+      const Eigen::Vector3<T> posd = pos - jointState.translation();
+
+      for (size_t d = 0; d < 3; d++) {
+        if (this->activeJointParams_[paramIndex + d]) {
+          // Create a temporary gradient vector for frame 1
+          gradient_jointParams_to_modelParams(
+              boneWeight * velocityDiff.dot(jointState.getTranslationDerivative(d)) * wgt,
+              paramIndex + d,
+              this->parameterTransform_,
+              grad1);
+        }
+        if (this->activeJointParams_[paramIndex + 3 + d]) {
+          gradient_jointParams_to_modelParams(
+              boneWeight * velocityDiff.dot(jointState.getRotationDerivative(d, posd)) * wgt,
+              paramIndex + 3 + d,
+              this->parameterTransform_,
+              grad1);
+        }
+      }
+      if (this->activeJointParams_[paramIndex + 6]) {
+        gradient_jointParams_to_modelParams(
+            boneWeight * velocityDiff.dot(jointState.getScaleDerivative(posd)) * wgt,
+            paramIndex + 6,
+            this->parameterTransform_,
+            grad1);
+      }
+    }
+  }
+
+  return constraint.weight * velocityDiff.squaredNorm() * kVelocityWeight;
+}
+
+template <typename T>
+double VertexSequenceErrorFunctionT<T>::getGradient(
+    gsl::span<const ModelParametersT<T>> modelParameters,
+    gsl::span<const SkeletonStateT<T>> skelStates,
+    Eigen::Ref<Eigen::VectorX<T>> gradient) const {
+  MT_PROFILE_FUNCTION();
+  MT_CHECK(modelParameters.size() == 2);
+  MT_CHECK(skelStates.size() == 2);
+
+  updateMeshes(modelParameters, skelStates);
+
+  double error = 0.0;
+
+  // Process constraints sequentially without multithreading
+  for (const auto& constraint : constraints_) {
+    error += calculateVelocityGradient(skelStates, constraint, gradient);
+  }
+
+  return this->weight_ * error;
+}
+
+template <typename T>
+double VertexSequenceErrorFunctionT<T>::calculateVelocityJacobian(
+    gsl::span<const SkeletonStateT<T>> skelStates,
+    const VertexVelocityConstraintT<T>& constraint,
+    Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+    Eigen::Ref<Eigen::VectorX<T>> residual,
+    Eigen::Index startRow) const {
+  const Eigen::Vector3<T>& vertex0 = posedMesh0_->vertices[constraint.vertexIndex];
+  const Eigen::Vector3<T>& vertex1 = posedMesh1_->vertices[constraint.vertexIndex];
+
+  const Eigen::Vector3<T> actualVelocity = vertex1 - vertex0;
+  const Eigen::Vector3<T> velocityDiff = actualVelocity - constraint.targetVelocity;
+
+  const T wgt = std::sqrt(constraint.weight * kVelocityWeight * this->weight_);
+
+  const Eigen::Index nParam = this->parameterTransform_.numAllModelParameters();
+
+  // Jacobian with respect to frame 0 (negative contribution to velocity)
+  {
+    SkinningWeightIteratorT<T> skinningIter(
+        character_, *restMesh_, skelStates[0], constraint.vertexIndex);
+
+    while (!skinningIter.finished()) {
+      size_t jointIndex = 0;
+      T boneWeight;
+      Eigen::Vector3<T> pos;
+      std::tie(jointIndex, boneWeight, pos) = skinningIter.next();
+
+      MT_CHECK(jointIndex < this->skeleton_.joints.size());
+
+      const auto& jointState = skelStates[0].jointState[jointIndex];
+      const size_t paramIndex = jointIndex * kParametersPerJoint;
+      const Eigen::Vector3<T> posd = pos - jointState.translation();
+
+      for (size_t d = 0; d < 3; d++) {
+        if (this->activeJointParams_[paramIndex + d]) {
+          jacobian_jointParams_to_modelParams<T>(
+              -boneWeight * wgt * jointState.getTranslationDerivative(d),
+              paramIndex + d,
+              this->parameterTransform_,
+              jacobian.block(startRow, 0, 3, nParam));
+        }
+        if (this->activeJointParams_[paramIndex + 3 + d]) {
+          jacobian_jointParams_to_modelParams<T>(
+              -boneWeight * wgt * jointState.getRotationDerivative(d, posd),
+              paramIndex + d + 3,
+              this->parameterTransform_,
+              jacobian.block(startRow, 0, 3, nParam));
+        }
+      }
+      if (this->activeJointParams_[paramIndex + 6]) {
+        jacobian_jointParams_to_modelParams<T>(
+            -boneWeight * wgt * jointState.getScaleDerivative(posd),
+            paramIndex + 6,
+            this->parameterTransform_,
+            jacobian.block(startRow, 0, 3, nParam));
+      }
+    }
+  }
+
+  // Jacobian with respect to frame 1 (positive contribution to velocity)
+  {
+    SkinningWeightIteratorT<T> skinningIter(
+        character_, *restMesh_, skelStates[1], constraint.vertexIndex);
+
+    while (!skinningIter.finished()) {
+      size_t jointIndex = 0;
+      T boneWeight;
+      Eigen::Vector3<T> pos;
+      std::tie(jointIndex, boneWeight, pos) = skinningIter.next();
+
+      MT_CHECK(jointIndex < this->skeleton_.joints.size());
+
+      const auto& jointState = skelStates[1].jointState[jointIndex];
+      const size_t paramIndex = jointIndex * kParametersPerJoint;
+      const Eigen::Vector3<T> posd = pos - jointState.translation();
+
+      for (size_t d = 0; d < 3; d++) {
+        if (this->activeJointParams_[paramIndex + d]) {
+          jacobian_jointParams_to_modelParams<T>(
+              boneWeight * wgt * jointState.getTranslationDerivative(d),
+              paramIndex + d,
+              this->parameterTransform_,
+              jacobian.block(startRow, nParam, 3, nParam));
+        }
+        if (this->activeJointParams_[paramIndex + 3 + d]) {
+          jacobian_jointParams_to_modelParams<T>(
+              boneWeight * wgt * jointState.getRotationDerivative(d, posd),
+              paramIndex + d + 3,
+              this->parameterTransform_,
+              jacobian.block(startRow, nParam, 3, nParam));
+        }
+      }
+      if (this->activeJointParams_[paramIndex + 6]) {
+        jacobian_jointParams_to_modelParams<T>(
+            boneWeight * wgt * jointState.getScaleDerivative(posd),
+            paramIndex + 6,
+            this->parameterTransform_,
+            jacobian.block(startRow, nParam, 3, nParam));
+      }
+    }
+  }
+
+  residual.segment(startRow, 3) = velocityDiff * wgt;
+
+  return wgt * wgt * velocityDiff.squaredNorm();
+}
+
+template <typename T>
+double VertexSequenceErrorFunctionT<T>::getJacobian(
+    gsl::span<const ModelParametersT<T>> modelParameters,
+    gsl::span<const SkeletonStateT<T>> skelStates,
+    Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+    Eigen::Ref<Eigen::VectorX<T>> residual,
+    int& usedRows) const {
+  MT_PROFILE_FUNCTION();
+  MT_CHECK(modelParameters.size() == 2);
+  MT_CHECK(skelStates.size() == 2);
+
+  const Eigen::Index nParam = this->parameterTransform_.numAllModelParameters();
+  MT_CHECK(jacobian.cols() == 2 * nParam);
+  MT_CHECK(jacobian.rows() >= (Eigen::Index)(3 * constraints_.size()));
+  MT_CHECK(residual.rows() >= (Eigen::Index)(3 * constraints_.size()));
+
+  updateMeshes(modelParameters, skelStates);
+
+  double error = 0.0;
+
+  // Process constraints sequentially without multithreading
+  for (size_t iCons = 0; iCons < constraints_.size(); ++iCons) {
+    error +=
+        calculateVelocityJacobian(skelStates, constraints_[iCons], jacobian, residual, 3 * iCons);
+  }
+
+  usedRows = gsl::narrow_cast<int>(3 * constraints_.size());
+  return error;
+}
+
+template <typename T>
+size_t VertexSequenceErrorFunctionT<T>::getJacobianSize() const {
+  return 3 * constraints_.size();
+}
+
+template class VertexSequenceErrorFunctionT<float>;
+template class VertexSequenceErrorFunctionT<double>;
+
+} // namespace momentum

--- a/momentum/character_sequence_solver/vertex_sequence_error_function.h
+++ b/momentum/character_sequence_solver/vertex_sequence_error_function.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/character/character.h>
+#include <momentum/character/skeleton_state.h>
+#include <momentum/character_sequence_solver/fwd.h>
+#include <momentum/character_sequence_solver/sequence_error_function.h>
+#include <momentum/character_solver/vertex_error_function.h>
+#include <momentum/math/mesh.h>
+
+#include <gsl/span>
+
+namespace momentum {
+
+/// Constraint structure for vertex velocity.
+template <typename T>
+struct VertexVelocityConstraintT {
+  int vertexIndex = -1;
+  T weight = 1;
+  Eigen::Vector3<T> targetVelocity;
+
+  template <typename T2>
+  VertexVelocityConstraintT<T2> cast() const {
+    return {
+        this->vertexIndex, static_cast<T2>(this->weight), this->targetVelocity.template cast<T2>()};
+  }
+};
+
+/// Error function that penalizes differences in vertex velocity between source and target motion.
+/// This function computes vertex velocities by taking the difference between consecutive frames
+/// and penalizes deviations from target vertex velocities. It combines the sequence aspect of
+/// StateSequenceErrorFunction with vertex constraints from VertexErrorFunction.
+template <typename T>
+class VertexSequenceErrorFunctionT : public SequenceErrorFunctionT<T> {
+ public:
+  explicit VertexSequenceErrorFunctionT(const Character& character);
+
+  [[nodiscard]] size_t numFrames() const final {
+    return 2;
+  }
+
+  double getError(
+      gsl::span<const ModelParametersT<T>> modelParameters,
+      gsl::span<const SkeletonStateT<T>> skelStates) const final;
+  double getGradient(
+      gsl::span<const ModelParametersT<T>> modelParameters,
+      gsl::span<const SkeletonStateT<T>> skelStates,
+      Eigen::Ref<Eigen::VectorX<T>> gradient) const final;
+
+  // modelParameters: [numFrames() * parameterTransform] parameter vector
+  // skelStates: [numFrames()] array of skeleton states
+  // jacobian: [getJacobianSize()] x [numFrames() * parameterTransform] Jacobian matrix
+  // residual: [getJacobianSize()] residual vector.
+  double getJacobian(
+      gsl::span<const ModelParametersT<T>> modelParameters,
+      gsl::span<const SkeletonStateT<T>> skelStates,
+      Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+      Eigen::Ref<Eigen::VectorX<T>> residual,
+      int& usedRows) const final;
+
+  [[nodiscard]] size_t getJacobianSize() const final;
+
+  /// Add a vertex velocity constraint.
+  /// @param vertexIndex Index of the vertex to constrain.
+  /// @param weight Weight for this constraint.
+  /// @param targetVelocity Target velocity for the vertex.
+  void addConstraint(int vertexIndex, T weight, const Eigen::Vector3<T>& targetVelocity);
+
+  /// Clear all vertex velocity constraints.
+  void clearConstraints();
+
+  /// Get all vertex velocity constraints.
+  [[nodiscard]] const std::vector<VertexVelocityConstraintT<T>>& getConstraints() const {
+    return constraints_;
+  }
+
+  /// Get the number of constraints.
+  [[nodiscard]] size_t numConstraints() const {
+    return constraints_.size();
+  }
+
+  /// Get the character reference.
+  [[nodiscard]] const Character& getCharacter() const {
+    return character_;
+  }
+
+  static constexpr T kVelocityWeight = 1e-3f;
+
+ private:
+  /// Calculate gradient for a single vertex velocity constraint.
+  double calculateVelocityGradient(
+      gsl::span<const SkeletonStateT<T>> skelStates,
+      const VertexVelocityConstraintT<T>& constraint,
+      Eigen::Ref<Eigen::VectorX<T>> gradient) const;
+
+  /// Calculate Jacobian for a single vertex velocity constraint.
+  double calculateVelocityJacobian(
+      gsl::span<const SkeletonStateT<T>> skelStates,
+      const VertexVelocityConstraintT<T>& constraint,
+      Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+      Eigen::Ref<Eigen::VectorX<T>> residual,
+      Eigen::Index startRow) const;
+
+  /// Update meshes for both frames.
+  void updateMeshes(
+      gsl::span<const ModelParametersT<T>> modelParameters,
+      gsl::span<const SkeletonStateT<T>> skelStates) const;
+
+  const Character& character_;
+  std::vector<VertexVelocityConstraintT<T>> constraints_;
+
+  // Meshes for the two frames
+  mutable std::unique_ptr<MeshT<T>> neutralMesh_;
+  mutable std::unique_ptr<MeshT<T>> restMesh_; // Single rest mesh used for both frames
+  mutable std::unique_ptr<MeshT<T>> posedMesh0_;
+  mutable std::unique_ptr<MeshT<T>> posedMesh1_;
+};
+
+} // namespace momentum

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -114,6 +114,7 @@ template_classes = [
     "SequenceSolver",
     "SequenceSolverFunction",
     "StateSequenceErrorFunction",
+    "VertexSequenceErrorFunction",
 ]
 
 [[fwd]]


### PR DESCRIPTION
Summary:
It can be useful to be able to apply velocity constraints to vertices, since we care more about the mesh in many cases than the bones.  Add the ability to apply these as a sequence constraint inside the SequenceSolver.

Currently I'm just doing the simplest thing here (difference of velocity vectors), and not implementing any "in-plane/out-of-plane" logic as in the VertexConstraint.

Reviewed By: jeongseok-meta

Differential Revision: D81085122


