### PR TITLE
Add support for turning the regularization parameter in marker_tracking.

### DIFF
--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -324,7 +324,7 @@ Eigen::MatrixXf trackSequence(
   solverOptions.multithreaded = true;
   solverOptions.verbose = config.debug;
   solverOptions.threshold = 1.f;
-  solverOptions.regularization = 0.05f;
+  solverOptions.regularization = config.regularization;
 
   // solve the problem
   SequenceSolver solver = SequenceSolver(solverOptions, &solverFunc);
@@ -379,7 +379,7 @@ Eigen::MatrixXf trackPosesPerframe(
   solverOptions.doLineSearch = false;
   solverOptions.verbose = config.debug;
   solverOptions.threshold = 1.f;
-  solverOptions.regularization = 0.05f;
+  solverOptions.regularization = config.regularization;
   auto solver = GaussNewtonSolver(solverOptions, &solverFunc);
   solver.setEnabledParameters(poseParams);
 
@@ -543,7 +543,7 @@ Eigen::MatrixXf trackPosesForFrames(
   solverOptions.doLineSearch = false;
   solverOptions.verbose = config.debug;
   solverOptions.threshold = 1.f;
-  solverOptions.regularization = 0.05f;
+  solverOptions.regularization = config.regularization;
   auto solver = GaussNewtonSolver(solverOptions, &solverFunc);
   solver.setEnabledParameters(poseParams);
 
@@ -680,7 +680,9 @@ void calibrateModel(
 
   // special trackingConfig for initialization: zero out smoothness and collision
   TrackingConfig trackingConfig{
-      {config.minVisPercent, config.lossAlpha, config.maxIter, config.debug}, 0.0, 0.0};
+      {config.minVisPercent, config.lossAlpha, config.maxIter, config.regularization, config.debug},
+      0.0,
+      0.0};
 
   // only keep one motion; no need to duplicate.
   // identity information will be initialized and updated in the motion matrix throughout all the
@@ -876,7 +878,9 @@ void calibrateLocators(
 
   // special trackingConfig for initialization: zero out smoothness and collision
   TrackingConfig trackingConfig{
-      {config.minVisPercent, config.lossAlpha, config.maxIter, config.debug}, 0.0, 0.0};
+      {config.minVisPercent, config.lossAlpha, config.maxIter, config.regularization, config.debug},
+      0.0,
+      0.0};
 
   // only keep one motion for both character and solvingCharacter; no need to duplicate.
   // identity information will be initialized and updated in the motion matrix throughout all the

--- a/momentum/marker_tracking/marker_tracker.h
+++ b/momentum/marker_tracking/marker_tracker.h
@@ -22,6 +22,8 @@ struct BaseConfig {
   float lossAlpha = 2.0;
   /// Max number of solver iterations to run.
   size_t maxIter = 30;
+  /// Regularization parameter (lambda) for Levenberg-Marquardt solver.
+  float regularization = 0.05f;
   /// True to print and save debug information.
   bool debug = false;
 };

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -2531,7 +2531,11 @@ The resulting tensors are as follows:
   //    pos
   //    occluded
   markerClass.def(py::init())
-      .def(py::init<const std::string&, const Eigen::Vector3d&, const bool>())
+      .def(
+          py::init<const std::string&, const Eigen::Vector3d&, const bool>(),
+          py::arg("name"),
+          py::arg("pos"),
+          py::arg("occluded"))
       .def_readwrite("name", &mm::Marker::name, "Name of the marker")
       .def_readwrite("pos", &mm::Marker::pos, "Marker 3d position")
       .def_readwrite(

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -72,17 +72,19 @@ PYBIND11_MODULE(marker_tracking, m) {
           "__repr__",
           [](const momentum::BaseConfig& self) {
             return fmt::format(
-                "BaseConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, debug={})",
+                "BaseConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, regularization={}, debug={})",
                 self.minVisPercent,
                 self.lossAlpha,
                 self.maxIter,
+                self.regularization,
                 boolToString(self.debug));
           })
       .def(
-          py::init<float, float, size_t, bool>(),
+          py::init<float, float, size_t, float, bool>(),
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
+          py::arg("regularization") = 0.05f,
           py::arg("debug") = false)
       .def_readwrite(
           "min_vis_percent",
@@ -109,10 +111,11 @@ PYBIND11_MODULE(marker_tracking, m) {
           "__repr__",
           [](const momentum::CalibrationConfig& self) {
             return fmt::format(
-                "CalibrationConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, debug={}, calib_frames={}, major_iter={}, global_scale_only={}, locators_only={}, greedy_sampling={}, enforce_floor_in_first_frame={}, first_frame_pose_constraint_set=\"{}\")",
+                "CalibrationConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, regularization={}, debug={}, calib_frames={}, major_iter={}, global_scale_only={}, locators_only={}, greedy_sampling={}, enforce_floor_in_first_frame={}, first_frame_pose_constraint_set=\"{}\")",
                 self.minVisPercent,
                 self.lossAlpha,
                 self.maxIter,
+                self.regularization,
                 boolToString(self.debug),
                 self.calibFrames,
                 self.majorIter,
@@ -127,6 +130,7 @@ PYBIND11_MODULE(marker_tracking, m) {
               float,
               float,
               size_t,
+              float,
               bool,
               size_t,
               size_t,
@@ -138,6 +142,7 @@ PYBIND11_MODULE(marker_tracking, m) {
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
+          py::arg("regularization") = 0.05f,
           py::arg("debug") = false,
           py::arg("calib_frames") = 100,
           py::arg("major_iter") = 3,
@@ -184,20 +189,30 @@ PYBIND11_MODULE(marker_tracking, m) {
           "__repr__",
           [](const momentum::TrackingConfig& self) {
             return fmt::format(
-                "TrackingConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, debug={}, smoothing={}, collision_error_weight={}, smoothing_weights={})",
+                "TrackingConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, regularization={}, debug={}, smoothing={}, collision_error_weight={}, smoothing_weights={})",
                 self.minVisPercent,
                 self.lossAlpha,
                 self.maxIter,
+                self.regularization,
                 boolToString(self.debug),
                 self.smoothing,
                 self.collisionErrorWeight,
                 vectorToString(self.smoothingWeights));
           })
       .def(
-          py::init<float, float, size_t, bool, float, float, Eigen::VectorXf>(),
+          py::init<
+              float,
+              float,
+              size_t,
+              float,
+              bool,
+              float,
+              float,
+              Eigen::VectorXf>(),
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
+          py::arg("regularization") = 0.05f,
           py::arg("debug") = false,
           py::arg("smoothing") = 0.0,
           py::arg("collision_error_weight") = 0.0,
@@ -225,10 +240,11 @@ PYBIND11_MODULE(marker_tracking, m) {
           "__repr__",
           [](const momentum::RefineConfig& self) {
             return fmt::format(
-                "RefineConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, debug={}, smoothing={}, collision_error_weight={}, smoothing_weights={}, regularizer={}, calib_id={}, calib_locators={})",
+                "RefineConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, regularization={}, debug={}, smoothing={}, collision_error_weight={}, smoothing_weights={}, regularizer={}, calib_id={}, calib_locators={})",
                 self.minVisPercent,
                 self.lossAlpha,
                 self.maxIter,
+                self.regularization,
                 boolToString(self.debug),
                 self.smoothing,
                 self.collisionErrorWeight,
@@ -242,6 +258,7 @@ PYBIND11_MODULE(marker_tracking, m) {
               float,
               float,
               size_t,
+              float,
               bool,
               float,
               float,
@@ -252,6 +269,7 @@ PYBIND11_MODULE(marker_tracking, m) {
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
+          py::arg("regularization") = 0.05f,
           py::arg("debug") = false,
           py::arg("smoothing") = 0.0,
           py::arg("collision_error_weight") = 0.0,


### PR DESCRIPTION
Summary: We have the ability to tune the iteration count, but not the regularization parameter.  This will be useful when writing tests because the testCharacter converges better with a smaller regularization value due to its smaller size.

Reviewed By: jeongseok-meta

Differential Revision: D81544774


