### PR TITLE
Fix missing argument names.

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -2531,7 +2531,11 @@ The resulting tensors are as follows:
   //    pos
   //    occluded
   markerClass.def(py::init())
-      .def(py::init<const std::string&, const Eigen::Vector3d&, const bool>())
+      .def(
+          py::init<const std::string&, const Eigen::Vector3d&, const bool>(),
+          py::arg("name"),
+          py::arg("pos"),
+          py::arg("occluded"))
       .def_readwrite("name", &mm::Marker::name, "Name of the marker")
       .def_readwrite("pos", &mm::Marker::pos, "Marker 3d position")
       .def_readwrite(


### PR DESCRIPTION
Summary: I was using this constructor and noticed that all the names are "arg1/2/3", so let's fix it.

Reviewed By: jeongseok-meta

Differential Revision: D81544775


