### PR TITLE
Replace Matrix<Scalar, 3, 1> -> Vector3<Scalar>

### DIFF
--- a/momentum/diff_ik/ceres_utility.h
+++ b/momentum/diff_ik/ceres_utility.h
@@ -16,17 +16,13 @@
 namespace momentum {
 
 template <typename T, typename T2>
-Eigen::Matrix<T, 3, 1> getRotationDerivative(
-    const JointStateT<T2>& js,
-    const size_t index,
-    const Eigen::Matrix<T, 3, 1>& ref) {
+Eigen::Vector3<T>
+getRotationDerivative(const JointStateT<T2>& js, const size_t index, const Eigen::Vector3<T>& ref) {
   return js.rotationAxis.col(index).cross(ref);
 }
 
 template <typename T, typename T2>
-Eigen::Matrix<T, 3, 1> getScaleDerivative(
-    const JointStateT<T2>& js,
-    const Eigen::Matrix<T, 3, 1>& ref) {
+Eigen::Vector3<T> getScaleDerivative(const JointStateT<T2>& js, const Eigen::Vector3<T>& ref) {
   (void)js;
   return ref * ln2<T2>();
 }

--- a/momentum/diff_ik/fully_differentiable_projection_error_function.cpp
+++ b/momentum/diff_ik/fully_differentiable_projection_error_function.cpp
@@ -58,7 +58,7 @@ template <typename JetType>
   //    (dError/dJointParameter[jFullBodyDOF] *
   //       dJointParameter[jFullBodyDOF]/dModelParametersT<T>)^JetType * v
   auto add_gradient_dot = [&](const size_t jFullBodyDOF,
-                              const Eigen::Matrix<JetType, 3, 1>& d_p_world_cm) {
+                              const Eigen::Vector3<JetType>& d_p_world_cm) {
     const Eigen::Vector3<JetType> d_p_projected =
         (projection_cons.template topLeftCorner<3, 3>() * d_p_world_cm).eval();
     const JetType& dx = d_p_projected(0);

--- a/momentum/gui/rerun/eigen_adapters.h
+++ b/momentum/gui/rerun/eigen_adapters.h
@@ -52,15 +52,15 @@ struct CollectionAdapter<TElement, std::vector<Eigen::Vector4<T>>> {
 
 // Adapter for converting a vector of Eigen::Vector3b to a vector of rerun::Color
 template <>
-struct CollectionAdapter<Color, std::vector<Eigen::Matrix<uint8_t, 3, 1>>> {
-  Collection<Color> operator()(const std::vector<Eigen::Matrix<uint8_t, 3, 1>>& container) {
+struct CollectionAdapter<Color, std::vector<Eigen::Vector3<uint8_t>>> {
+  Collection<Color> operator()(const std::vector<Eigen::Vector3<uint8_t>>& container) {
     std::vector<rerun::Color> colors;
     colors.reserve(container.size());
     std::transform(
         container.cbegin(),
         container.cend(),
         std::back_inserter(colors),
-        [](const Eigen::Matrix<uint8_t, 3, 1>& vertexColor) {
+        [](const Eigen::Vector3<uint8_t>& vertexColor) {
           return rerun::Color(vertexColor[0], vertexColor[1], vertexColor[2]);
         });
     return Collection<Color>::take_ownership(std::move(colors));

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -110,9 +110,9 @@ const char* propertyTypeStr(ofbx::IElementProperty::Type type) {
 
 template <typename T>
 Eigen::Quaternion<T> computeEulerRotation(
-    const Eigen::Matrix<T, 3, 1>& angles,
+    const Eigen::Vector3<T>& angles,
     ofbx::RotationOrder order) {
-  using VecType = Eigen::Matrix<T, 3, 1>;
+  using VecType = Eigen::Vector3<T>;
   using QuaternionType = Eigen::Quaternion<T>;
 
   if (order == ofbx::RotationOrder::SPHERIC_XYZ) {

--- a/momentum/io/legacy_json/legacy_json_io.cpp
+++ b/momentum/io/legacy_json/legacy_json_io.cpp
@@ -29,13 +29,13 @@ namespace {
 
 /// Helper function to convert Vector3 to JSON array
 template <typename T>
-nlohmann::json eigenToJsonArray(const Eigen::Matrix<T, 3, 1>& vec) {
+nlohmann::json eigenToJsonArray(const Eigen::Vector3<T>& vec) {
   return nlohmann::json::array({vec.x(), vec.y(), vec.z()});
 }
 
 /// Helper function to convert Vector2 to JSON array
 template <typename T>
-nlohmann::json eigenToJsonArray(const Eigen::Matrix<T, 2, 1>& vec) {
+nlohmann::json eigenToJsonArray(const Eigen::Vector2<T>& vec) {
   return nlohmann::json::array({vec.x(), vec.y()});
 }
 
@@ -64,16 +64,16 @@ nlohmann::json transformToJson(const TransformT<T>& transform) {
 
 /// Helper function to convert JSON array to Vector3
 template <typename T>
-Eigen::Matrix<T, 3, 1> jsonArrayToEigenVector3(const nlohmann::json& j) {
+Eigen::Vector3<T> jsonArrayToEigenVector3(const nlohmann::json& j) {
   MT_THROW_IF(j.size() != 3, "Expected array of size 3 for Vector3");
-  return Eigen::Matrix<T, 3, 1>(j[0].get<T>(), j[1].get<T>(), j[2].get<T>());
+  return Eigen::Vector3<T>(j[0].get<T>(), j[1].get<T>(), j[2].get<T>());
 }
 
 /// Helper function to convert JSON array to Vector2
 template <typename T>
-Eigen::Matrix<T, 2, 1> jsonArrayToEigenVector2(const nlohmann::json& j) {
+Eigen::Vector2<T> jsonArrayToEigenVector2(const nlohmann::json& j) {
   MT_THROW_IF(j.size() != 2, "Expected array of size 2 for Vector2");
-  return Eigen::Matrix<T, 2, 1>(j[0].get<T>(), j[1].get<T>());
+  return Eigen::Vector2<T>(j[0].get<T>(), j[1].get<T>());
 }
 
 /// Helper function to convert JSON array to Quaternion (w, x, y, z)

--- a/momentum/math/types.h
+++ b/momentum/math/types.h
@@ -33,7 +33,7 @@
 //------------------------------------------------------------------------------
 
 namespace Eigen {
-using Vector3b = Matrix<uint8_t, 3, 1>;
+using Vector3b = Vector3<uint8_t>;
 }
 
 namespace momentum {

--- a/momentum/math/utility.h
+++ b/momentum/math/utility.h
@@ -234,7 +234,7 @@ template <typename T>
 /// @param v Input vector
 /// @return 3×3 skew-symmetric matrix
 template <typename T>
-Eigen::Matrix<T, 3, 3> crossProductMatrix(const Eigen::Matrix<T, 3, 1>& v) {
+Eigen::Matrix<T, 3, 3> crossProductMatrix(const Eigen::Vector3<T>& v) {
   Eigen::Matrix<T, 3, 3> result;
   result << T(0), -v.z(), v.y(), v.z(), T(0), -v.x(), -v.y(), v.x(), T(0);
   return result;

--- a/momentum/test/math/online_qr_test.cpp
+++ b/momentum/test/math/online_qr_test.cpp
@@ -467,7 +467,7 @@ TEST(OnlineBlockQR, Basic) {
   Eigen::Matrix<double, 3, 2> A_diag;
   A_diag << 1, 3, 4, 2, 1, 4;
 
-  Eigen::Matrix<double, 3, 1> A_common;
+  Eigen::Vector3<double> A_common;
   A_common << 1, 4, 2;
 
   const Eigen::MatrixXd A_dense = assembleBlockMatrix<double>({A_diag}, {A_common}, 1);
@@ -506,13 +506,13 @@ TEST(OnlineBlockQR, TwoBlocks) {
   Eigen::Matrix<double, 3, 2> A1_diag;
   A1_diag << 1, 3, 4, 2, 1, 4;
 
-  Eigen::Matrix<double, 3, 1> A1_common;
+  Eigen::Vector3<double> A1_common;
   A1_common << 1, 4, 2;
 
   Eigen::Matrix<double, 3, 2> A2_diag;
   A2_diag << 2, 4, 7, -1, -4, 4;
 
-  Eigen::Matrix<double, 3, 1> A2_common;
+  Eigen::Vector3<double> A2_common;
   A2_common << -3, 5, -2;
 
   const Eigen::MatrixXd A_dense =


### PR DESCRIPTION
Summary: Replace verbose `Eigen::Matrix<Scalar, 3, 1>` declarations with the more concise `Eigen::Vector3<Scalar>` alias.

Differential Revision: D81852615


