### PR TITLE
to_gltf renamed to save_gltf_to_dict.

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -236,7 +236,7 @@ PYBIND11_MODULE(geometry, m) {
   //
   // [static methods for io]
   // - load_gltf_from_bytes(gltf_btyes)
-  // - to_gltf(character, fps, motion, offsets)
+  // - save_gltf_to_dict(character, fps, motion, offsets)
   // - load_fbx(fbxFilename, modelFilename, locatorsFilename)
   // - load_fbx_from_bytes(fbx_bytes, permissive)
   // - load_fbx_with_motion(fbxFilename, permissive)
@@ -689,7 +689,7 @@ Note: In practice, most limits are enforced on the model parameters, but momentu
           py::arg("gltf_bytes"))
       // toGLTF(character, fps, motion)
       .def_static(
-          "to_gltf",
+          "save_gltf_to_dict",
           &toGLTF,
           py::call_guard<py::gil_scoped_release>(),
           R"(Serialize a character as a GLTF using dictionary form.

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -246,7 +246,7 @@ PYBIND11_MODULE(geometry, m) {
   // - load_urdf(urdf_filename)
   // - load_urdf_from_bytes(urdf_bytes)
   // - save_gltf(path, character, fps, motion, offsets, markers)
-  // - save_gltf_from_skel_states(path, character, fps, skel_states,
+  // - save_gltf_with_skel_states(path, character, fps, skel_states,
   // joint_params, markers)
   // - save_fbx(path, character, fps, motion, offsets)
   // - save_fbx_with_joint_params(path, character, fps, joint_params)
@@ -890,7 +890,7 @@ support the proprietary momentum motion format for storing model parameters in G
           py::arg("markers") =
               std::optional<const std::vector<std::vector<momentum::Marker>>>{})
       .def_static(
-          "save_gltf_from_skel_states",
+          "save_gltf_with_skel_states",
           &saveGLTFCharacterToFileFromSkelStates,
           py::call_guard<py::gil_scoped_release>(),
           R"(Save a character to a gltf file.


### PR DESCRIPTION
Summary: This naming was a bit confusing because there are many to_gltf functions, so let's specify that we're converting it to a Dict.

Reviewed By: jeongseok-meta

Differential Revision: D82411874


