### PR TITLE
Add copyright header to USD test resource file

### DIFF
--- a/momentum/test/resources/usd/character_with_materials.usda
+++ b/momentum/test/resources/usd/character_with_materials.usda
@@ -1,4 +1,8 @@
 #usda 1.0
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 (
     defaultPrim = "SkelRoot"
     metersPerUnit = 1


### PR DESCRIPTION
Summary: Add Meta copyright header to character_with_materials.usda test resource file to comply with copyright header validation requirements.

Differential Revision: D82537529


