### PR TITLE
VertexVertexDistanceErrorFunction.

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -227,6 +227,7 @@ character_solver_public_headers = [
     "character_solver/normal_error_function.h",
     "character_solver/orientation_error_function.h",
     "character_solver/plane_error_function.h",
+    "character_solver/point_triangle_vertex_error_function.h",
     "character_solver/pose_prior_error_function.h",
     "character_solver/position_error_function.h",
     "character_solver/projection_error_function.h",
@@ -240,7 +241,7 @@ character_solver_public_headers = [
     "character_solver/trust_region_qr.h",
     "character_solver/vertex_error_function.h",
     "character_solver/vertex_projection_error_function.h",
-    "character_solver/point_triangle_vertex_error_function.h",
+    "character_solver/vertex_vertex_distance_error_function.h",
 ]
 
 character_solver_sources = [
@@ -255,6 +256,7 @@ character_solver_sources = [
     "character_solver/normal_error_function.cpp",
     "character_solver/orientation_error_function.cpp",
     "character_solver/plane_error_function.cpp",
+    "character_solver/point_triangle_vertex_error_function.cpp",
     "character_solver/pose_prior_error_function.cpp",
     "character_solver/position_error_function.cpp",
     "character_solver/projection_error_function.cpp",
@@ -267,7 +269,7 @@ character_solver_sources = [
     "character_solver/trust_region_qr.cpp",
     "character_solver/vertex_error_function.cpp",
     "character_solver/vertex_projection_error_function.cpp",
-    "character_solver/point_triangle_vertex_error_function.cpp",
+    "character_solver/vertex_vertex_distance_error_function.cpp",
 ]
 
 character_solver_test_sources = [

--- a/momentum/character_solver/fwd.h
+++ b/momentum/character_solver/fwd.h
@@ -609,6 +609,31 @@ using PlaneErrorFunctiond_const_u = ::std::unique_ptr<const PlaneErrorFunctiond>
 using PlaneErrorFunctiond_const_w = ::std::weak_ptr<const PlaneErrorFunctiond>;
 
 template <typename T>
+class PointTriangleVertexErrorFunctionT;
+using PointTriangleVertexErrorFunction = PointTriangleVertexErrorFunctionT<float>;
+using PointTriangleVertexErrorFunctiond = PointTriangleVertexErrorFunctionT<double>;
+
+using PointTriangleVertexErrorFunction_p = ::std::shared_ptr<PointTriangleVertexErrorFunction>;
+using PointTriangleVertexErrorFunction_u = ::std::unique_ptr<PointTriangleVertexErrorFunction>;
+using PointTriangleVertexErrorFunction_w = ::std::weak_ptr<PointTriangleVertexErrorFunction>;
+using PointTriangleVertexErrorFunction_const_p =
+    ::std::shared_ptr<const PointTriangleVertexErrorFunction>;
+using PointTriangleVertexErrorFunction_const_u =
+    ::std::unique_ptr<const PointTriangleVertexErrorFunction>;
+using PointTriangleVertexErrorFunction_const_w =
+    ::std::weak_ptr<const PointTriangleVertexErrorFunction>;
+
+using PointTriangleVertexErrorFunctiond_p = ::std::shared_ptr<PointTriangleVertexErrorFunctiond>;
+using PointTriangleVertexErrorFunctiond_u = ::std::unique_ptr<PointTriangleVertexErrorFunctiond>;
+using PointTriangleVertexErrorFunctiond_w = ::std::weak_ptr<PointTriangleVertexErrorFunctiond>;
+using PointTriangleVertexErrorFunctiond_const_p =
+    ::std::shared_ptr<const PointTriangleVertexErrorFunctiond>;
+using PointTriangleVertexErrorFunctiond_const_u =
+    ::std::unique_ptr<const PointTriangleVertexErrorFunctiond>;
+using PointTriangleVertexErrorFunctiond_const_w =
+    ::std::weak_ptr<const PointTriangleVertexErrorFunctiond>;
+
+template <typename T>
 class PosePriorErrorFunctionT;
 using PosePriorErrorFunction = PosePriorErrorFunctionT<float>;
 using PosePriorErrorFunctiond = PosePriorErrorFunctionT<double>;
@@ -872,28 +897,28 @@ using VertexProjectionErrorFunctiond_const_w =
     ::std::weak_ptr<const VertexProjectionErrorFunctiond>;
 
 template <typename T>
-class PointTriangleVertexErrorFunctionT;
-using PointTriangleVertexErrorFunction = PointTriangleVertexErrorFunctionT<float>;
-using PointTriangleVertexErrorFunctiond = PointTriangleVertexErrorFunctionT<double>;
+class VertexVertexDistanceErrorFunctionT;
+using VertexVertexDistanceErrorFunction = VertexVertexDistanceErrorFunctionT<float>;
+using VertexVertexDistanceErrorFunctiond = VertexVertexDistanceErrorFunctionT<double>;
 
-using PointTriangleVertexErrorFunction_p = ::std::shared_ptr<PointTriangleVertexErrorFunction>;
-using PointTriangleVertexErrorFunction_u = ::std::unique_ptr<PointTriangleVertexErrorFunction>;
-using PointTriangleVertexErrorFunction_w = ::std::weak_ptr<PointTriangleVertexErrorFunction>;
-using PointTriangleVertexErrorFunction_const_p =
-    ::std::shared_ptr<const PointTriangleVertexErrorFunction>;
-using PointTriangleVertexErrorFunction_const_u =
-    ::std::unique_ptr<const PointTriangleVertexErrorFunction>;
-using PointTriangleVertexErrorFunction_const_w =
-    ::std::weak_ptr<const PointTriangleVertexErrorFunction>;
+using VertexVertexDistanceErrorFunction_p = ::std::shared_ptr<VertexVertexDistanceErrorFunction>;
+using VertexVertexDistanceErrorFunction_u = ::std::unique_ptr<VertexVertexDistanceErrorFunction>;
+using VertexVertexDistanceErrorFunction_w = ::std::weak_ptr<VertexVertexDistanceErrorFunction>;
+using VertexVertexDistanceErrorFunction_const_p =
+    ::std::shared_ptr<const VertexVertexDistanceErrorFunction>;
+using VertexVertexDistanceErrorFunction_const_u =
+    ::std::unique_ptr<const VertexVertexDistanceErrorFunction>;
+using VertexVertexDistanceErrorFunction_const_w =
+    ::std::weak_ptr<const VertexVertexDistanceErrorFunction>;
 
-using PointTriangleVertexErrorFunctiond_p = ::std::shared_ptr<PointTriangleVertexErrorFunctiond>;
-using PointTriangleVertexErrorFunctiond_u = ::std::unique_ptr<PointTriangleVertexErrorFunctiond>;
-using PointTriangleVertexErrorFunctiond_w = ::std::weak_ptr<PointTriangleVertexErrorFunctiond>;
-using PointTriangleVertexErrorFunctiond_const_p =
-    ::std::shared_ptr<const PointTriangleVertexErrorFunctiond>;
-using PointTriangleVertexErrorFunctiond_const_u =
-    ::std::unique_ptr<const PointTriangleVertexErrorFunctiond>;
-using PointTriangleVertexErrorFunctiond_const_w =
-    ::std::weak_ptr<const PointTriangleVertexErrorFunctiond>;
+using VertexVertexDistanceErrorFunctiond_p = ::std::shared_ptr<VertexVertexDistanceErrorFunctiond>;
+using VertexVertexDistanceErrorFunctiond_u = ::std::unique_ptr<VertexVertexDistanceErrorFunctiond>;
+using VertexVertexDistanceErrorFunctiond_w = ::std::weak_ptr<VertexVertexDistanceErrorFunctiond>;
+using VertexVertexDistanceErrorFunctiond_const_p =
+    ::std::shared_ptr<const VertexVertexDistanceErrorFunctiond>;
+using VertexVertexDistanceErrorFunctiond_const_u =
+    ::std::unique_ptr<const VertexVertexDistanceErrorFunctiond>;
+using VertexVertexDistanceErrorFunctiond_const_w =
+    ::std::weak_ptr<const VertexVertexDistanceErrorFunctiond>;
 
 } // namespace momentum

--- a/momentum/character_solver/vertex_vertex_distance_error_function.cpp
+++ b/momentum/character_solver/vertex_vertex_distance_error_function.cpp
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/character_solver/vertex_vertex_distance_error_function.h"
+
+#include "momentum/character/blend_shape.h"
+#include "momentum/character/blend_shape_skinning.h"
+#include "momentum/character/character.h"
+#include "momentum/character/linear_skinning.h"
+#include "momentum/character/skeleton.h"
+#include "momentum/character/skeleton_state.h"
+#include "momentum/character_solver/error_function_utils.h"
+#include "momentum/character_solver/skinning_weight_iterator.h"
+#include "momentum/common/checks.h"
+#include "momentum/common/profile.h"
+#include "momentum/math/mesh.h"
+
+namespace momentum {
+
+template <typename T>
+VertexVertexDistanceErrorFunctionT<T>::VertexVertexDistanceErrorFunctionT(
+    const Character& character)
+    : SkeletonErrorFunctionT<T>(character.skeleton, character.parameterTransform),
+      character_(character) {
+  MT_CHECK(static_cast<bool>(character.mesh));
+  MT_CHECK(static_cast<bool>(character.skinWeights));
+
+  this->restMesh_ = std::make_unique<MeshT<T>>(character.mesh->template cast<T>());
+  this->posedMesh_ = std::make_unique<MeshT<T>>(character.mesh->template cast<T>());
+}
+
+template <typename T>
+VertexVertexDistanceErrorFunctionT<T>::~VertexVertexDistanceErrorFunctionT() {}
+
+template <typename T>
+void VertexVertexDistanceErrorFunctionT<T>::addConstraint(
+    int vertexIndex1,
+    int vertexIndex2,
+    T weight,
+    T targetDistance) {
+  MT_CHECK(vertexIndex1 >= 0 && ((size_t)vertexIndex1) < character_.mesh->vertices.size());
+  MT_CHECK(vertexIndex2 >= 0 && ((size_t)vertexIndex2) < character_.mesh->vertices.size());
+  MT_CHECK(vertexIndex1 != vertexIndex2);
+
+  constraints_.push_back(
+      VertexVertexDistanceConstraintT<T>{vertexIndex1, vertexIndex2, weight, targetDistance});
+}
+
+template <typename T>
+void VertexVertexDistanceErrorFunctionT<T>::clearConstraints() {
+  constraints_.clear();
+}
+
+template <typename T>
+double VertexVertexDistanceErrorFunctionT<T>::getError(
+    const ModelParametersT<T>& modelParameters,
+    const SkeletonStateT<T>& state) {
+  MT_PROFILE_FUNCTION();
+
+  updateMeshes(modelParameters, state);
+
+  double error = 0.0;
+
+  for (const auto& constraint : constraints_) {
+    const auto& pos1 = posedMesh_->vertices[constraint.vertexIndex1];
+    const auto& pos2 = posedMesh_->vertices[constraint.vertexIndex2];
+
+    const T actualDistance = (pos1 - pos2).norm();
+    const T distanceDiff = actualDistance - constraint.targetDistance;
+
+    error += constraint.weight * distanceDiff * distanceDiff;
+  }
+
+  return error * this->weight_;
+}
+
+template <typename T>
+void VertexVertexDistanceErrorFunctionT<T>::updateMeshes(
+    const ModelParametersT<T>& modelParameters,
+    const SkeletonStateT<T>& state) {
+  MT_PROFILE_FUNCTION();
+
+  // Update rest mesh with blend shapes if present
+  bool doUpdateNormals = false;
+  if (this->character_.blendShape) {
+    const BlendWeightsT<T> blendWeights =
+        extractBlendWeights(this->parameterTransform_, modelParameters);
+    this->character_.blendShape->computeShape(blendWeights, this->restMesh_->vertices);
+    doUpdateNormals = true;
+  }
+
+  if (doUpdateNormals) {
+    this->restMesh_->updateNormals();
+  }
+
+  // Apply skinning to get the posed mesh
+  applySSD(
+      cast<T>(character_.inverseBindPose),
+      *this->character_.skinWeights,
+      *this->restMesh_,
+      state,
+      *this->posedMesh_);
+}
+
+template <typename T>
+double VertexVertexDistanceErrorFunctionT<T>::getGradient(
+    const ModelParametersT<T>& modelParameters,
+    const SkeletonStateT<T>& state,
+    Eigen::Ref<Eigen::VectorX<T>> gradient) {
+  MT_PROFILE_FUNCTION();
+
+  updateMeshes(modelParameters, state);
+
+  double error = 0.0;
+
+  for (const auto& constraint : constraints_) {
+    error += calculateGradient(modelParameters, state, constraint, gradient);
+  }
+
+  return error * this->weight_;
+}
+
+template <typename T>
+double VertexVertexDistanceErrorFunctionT<T>::getJacobian(
+    const ModelParametersT<T>& modelParameters,
+    const SkeletonStateT<T>& state,
+    Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+    Eigen::Ref<Eigen::VectorX<T>> residual,
+    int& usedRows) {
+  MT_PROFILE_FUNCTION();
+
+  MT_CHECK(
+      jacobian.cols() == static_cast<Eigen::Index>(this->parameterTransform_.transform.cols()));
+  MT_CHECK(jacobian.rows() >= static_cast<Eigen::Index>(constraints_.size()));
+  MT_CHECK(residual.rows() >= static_cast<Eigen::Index>(constraints_.size()));
+
+  updateMeshes(modelParameters, state);
+
+  double error = 0.0;
+
+  for (size_t i = 0; i < constraints_.size(); i++) {
+    T residualValue;
+    error += calculateJacobian(
+        modelParameters,
+        state,
+        constraints_[i],
+        jacobian.block(i, 0, 1, modelParameters.size()),
+        residualValue);
+    residual(i) = residualValue;
+  }
+
+  usedRows = static_cast<int>(constraints_.size());
+  return error;
+}
+
+template <typename T>
+size_t VertexVertexDistanceErrorFunctionT<T>::getJacobianSize() const {
+  return constraints_.size();
+}
+
+template <typename T>
+double VertexVertexDistanceErrorFunctionT<T>::calculateJacobian(
+    const ModelParametersT<T>& modelParameters,
+    const SkeletonStateT<T>& state,
+    const VertexVertexDistanceConstraintT<T>& constraint,
+    Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+    T& residual) const {
+  MT_PROFILE_FUNCTION();
+
+  const auto& pos1 = posedMesh_->vertices[constraint.vertexIndex1];
+  const auto& pos2 = posedMesh_->vertices[constraint.vertexIndex2];
+
+  const Eigen::Vector3<T> diff = pos1 - pos2;
+  const T actualDistance = diff.norm();
+
+  // Handle degenerate case where vertices are at the same position
+  if (actualDistance == T(0)) {
+    residual = T(0);
+    return T(0); // No meaningful jacobian when distance is zero
+  }
+
+  const T distanceDiff = actualDistance - constraint.targetDistance;
+  const Eigen::Vector3<T> distanceGradient = diff / actualDistance; // normalized difference vector
+
+  // Weight for the jacobian: sqrt(weight * this->weight_)
+  const T wgt = std::sqrt(constraint.weight * this->weight_);
+
+  // Set residual: wgt * distanceDiff
+  residual = wgt * distanceDiff;
+
+  // Calculate jacobian contribution from vertex1 (positive contribution)
+  calculateVertexJacobian(
+      modelParameters, state, constraint.vertexIndex1, wgt * distanceGradient, jacobian);
+
+  // Calculate jacobian contribution from vertex2 (negative contribution)
+  calculateVertexJacobian(
+      modelParameters, state, constraint.vertexIndex2, -wgt * distanceGradient, jacobian);
+
+  return wgt * wgt * distanceDiff * distanceDiff;
+}
+
+template <typename T>
+void VertexVertexDistanceErrorFunctionT<T>::calculateVertexJacobian(
+    const ModelParametersT<T>& /*modelParameters*/,
+    const SkeletonStateT<T>& state,
+    int vertexIndex,
+    const Eigen::Vector3<T>& jacobianDirection,
+    Eigen::Ref<Eigen::MatrixX<T>> jacobian) const {
+  MT_PROFILE_FUNCTION();
+
+  SkinningWeightIteratorT<T> skinningIter(this->character_, *this->restMesh_, state, vertexIndex);
+
+  // Handle derivatives wrt joint parameters
+  while (!skinningIter.finished()) {
+    size_t jointIndex = 0;
+    T boneWeight;
+    Eigen::Vector3<T> pos;
+    std::tie(jointIndex, boneWeight, pos) = skinningIter.next();
+
+    // Check for valid index
+    MT_CHECK(jointIndex < this->skeleton_.joints.size());
+
+    const auto& jointState = state.jointState[jointIndex];
+    const size_t paramIndex = jointIndex * kParametersPerJoint;
+    const Eigen::Vector3<T> posd = pos - jointState.translation();
+
+    // Calculate derivatives based on active joints
+    for (size_t d = 0; d < 3; d++) {
+      if (this->activeJointParams_[paramIndex + d]) {
+        // Jacobian wrt translation:
+        jacobian_jointParams_to_modelParams<T>(
+            boneWeight * jacobianDirection.dot(jointState.getTranslationDerivative(d)),
+            paramIndex + d,
+            this->parameterTransform_,
+            jacobian);
+      }
+      if (this->activeJointParams_[paramIndex + 3 + d]) {
+        // Jacobian wrt rotation:
+        jacobian_jointParams_to_modelParams<T>(
+            boneWeight * jacobianDirection.dot(jointState.getRotationDerivative(d, posd)),
+            paramIndex + 3 + d,
+            this->parameterTransform_,
+            jacobian);
+      }
+    }
+    if (this->activeJointParams_[paramIndex + 6]) {
+      // Jacobian wrt scale:
+      jacobian_jointParams_to_modelParams<T>(
+          boneWeight * jacobianDirection.dot(jointState.getScaleDerivative(posd)),
+          paramIndex + 6,
+          this->parameterTransform_,
+          jacobian);
+    }
+  }
+
+  // Handle derivatives wrt blend shape parameters
+  if (this->character_.blendShape) {
+    for (Eigen::Index iBlendShape = 0;
+         iBlendShape < this->parameterTransform_.blendShapeParameters.size();
+         ++iBlendShape) {
+      const auto paramIdx = this->parameterTransform_.blendShapeParameters[iBlendShape];
+      if (paramIdx < 0) {
+        continue;
+      }
+
+      const Eigen::Vector3<T> d_restPos =
+          this->character_.blendShape->getShapeVectors()
+              .template block<3, 1>(3 * vertexIndex, iBlendShape, 3, 1)
+              .template cast<T>();
+      Eigen::Vector3<T> d_worldPos = Eigen::Vector3<T>::Zero();
+      calculateDWorldPos(state, vertexIndex, d_restPos, d_worldPos);
+
+      jacobian(0, paramIdx) += jacobianDirection.dot(d_worldPos);
+    }
+  }
+
+  // Handle derivatives wrt face expression blend shape parameters
+  if (this->character_.faceExpressionBlendShape) {
+    for (Eigen::Index iBlendShape = 0;
+         iBlendShape < this->parameterTransform_.faceExpressionParameters.size();
+         ++iBlendShape) {
+      const auto paramIdx = this->parameterTransform_.faceExpressionParameters[iBlendShape];
+      if (paramIdx < 0) {
+        continue;
+      }
+
+      const Eigen::Vector3<T> d_restPos =
+          this->character_.faceExpressionBlendShape->getShapeVectors()
+              .template block<3, 1>(3 * vertexIndex, iBlendShape, 3, 1)
+              .template cast<T>();
+      Eigen::Vector3<T> d_worldPos = Eigen::Vector3<T>::Zero();
+      calculateDWorldPos(state, vertexIndex, d_restPos, d_worldPos);
+
+      jacobian(0, paramIdx) += jacobianDirection.dot(d_worldPos);
+    }
+  }
+}
+
+template <typename T>
+double VertexVertexDistanceErrorFunctionT<T>::calculateGradient(
+    const ModelParametersT<T>& modelParameters,
+    const SkeletonStateT<T>& state,
+    const VertexVertexDistanceConstraintT<T>& constraint,
+    Eigen::Ref<Eigen::VectorX<T>> gradient) const {
+  MT_PROFILE_FUNCTION();
+
+  const auto& pos1 = posedMesh_->vertices[constraint.vertexIndex1];
+  const auto& pos2 = posedMesh_->vertices[constraint.vertexIndex2];
+
+  const Eigen::Vector3<T> diff = pos1 - pos2;
+  const T actualDistance = diff.norm();
+
+  // Handle degenerate case where vertices are at the same position
+  if (actualDistance == T(0)) {
+    return T(0); // No meaningful gradient when distance is zero
+  }
+
+  const T distanceDiff = actualDistance - constraint.targetDistance;
+  const Eigen::Vector3<T> distanceGradient = diff / actualDistance; // normalized difference vector
+
+  // Weight for the gradient: 2 * weight * distanceDiff * this->weight_
+  const T wgt = T(2) * constraint.weight * distanceDiff * this->weight_;
+
+  // Calculate gradient contribution from vertex1 (positive contribution)
+  calculateVertexGradient(
+      modelParameters, state, constraint.vertexIndex1, wgt * distanceGradient, gradient);
+
+  // Calculate gradient contribution from vertex2 (negative contribution)
+  calculateVertexGradient(
+      modelParameters, state, constraint.vertexIndex2, -wgt * distanceGradient, gradient);
+
+  return constraint.weight * distanceDiff * distanceDiff;
+}
+
+template <typename T>
+void VertexVertexDistanceErrorFunctionT<T>::calculateVertexGradient(
+    const ModelParametersT<T>& /*modelParameters*/,
+    const SkeletonStateT<T>& state,
+    int vertexIndex,
+    const Eigen::Vector3<T>& gradientDirection,
+    Eigen::Ref<Eigen::VectorX<T>> gradient) const {
+  MT_PROFILE_FUNCTION();
+
+  SkinningWeightIteratorT<T> skinningIter(this->character_, *this->restMesh_, state, vertexIndex);
+
+  // Handle derivatives wrt joint parameters
+  while (!skinningIter.finished()) {
+    size_t jointIndex = 0;
+    T boneWeight;
+    Eigen::Vector3<T> pos;
+    std::tie(jointIndex, boneWeight, pos) = skinningIter.next();
+
+    // Check for valid index
+    MT_CHECK(jointIndex < this->skeleton_.joints.size());
+
+    const auto& jointState = state.jointState[jointIndex];
+    const size_t paramIndex = jointIndex * kParametersPerJoint;
+    const Eigen::Vector3<T> posd = pos - jointState.translation();
+
+    // Calculate derivatives based on active joints
+    for (size_t d = 0; d < 3; d++) {
+      if (this->activeJointParams_[paramIndex + d]) {
+        // Gradient wrt translation:
+        gradient_jointParams_to_modelParams(
+            boneWeight * gradientDirection.dot(jointState.getTranslationDerivative(d)),
+            paramIndex + d,
+            this->parameterTransform_,
+            gradient);
+      }
+      if (this->activeJointParams_[paramIndex + 3 + d]) {
+        // Gradient wrt rotation:
+        gradient_jointParams_to_modelParams(
+            boneWeight * gradientDirection.dot(jointState.getRotationDerivative(d, posd)),
+            paramIndex + 3 + d,
+            this->parameterTransform_,
+            gradient);
+      }
+    }
+    if (this->activeJointParams_[paramIndex + 6]) {
+      // Gradient wrt scale:
+      gradient_jointParams_to_modelParams(
+          boneWeight * gradientDirection.dot(jointState.getScaleDerivative(posd)),
+          paramIndex + 6,
+          this->parameterTransform_,
+          gradient);
+    }
+  }
+
+  // Handle derivatives wrt blend shape parameters
+  if (this->character_.blendShape) {
+    for (Eigen::Index iBlendShape = 0;
+         iBlendShape < this->parameterTransform_.blendShapeParameters.size();
+         ++iBlendShape) {
+      const auto paramIdx = this->parameterTransform_.blendShapeParameters[iBlendShape];
+      if (paramIdx < 0) {
+        continue;
+      }
+
+      const Eigen::Vector3<T> d_restPos =
+          this->character_.blendShape->getShapeVectors()
+              .template block<3, 1>(3 * vertexIndex, iBlendShape, 3, 1)
+              .template cast<T>();
+      Eigen::Vector3<T> d_worldPos = Eigen::Vector3<T>::Zero();
+      calculateDWorldPos(state, vertexIndex, d_restPos, d_worldPos);
+
+      gradient[paramIdx] += gradientDirection.dot(d_worldPos);
+    }
+  }
+
+  // Handle derivatives wrt face expression blend shape parameters
+  if (this->character_.faceExpressionBlendShape) {
+    for (Eigen::Index iBlendShape = 0;
+         iBlendShape < this->parameterTransform_.faceExpressionParameters.size();
+         ++iBlendShape) {
+      const auto paramIdx = this->parameterTransform_.faceExpressionParameters[iBlendShape];
+      if (paramIdx < 0) {
+        continue;
+      }
+
+      const Eigen::Vector3<T> d_restPos =
+          this->character_.faceExpressionBlendShape->getShapeVectors()
+              .template block<3, 1>(3 * vertexIndex, iBlendShape, 3, 1)
+              .template cast<T>();
+      Eigen::Vector3<T> d_worldPos = Eigen::Vector3<T>::Zero();
+      calculateDWorldPos(state, vertexIndex, d_restPos, d_worldPos);
+
+      gradient[paramIdx] += gradientDirection.dot(d_worldPos);
+    }
+  }
+}
+
+template <typename T>
+void VertexVertexDistanceErrorFunctionT<T>::calculateDWorldPos(
+    const SkeletonStateT<T>& state,
+    int vertexIndex,
+    const Eigen::Vector3<T>& d_restPos,
+    Eigen::Vector3<T>& d_worldPos) const {
+  const auto& skinWeights = *character_.skinWeights;
+
+  for (uint32_t i = 0; i < kMaxSkinJoints; ++i) {
+    const auto w = skinWeights.weight(vertexIndex, i);
+    const auto parentBone = skinWeights.index(vertexIndex, i);
+    if (w > 0) {
+      d_worldPos += w *
+          (state.jointState[parentBone].transform.toLinear() *
+           (character_.inverseBindPose[parentBone].linear().template cast<T>() * d_restPos));
+    }
+  }
+}
+
+// Explicit template instantiations
+template class VertexVertexDistanceErrorFunctionT<float>;
+template class VertexVertexDistanceErrorFunctionT<double>;
+
+template struct VertexVertexDistanceConstraintT<float>;
+template struct VertexVertexDistanceConstraintT<double>;
+
+} // namespace momentum

--- a/momentum/character_solver/vertex_vertex_distance_error_function.h
+++ b/momentum/character_solver/vertex_vertex_distance_error_function.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/character_solver/fwd.h>
+#include <momentum/character_solver/skeleton_error_function.h>
+#include <momentum/math/fwd.h>
+
+#include <Eigen/Dense>
+#include <memory>
+#include <vector>
+
+namespace momentum {
+
+/// Constraint for vertex-to-vertex distance errors
+template <typename T>
+struct VertexVertexDistanceConstraintT {
+  int vertexIndex1 = -1; ///< First vertex index
+  int vertexIndex2 = -1; ///< Second vertex index
+  T weight = 1; ///< Constraint weight
+  T targetDistance = 0; ///< Desired distance between the two vertices
+
+  template <typename T2>
+  VertexVertexDistanceConstraintT<T2> cast() const {
+    return {
+        this->vertexIndex1,
+        this->vertexIndex2,
+        static_cast<T2>(this->weight),
+        static_cast<T2>(this->targetDistance)};
+  }
+};
+
+/// Error function for vertex-to-vertex distance constraints
+template <typename T>
+class VertexVertexDistanceErrorFunctionT : public SkeletonErrorFunctionT<T> {
+ public:
+  explicit VertexVertexDistanceErrorFunctionT(const Character& character);
+  ~VertexVertexDistanceErrorFunctionT() override;
+
+  VertexVertexDistanceErrorFunctionT(const VertexVertexDistanceErrorFunctionT& other) = delete;
+  VertexVertexDistanceErrorFunctionT(VertexVertexDistanceErrorFunctionT&& other) noexcept = delete;
+  VertexVertexDistanceErrorFunctionT& operator=(const VertexVertexDistanceErrorFunctionT& other) =
+      delete;
+  VertexVertexDistanceErrorFunctionT& operator=(VertexVertexDistanceErrorFunctionT&& other) =
+      delete;
+
+  [[nodiscard]] double getError(
+      const ModelParametersT<T>& modelParameters,
+      const SkeletonStateT<T>& state) final;
+
+  double getGradient(
+      const ModelParametersT<T>& modelParameters,
+      const SkeletonStateT<T>& state,
+      Eigen::Ref<Eigen::VectorX<T>> gradient) final;
+
+  double getJacobian(
+      const ModelParametersT<T>& modelParameters,
+      const SkeletonStateT<T>& state,
+      Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+      Eigen::Ref<Eigen::VectorX<T>> residual,
+      int& usedRows) final;
+
+  [[nodiscard]] size_t getJacobianSize() const final;
+
+  /// Add a vertex-to-vertex distance constraint
+  void addConstraint(int vertexIndex1, int vertexIndex2, T weight, T targetDistance);
+
+  /// Clear all constraints
+  void clearConstraints();
+
+  /// Get all constraints
+  [[nodiscard]] const std::vector<VertexVertexDistanceConstraintT<T>>& getConstraints() const {
+    return constraints_;
+  }
+
+  /// Get the number of constraints
+  [[nodiscard]] size_t numConstraints() const {
+    return constraints_.size();
+  }
+
+  /// Get the character
+  [[nodiscard]] const Character& getCharacter() const {
+    return character_;
+  }
+
+ private:
+  /// Calculate jacobian for a distance constraint
+  double calculateJacobian(
+      const ModelParametersT<T>& modelParameters,
+      const SkeletonStateT<T>& state,
+      const VertexVertexDistanceConstraintT<T>& constraint,
+      Eigen::Ref<Eigen::MatrixX<T>> jacobian,
+      T& residual) const;
+
+  /// Calculate gradient for a distance constraint
+  double calculateGradient(
+      const ModelParametersT<T>& modelParameters,
+      const SkeletonStateT<T>& state,
+      const VertexVertexDistanceConstraintT<T>& constraint,
+      Eigen::Ref<Eigen::VectorX<T>> gradient) const;
+
+  /// Calculate gradient contribution from a single vertex
+  void calculateVertexGradient(
+      const ModelParametersT<T>& modelParameters,
+      const SkeletonStateT<T>& state,
+      int vertexIndex,
+      const Eigen::Vector3<T>& gradientDirection,
+      Eigen::Ref<Eigen::VectorX<T>> gradient) const;
+
+  /// Calculate jacobian contribution from a single vertex
+  void calculateVertexJacobian(
+      const ModelParametersT<T>& modelParameters,
+      const SkeletonStateT<T>& state,
+      int vertexIndex,
+      const Eigen::Vector3<T>& jacobianDirection,
+      Eigen::Ref<Eigen::MatrixX<T>> jacobian) const;
+
+  /// Calculate world space position derivative for blend shape parameters
+  void calculateDWorldPos(
+      const SkeletonStateT<T>& state,
+      int vertexIndex,
+      const Eigen::Vector3<T>& d_restPos,
+      Eigen::Vector3<T>& d_worldPos) const;
+
+  /// Update the meshes with current parameters and state
+  void updateMeshes(const ModelParametersT<T>& modelParameters, const SkeletonStateT<T>& state);
+
+  const Character& character_;
+
+  std::vector<VertexVertexDistanceConstraintT<T>> constraints_;
+
+  /// Mesh used to store rest positions
+  std::unique_ptr<MeshT<T>> restMesh_;
+  /// Mesh used to store posed positions
+  std::unique_ptr<MeshT<T>> posedMesh_;
+};
+
+} // namespace momentum

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -84,6 +84,7 @@ template_classes = [
     "NormalErrorFunction",
     "OrientationErrorFunction",
     "PlaneErrorFunction",
+    "PointTriangleVertexErrorFunction",
     "PosePriorErrorFunction",
     "PoseTransformSolver",
     "PositionErrorFunction",
@@ -97,7 +98,7 @@ template_classes = [
     "TrustRegionQR",
     "VertexErrorFunction",
     "VertexProjectionErrorFunction",
-    "PointTriangleVertexErrorFunction",
+    "VertexVertexDistanceErrorFunction",
 ]
 
 [[fwd]]

--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -37,6 +37,7 @@
 #include "momentum/character_solver/state_error_function.h"
 #include "momentum/character_solver/vertex_error_function.h"
 #include "momentum/character_solver/vertex_projection_error_function.h"
+#include "momentum/character_solver/vertex_vertex_distance_error_function.h"
 #include "momentum/math/constants.h"
 #include "momentum/math/mesh.h"
 #include "momentum/math/random.h"
@@ -386,6 +387,132 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, StateError_GradientsAndJacobians) {
       TEST_GRADIENT_AND_JACOBIAN(
           T, &errorFunction, parameters, skeleton, transform, Eps<T>(1e-2f, 5e-6));
     }
+  }
+}
+
+TYPED_TEST(Momentum_ErrorFunctionsTest, VertexVertexDistanceError_GradientsAndJacobians) {
+  using T = typename TestFixture::Type;
+  SCOPED_TRACE(fmt::format("ScalarType: {}", typeid(T).name()));
+
+  // create skeleton and reference values
+  const size_t nConstraints = 10;
+
+  // Test WITHOUT blend shapes:
+  {
+    SCOPED_TRACE("Without blend shapes");
+
+    const Character character_orig = createTestCharacter();
+    const Eigen::VectorX<T> refParams = 0.25 *
+        uniform<VectorX<T>>(character_orig.parameterTransform.numAllModelParameters(), -1, 1);
+    const ModelParametersT<T> modelParams = refParams;
+    const ParameterTransformT<T> transform = character_orig.parameterTransform.cast<T>();
+
+    VertexVertexDistanceErrorFunctionT<T> errorFunction(character_orig);
+
+    // Add some vertex-vertex distance constraints
+    for (size_t iCons = 0; iCons < nConstraints; ++iCons) {
+      const int vertexIndex1 =
+          uniform<int>(0, static_cast<int>(character_orig.mesh->vertices.size() - 1));
+      int vertexIndex2 =
+          uniform<int>(0, static_cast<int>(character_orig.mesh->vertices.size() - 1));
+
+      // Ensure we don't constrain the same vertex to itself
+      while (vertexIndex2 == vertexIndex1) {
+        vertexIndex2 = uniform<int>(0, static_cast<int>(character_orig.mesh->vertices.size() - 1));
+      }
+
+      const T weight = uniform<T>(0.1, 2.0);
+      const T targetDistance = uniform<T>(0.1, 1.0);
+
+      errorFunction.addConstraint(vertexIndex1, vertexIndex2, weight, targetDistance);
+    }
+
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunction,
+        modelParams,
+        character_orig.skeleton,
+        character_orig.parameterTransform.cast<T>(),
+        Eps<T>(5e-2f, 1e-5),
+        Eps<T>(1e-6f, 1e-14),
+        true,
+        false);
+  }
+
+  // Test WITH blend shapes:
+  {
+    SCOPED_TRACE("With blend shapes");
+
+    const Character character_blend = withTestBlendShapes(createTestCharacter());
+    const Eigen::VectorX<T> refParams = 0.25 *
+        uniform<VectorX<T>>(character_blend.parameterTransform.numAllModelParameters(), -1, 1);
+    const ModelParametersT<T> modelParams = refParams;
+    const ParameterTransformT<T> transform = character_blend.parameterTransform.cast<T>();
+
+    VertexVertexDistanceErrorFunctionT<T> errorFunction(character_blend);
+
+    // Add some vertex-vertex distance constraints
+    for (size_t iCons = 0; iCons < nConstraints; ++iCons) {
+      const int vertexIndex1 =
+          uniform<int>(0, static_cast<int>(character_blend.mesh->vertices.size() - 1));
+      int vertexIndex2 =
+          uniform<int>(0, static_cast<int>(character_blend.mesh->vertices.size() - 1));
+
+      // Ensure we don't constrain the same vertex to itself
+      while (vertexIndex2 == vertexIndex1) {
+        vertexIndex2 = uniform<int>(0, static_cast<int>(character_blend.mesh->vertices.size() - 1));
+      }
+
+      const T weight = uniform<T>(0.1, 2.0);
+      const T targetDistance = uniform<T>(0.1, 1.0);
+
+      errorFunction.addConstraint(vertexIndex1, vertexIndex2, weight, targetDistance);
+    }
+
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunction,
+        modelParams,
+        character_blend.skeleton,
+        character_blend.parameterTransform.cast<T>(),
+        Eps<T>(1e-2f, 1e-5),
+        Eps<T>(1e-6f, 1e-14),
+        true,
+        false);
+  }
+
+  // Test that error is zero when vertices are at target distance
+  {
+    SCOPED_TRACE("Zero error test");
+
+    const Character character = createTestCharacter();
+    const ModelParametersT<T> modelParams =
+        ModelParametersT<T>::Zero(character.parameterTransform.numAllModelParameters());
+    const SkeletonStateT<T> skelState(
+        character.parameterTransform.cast<T>().apply(modelParams), character.skeleton);
+
+    VertexVertexDistanceErrorFunctionT<T> errorFunction(character);
+
+    // Calculate actual distance between two vertices
+    momentum::TransformationListT<T> ibp;
+    for (const auto& js : character.inverseBindPose) {
+      ibp.push_back(js.cast<T>());
+    }
+    const auto mesh = character.mesh->cast<T>();
+    const auto& skin = *character.skinWeights;
+    momentum::MeshT<T> posedMesh = character.mesh->cast<T>();
+    applySSD(ibp, skin, mesh, skelState, posedMesh);
+
+    const int vertexIndex1 = 0;
+    const int vertexIndex2 = 1;
+    const T actualDistance =
+        (posedMesh.vertices[vertexIndex1] - posedMesh.vertices[vertexIndex2]).norm();
+
+    // Add constraint with the actual distance as target
+    errorFunction.addConstraint(vertexIndex1, vertexIndex2, T(1.0), actualDistance);
+
+    const double error = errorFunction.getError(modelParams, skelState);
+    EXPECT_NEAR(error, 0.0, Eps<T>(1e-10f, 1e-15));
   }
 }
 


### PR DESCRIPTION
Summary:
We want to be able to pin certain vertices to be a specific distance apart.  This has some similarities to the PointTriangleVertexErrorFunction since it is a mesh-mesh distance, but should work better for long distances.   

Recall that the point-triangle error function defines a local space using the triangle plane and normal, and the target point is rigidly attached in this space.  This works well when you are close to the triangle, but as you get far away from the triangle you end up with a very large moment arm torquing the triangle (basically the error function may "prefer" to rotate the triangle rather than actually changing the distance).  

For this reason it makes sense to have a much simpler point-to-point error that just acts on vertices, it won't be able to constrain the location rigidly in the same way (since there is no rigid frame defined on an individual vertex) but it should be numerically well-behaved.

Reviewed By: jeongseok-meta

Differential Revision: D82848960


