### PR TITLE
Add troubleshooting guide for FBX retargeting issues

### DIFF
--- a/momentum/website/docs_cpp/02_user_guide/03_troubleshooting_guide.md
+++ b/momentum/website/docs_cpp/02_user_guide/03_troubleshooting_guide.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 3
+---
+
+# Troubleshooting Guide
+
+Common issues and solutions when working with Momentum.
+
+## FBX Retargeting: Incorrect Bind Pose
+
+**Problem:** FBX shows correctly in `fbx_viewer` but fails to convert to GLB or produces wrong joint transforms.
+
+**Cause:** Retargeting changes joint ordering, making skeleton incompatible with Momentum format.
+
+**Solution:**
+
+The core approach involves creating a joint name mapping between retargeted and expected joint names, then applying this mapping to reorder skeleton states before conversion.
+
+1. **Identify Joint Mapping**: Compare joint names between retargeted FBX and expected character format
+2. **Apply Remapping**: Use mapping to reorder skeleton states to match expected format
+3. **Convert to Transforms**: Apply `SkeletonState::compare()` to validate and convert to joint transforms
+
+**Validation:**
+
+See `test/io/io_fbx_test.cpp::Fbx_Retargeting_JointRemapping` for a complete working example that:
+- Simulates the joint reordering problem (demonstrates failure without remapping)
+- Implements the remapping solution (demonstrates success with remapping)
+- Validates that remapping significantly improves skeleton state accuracy
+
+**Tools:**
+- [`fbx_viewer`](../03_examples/01_viewers.md#fbx-viewer): Visual validation of FBX files
+- [`convert_model`](../03_examples/03_convert_model.md): Convert between FBX and GLB formats
+- [`glb_viewer`](../03_examples/01_viewers.md#glb-viewer): Validate converted GLB results
+
+**Related Examples:**
+- [Viewers Guide](../03_examples/01_viewers.md): Visual validation tools for different file formats
+- [Convert Model](../03_examples/03_convert_model.md): Comprehensive FBX/GLB conversion examples


### PR DESCRIPTION
Summary:
• **Added FBX retargeting troubleshooting documentation**: Created [`**03_troubleshooting_guide.md**`](command:code-compose.open?%5B%22%2Farvr%2Flibraries%2Fmomentum%2Fwebsite%2Fdocs_cpp%2F02_user_guide%2F03_troubleshooting_guide.md%22%2Cnull%5D "/arvr/libraries/momentum/website/docs_cpp/02_user_guide/03_troubleshooting_guide.md") with a concise guide for resolving joint reordering issues that cause FBX files to display correctly in `fbx_viewer` but fail GLB conversion, referencing validation tests instead of including code examples

• **Implemented comprehensive unit test validation**: Added `Fbx_Retargeting_JointRemapping` test in [`**io_fbx_test.cpp**`](command:code-compose.open?%5B%22%2Ftest%2Fio%2Fio_fbx_test.cpp%22%2Cnull%5D "/test/io/io_fbx_test.cpp") that demonstrates both the problem (high skeleton state error without remapping) and the solution (low error with proper joint remapping), proving the documented approach works and preventing regressions

• **Established documentation code style guidelines**: Added rules to [`**code_style.md**`](command:code-compose.open?%5B%22%2Farvr%2Flibraries%2Fmomentum%2F.llms%2Frules%2Fcode_style.md%22%2Cnull%5D "/arvr/libraries/momentum/.llms/rules/code_style.md") requiring minimal code in website documentation to reduce maintenance burden, with preference for referencing validated test implementations over inline code examples

Differential Revision: D81791043


