### PR TITLE
Add Sphinx autodoc configuration for constructor documentation

### DIFF
--- a/pymomentum/doc/conf.py
+++ b/pymomentum/doc/conf.py
@@ -9,6 +9,14 @@ extensions = [
     "sphinx.ext.autodoc",
 ]
 
+# Configure autodoc to include constructors and other special methods
+autodoc_default_options = {
+    "special-members": "__init__",
+    "show-inheritance": True,
+    "members": True,
+    "undoc-members": True,
+}
+
 exclude_patterns = [
     ".pixi",
     "build",

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -2445,7 +2445,11 @@ The resulting tensors are as follows:
   //    pos
   //    occluded
   markerClass.def(py::init())
-      .def(py::init<const std::string&, const Eigen::Vector3d&, const bool>())
+      .def(
+          py::init<const std::string&, const Eigen::Vector3d&, const bool>(),
+          py::arg("name"),
+          py::arg("pos"),
+          py::arg("occluded"))
       .def_readwrite("name", &mm::Marker::name, "Name of the marker")
       .def_readwrite("pos", &mm::Marker::pos, "Marker 3d position")
       .def_readwrite(

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -287,10 +287,14 @@ PYBIND11_MODULE(marker_tracking, m) {
                 self.parameters,
                 self.locators);
           })
-      .def(py::init<
-           const std::string&,
-           const std::string&,
-           const std::string&>())
+      .def(
+          py::init<
+              const std::string&,
+              const std::string&,
+              const std::string&>(),
+          py::arg("model"),
+          py::arg("parameters"),
+          py::arg("locators"))
       .def_readwrite(
           "model",
           &momentum::ModelOptions::model,


### PR DESCRIPTION
Summary:
Configure Sphinx autodoc to include constructor documentation in generated API docs, which currently not being generated as:

 {F1981679710,width=300} 

This ensures that `__init__` methods and other special members are properly documented, addressing the issue where Python binding constructors were not appearing in the Sphinx-generated documentation.

The configuration adds:
- `'special-members': '__init__'` to include constructors
- `'show-inheritance': True'` to display class hierarchy
- `'members': True'` to include all class members
- `'undoc-members': True'` to include members without explicit docstrings

This complements the existing Python binding argument name fixes and ensures constructors are visible in the documentation even when detailed docstrings are not present in the pybind11 bindings.

Sphinx doc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_options

Reviewed By: cdtwigg

Differential Revision: D81549409


