### PR TITLE
Add convert_locators_to_skinned_locators

### DIFF
--- a/momentum/marker_tracking/tracker_utils.h
+++ b/momentum/marker_tracking/tracker_utils.h
@@ -26,6 +26,17 @@ momentum::Character createLocatorCharacter(
     const momentum::Character& sourceCharacter,
     const std::string& prefix);
 
+/// Convert locators to skinned locators by finding the closest point on the mesh surface that
+/// matches the correct bone index and using the skinned weights from that point.  Does not add
+/// parameters for the skinned locators, however, that should be a separate step if you are planning
+/// to solve for their locations.
+/// @param sourceCharacter Character with locators to convert
+/// @param maxDistance Maximum distance to search for the closest point on the mesh surface.  If the
+/// locator is further than this distance, it will not be converted.
+momentum::Character locatorsToSkinnedLocators(
+    const momentum::Character& sourceCharacter,
+    float maxDistance = 3.0f);
+
 // Extract locator offsets from a LocatorCharacter for a normal Character given input calibrated
 // parameters
 momentum::LocatorList extractLocatorsFromCharacter(

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -457,4 +457,29 @@ PYBIND11_MODULE(marker_tracking, m) {
       py::arg("motion"),
       py::arg("marker_data"),
       py::arg("refine_config"));
+
+  m.def(
+      "convert_locators_to_skinned_locators",
+      &momentum::locatorsToSkinnedLocators,
+      R"(Convert regular locators to skinned locators based on mesh proximity.
+
+This function converts locators attached to specific joints into skinned locators
+that are weighted across multiple joints based on the underlying mesh skin weights.
+For each locator, it:
+
+1. Computes the locator's world space position using the rest skeleton state
+2. Finds the closest point on the character's mesh surface that is skinned to the same
+   bone as the locator (this is to avoid skinning the locator to the wrong bone)
+3. If the distance is within max_distance, converts the locator to a skinned locator
+   with bone weights interpolated from the closest mesh triangle
+4. Otherwise, keeps the original locator unchanged
+
+The resulting skinned locators maintain the same world space position but are now
+influenced by multiple joints through skin weights.
+
+:param character: Character with mesh, skin weights, and locators to convert
+:param max_distance: Maximum distance from mesh surface to convert a locator (default: 3.0)
+:return: New character with converted skinned locators and remaining regular locators)",
+      py::arg("character"),
+      py::arg("max_distance") = 3.0f);
 }


### PR DESCRIPTION
Summary: We'd like to experiment with the new skinned locators but this will require working with existing mocap data where the locators are the traditional kind which are skinned to a single bone.  Add the ability to automatically convert these to skinned locators using mesh proximity.

Reviewed By: jeongseok-meta

Differential Revision: D78744919


