### PR TITLE
Better quaternion normalization.

### DIFF
--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -135,7 +135,7 @@ def normalize(q: torch.Tensor) -> torch.Tensor:
     :return: The normalized quaternion.
     """
     check(q)
-    return q / q.norm(2, dim=-1, keepdim=True)
+    return torch.nn.functional.normalize(q, dim=-1)
 
 
 def conjugate(q: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Summary: We occasionally see NaNs if we accidentally pass in an all-zeros quat, let's use this normalization operator that automatically detects this case and handles it.

Reviewed By: jeongseok-meta

Differential Revision: D83084925


