### PR TITLE
Remove redundant return statements after GTEST_SKIP()

### DIFF
--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -28,7 +28,6 @@ TEST(IoUrdfTest, LoadCharacter) {
   auto urdfPath = getTestFilePath("character.urdf");
   if (!urdfPath.has_value()) {
     GTEST_SKIP() << "Environment variable 'TEST_MOMENTUM_MODELS_PATH' is not set.";
-    return;
   }
 
   const auto& character = loadUrdfCharacter(*urdfPath);

--- a/momentum/test/io/io_usd_test.cpp
+++ b/momentum/test/io/io_usd_test.cpp
@@ -50,7 +50,6 @@ TEST_F(UsdIoTest, LoadSimpleCharacter) {
   auto usdPath = getTestResourcePath("simple_character.usda");
   if (!usdPath.has_value()) {
     GTEST_SKIP() << "Environment variable 'TEST_RESOURCES_PATH' is not set.";
-    return;
   }
 
   if (!filesystem::exists(*usdPath)) {
@@ -71,7 +70,6 @@ TEST_F(UsdIoTest, LoadSimpleMesh) {
   auto usdPath = getTestResourcePath("simple_mesh.usda");
   if (!usdPath.has_value()) {
     GTEST_SKIP() << "Environment variable 'TEST_RESOURCES_PATH' is not set.";
-    return;
   }
 
   if (!filesystem::exists(*usdPath)) {
@@ -89,7 +87,6 @@ TEST_F(UsdIoTest, LoadCharacterWithMaterials) {
   auto usdPath = getTestResourcePath("character_with_materials.usda");
   if (!usdPath.has_value()) {
     GTEST_SKIP() << "Environment variable 'TEST_RESOURCES_PATH' is not set.";
-    return;
   }
 
   if (!filesystem::exists(*usdPath)) {
@@ -129,7 +126,6 @@ TEST_F(UsdIoTest, LoadFromBuffer) {
   auto usdPath = getTestResourcePath("simple_character.usda");
   if (!usdPath.has_value()) {
     GTEST_SKIP() << "Environment variable 'TEST_RESOURCES_PATH' is not set.";
-    return;
   }
 
   if (!filesystem::exists(*usdPath)) {


### PR DESCRIPTION
Summary:
Remove redundant `return` statements that appear after `GTEST_SKIP()` calls in test files.

The `GTEST_SKIP()` macro already contains a `return` statement in its implementation (`#define GTEST_SKIP_(message) return GTEST_MESSAGE_(message, ::testing::TestPartResult::kSkip)`), making any explicit `return` after it unreachable and redundant.

This cleanup improves code readability and removes dead code that could confuse developers about the control flow behavior of `GTEST_SKIP()`.

Differential Revision: D81414789


