### PR TITLE
Fix clang-format violations in C++ codebase

### DIFF
--- a/momentum/io/skeleton/parameter_limits_io.cpp
+++ b/momentum/io/skeleton/parameter_limits_io.cpp
@@ -725,8 +725,9 @@ std::string writeParameterLimits(
           if (itr->data.linear.rangeMax == kPositiveInfinity) {
             oss << vecToString(Eigen::Vector2f(itr->data.linear.scale, itr->data.linear.offset));
           } else {
-            oss << vecToString(Eigen::Vector3f(
-                itr->data.linear.scale, itr->data.linear.offset, itr->data.linear.rangeMax));
+            oss << vecToString(
+                Eigen::Vector3f(
+                    itr->data.linear.scale, itr->data.linear.offset, itr->data.linear.rangeMax));
           }
 
           prevRangeMax = itr->data.linear.rangeMax;
@@ -764,10 +765,11 @@ std::string writeParameterLimits(
             oss << vecToString(
                 Eigen::Vector2f(itr->data.linearJoint.scale, itr->data.linearJoint.offset));
           } else {
-            oss << vecToString(Eigen::Vector3f(
-                itr->data.linearJoint.scale,
-                itr->data.linearJoint.offset,
-                itr->data.linearJoint.rangeMax));
+            oss << vecToString(
+                Eigen::Vector3f(
+                    itr->data.linearJoint.scale,
+                    itr->data.linearJoint.offset,
+                    itr->data.linearJoint.rangeMax));
           }
 
           prevRangeMax = itr->data.linearJoint.rangeMax;

--- a/momentum/io/skeleton/parameter_transform_io.cpp
+++ b/momentum/io/skeleton/parameter_transform_io.cpp
@@ -160,10 +160,11 @@ void parseParameter(
       pt.name.push_back(parameterName);
 
       // add triplet
-      triplets.push_back(Eigen::Triplet<float>(
-          static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
-          static_cast<int>(parameterIndex),
-          weight));
+      triplets.push_back(
+          Eigen::Triplet<float>(
+              static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
+              static_cast<int>(parameterIndex),
+              weight));
     } else if (
         parameterIndex == kInvalidIndex && refJointIndex != kInvalidIndex &&
         refJointParameter != kInvalidIndex) {
@@ -173,18 +174,21 @@ void parseParameter(
       for (size_t tr = 0; tr < triplets.size(); tr++) {
         const auto& t = triplets[tr];
         if (static_cast<size_t>(t.row()) == refJointId) {
-          triplets.push_back(Eigen::Triplet<float>(
-              static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
-              static_cast<int>(t.col()),
-              t.value() * weight));
+          triplets.push_back(
+              Eigen::Triplet<float>(
+                  static_cast<int>(jointIndex) * kParametersPerJoint +
+                      static_cast<int>(attributeIndex),
+                  static_cast<int>(t.col()),
+                  t.value() * weight));
         }
       }
     } else if (parameterIndex != kInvalidIndex) {
       // add triplet
-      triplets.push_back(Eigen::Triplet<float>(
-          static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
-          static_cast<int>(parameterIndex),
-          weight));
+      triplets.push_back(
+          Eigen::Triplet<float>(
+              static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
+              static_cast<int>(parameterIndex),
+              weight));
     } else {
       MT_THROW("Could not parse channel expression : {}", line);
     }

--- a/momentum/test/character/character_helpers.cpp
+++ b/momentum/test/character/character_helpers.cpp
@@ -134,8 +134,9 @@ CollisionGeometry createDefaultCollisionGeometry(size_t numJoints) {
   triplets.push_back(Eigen::Triplet<float>(1 * kParametersPerJoint + 5, 8, 0.5f)); // shared_rz
   triplets.push_back(Eigen::Triplet<float>(2 * kParametersPerJoint + 5, 8, 0.5f)); // shared_rz
   for (size_t iJoint = 2; iJoint < numJoints; ++iJoint) {
-    triplets.push_back(Eigen::Triplet<float>(
-        iJoint * kParametersPerJoint + 3, rxStart + iJoint - 2, 1.0f)); // joint1_rx
+    triplets.push_back(
+        Eigen::Triplet<float>(
+            iJoint * kParametersPerJoint + 3, rxStart + iJoint - 2, 1.0f)); // joint1_rx
   }
 
   result.transform.setFromTriplets(triplets.begin(), triplets.end());

--- a/momentum/test/character/forward_kinematics_test.cpp
+++ b/momentum/test/character/forward_kinematics_test.cpp
@@ -142,9 +142,10 @@ TYPED_TEST(Momentum_ForwardKinematicsTest, RelativeTransform) {
 
   for (size_t iJoint = 0; iJoint < skeleton.joints.size(); ++iJoint) {
     // A-to-world:
-    EXPECT_TRUE(transformAtoB<T>(iJoint, kInvalidIndex, skeleton, state)
-                    .toAffine3()
-                    .isApprox(state.jointState[iJoint].transformation, Eps<T>(1e-8f, 1e-8)));
+    EXPECT_TRUE(
+        transformAtoB<T>(iJoint, kInvalidIndex, skeleton, state)
+            .toAffine3()
+            .isApprox(state.jointState[iJoint].transformation, Eps<T>(1e-8f, 1e-8)));
 
     // world-to-B:
     EXPECT_TRUE(

--- a/momentum/test/character/parameter_transform_test.cpp
+++ b/momentum/test/character/parameter_transform_test.cpp
@@ -246,7 +246,9 @@ TYPED_TEST(Momentum_ParameterTransformTest, GetParameterSets) {
   }
 
   // Test getParameterSet with non-existent set (should throw)
-  { EXPECT_THROW((void)transform.getParameterSet("non_existent"), std::runtime_error); }
+  {
+    EXPECT_THROW((void)transform.getParameterSet("non_existent"), std::runtime_error);
+  }
 
   // Test getParameterSet with non-existent set and allowMissing=true
   {

--- a/momentum/test/character_sequence_solver/solver_test.cpp
+++ b/momentum/test/character_sequence_solver/solver_test.cpp
@@ -83,16 +83,18 @@ MultiPoseTestProblem<T>::MultiPoseTestProblem(
     positionErrors[iFrame] = std::make_unique<PositionErrorFunctionT<T>>(character);
     orientErrors[iFrame] = std::make_unique<OrientationErrorFunctionT<T>>(character);
     for (size_t iJoint = 0; iJoint < skelState_cur.jointState.size(); ++iJoint) {
-      positionErrors[iFrame]->addConstraint(PositionDataT<T>(
-          Eigen::Vector3<T>::Zero(),
-          skelState_cur.jointState[iJoint].translation().template cast<T>(),
-          iJoint,
-          1.0));
-      orientErrors[iFrame]->addConstraint(OrientationDataT<T>(
-          Eigen::Quaternion<T>::Identity(),
-          skelState_cur.jointState[iJoint].rotation().template cast<T>(),
-          iJoint,
-          1.0));
+      positionErrors[iFrame]->addConstraint(
+          PositionDataT<T>(
+              Eigen::Vector3<T>::Zero(),
+              skelState_cur.jointState[iJoint].translation().template cast<T>(),
+              iJoint,
+              1.0));
+      orientErrors[iFrame]->addConstraint(
+          OrientationDataT<T>(
+              Eigen::Quaternion<T>::Identity(),
+              skelState_cur.jointState[iJoint].rotation().template cast<T>(),
+              iJoint,
+              1.0));
     }
   }
 }

--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -603,11 +603,12 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, TestSkinningErrorFunction) {
           continue;
         }
         const auto parent = skin.index(vi, si);
-        cl.push_back(PositionDataT<T>(
-            (target - bindState.jointState[parent].translation()),
-            target,
-            parent,
-            skin.weight(vi, si)));
+        cl.push_back(
+            PositionDataT<T>(
+                (target - bindState.jointState[parent].translation()),
+                target,
+                parent,
+                skin.weight(vi, si)));
       }
       errorFunction.setConstraints(cl);
 
@@ -1865,12 +1866,13 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, ProjectionError_GradientsAndJacobians) {
     // Make a few projection constraints to ensure that at least one of them is active, since
     // projections are ignored behind the camera
     for (int i = 0; i < 5; ++i) {
-      errorFunction.addConstraint(ProjectionConstraintDataT<T>{
-          (projection + uniformAffine3<T>().matrix()).topRows(3),
-          uniform<size_t>(0, 2),
-          normal<Vector3<T>>(Vector3<T>::Zero(), Vector3<T>::Ones()),
-          uniform<T>(0.1, 2.0),
-          normal<Vector2<T>>(Vector2<T>::Zero(), Vector2<T>::Ones())});
+      errorFunction.addConstraint(
+          ProjectionConstraintDataT<T>{
+              (projection + uniformAffine3<T>().matrix()).topRows(3),
+              uniform<size_t>(0, 2),
+              normal<Vector3<T>>(Vector3<T>::Zero(), Vector3<T>::Ones()),
+              uniform<T>(0.1, 2.0),
+              normal<Vector2<T>>(Vector2<T>::Zero(), Vector2<T>::Ones())});
     }
 
     if constexpr (std::is_same_v<T, float>) {

--- a/momentum/test/character_solver/inverse_kinematics_test.cpp
+++ b/momentum/test/character_solver/inverse_kinematics_test.cpp
@@ -58,8 +58,9 @@ void testSimpleTargets(const SolverOptionsT& options) {
   // generate rest state and constraints
   SkeletonStateT<T> state(castedCharacterParameterTransform.apply(parameters), skeleton);
   std::vector<PositionDataT<T>> constraints;
-  constraints.push_back(PositionDataT<T>(
-      Vector3<T>::UnitY(), state.jointState[2].transformation * Vector3<T>::UnitY(), 2, 1.0));
+  constraints.push_back(
+      PositionDataT<T>(
+          Vector3<T>::UnitY(), state.jointState[2].transformation * Vector3<T>::UnitY(), 2, 1.0));
 
   {
     SCOPED_TRACE("Checking restpose");

--- a/momentum/test/character_solver/solver_test.cpp
+++ b/momentum/test/character_solver/solver_test.cpp
@@ -87,16 +87,18 @@ TYPED_TEST(GaussNewtonQRTest, CompareGaussNewton) {
     SkeletonStateT<T> skelState_cur(
         castedCharacterParameterTransform.apply(randomParams_cur), character.skeleton);
     for (size_t iJoint = 0; iJoint < skelState_cur.jointState.size(); ++iJoint) {
-      positionErrorFunction->addConstraint(PositionDataT<T>(
-          Eigen::Vector3<T>::Zero(),
-          skelState_cur.jointState[iJoint].translation().template cast<T>(),
-          iJoint,
-          1.0));
-      orientErrorFunction->addConstraint(OrientationDataT<T>(
-          Eigen::Quaternion<T>::Identity(),
-          skelState_cur.jointState[iJoint].rotation().template cast<T>(),
-          iJoint,
-          1.0));
+      positionErrorFunction->addConstraint(
+          PositionDataT<T>(
+              Eigen::Vector3<T>::Zero(),
+              skelState_cur.jointState[iJoint].translation().template cast<T>(),
+              iJoint,
+              1.0));
+      orientErrorFunction->addConstraint(
+          OrientationDataT<T>(
+              Eigen::Quaternion<T>::Identity(),
+              skelState_cur.jointState[iJoint].rotation().template cast<T>(),
+              iJoint,
+              1.0));
     }
 
     solverFunction.addErrorFunction(positionErrorFunction);
@@ -193,16 +195,18 @@ TYPED_TEST(TrustRegionTest, SanityCheck) {
     SkeletonStateT<T> skelState_cur(
         castedCharacterParameterTransform.apply(randomParams_cur), character.skeleton);
     for (size_t iJoint = 0; iJoint < skelState_cur.jointState.size(); ++iJoint) {
-      positionErrorFunction->addConstraint(PositionDataT<T>(
-          Eigen::Vector3<T>::Zero(),
-          skelState_cur.jointState[iJoint].translation().template cast<T>(),
-          iJoint,
-          1.0));
-      orientErrorFunction->addConstraint(OrientationDataT<T>(
-          Eigen::Quaternion<T>::Identity(),
-          skelState_cur.jointState[iJoint].rotation().template cast<T>(),
-          iJoint,
-          1.0));
+      positionErrorFunction->addConstraint(
+          PositionDataT<T>(
+              Eigen::Vector3<T>::Zero(),
+              skelState_cur.jointState[iJoint].translation().template cast<T>(),
+              iJoint,
+              1.0));
+      orientErrorFunction->addConstraint(
+          OrientationDataT<T>(
+              Eigen::Quaternion<T>::Identity(),
+              skelState_cur.jointState[iJoint].rotation().template cast<T>(),
+              iJoint,
+              1.0));
     }
 
     solverFunction.addErrorFunction(positionErrorFunction);

--- a/momentum/test/diff_ik/test_differentiable_ik.cpp
+++ b/momentum/test/diff_ik/test_differentiable_ik.cpp
@@ -87,12 +87,13 @@ TEST(DifferentiableIK, Basic) {
     auto positionError = std::make_shared<FullyDifferentiablePositionErrorFunctionT<T>>(
         skeleton, character.parameterTransform);
     for (size_t iJoint = 0; iJoint < skelState_target.jointState.size(); ++iJoint) {
-      positionError->addConstraint(PositionConstraintT<T>(
-          Eigen::Vector3<T>::Zero(),
-          skelState_target.jointState[iJoint].translation().cast<T>() +
-              4.0 * randomVec(rng, 3).cast<T>(),
-          iJoint,
-          1.f));
+      positionError->addConstraint(
+          PositionConstraintT<T>(
+              Eigen::Vector3<T>::Zero(),
+              skelState_target.jointState[iJoint].translation().cast<T>() +
+                  4.0 * randomVec(rng, 3).cast<T>(),
+              iJoint,
+              1.f));
     }
     positionError->setWeight(j + 1);
     errorFunctions.push_back(positionError);
@@ -103,11 +104,12 @@ TEST(DifferentiableIK, Basic) {
     auto rotationError = std::make_shared<FullyDifferentiableOrientationErrorFunctionT<T>>(
         skeleton, character.parameterTransform);
     for (size_t iJoint = 0; iJoint < skelState_target.jointState.size(); ++iJoint) {
-      rotationError->addConstraint(OrientationConstraintT<T>(
-          Eigen::Quaternion<T>::Identity(),
-          skelState_target.jointState[iJoint].rotation().cast<T>(),
-          iJoint,
-          1.0));
+      rotationError->addConstraint(
+          OrientationConstraintT<T>(
+              Eigen::Quaternion<T>::Identity(),
+              skelState_target.jointState[iJoint].rotation().cast<T>(),
+              iJoint,
+              1.0));
     }
     rotationError->setWeight(3);
     errorFunctions.push_back(rotationError);

--- a/momentum/test/diff_ik/test_error_functions.cpp
+++ b/momentum/test/diff_ik/test_error_functions.cpp
@@ -497,12 +497,13 @@ TEST(ErrorFunction, ProjectionErrorFunction) {
   Eigen::Matrix4<T> projection = Eigen::Matrix4<T>::Identity();
   projection(2, 3) = 10;
   for (int i = 0; i < 5; ++i) {
-    errorFunction.addConstraint(ProjectionConstraintDataT<T>{
-        (projection + rng.uniformAffine3<T>().matrix()).topRows(3),
-        rng.uniform<size_t>(size_t(0), size_t(2)),
-        rng.normal<Vector3<T>>(Vector3<T>::Zero(), Vector3<T>::Ones()),
-        rng.uniform<T>(0.1, 2.0),
-        rng.normal<Vector2<T>>(Vector2<T>::Zero(), Vector2<T>::Ones())});
+    errorFunction.addConstraint(
+        ProjectionConstraintDataT<T>{
+            (projection + rng.uniformAffine3<T>().matrix()).topRows(3),
+            rng.uniform<size_t>(size_t(0), size_t(2)),
+            rng.normal<Vector3<T>>(Vector3<T>::Zero(), Vector3<T>::Ones()),
+            rng.uniform<T>(0.1, 2.0),
+            rng.normal<Vector2<T>>(Vector2<T>::Zero(), Vector2<T>::Ones())});
   }
 
   testConstraintDerivs<double>(skeleton, parameterTransform, errorFunction, true);

--- a/momentum/test/math/mesh_test.cpp
+++ b/momentum/test/math/mesh_test.cpp
@@ -261,24 +261,25 @@ TYPED_TEST(MeshTest, ComplexMesh) {
   };
 
   // Define the faces of the cube (6 faces, 2 triangles each)
-  mesh.faces = {// Front face
-                Eigen::Vector3i(0, 1, 2),
-                Eigen::Vector3i(0, 2, 3),
-                // Right face
-                Eigen::Vector3i(1, 5, 6),
-                Eigen::Vector3i(1, 6, 2),
-                // Back face
-                Eigen::Vector3i(5, 4, 7),
-                Eigen::Vector3i(5, 7, 6),
-                // Left face
-                Eigen::Vector3i(4, 0, 3),
-                Eigen::Vector3i(4, 3, 7),
-                // Top face
-                Eigen::Vector3i(3, 2, 6),
-                Eigen::Vector3i(3, 6, 7),
-                // Bottom face
-                Eigen::Vector3i(4, 5, 1),
-                Eigen::Vector3i(4, 1, 0)};
+  mesh.faces = {
+      // Front face
+      Eigen::Vector3i(0, 1, 2),
+      Eigen::Vector3i(0, 2, 3),
+      // Right face
+      Eigen::Vector3i(1, 5, 6),
+      Eigen::Vector3i(1, 6, 2),
+      // Back face
+      Eigen::Vector3i(5, 4, 7),
+      Eigen::Vector3i(5, 7, 6),
+      // Left face
+      Eigen::Vector3i(4, 0, 3),
+      Eigen::Vector3i(4, 3, 7),
+      // Top face
+      Eigen::Vector3i(3, 2, 6),
+      Eigen::Vector3i(3, 6, 7),
+      // Bottom face
+      Eigen::Vector3i(4, 5, 1),
+      Eigen::Vector3i(4, 1, 0)};
 
   // Define the edges of the cube
   mesh.lines = {

--- a/momentum/test/simd/simd_test.cpp
+++ b/momentum/test/simd/simd_test.cpp
@@ -169,17 +169,21 @@ TEST(SimdTest, Utilities) {
   const Vector3fP crossProd1 = momentum::cross(eigenVec1, vec1);
   const Vector3fP crossProd2 = momentum::cross(vec1, eigenVec1);
   for (auto i = 0u; i < kSimdPacketSize; ++i) {
-    EXPECT_TRUE(Eigen::Vector3f(crossProd1.x()[i], crossProd1.y()[i], crossProd1.z()[i])
-                    .isApprox(eigenVec1.cross(Eigen::Vector3f(pX1[i], pY1[i], pZ1[i]))));
-    EXPECT_TRUE(Eigen::Vector3f(crossProd2.x()[i], crossProd2.y()[i], crossProd2.z()[i])
-                    .isApprox(Eigen::Vector3f(pX1[i], pY1[i], pZ1[i]).cross(eigenVec1)));
+    EXPECT_TRUE(
+        Eigen::Vector3f(crossProd1.x()[i], crossProd1.y()[i], crossProd1.z()[i])
+            .isApprox(eigenVec1.cross(Eigen::Vector3f(pX1[i], pY1[i], pZ1[i]))));
+    EXPECT_TRUE(
+        Eigen::Vector3f(crossProd2.x()[i], crossProd2.y()[i], crossProd2.z()[i])
+            .isApprox(Eigen::Vector3f(pX1[i], pY1[i], pZ1[i]).cross(eigenVec1)));
   }
 
   // Cross product of two Vector3fP-s
   const Vector3fP crossProd3 = cross(vec1, vec2);
   for (auto i = 0u; i < kSimdPacketSize; ++i) {
-    EXPECT_TRUE(Eigen::Vector3f(crossProd3.x()[i], crossProd3.y()[i], crossProd3.z()[i])
-                    .isApprox(Eigen::Vector3f(pX1[i], pY1[i], pZ1[i])
-                                  .cross(Eigen::Vector3f(pX2[i], pY2[i], pZ2[i]))));
+    EXPECT_TRUE(
+        Eigen::Vector3f(crossProd3.x()[i], crossProd3.y()[i], crossProd3.z()[i])
+            .isApprox(
+                Eigen::Vector3f(pX1[i], pY1[i], pZ1[i])
+                    .cross(Eigen::Vector3f(pX2[i], pY2[i], pZ2[i]))));
   }
 }


### PR DESCRIPTION
This pull request fixes clang-format violations across the C++ codebase. The changes ensure consistent code formatting and improve readability by applying clang-format to all affected files in the axel/, momentum/, and pymomentum/ directories.