### PR TITLE
Add constraints pinning skinned locators to the mesh

### DIFF
--- a/momentum/marker_tracking/tracker_utils.h
+++ b/momentum/marker_tracking/tracker_utils.h
@@ -11,6 +11,7 @@
 #include <momentum/character/locator.h>
 #include <momentum/character/marker.h>
 #include <momentum/character_solver/fwd.h>
+#include <momentum/character_solver/skinned_locator_triangle_error_function.h>
 
 namespace momentum {
 
@@ -40,6 +41,10 @@ momentum::Character createLocatorCharacter(
 momentum::Character locatorsToSkinnedLocators(
     const momentum::Character& sourceCharacter,
     float maxDistance = 3.0f);
+
+std::vector<momentum::SkinnedLocatorTriangleConstraintT<float>> createSkinnedLocatorMeshConstraints(
+    const momentum::Character& character,
+    float targetDepth = 1.0f);
 
 // Extract locator offsets from a LocatorCharacter for a normal Character given input calibrated
 // parameters


### PR DESCRIPTION
Summary: We want to be able to solve for shape using the skinned locators, but in order for this to work we need some constraint pulling acting between the locators and the mesh.

Reviewed By: jeongseok-meta

Differential Revision: D78744920
