### PR TITLE
Add copyright header to USD test resource file 2

### DIFF
--- a/momentum/test/resources/usd/simple_character.usda
+++ b/momentum/test/resources/usd/simple_character.usda
@@ -1,4 +1,8 @@
 #usda 1.0
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 (
     defaultPrim = "SkelRoot"
     metersPerUnit = 1

--- a/momentum/test/resources/usd/simple_mesh.usda
+++ b/momentum/test/resources/usd/simple_mesh.usda
@@ -1,4 +1,8 @@
 #usda 1.0
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 (
     defaultPrim = "Mesh"
     metersPerUnit = 1


### PR DESCRIPTION
Summary:
Similar to D82537529, two more files need a copyright header to fix:
 {F1982119199}

Differential Revision: D82797852


