### PR TITLE
Add new TRS functionality.

### DIFF
--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -135,6 +135,10 @@ skel_state_sources = [
     "skel_state.py",
 ]
 
+trs_sources = [
+    "trs.py",
+]
+
 marker_tracking_public_headers = [
 ]
 

--- a/pymomentum/test/test_trs.py
+++ b/pymomentum/test/test_trs.py
@@ -1,0 +1,453 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import pymomentum.trs as pym_trs
+import torch
+
+
+class TestTRS(unittest.TestCase):
+    def test_from_translation(self) -> None:
+        """Test creating TRS from translation vector."""
+        translation = torch.tensor([1.0, 2.0, 3.0])
+        t, r, s = pym_trs.from_translation(translation)
+
+        # Check translation matches
+        self.assertTrue(torch.allclose(t, translation))
+
+        # Check rotation is identity matrix
+        expected_rotation = torch.eye(3)
+        self.assertTrue(torch.allclose(r, expected_rotation))
+
+        # Check scale is 1
+        expected_scale = torch.tensor([1.0])
+        self.assertTrue(torch.allclose(s, expected_scale))
+
+    def test_from_rotation_matrix(self) -> None:
+        """Test creating TRS from rotation matrix."""
+        # Create a simple rotation matrix (90 degrees around Z axis)
+        rotation_matrix = torch.tensor(
+            [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+        t, r, s = pym_trs.from_rotation_matrix(rotation_matrix)
+
+        # Check rotation matches
+        self.assertTrue(torch.allclose(r, rotation_matrix))
+
+        # Check translation is zero
+        expected_translation = torch.zeros(3)
+        self.assertTrue(torch.allclose(t, expected_translation))
+
+        # Check scale is 1
+        expected_scale = torch.tensor([1.0])
+        self.assertTrue(torch.allclose(s, expected_scale))
+
+    def test_from_scale(self) -> None:
+        """Test creating TRS from scale factor."""
+        scale = torch.tensor([2.5])
+        t, r, s = pym_trs.from_scale(scale)
+
+        # Check scale matches
+        self.assertTrue(torch.allclose(s, scale))
+
+        # Check translation is zero
+        expected_translation = torch.zeros(3)
+        self.assertTrue(torch.allclose(t, expected_translation))
+
+        # Check rotation is identity matrix
+        expected_rotation = torch.eye(3)
+        self.assertTrue(torch.allclose(r, expected_rotation))
+
+    def test_identity_no_batch(self) -> None:
+        """Test identity transform with no batch dimensions."""
+        t, r, s = pym_trs.identity()
+
+        # Check shapes
+        self.assertEqual(t.shape, (3,))
+        self.assertEqual(r.shape, (3, 3))
+        self.assertEqual(s.shape, (1,))
+
+        # Check values
+        self.assertTrue(torch.allclose(t, torch.zeros(3)))
+        self.assertTrue(torch.allclose(r, torch.eye(3)))
+        self.assertTrue(torch.allclose(s, torch.ones(1)))
+
+    def test_identity_with_batch(self) -> None:
+        """Test identity transform with batch dimensions."""
+        batch_size = [2, 3]
+        t, r, s = pym_trs.identity(size=batch_size)
+
+        # Check shapes
+        self.assertEqual(t.shape, (2, 3, 3))
+        self.assertEqual(r.shape, (2, 3, 3, 3))
+        self.assertEqual(s.shape, (2, 3, 1))
+
+        # Check values - all should be identity transforms
+        expected_t = torch.zeros(2, 3, 3)
+        expected_r = torch.eye(3).expand(2, 3, 3, 3)
+        expected_s = torch.ones(2, 3, 1)
+
+        self.assertTrue(torch.allclose(t, expected_t))
+        self.assertTrue(torch.allclose(r, expected_r))
+        self.assertTrue(torch.allclose(s, expected_s))
+
+    def test_multiply(self) -> None:
+        """Test multiplying two TRS transforms."""
+        # Create first transform: translation only
+        t1 = torch.tensor([1.0, 0.0, 0.0])
+        trs1 = pym_trs.from_translation(t1)
+
+        # Create second transform: scale only
+        s2 = torch.tensor([2.0])
+        trs2 = pym_trs.from_scale(s2)
+
+        # Multiply transforms
+        t_result, r_result, s_result = pym_trs.multiply(trs1, trs2)
+
+        # Check that rotation is still identity
+        self.assertTrue(torch.allclose(r_result, torch.eye(3)))
+
+        # Check that scale is 2.0
+        self.assertTrue(torch.allclose(s_result, torch.tensor([2.0])))
+
+        # For TRS1 * TRS2, the translation should be t1 + R1 * (s1 * t2)
+        # t1 = [1,0,0], R1 = I, s1 = 1, t2 = [0,0,0]
+        # So result should be [1,0,0] + I * (1 * [0,0,0]) = [1,0,0]
+        expected_translation = torch.tensor([1.0, 0.0, 0.0])
+        self.assertTrue(torch.allclose(t_result, expected_translation))
+
+    def test_inverse(self) -> None:
+        """Test inverting a TRS transform."""
+        # Create a transform with translation and scale
+        t = torch.tensor([2.0, 4.0, 6.0])
+        s = torch.tensor([2.0])
+        trs_original = pym_trs.multiply(
+            pym_trs.from_translation(t), pym_trs.from_scale(s)
+        )
+
+        # Compute inverse
+        trs_inv = pym_trs.inverse(trs_original)
+
+        # Multiply original by inverse should give identity
+        identity_result = pym_trs.multiply(trs_original, trs_inv)
+        t_id, r_id, s_id = identity_result
+
+        # Check that result is close to identity
+        self.assertTrue(torch.allclose(t_id, torch.zeros(3), atol=1e-6))
+        self.assertTrue(torch.allclose(r_id, torch.eye(3), atol=1e-6))
+        self.assertTrue(torch.allclose(s_id, torch.ones(1), atol=1e-6))
+
+    def test_transform_points(self) -> None:
+        """Test transforming points with TRS transform."""
+        # Create a simple translation transform
+        translation = torch.tensor([1.0, 2.0, 3.0])
+        trs_trans = pym_trs.from_translation(translation)
+
+        # Transform a point
+        points = torch.tensor([[0.0, 0.0, 0.0]])
+        transformed = pym_trs.transform_points(trs_trans, points)
+
+        # Should be translated by [1, 2, 3]
+        expected = torch.tensor([[1.0, 2.0, 3.0]])
+        self.assertTrue(torch.allclose(transformed, expected))
+
+    def test_transform_points_invalid_shape(self) -> None:
+        """Test that transform_points raises error for invalid point shapes."""
+        trs_identity = pym_trs.identity()
+
+        # Test points with wrong last dimension
+        invalid_points = torch.randn(5, 2)  # Should be (..., 3)
+
+        with self.assertRaises(ValueError) as context:
+            pym_trs.transform_points(trs_identity, invalid_points)
+
+        self.assertIn(
+            "Points tensor should have last dimension 3", str(context.exception)
+        )
+
+    def test_to_matrix(self) -> None:
+        """Test converting TRS transform to 4x4 matrix."""
+        # Create a TRS with translation and scale
+        translation = torch.tensor([1.0, 2.0, 3.0])
+        scale = torch.tensor([2.0])
+        trs_transform = pym_trs.multiply(
+            pym_trs.from_translation(translation), pym_trs.from_scale(scale)
+        )
+
+        # Convert to matrix
+        matrix = pym_trs.to_matrix(trs_transform)
+
+        # Check shape
+        self.assertEqual(matrix.shape, (4, 4))
+
+        # Check that it matches expected structure
+        # Top-left 3x3 should be scaled identity matrix
+        expected_linear = torch.eye(3) * 2.0
+        self.assertTrue(torch.allclose(matrix[:3, :3], expected_linear))
+
+        # Right column should be translation
+        self.assertTrue(torch.allclose(matrix[:3, 3], translation))
+
+        # Bottom row should be [0, 0, 0, 1]
+        expected_bottom = torch.tensor([0.0, 0.0, 0.0, 1.0])
+        self.assertTrue(torch.allclose(matrix[3, :], expected_bottom))
+
+    def test_from_matrix(self) -> None:
+        """Test converting 4x4 matrix to TRS transform."""
+        # Create a 4x4 matrix manually
+        matrix = torch.tensor(
+            [
+                [2.0, 0.0, 0.0, 1.0],
+                [0.0, 2.0, 0.0, 2.0],
+                [0.0, 0.0, 2.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
+
+        # Convert to TRS
+        t, r, s = pym_trs.from_matrix(matrix)
+
+        # Check translation
+        expected_translation = torch.tensor([1.0, 2.0, 3.0])
+        self.assertTrue(torch.allclose(t, expected_translation))
+
+        # Check rotation (should be identity)
+        expected_rotation = torch.eye(3)
+        self.assertTrue(torch.allclose(r, expected_rotation, atol=1e-6))
+
+        # Check scale
+        expected_scale = torch.tensor([2.0])
+        self.assertTrue(torch.allclose(s, expected_scale, atol=1e-6))
+
+    def test_matrix_roundtrip(self) -> None:
+        """Test that to_matrix and from_matrix are inverse operations."""
+        # Create a random TRS transform
+        translation = torch.tensor([1.5, -2.3, 0.7])
+        scale = torch.tensor([1.8])
+        trs_original = pym_trs.multiply(
+            pym_trs.from_translation(translation), pym_trs.from_scale(scale)
+        )
+
+        # Convert to matrix and back
+        matrix = pym_trs.to_matrix(trs_original)
+        trs_reconstructed = pym_trs.from_matrix(matrix)
+
+        # Convert both to matrices for comparison (since TRS may not be identical due to rotation extraction)
+        matrix_original = pym_trs.to_matrix(trs_original)
+        matrix_reconstructed = pym_trs.to_matrix(trs_reconstructed)
+
+        # Matrices should be very close
+        self.assertTrue(
+            torch.allclose(matrix_original, matrix_reconstructed, atol=1e-6)
+        )
+
+    def test_from_matrix_invalid_shape(self) -> None:
+        """Test that from_matrix raises error for invalid matrix shapes."""
+        # Test matrix with wrong dimensions
+        invalid_matrix = torch.randn(3, 3)  # Should be 4x4
+
+        with self.assertRaises(ValueError) as context:
+            pym_trs.from_matrix(invalid_matrix)
+
+        self.assertIn("Expected a tensor of 4x4 matrices", str(context.exception))
+
+    def test_from_skeleton_state(self) -> None:
+        """Test converting skeleton state to TRS transform."""
+        # Create a skeleton state: [tx, ty, tz, rx, ry, rz, rw, s]
+        # Using identity quaternion (0, 0, 0, 1) and scale 2.0
+        skeleton_state = torch.tensor([1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0, 2.0])
+
+        # Convert to TRS
+        t, r, s = pym_trs.from_skeleton_state(skeleton_state)
+
+        # Check translation
+        expected_translation = torch.tensor([1.0, 2.0, 3.0])
+        self.assertTrue(torch.allclose(t, expected_translation))
+
+        # Check rotation (should be identity for identity quaternion)
+        expected_rotation = torch.eye(3)
+        self.assertTrue(torch.allclose(r, expected_rotation, atol=1e-6))
+
+        # Check scale
+        expected_scale = torch.tensor([2.0])
+        self.assertTrue(torch.allclose(s, expected_scale))
+
+    def test_to_skeleton_state(self) -> None:
+        """Test converting TRS transform to skeleton state."""
+        # Create a TRS transform
+        translation = torch.tensor([1.5, -2.3, 0.7])
+        scale = torch.tensor([1.8])
+        trs_transform = pym_trs.multiply(
+            pym_trs.from_translation(translation), pym_trs.from_scale(scale)
+        )
+
+        # Convert to skeleton state
+        skeleton_state = pym_trs.to_skeleton_state(trs_transform)
+
+        # Check shape
+        self.assertEqual(skeleton_state.shape, (8,))
+
+        # Check translation part
+        self.assertTrue(torch.allclose(skeleton_state[:3], translation))
+
+        # Check scale part
+        self.assertTrue(torch.allclose(skeleton_state[7:], scale))
+
+        # Check that quaternion part is identity (since rotation was identity)
+        identity_quaternion = torch.tensor([0.0, 0.0, 0.0, 1.0])
+        self.assertTrue(
+            torch.allclose(skeleton_state[3:7], identity_quaternion, atol=1e-6)
+        )
+
+    def test_skeleton_state_roundtrip(self) -> None:
+        """Test that skeleton state conversion is round-trip consistent."""
+        # Create a skeleton state with non-trivial quaternion
+        import math
+
+        # Quaternion for 45 degree rotation around Z axis
+        angle = math.pi / 4
+        z_quat = torch.tensor([0.0, 0.0, math.sin(angle / 2), math.cos(angle / 2)])
+        skeleton_state = torch.tensor(
+            [1.0, 2.0, 3.0, z_quat[0], z_quat[1], z_quat[2], z_quat[3], 1.5]
+        )
+
+        # Convert to TRS and back
+        trs_transform = pym_trs.from_skeleton_state(skeleton_state)
+        skeleton_state_reconstructed = pym_trs.to_skeleton_state(trs_transform)
+
+        # Should be very close (allowing for quaternion sign ambiguity)
+        diff = torch.abs(skeleton_state - skeleton_state_reconstructed)
+        # Alternative quaternion (negated) should also be close
+        alt_quat = skeleton_state_reconstructed.clone()
+        alt_quat[3:7] *= -1
+        diff_alt = torch.abs(skeleton_state - alt_quat)
+
+        # Either the original or the negated quaternion should be close
+        is_close = torch.all(diff < 1e-5) or torch.all(diff_alt < 1e-5)
+        self.assertTrue(
+            is_close, f"Roundtrip failed. Diff: {diff}, Alt diff: {diff_alt}"
+        )
+
+    def test_from_skeleton_state_invalid_shape(self) -> None:
+        """Test that from_skeleton_state raises error for invalid shapes."""
+        # Test skeleton state with wrong dimensions
+        invalid_skeleton_state = torch.randn(7)  # Should be 8
+
+        with self.assertRaises(ValueError) as context:
+            pym_trs.from_skeleton_state(invalid_skeleton_state)
+
+        self.assertIn(
+            "Expected skeleton state to have last dimension 8", str(context.exception)
+        )
+
+    def test_slerp_extremes(self) -> None:
+        """Test slerp at t=0 and t=1."""
+        # Create two different TRS transforms
+        trs0 = pym_trs.from_translation(torch.tensor([1.0, 0.0, 0.0]))
+        trs1 = pym_trs.from_translation(torch.tensor([0.0, 1.0, 0.0]))
+
+        # Test slerp at t=0 should return trs0
+        t_interp_0, r_interp_0, s_interp_0 = pym_trs.slerp(
+            trs0, trs1, torch.tensor([0.0])
+        )
+        expected_t0 = torch.tensor([1.0, 0.0, 0.0])
+        self.assertTrue(torch.allclose(t_interp_0, expected_t0, atol=1e-6))
+
+        # Test slerp at t=1 should return trs1
+        t_interp_1, r_interp_1, s_interp_1 = pym_trs.slerp(
+            trs0, trs1, torch.tensor([1.0])
+        )
+        expected_t1 = torch.tensor([0.0, 1.0, 0.0])
+        self.assertTrue(torch.allclose(t_interp_1, expected_t1, atol=1e-6))
+
+    def test_slerp_midpoint(self) -> None:
+        """Test slerp at t=0.5."""
+        # Create two TRS transforms with different translation and scale
+        trs0 = pym_trs.multiply(
+            pym_trs.from_translation(torch.tensor([0.0, 0.0, 0.0])),
+            pym_trs.from_scale(torch.tensor([1.0])),
+        )
+        trs1 = pym_trs.multiply(
+            pym_trs.from_translation(torch.tensor([2.0, 4.0, 6.0])),
+            pym_trs.from_scale(torch.tensor([3.0])),
+        )
+
+        # Interpolate at midpoint
+        t_interp, r_interp, s_interp = pym_trs.slerp(trs0, trs1, torch.tensor([0.5]))
+
+        # Translation should be midpoint
+        expected_t = torch.tensor([1.0, 2.0, 3.0])  # (0+2)/2, (0+4)/2, (0+6)/2
+        self.assertTrue(torch.allclose(t_interp, expected_t, atol=1e-6))
+
+        # Scale should be midpoint
+        expected_s = torch.tensor([2.0])  # (1+3)/2
+        self.assertTrue(torch.allclose(s_interp, expected_s, atol=1e-6))
+
+        # Rotation should still be identity (since both inputs have identity rotation)
+        self.assertTrue(torch.allclose(r_interp, torch.eye(3), atol=1e-6))
+
+    def test_blend_equal_weights(self) -> None:
+        """Test blending with equal weights."""
+        # Create three TRS transforms
+        trs_list = [
+            pym_trs.from_translation(torch.tensor([1.0, 0.0, 0.0])),
+            pym_trs.from_translation(torch.tensor([0.0, 1.0, 0.0])),
+            pym_trs.from_translation(torch.tensor([0.0, 0.0, 1.0])),
+        ]
+
+        # Blend with equal weights (should use default equal weights)
+        t_blend, r_blend, s_blend = pym_trs.blend(trs_list)
+
+        # Translation should be average
+        expected_t = torch.tensor([1.0 / 3, 1.0 / 3, 1.0 / 3])
+        self.assertTrue(torch.allclose(t_blend, expected_t, atol=1e-6))
+
+        # Rotation should be identity (all inputs have identity)
+        self.assertTrue(torch.allclose(r_blend, torch.eye(3), atol=1e-6))
+
+        # Scale should be 1 (all inputs have scale 1)
+        expected_s = torch.tensor([1.0])
+        self.assertTrue(torch.allclose(s_blend, expected_s, atol=1e-6))
+
+    def test_blend_custom_weights(self) -> None:
+        """Test blending with custom weights."""
+        # Create two TRS transforms
+        trs_list = [
+            pym_trs.from_translation(torch.tensor([0.0, 0.0, 0.0])),
+            pym_trs.from_translation(torch.tensor([4.0, 0.0, 0.0])),
+        ]
+
+        # Blend with custom weights [0.25, 0.75]
+        weights = torch.tensor([0.25, 0.75])
+        t_blend, r_blend, s_blend = pym_trs.blend(trs_list, weights)
+
+        # Translation should be weighted average: 0.25*[0,0,0] + 0.75*[4,0,0] = [3,0,0]
+        expected_t = torch.tensor([3.0, 0.0, 0.0])
+        self.assertTrue(torch.allclose(t_blend, expected_t, atol=1e-6))
+
+    def test_blend_single_transform(self) -> None:
+        """Test that blending a single transform returns the transform itself."""
+        trs_single = pym_trs.from_translation(torch.tensor([1.0, 2.0, 3.0]))
+
+        result = pym_trs.blend([trs_single])
+
+        # Should return the same transform
+        self.assertTrue(torch.allclose(result[0], trs_single[0]))
+        self.assertTrue(torch.allclose(result[1], trs_single[1]))
+        self.assertTrue(torch.allclose(result[2], trs_single[2]))
+
+    def test_blend_empty_list(self) -> None:
+        """Test that blending empty list raises error."""
+        with self.assertRaises(ValueError) as context:
+            pym_trs.blend([])
+
+        self.assertIn("Cannot blend empty list of transforms", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pymomentum/trs.py
+++ b/pymomentum/trs.py
@@ -1,0 +1,455 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+TRS (Translation-Rotation-Scale) Utilities
+===========================================
+
+This module provides utilities for working with TRS (Translation-Rotation-Scale)
+transforms in PyMomentum.
+
+A TRS transform is represented as a tuple of three separate tensors:
+
+- **Translation (t)**: tensor of shape [..., 3] - 3D position offset
+- **Rotation (r)**: tensor of shape [..., 3, 3] - 3x3 rotation matrix
+- **Scale (s)**: tensor of shape [..., 1] - uniform scale factor
+
+This representation provides efficient operations since rotation matrices can be
+directly used for transformations and inverted via transpose, avoiding quaternion
+to matrix conversions.  It is also preferable to working with 4x4 matrices, because
+extracting the scale from a fully general 4x4 matrix is expensive.
+
+Note that internally, momentum mostly uses skel_states which use quaternions rather
+than rotation matrices.  However, many use cases (particularly for ML) prefer rotation
+matrices (such as the widely-used 6D rotation representation), so this library provides
+useful functionality for converting between the two.
+
+Key features:
+- Creating TRS transforms from individual components (:func:`from_translation`,
+  :func:`from_rotation_matrix`, :func:`from_scale`)
+- Converting between TRS transforms and 4x4 transformation matrices
+  (:func:`to_matrix`, :func:`from_matrix`)
+- Performing transformations and operations (:func:`multiply`, :func:`inverse`,
+  :func:`transform_points`)
+- Interoperability with skeleton states (:func:`from_skeleton_state`,
+  :func:`to_skeleton_state`)
+- Fast inverse computation using rotation matrix transpose
+
+Example:
+    Creating and using a TRS transform::
+
+        import torch
+        from pymomentum import trs
+
+        # Create identity transform
+        t, r, s = trs.identity()
+
+        # Create from translation
+        translation = torch.tensor([1.0, 2.0, 3.0])
+        t, r, s = trs.from_translation(translation)
+
+        # Transform points
+        points = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        transformed = trs.transform_points((t, r, s), points)
+
+Note:
+    All functions in this module work with TRS transforms represented as tuples
+    of (translation, rotation_matrix, scale) tensors.
+"""
+
+from typing import Sequence
+
+import torch
+from pymomentum import quaternion
+
+# pyre-strict
+
+# Type alias for TRS transform tuple
+TRSTransform = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+
+def from_translation(translation: torch.Tensor) -> TRSTransform:
+    """
+    Create a TRS transform from translation.
+
+    :parameter translation: The translation component of shape [..., 3].
+    :type translation: torch.Tensor
+    :return: TRS transform tuple (translation, identity_rotation, unit_scale).
+    :rtype: TRSTransform
+    """
+    batch_shape = translation.shape[:-1]
+    device = translation.device
+    dtype = translation.dtype
+
+    # Identity rotation matrix
+    rotation = (
+        torch.eye(3, device=device, dtype=dtype).expand(*batch_shape, 3, 3).contiguous()
+    )
+
+    # Unit scale
+    scale = torch.ones(*batch_shape, 1, device=device, dtype=dtype)
+
+    return translation, rotation, scale
+
+
+def from_rotation_matrix(rotation_matrix: torch.Tensor) -> TRSTransform:
+    """
+    Create a TRS transform from rotation matrix.
+
+    :parameter rotation_matrix: The rotation matrix component of shape [..., 3, 3].
+    :type rotation_matrix: torch.Tensor
+    :return: TRS transform tuple (zero_translation, rotation_matrix, unit_scale).
+    :rtype: TRSTransform
+    """
+    batch_shape = rotation_matrix.shape[:-2]
+    device = rotation_matrix.device
+    dtype = rotation_matrix.dtype
+
+    # Zero translation
+    translation = torch.zeros(*batch_shape, 3, device=device, dtype=dtype)
+
+    # Unit scale
+    scale = torch.ones(*batch_shape, 1, device=device, dtype=dtype)
+
+    return translation, rotation_matrix, scale
+
+
+def from_scale(scale: torch.Tensor) -> TRSTransform:
+    """
+    Create a TRS transform from scale.
+
+    :parameter scale: The scale component of shape [..., 1].
+    :type scale: torch.Tensor
+    :return: TRS transform tuple (zero_translation, identity_rotation, scale).
+    :rtype: TRSTransform
+    """
+    batch_shape = scale.shape[:-1]
+    device = scale.device
+    dtype = scale.dtype
+
+    # Zero translation
+    translation = torch.zeros(*batch_shape, 3, device=device, dtype=dtype)
+
+    # Identity rotation matrix
+    rotation = (
+        torch.eye(3, device=device, dtype=dtype).expand(*batch_shape, 3, 3).contiguous()
+    )
+
+    return translation, rotation, scale
+
+
+def identity(
+    size: Sequence[int] | None = None,
+    device: torch.device | None = None,
+    dtype: torch.dtype | None = None,
+) -> TRSTransform:
+    """
+    Returns a TRS transform representing the identity transform.
+
+    :parameter size: The size of each batch dimension in the output tensors.
+                     Defaults to None, which means the output will have no batch dimensions.
+    :type size: Sequence[int], optional
+    :parameter device: The device on which to create the tensors. Defaults to None.
+    :type device: torch.device, optional
+    :parameter dtype: The data type of the tensors. Defaults to None (float32).
+    :type dtype: torch.dtype, optional
+    :return: Identity TRS transform tuple.
+    :rtype: TRSTransform
+    """
+    if dtype is None:
+        dtype = torch.float32
+
+    if size is None:
+        size = []
+
+    # Zero translation
+    translation = torch.zeros(*size, 3, device=device, dtype=dtype)
+
+    # Identity rotation matrix
+    rotation = torch.eye(3, device=device, dtype=dtype).expand(*size, 3, 3).contiguous()
+
+    # Unit scale
+    scale = torch.ones(*size, 1, device=device, dtype=dtype)
+
+    return translation, rotation, scale
+
+
+def multiply(trs1: TRSTransform, trs2: TRSTransform) -> TRSTransform:
+    """
+    Multiply (compose) two TRS transforms.
+
+    :parameter trs1: The first TRS transform tuple (t1, r1, s1).
+    :type trs1: TRSTransform
+    :parameter trs2: The second TRS transform tuple (t2, r2, s2).
+    :type trs2: TRSTransform
+    :return: The composed TRS transform tuple representing trs1 * trs2.
+    :rtype: TRSTransform
+    """
+    t1, r1, s1 = trs1
+    t2, r2, s2 = trs2
+
+    # Composed rotation: r1 @ r2
+    r_result = torch.bmm(r1.view(-1, 3, 3), r2.view(-1, 3, 3)).view_as(r1)
+
+    # Composed scale: s1 * s2
+    s_result = s1 * s2
+
+    # Composed translation: t1 + r1 @ (s1 * t2)
+    # First scale t2 by s1, then rotate by r1, then add t1
+    scaled_t2 = s1.unsqueeze(-1) * t2.unsqueeze(-1)  # [..., 3, 1]
+    rotated_scaled_t2 = torch.bmm(r1.view(-1, 3, 3), scaled_t2.view(-1, 3, 1)).view_as(
+        t1
+    )
+    t_result = t1 + rotated_scaled_t2
+
+    return t_result, r_result, s_result
+
+
+def inverse(trs: TRSTransform) -> TRSTransform:
+    """
+    Compute the inverse of a TRS transform. This is efficient since rotation
+    matrix inverse is just transpose.
+
+    :parameter trs: The TRS transform tuple to invert.
+    :type trs: TRSTransform
+    :return: The inverted TRS transform tuple.
+    :rtype: TRSTransform
+    """
+    t, r, s = trs
+
+    # Inverse rotation: transpose of rotation matrix
+    r_inv = r.transpose(-2, -1)
+
+    # Inverse scale: reciprocal
+    s_inv = torch.reciprocal(s)
+
+    # Inverse translation: -R^T * (t / s)
+    # First scale translation by inverse scale, then apply inverse rotation
+    scaled_t = s_inv.unsqueeze(-1) * t.unsqueeze(-1)  # [..., 3, 1]
+    t_inv = -torch.bmm(r_inv.view(-1, 3, 3), scaled_t.view(-1, 3, 1)).view_as(t)
+
+    return t_inv, r_inv, s_inv
+
+
+def transform_points(trs: TRSTransform, points: torch.Tensor) -> torch.Tensor:
+    """
+    Transform 3D points by the TRS transform.
+
+    :parameter trs: The TRS transform tuple to use for transformation.
+    :type trs: TRSTransform
+    :parameter points: The points to transform of shape [..., 3].
+    :type points: torch.Tensor
+    :return: The transformed points of shape [..., 3].
+    :rtype: torch.Tensor
+    """
+    if points.dim() < 1 or points.shape[-1] != 3:
+        raise ValueError("Points tensor should have last dimension 3.")
+
+    t, r, s = trs
+
+    # Apply scale, then rotation, then translation: t + r @ (s * points)
+    scaled_points = s.unsqueeze(-1) * points.unsqueeze(-1)  # [..., 3, 1]
+    rotated_points = torch.bmm(r.view(-1, 3, 3), scaled_points.view(-1, 3, 1)).view_as(
+        points
+    )
+    transformed_points = t + rotated_points
+
+    return transformed_points
+
+
+def to_matrix(trs: TRSTransform) -> torch.Tensor:
+    """
+    Convert TRS transform to 4x4 transformation matrix.
+
+    :parameter trs: The TRS transform tuple to convert.
+    :type trs: TRSTransform
+    :return: A tensor containing 4x4 transformation matrices of shape [..., 4, 4].
+    :rtype: torch.Tensor
+    """
+    t, r, s = trs
+
+    # Scale the rotation matrix
+    linear = r * s.unsqueeze(-2).expand_as(r)
+
+    # Construct the affine part [linear | translation]
+    affine = torch.cat((linear, t.unsqueeze(-1)), -1)
+
+    # Add the homogeneous row [0, 0, 0, 1]
+    batch_shape = t.shape[:-1]
+    last_row = torch.tensor([0, 0, 0, 1], device=t.device, dtype=t.dtype)
+    last_row = last_row.expand(*batch_shape, 1, 4)
+
+    # Combine affine and homogeneous row
+    matrix = torch.cat((affine, last_row), -2)
+
+    return matrix
+
+
+def from_matrix(matrices: torch.Tensor) -> TRSTransform:
+    """
+    Convert 4x4 transformation matrices to TRS transforms. Assumes uniform scaling.
+
+    :parameter matrices: A tensor of 4x4 matrices of shape [..., 4, 4].
+    :type matrices: torch.Tensor
+    :return: TRS transform tuple (translation, rotation_matrix, scale).
+    :rtype: TRSTransform
+    """
+    if matrices.dim() < 2 or matrices.shape[-1] != 4 or matrices.shape[-2] != 4:
+        raise ValueError("Expected a tensor of 4x4 matrices")
+
+    initial_shape = matrices.shape
+    if matrices.dim() == 2:
+        matrices = matrices.unsqueeze(0)
+    else:
+        matrices = matrices.flatten(0, -3)
+
+    # Extract linear part and translation
+    linear = matrices[..., :3, :3]
+    translation = matrices[..., :3, 3]
+
+    # Use SVD to decompose linear part: linear = U * S * V^T
+    # where U and V^T are rotations and S contains scales
+    U, S, Vt = torch.linalg.svd(linear)
+
+    # Extract scale (assuming uniform scaling, take first singular value)
+    scale = S[..., :1]
+
+    # Extract rotation matrix: R = U * V^T
+    rotation_matrix = torch.bmm(U, Vt)
+
+    # Reshape back to original batch dimensions
+    result_shape_t = list(initial_shape[:-2]) + [3]
+    result_shape_r = list(initial_shape[:-2]) + [3, 3]
+    result_shape_s = list(initial_shape[:-2]) + [1]
+
+    translation = translation.reshape(result_shape_t)
+    rotation_matrix = rotation_matrix.reshape(result_shape_r)
+    scale = scale.reshape(result_shape_s)
+
+    return translation, rotation_matrix, scale
+
+
+def from_skeleton_state(skeleton_state: torch.Tensor) -> TRSTransform:
+    """
+    Convert skeleton state to TRS transform.
+
+    :parameter skeleton_state: The skeleton state tensor of shape [..., 8] containing
+                               (tx, ty, tz, rx, ry, rz, rw, s).
+    :type skeleton_state: torch.Tensor
+    :return: TRS transform tuple (translation, rotation_matrix, scale).
+    :rtype: TRSTransform
+    """
+    if skeleton_state.shape[-1] != 8:
+        raise ValueError("Expected skeleton state to have last dimension 8")
+
+    # Extract translation, quaternion, and scale
+    translation = skeleton_state[..., :3]
+    quaternion_xyzw = skeleton_state[..., 3:7]
+    scale = skeleton_state[..., 7:]
+
+    # Convert quaternion to rotation matrix
+    rotation_matrix = quaternion.to_rotation_matrix(quaternion_xyzw)
+
+    return translation, rotation_matrix, scale
+
+
+def to_skeleton_state(trs: TRSTransform) -> torch.Tensor:
+    """
+    Convert TRS transform to skeleton state.
+
+    :parameter trs: The TRS transform tuple to convert.
+    :type trs: TRSTransform
+    :return: Skeleton state tensor of shape [..., 8] containing (tx, ty, tz, rx, ry, rz, rw, s).
+    :rtype: torch.Tensor
+    """
+    t, r, s = trs
+
+    # Convert rotation matrix to quaternion
+    quaternion_xyzw = quaternion.from_rotation_matrix(r)
+
+    # Combine into skeleton state format
+    skeleton_state = torch.cat([t, quaternion_xyzw, s], dim=-1)
+
+    return skeleton_state
+
+
+def slerp(trs0: TRSTransform, trs1: TRSTransform, t: torch.Tensor) -> TRSTransform:
+    """
+    Spherical linear interpolation between two TRS transforms.
+
+    :parameter trs0: The first TRS transform tuple.
+    :type trs0: TRSTransform
+    :parameter trs1: The second TRS transform tuple.
+    :type trs1: TRSTransform
+    :parameter t: The interpolation factor where 0 <= t <= 1. t=0 corresponds to trs0, t=1 corresponds to trs1.
+    :type t: torch.Tensor
+    :return: The interpolated TRS transform.
+    :rtype: TRSTransform
+    """
+    t0, r0, s0 = trs0
+    t1, r1, s1 = trs1
+
+    # Linear interpolation for translation and scale
+    t_interp = (1 - t).unsqueeze(-1) * t0 + t.unsqueeze(-1) * t1
+    s_interp = (1 - t).unsqueeze(-1) * s0 + t.unsqueeze(-1) * s1
+
+    # Spherical interpolation for rotation matrices via quaternions
+    q0 = quaternion.from_rotation_matrix(r0)
+    q1 = quaternion.from_rotation_matrix(r1)
+    q_interp = quaternion.slerp(q0, q1, t)
+    r_interp = quaternion.to_rotation_matrix(q_interp)
+
+    return t_interp, r_interp, s_interp
+
+
+def blend(
+    trs_transforms: Sequence[TRSTransform], weights: torch.Tensor | None = None
+) -> TRSTransform:
+    """
+    Blend multiple TRS transforms with the given weights.
+
+    :parameter trs_transforms: A sequence of TRS transform tuples to blend.
+    :type trs_transforms: Sequence[TRSTransform]
+    :parameter weights: The weights to use for blending. If not provided, equal weights are used.
+                        Should have shape [num_transforms] or [..., num_transforms].
+    :type weights: torch.Tensor, optional
+    :return: The blended TRS transform.
+    :rtype: TRSTransform
+    """
+    if len(trs_transforms) == 0:
+        raise ValueError("Cannot blend empty list of transforms")
+
+    if len(trs_transforms) == 1:
+        return trs_transforms[0]
+
+    # Stack all transforms
+    translations = torch.stack([trs[0] for trs in trs_transforms], dim=-2)
+    rotations = torch.stack([trs[1] for trs in trs_transforms], dim=-3)
+    scales = torch.stack([trs[2] for trs in trs_transforms], dim=-2)
+
+    # Handle weights
+    if weights is None:
+        num_transforms = len(trs_transforms)
+        device = translations.device
+        dtype = translations.dtype
+        weights = (
+            torch.ones(num_transforms, device=device, dtype=dtype) / num_transforms
+        )
+
+    # Normalize weights
+    weights = weights / weights.sum(dim=-1, keepdim=True)
+
+    # Blend translation and scale with linear interpolation
+    t_blend = (weights.unsqueeze(-1) * translations).sum(dim=-2)
+    s_blend = (weights.unsqueeze(-1) * scales).sum(dim=-2)
+
+    # Blend rotations via quaternions
+    quaternions = torch.stack(
+        [quaternion.from_rotation_matrix(r) for r in rotations], dim=-2
+    )
+    q_blend = quaternion.blend(quaternions, weights)
+    r_blend = quaternion.to_rotation_matrix(q_blend)
+
+    return t_blend, r_blend, s_blend


### PR DESCRIPTION
Summary: We are finding that many users of the PyMomentum library prefer the use of rotation matrices to quaternions because rotation matrices tend to function better in ML learning algorithms.  However the existing skel_state matrix functionality converts to 4x4 matrices which is challenging to work with because scale has been baked into the matrix and needs to be removed.  Therefore we decided it likely make sense to have support for a TRS format that stores separate translations, 3x3 rotations, and uniform scales.  This format can be easily converted to-and-from skel_states, and is generally safer to work with than 4x4 matrices (for example inversion just involves a transpose).

Reviewed By: jeongseok-meta

Differential Revision: D82840072


