### PR TITLE
Implement TriBvh in a more simd-efficient way.

### DIFF
--- a/axel/CMakeLists.txt
+++ b/axel/CMakeLists.txt
@@ -33,6 +33,7 @@ set(headers
   axel/math/BoundingBoxUtils.h
   axel/math/PointTriangleProjection.h
   axel/math/PointTriangleProjectionDefinitions.h
+  axel/math/RayBoxIntersection.h
   axel/math/RayTriangleIntersection.h
   axel/BoundingBox.h
   axel/Bvh.h
@@ -45,6 +46,7 @@ set(headers
 
 set(sources
   axel/math/PointTriangleProjection.cpp
+  axel/math/RayBoxIntersection.cpp
   axel/math/RayTriangleIntersection.cpp
   axel/BoundingBox.cpp
   axel/Bvh.cpp

--- a/axel/axel/TriBvh.cpp
+++ b/axel/axel/TriBvh.cpp
@@ -11,267 +11,1337 @@
 #include "axel/Profile.h"
 #include "axel/math/BoundingBoxUtils.h"
 #include "axel/math/PointTriangleProjection.h"
+#include "axel/math/RayBoxIntersection.h"
+#include "axel/math/RayTriangleIntersection.h"
+
+#include <algorithm>
+#include <cfloat>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <set>
 
 namespace axel {
-namespace {
-template <typename S>
-struct HitResult {
-  S bary0;
-  S bary1;
-  S t{-1.0};
-  uint32_t triangleIdx = kInvalidTriangleIdx;
-};
 
-template <typename T, typename MatrixType>
-Eigen::Vector3<T> interpolatePosition(
-    const Eigen::Vector3i& triangleIndices,
-    const MatrixType& positions,
-    const Eigen::Vector3<T>& bary) {
-  return positions.row(triangleIndices[0]) * bary[0] + positions.row(triangleIndices[1]) * bary[1] +
-      positions.row(triangleIndices[2]) * bary[2];
+namespace {
+
+// Anonymous helper functions for accessing triangles and vertices from different container types
+Eigen::Vector3i getTriangle(gsl::span<const Eigen::Vector3i> triangles, size_t index) {
+  return triangles[index];
 }
 
-template <typename S, size_t LeafCapacity>
-Bvh<S, LeafCapacity> buildBvh(
+Eigen::Vector3i getTriangle(const Eigen::MatrixX3i& triangles, size_t index) {
+  return triangles.row(index);
+}
+
+template <typename S>
+Eigen::Vector3<S> getVertex(gsl::span<const Eigen::Vector3<S>> vertices, size_t index) {
+  return vertices[index];
+}
+
+template <typename S>
+Eigen::Vector3<S> getVertex(const Eigen::MatrixX3<S>& vertices, size_t index) {
+  return vertices.row(index);
+}
+
+} // anonymous namespace
+
+constexpr float kFarValueFloat = 1e10f;
+
+// Constants for optimized tree building
+constexpr size_t kMaxDepth = 16;
+constexpr size_t kLeafBlocks = 4;
+
+// Node constructors for 8-way tree structure
+template <typename S>
+TriBvh<S>::Node::Node(
+    const Vector3SP& bboxMin_in,
+    const Vector3SP& bboxMax_in,
+    const std::array<SizeType, TreeSplit>& children_in)
+    : childBoxMin(bboxMin_in),
+      childBoxMax(bboxMax_in),
+      children(children_in),
+      trianglesStart(kInvalidTriangleBlockIdx),
+      trianglesEnd(kInvalidTriangleBlockIdx) {}
+
+template <typename S>
+TriBvh<S>::Node::Node(const SizeType trianglesStart_in, const SizeType trianglesEnd_in)
+    : trianglesStart(trianglesStart_in), trianglesEnd(trianglesEnd_in) {
+  std::fill(children.begin(), children.end(), kInvalidNodeIdx);
+  for (int i = 0; i < 3; ++i) {
+    childBoxMin[i] = FloatSP(static_cast<S>(kFarValueFloat));
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    childBoxMax[i] = FloatSP(static_cast<S>(kFarValueFloat));
+  }
+}
+
+// Helper function to compute triangle center - templated for different container types
+template <typename S, typename TriangleContainer, typename VertexContainer>
+Eigen::Vector3<S> computeTriangleCenter(
+    const TriangleContainer& triangles,
+    size_t triangleIndex,
+    const VertexContainer& vertices) {
+  const auto triangle = getTriangle(triangles, triangleIndex);
+  Eigen::Vector3<S> result = getVertex<S>(vertices, triangle[0]);
+
+  for (int i = 1; i < 3; ++i) {
+    result += (getVertex<S>(vertices, triangle[i]) - result) / (i + 1);
+  }
+
+  return result;
+}
+
+// Backwards-compatible constructor with Eigen matrices
+template <typename S>
+TriBvh<S>::TriBvh(
     const Eigen::MatrixX3<S>& positions,
     const Eigen::MatrixX3i& triangles,
-    const std::optional<S>& boundingBoxThickness) {
-  XR_PROFILE_EVENT("build_bvh");
-  const Eigen::Index triangleCount{triangles.rows()};
-  std::vector<BoundingBox<S>> boundingBoxes(triangleCount);
-
-  const auto boundingBoxComputeLambda = [&](const Eigen::Index triangleIndex) {
-    const Eigen::Vector3i triangle = triangles.row(triangleIndex);
-
-    const Eigen::Index positionCount{positions.rows()};
-    XR_CHECK(
-        triangle[0] < positionCount && triangle[1] < positionCount && triangle[2] < positionCount,
-        "Triangle {} index out of bounds! It has vertices {}, {}, {}, but the last vertex is at {}.",
-        triangleIndex,
-        triangle[0],
-        triangle[1],
-        triangle[2],
-        positionCount - 1);
-    Eigen::Vector3<S> minBound;
-    Eigen::Vector3<S> maxBound;
-    if (boundingBoxThickness.has_value()) {
-      getMinMaxBoundTriangle<S>(
-          positions.row(triangle[0]),
-          positions.row(triangle[1]),
-          positions.row(triangle[2]),
-          minBound,
-          maxBound,
-          boundingBoxThickness.value());
-    } else {
-      getAdaptiveMinMaxBoundTriangle<S>(
-          positions.row(triangle[0]),
-          positions.row(triangle[1]),
-          positions.row(triangle[2]),
-          minBound,
-          maxBound,
-          /*multiplicativeFactor*/ 0.01);
-    }
-    boundingBoxes[triangleIndex] =
-        BoundingBox<S>(minBound, maxBound, static_cast<int>(triangleIndex));
-  };
-#ifdef AXEL_NO_DISPENSO
-  for (size_t triangleIndex = 0; triangleIndex < triangleCount; ++triangleIndex) {
-    boundingBoxComputeLambda(triangleIndex);
-  }
-#else
-  dispenso::parallel_for(0, triangleCount, boundingBoxComputeLambda);
-#endif
-  return Bvh<S, LeafCapacity>{boundingBoxes};
-}
-} // namespace
-
-template <typename S, size_t LeafCapacity>
-TriBvh<S, LeafCapacity>::TriBvh(
-    Eigen::MatrixX3<S>&& positions,
-    Eigen::MatrixX3i&& triangles,
     const std::optional<S>& boundingBoxThickness)
-    : positions_{std::move(positions)},
-      triangles_{std::move(triangles)},
-      bvh_{buildBvh<S, LeafCapacity>(positions_, triangles_, boundingBoxThickness)} {}
+    : depth_(0) {
+  numTriangles_ = static_cast<uint32_t>(triangles.rows());
+  if (numTriangles_ == 0) {
+    return;
+  }
 
-template <typename S, size_t LeafCapacity>
-std::vector<uint32_t> TriBvh<S, LeafCapacity>::boxQuery(const BoundingBox<S>& box) const {
-  return bvh_.query(box);
+  // Validate that we're getting reasonable SIMD width
+  static_assert(TriangleBlockSize >= 1, "SIMD width must be at least 1");
+
+  // Store bounding box thickness for use during tree construction
+  S bboxThickness = boundingBoxThickness.value_or(static_cast<S>(0));
+  if (bboxThickness < static_cast<S>(0)) {
+    bboxThickness = static_cast<S>(0);
+  }
+
+  // Create triangle indices with centers for spatial partitioning
+  std::vector<std::tuple<uint32_t, Eigen::Vector3<S>>> triangleIndices;
+  triangleIndices.reserve(numTriangles_);
+  for (uint32_t iTri = 0; iTri < numTriangles_; ++iTri) {
+    triangleIndices.emplace_back(iTri, computeTriangleCenter<S>(triangles, iTri, positions));
+  }
+
+  // Build the tree using recursive splitting - no conversion needed
+  std::tie(root_, boundingBox_) =
+      split(triangles, positions, triangleIndices, 0, numTriangles_, 0, bboxThickness);
 }
 
-template <typename S, size_t LeafCapacity>
-uint32_t TriBvh<S, LeafCapacity>::boxQuery(const BoundingBox<S>& box, QueryBuffer& hits) const {
-  return bvh_.query(box, hits);
+// Flexible constructor with gsl::span inputs for maximum compatibility
+template <typename S>
+TriBvh<S>::TriBvh(
+    gsl::span<const Eigen::Vector3<S>> vertices,
+    gsl::span<const Eigen::Vector3i> triangles,
+    const std::optional<S>& boundingBoxThickness)
+    : depth_(0) {
+  numTriangles_ = static_cast<uint32_t>(triangles.size());
+  if (numTriangles_ == 0) {
+    return;
+  }
+
+  // Validate that we're getting reasonable SIMD width
+  static_assert(TriangleBlockSize >= 1, "SIMD width must be at least 1");
+
+  // Store bounding box thickness for use during tree construction
+  S bboxThickness = boundingBoxThickness.value_or(static_cast<S>(0));
+  if (bboxThickness < static_cast<S>(0)) {
+    bboxThickness = static_cast<S>(0);
+  }
+
+  // Create triangle indices with centers for spatial partitioning
+  // gsl::span works seamlessly with our templated helper functions
+  std::vector<std::tuple<uint32_t, Eigen::Vector3<S>>> triangleIndices;
+  triangleIndices.reserve(numTriangles_);
+  for (uint32_t iTri = 0; iTri < numTriangles_; ++iTri) {
+    triangleIndices.emplace_back(iTri, computeTriangleCenter<S>(triangles, iTri, vertices));
+  }
+
+  // Build the tree using recursive splitting - gsl::span works with our templated split function
+  std::tie(root_, boundingBox_) =
+      split(triangles, vertices, triangleIndices, 0, numTriangles_, 0, bboxThickness);
 }
 
-template <typename S, size_t LeafCapacity>
-std::vector<uint32_t> TriBvh<S, LeafCapacity>::lineHits(const Ray3<S>& ray) const {
-  return bvh_.query(ray.origin, ray.direction);
-}
+// Tree building split function with 8-way spatial subdivision - now templated for different
+// container types
+template <typename S>
+template <typename TriangleContainer, typename VertexContainer>
+std::pair<typename TriBvh<S>::SizeType, Eigen::AlignedBox<S, 3>> TriBvh<S>::split(
+    const TriangleContainer& triangles,
+    const VertexContainer& vertices,
+    std::vector<std::tuple<uint32_t, Eigen::Vector3<S>>>& triIndices,
+    const SizeType start,
+    const SizeType end,
+    SizeType depth,
+    S boundingBoxThickness) {
+  XR_CHECK(end > start, "Invalid range for split");
 
-template <typename S, size_t LeafCapacity>
-std::optional<IntersectionResult<S>> TriBvh<S, LeafCapacity>::closestHit(const Ray3<S>& ray) const {
-  auto result = bvh_.template rayQueryClosestHit<HitResult<S>>(
-      ray.origin,
-      ray.direction,
-      ray.minT,
-      ray.maxT,
-      [this, &ray](const uint32_t primIdx, HitResult<S>& result, S& maxT) {
-        const Eigen::Vector3i tri = triangles_.row(primIdx);
-        const Eigen::Vector3<S> p0 = positions_.row(tri[0]);
-        const Eigen::Vector3<S> p1 = positions_.row(tri[1]);
-        const Eigen::Vector3<S> p2 = positions_.row(tri[2]);
+  depth_ = std::max(depth, depth_);
 
-        S u;
-        S v;
-        S tOut;
-        Eigen::Vector3<S> itsPoint;
-        if (rayTriangleIntersect(ray.origin, ray.direction, p0, p1, p2, itsPoint, tOut, u, v) &&
-            tOut >= ray.minT && tOut <= maxT) {
-          result.t = tOut;
-          result.triangleIdx = primIdx;
-          result.bary0 = u;
-          result.bary1 = v;
-          maxT = tOut;
+  // Compute bounding box for this range of triangles
+  Eigen::AlignedBox<S, 3> box;
+  for (SizeType i = start; i != end; ++i) {
+    const auto [triIndex, triCenter] = triIndices[i];
+    const auto tri = getTriangle(triangles, triIndex);
+    for (int j = 0; j < 3; ++j) {
+      box.extend(getVertex(vertices, tri[j]));
+    }
+  }
+
+  // Apply bounding box thickness to avoid zero-thickness boxes
+  if (boundingBoxThickness > static_cast<S>(0)) {
+    const Eigen::Vector3<S> thickness = Eigen::Vector3<S>::Constant(boundingBoxThickness);
+    box.min() -= thickness;
+    box.max() += thickness;
+  }
+
+  const SizeType nBlocks = (end - start) / TriangleBlockSize;
+
+  // Create leaf node if we've reached depth limit or have few enough triangles
+  if (depth_ == kMaxDepth || nBlocks <= kLeafBlocks) {
+    const auto node_id = static_cast<SizeType>(nodes_.size());
+
+    auto blocksStart = static_cast<SizeType>(triangleBlocks_.size());
+
+    // Pack triangles into SIMD blocks
+    for (SizeType curBlockStart = start; curBlockStart < end; curBlockStart += TriangleBlockSize) {
+      // Initialize triangle block with vectorized types directly
+      TriangleBlock triangleBlock;
+
+      // Initialize with far values and invalid indices
+      triangleBlock.triIndex = UIntP(kInvalidTriangleIdx);
+
+      for (int iTriVert = 0; iTriVert < 3; ++iTriVert) {
+        triangleBlock.triPos[iTriVert] = Vector3P(
+            FloatP(static_cast<S>(kFarValueFloat)),
+            FloatP(static_cast<S>(kFarValueFloat)),
+            FloatP(static_cast<S>(kFarValueFloat)));
+      }
+
+      const SizeType curBlockEnd = std::min(curBlockStart + TriangleBlockSize, end);
+      for (SizeType curTri = curBlockStart; curTri != curBlockEnd; ++curTri) {
+        const SizeType offset = curTri - curBlockStart;
+        const auto [triIndex, triCenter] = triIndices[curTri];
+
+        // Set triangle index directly in vectorized format
+        triangleBlock.triIndex[offset] = triIndex;
+
+        const auto tri = getTriangle(triangles, triIndex);
+        for (int jTriVert = 0; jTriVert < 3; ++jTriVert) {
+          const auto vertex = getVertex(vertices, tri[jTriVert]);
+          // Pack vertex coordinates directly into vectorized types
+          triangleBlock.triPos[jTriVert][0][offset] = vertex[0];
+          triangleBlock.triPos[jTriVert][1][offset] = vertex[1];
+          triangleBlock.triPos[jTriVert][2][offset] = vertex[2];
         }
-      });
-  if (result.triangleIdx == kInvalidTriangleIdx) {
+      }
+
+      triangleBlocks_.push_back(triangleBlock);
+    }
+
+    auto blocksEnd = static_cast<SizeType>(triangleBlocks_.size());
+
+    nodes_.push_back(Node(blocksStart, blocksEnd));
+    return std::make_pair(node_id, box);
+  }
+
+  // Create 8-way split for internal node
+  const Eigen::Vector3<S> low = Eigen::Vector3<S>::Constant(-std::numeric_limits<S>::max());
+  const Eigen::Vector3<S> mid = box.center();
+  const Eigen::Vector3<S> high = Eigen::Vector3<S>::Constant(std::numeric_limits<S>::max());
+
+  std::array<Eigen::AlignedBox<S, 3>, TreeSplit> boxes = {
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(low.x(), low.y(), low.z()),
+          Eigen::Vector3<S>(mid.x(), mid.y(), mid.z())),
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(low.x(), low.y(), mid.z()),
+          Eigen::Vector3<S>(mid.x(), mid.y(), high.z())),
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(low.x(), mid.y(), low.z()),
+          Eigen::Vector3<S>(mid.x(), high.y(), mid.z())),
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(low.x(), mid.y(), mid.z()),
+          Eigen::Vector3<S>(mid.x(), high.y(), high.z())),
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(mid.x(), low.y(), low.z()),
+          Eigen::Vector3<S>(high.x(), mid.y(), mid.z())),
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(mid.x(), low.y(), mid.z()),
+          Eigen::Vector3<S>(high.x(), mid.y(), high.z())),
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(mid.x(), mid.y(), low.z()),
+          Eigen::Vector3<S>(high.x(), high.y(), mid.z())),
+      Eigen::AlignedBox<S, 3>(
+          Eigen::Vector3<S>(mid.x(), mid.y(), mid.z()),
+          Eigen::Vector3<S>(high.x(), high.y(), high.z()))};
+
+  std::array<SizeType, TreeSplit> children{};
+
+  SizeType lastEnd = start;
+  for (uint32_t iBox = 0; iBox < TreeSplit; ++iBox) {
+    const auto it = std::partition(
+        triIndices.begin() + lastEnd,
+        triIndices.begin() + end,
+        [&](const std::tuple<uint32_t, Eigen::Vector3<S>>& triIndexAndCenter) -> bool {
+          const auto& [triIndex, triCenter] = triIndexAndCenter;
+          return boxes[iBox].contains(triCenter);
+        });
+
+    const auto curEnd = static_cast<uint32_t>(std::distance(triIndices.begin(), it));
+
+    // No triangles in current child:
+    if (lastEnd == curEnd) {
+      children[iBox] = kInvalidNodeIdx;
+      // Make an empty box:
+      boxes[iBox] = Eigen::AlignedBox<S, 3>(mid, mid);
+    } else {
+      // Recursively split this child
+      std::tie(children[iBox], boxes[iBox]) =
+          split(triangles, vertices, triIndices, lastEnd, curEnd, depth + 1, boundingBoxThickness);
+    }
+    lastEnd = curEnd;
+  }
+  XR_CHECK(lastEnd == end, "Triangle partitioning failed");
+
+  // Create SIMD bounding box data
+  Vector3SP bbox_min;
+  Vector3SP bbox_max;
+  for (int i = 0; i < 3; ++i) {
+    for (uint32_t j = 0; j < TreeSplit; ++j) {
+      bbox_min[i][j] = boxes[j].min()[i];
+      bbox_max[i][j] = boxes[j].max()[i];
+    }
+  }
+
+  const auto node_id = static_cast<SizeType>(nodes_.size());
+  nodes_.push_back(Node(bbox_min, bbox_max, children));
+
+  return std::make_pair(node_id, box);
+}
+
+// SIMD bounding box intersection test
+template <typename S>
+typename TriBvh<S>::IntSP::MaskType TriBvh<S>::intersectBoxWithBox(
+    const BoundingBox<S>& queryBox,
+    const Vector3SP& boxMin,
+    const Vector3SP& boxMax) const {
+  // Convert query box to SIMD format for comparison
+  const Vector3SP queryMin = Vector3SP(
+      FloatSP(queryBox.aabb.min().x()),
+      FloatSP(queryBox.aabb.min().y()),
+      FloatSP(queryBox.aabb.min().z()));
+
+  const Vector3SP queryMax = Vector3SP(
+      FloatSP(queryBox.aabb.max().x()),
+      FloatSP(queryBox.aabb.max().y()),
+      FloatSP(queryBox.aabb.max().z()));
+
+  // Test intersection on all three axes
+  auto intersects = typename IntSP::MaskType(true);
+
+  for (int i = 0; i < 3; ++i) {
+    // Boxes intersect on axis i if:
+    // queryMin[i] <= boxMax[i] && queryMax[i] >= boxMin[i]
+    const auto axisIntersects = (queryMin[i] <= boxMax[i]) & (queryMax[i] >= boxMin[i]);
+    intersects = intersects & axisIntersects;
+  }
+
+  return intersects;
+}
+
+template <typename S>
+std::vector<uint32_t> TriBvh<S>::boxQuery(const BoundingBox<S>& box) const {
+  std::vector<uint32_t> results;
+
+  if (numTriangles_ == 0 || root_ == kInvalidNodeIdx) {
+    return results;
+  }
+
+  // Use explicit stack for traversal
+  const size_t kMaxStackSize = (TreeSplit - 1) * kMaxDepth + 1;
+  std::array<SizeType, kMaxStackSize> nodeStack{};
+
+  // Start with root on the stack
+  nodeStack[0] = root_;
+  SizeType stackSize = 1;
+
+  while (stackSize != 0) {
+    // Pop the top of the stack
+    --stackSize;
+    const SizeType cur = nodeStack[stackSize];
+    const auto& cur_node = nodes_[cur];
+
+    if (cur_node.isLeaf()) {
+      // Process leaf node - test individual triangles against query box
+      const SizeType triBlocksStart = cur_node.trianglesStart;
+      const SizeType triBlocksEnd = cur_node.trianglesEnd;
+
+      for (SizeType iBlock = triBlocksStart; iBlock < triBlocksEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        // Vectorized triangle-box intersection test for the entire block
+
+        // Compute triangle bounding boxes for the entire block using SIMD
+        Vector3P triangleBoxMin = triBlock.triPos[0];
+        Vector3P triangleBoxMax = triBlock.triPos[0];
+
+        // Extend with other vertices
+        for (int vert = 1; vert < 3; ++vert) {
+          triangleBoxMin = drjit::minimum(triangleBoxMin, triBlock.triPos[vert]);
+          triangleBoxMax = drjit::maximum(triangleBoxMax, triBlock.triPos[vert]);
+        }
+
+        // Test all triangle bounding boxes against query box using SIMD
+        const Vector3P queryMin = Vector3P(
+            FloatP(box.aabb.min().x()), FloatP(box.aabb.min().y()), FloatP(box.aabb.min().z()));
+
+        const Vector3P queryMax = Vector3P(
+            FloatP(box.aabb.max().x()), FloatP(box.aabb.max().y()), FloatP(box.aabb.max().z()));
+
+        // Test intersection on all three axes
+        auto intersects = typename FloatP::MaskType(true);
+        for (int i = 0; i < 3; ++i) {
+          // Boxes intersect on axis i if:
+          // queryMin[i] <= triangleBoxMax[i] && queryMax[i] >= triangleBoxMin[i]
+          const auto axisIntersects =
+              (queryMin[i] <= triangleBoxMax[i]) & (queryMax[i] >= triangleBoxMin[i]);
+          intersects = intersects & axisIntersects;
+        }
+
+        // Also need to mask out invalid triangles
+        const auto validTriangles = (triBlock.triIndex != UIntP(kInvalidTriangleIdx));
+        intersects = intersects & validTriangles;
+
+        // Only unpack if any triangles intersect
+        if (drjit::any(intersects)) {
+          for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+            if (intersects[i]) {
+              results.push_back(static_cast<uint32_t>(triBlock.triIndex[i]));
+            }
+          }
+        }
+      }
+
+    } else {
+      // Process internal node - test bounding box intersections
+      const auto mask = intersectBoxWithBox(box, cur_node.childBoxMin, cur_node.childBoxMax);
+
+      // Add intersecting children to stack
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (mask[i] && cur_node.children[i] != kInvalidNodeIdx) {
+          nodeStack[stackSize] = cur_node.children[i];
+          ++stackSize;
+        }
+      }
+    }
+  }
+
+  // Remove duplicates and sort
+  std::sort(results.begin(), results.end());
+  results.erase(std::unique(results.begin(), results.end()), results.end());
+
+  return results;
+}
+
+template <typename S>
+uint32_t TriBvh<S>::boxQuery(const BoundingBox<S>& box, QueryBuffer& hits) const {
+  if (numTriangles_ == 0 || root_ == kInvalidNodeIdx) {
+    return 0;
+  }
+
+  // Use explicit stack for traversal
+  const size_t kMaxStackSize = (TreeSplit - 1) * kMaxDepth + 1;
+  std::array<SizeType, kMaxStackSize> nodeStack{};
+
+  // Start with root on the stack
+  nodeStack[0] = root_;
+  SizeType stackSize = 1;
+
+  uint32_t hitCount = 0;
+  const auto maxHits = static_cast<uint32_t>(hits.size());
+
+  while (stackSize != 0 && hitCount < maxHits) {
+    // Pop the top of the stack
+    --stackSize;
+    const SizeType cur = nodeStack[stackSize];
+    const auto& cur_node = nodes_[cur];
+
+    if (cur_node.isLeaf()) {
+      // Process leaf node - test individual triangles against query box up to buffer limit
+      const SizeType triBlocksStart = cur_node.trianglesStart;
+      const SizeType triBlocksEnd = cur_node.trianglesEnd;
+
+      for (SizeType iBlock = triBlocksStart; iBlock < triBlocksEnd && hitCount < maxHits;
+           ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        // Vectorized triangle-box intersection test for the entire block
+
+        // Compute triangle bounding boxes for the entire block using SIMD
+        Vector3P triangleBoxMin = triBlock.triPos[0];
+        Vector3P triangleBoxMax = triBlock.triPos[0];
+
+        // Extend with other vertices
+        for (int vert = 1; vert < 3; ++vert) {
+          triangleBoxMin = drjit::minimum(triangleBoxMin, triBlock.triPos[vert]);
+          triangleBoxMax = drjit::maximum(triangleBoxMax, triBlock.triPos[vert]);
+        }
+
+        // Test all triangle bounding boxes against query box using SIMD
+        const Vector3P queryMin = Vector3P(
+            FloatP(box.aabb.min().x()), FloatP(box.aabb.min().y()), FloatP(box.aabb.min().z()));
+
+        const Vector3P queryMax = Vector3P(
+            FloatP(box.aabb.max().x()), FloatP(box.aabb.max().y()), FloatP(box.aabb.max().z()));
+
+        // Test intersection on all three axes
+        auto intersects = typename FloatP::MaskType(true);
+        for (int i = 0; i < 3; ++i) {
+          // Boxes intersect on axis i if:
+          // queryMin[i] <= triangleBoxMax[i] && queryMax[i] >= triangleBoxMin[i]
+          const auto axisIntersects =
+              (queryMin[i] <= triangleBoxMax[i]) & (queryMax[i] >= triangleBoxMin[i]);
+          intersects = intersects & axisIntersects;
+        }
+
+        // Also need to mask out invalid triangles
+        const auto validTriangles = (triBlock.triIndex != UIntP(kInvalidTriangleIdx));
+        intersects = intersects & validTriangles;
+
+        // Only unpack if any triangles intersect, and up to buffer limit
+        if (drjit::any(intersects)) {
+          for (uint32_t i = 0; i < TriangleBlockSize && hitCount < maxHits; ++i) {
+            if (intersects[i]) {
+              hits[hitCount] = static_cast<uint32_t>(triBlock.triIndex[i]);
+              ++hitCount;
+            }
+          }
+        }
+      }
+
+    } else {
+      // Process internal node - test bounding box intersections
+      const auto mask = intersectBoxWithBox(box, cur_node.childBoxMin, cur_node.childBoxMax);
+
+      // Add intersecting children to stack
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (mask[i] && cur_node.children[i] != kInvalidNodeIdx) {
+          nodeStack[stackSize] = cur_node.children[i];
+          ++stackSize;
+        }
+      }
+    }
+  }
+
+  return hitCount;
+}
+
+template <typename S>
+std::vector<uint32_t> TriBvh<S>::lineHits(const Ray3<S>& ray) const {
+  std::vector<uint32_t> results;
+
+  if (numTriangles_ == 0 || root_ == kInvalidNodeIdx) {
+    return results;
+  }
+
+  // Use explicit stack for traversal (similar to ray intersection but collect triangle indices)
+  const size_t kMaxStackSize = (TreeSplit - 1) * kMaxDepth + 1;
+
+  struct NodeElt {
+    SizeType nodeIdx;
+    S near_tVal;
+  };
+
+  std::array<NodeElt, kMaxStackSize> nodeStack{};
+
+  // Start with root on the stack
+  nodeStack[0].nodeIdx = root_;
+  nodeStack[0].near_tVal = ray.minT;
+  SizeType stackSize = 1;
+
+  // Use a large maxT for line hits (we want all triangles the line passes through)
+  const S line_maxT = std::numeric_limits<S>::max();
+
+  while (stackSize != 0) {
+    // Pop the top of the stack
+    --stackSize;
+    const SizeType cur = nodeStack[stackSize].nodeIdx;
+    const S cur_min_t = nodeStack[stackSize].near_tVal;
+
+    if (cur_min_t >= line_maxT) {
+      continue;
+    }
+
+    const auto& cur_node = nodes_[cur];
+
+    if (cur_node.isLeaf()) {
+      // Process leaf node - collect all triangle indices in blocks that intersect the ray line
+      const SizeType triBlocksStart = cur_node.trianglesStart;
+      const SizeType triBlocksEnd = cur_node.trianglesEnd;
+
+      for (SizeType iBlock = triBlocksStart; iBlock < triBlocksEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        // For lineHits, we don't need to do actual triangle intersection
+        // We just collect all valid triangle indices in blocks that the ray reaches
+        for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+          if (triBlock.triIndex[i] != kInvalidTriangleIdx) {
+            results.push_back(static_cast<uint32_t>(triBlock.triIndex[i]));
+          }
+        }
+      }
+
+    } else {
+      // Process internal node - test bounding boxes
+      const auto [mask, tMin, tMax] =
+          intersectBBox(ray, cur_node.childBoxMin, cur_node.childBoxMax, ray.minT, line_maxT);
+
+      // Missed all boxes
+      if (!drjit::any(mask)) {
+        continue;
+      }
+
+      // Add children to stack
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (!mask[i]) {
+          continue;
+        }
+
+        if (cur_node.children[i] == kInvalidNodeIdx) {
+          continue;
+        }
+
+        nodeStack[stackSize].nodeIdx = cur_node.children[i];
+        nodeStack[stackSize].near_tVal = tMin[i];
+        ++stackSize;
+      }
+    }
+  }
+
+  // Remove duplicates and sort (triangle indices might be duplicated if they appear in multiple
+  // blocks)
+  std::sort(results.begin(), results.end());
+  results.erase(std::unique(results.begin(), results.end()), results.end());
+
+  return results;
+}
+
+// SIMD bounding box intersection function using our tested ray-box intersection implementation
+template <typename S>
+std::tuple<
+    typename TriBvh<S>::IntSP::MaskType,
+    typename TriBvh<S>::FloatSP,
+    typename TriBvh<S>::FloatSP>
+TriBvh<S>::intersectBBox(
+    const Ray3<S>& ray,
+    const Vector3SP& boxMin,
+    const Vector3SP& boxMax,
+    const S& t0,
+    const S& t1) const {
+  // Create a ray with the proper parameter range for intersection testing
+  Ray3<S> testRay = ray;
+  testRay.minT = t0;
+  testRay.maxT = t1;
+
+  // Use our tested ray-box intersection function directly with Vector3SP
+  auto [mask, tMin, tMax] = intersectRayBoxes<S, TreeSplit>(testRay, boxMin, boxMax);
+
+  return std::make_tuple(mask, tMin, tMax);
+}
+
+// SIMD triangle intersection function using the corrected wide vector implementation
+template <typename S>
+std::pair<typename TriBvh<S>::FloatP, typename TriBvh<S>::Vector3P> TriBvh<S>::intersectTriangle(
+    const Ray3<S>& ray,
+    const Vector3P& v0,
+    const Vector3P& v1,
+    const Vector3P& v2) const {
+  // Use the corrected wide vector ray-triangle intersection with axel types
+  Vector3P intersectionPoint;
+  FloatP t, u, v;
+
+  // Call with default template parameters that match the explicit instantiations
+  auto hitMask = rayTriangleIntersectWide<S>(
+      ray.origin, ray.direction, v0, v1, v2, intersectionPoint, t, u, v);
+
+  // Apply ray t-range constraints
+  auto tInRange = (t >= FloatP(ray.minT)) & (t <= FloatP(ray.maxT));
+  auto validMask = hitMask & tInRange;
+
+  // Set invalid intersections to max value
+  t = drjit::select(validMask, t, FloatP(std::numeric_limits<S>::max()));
+
+  // Compute barycentric coordinates (w, u, v) where w = 1 - u - v
+  const auto w = FloatP(static_cast<S>(1)) - u - v;
+
+  return {t, Vector3P(w, u, v)};
+}
+
+template <typename S>
+std::optional<IntersectionResult<S>> TriBvh<S>::closestHit(const Ray3<S>& ray) const {
+  if (numTriangles_ == 0 || root_ == kInvalidNodeIdx) {
     return std::nullopt;
   }
 
-  const Eigen::Vector3<S> bary(
-      static_cast<S>(1.0) - result.bary0 - result.bary1, result.bary0, result.bary1);
-  return IntersectionResult<S>{
-      static_cast<int32_t>(result.triangleIdx),
-      result.t,
-      interpolatePosition(triangles_.row(result.triangleIdx), positions_, bary),
-      bary};
-}
+  // Use explicit stack for traversal with optimized 8-way tree structure
+  const size_t kMaxStackSize = (TreeSplit - 1) * kMaxDepth + 1;
 
-template <typename S, size_t LeafCapacity>
-std::vector<IntersectionResult<S>> TriBvh<S, LeafCapacity>::allHits(const Ray3<S>& ray) const {
-  const auto results = bvh_.template rayQueryClosestHit<std::vector<HitResult<S>>>(
-      ray.origin,
-      ray.direction,
-      ray.minT,
-      ray.maxT,
-      [this, &ray](const uint32_t primIdx, auto& results, S& maxT) {
-        const Eigen::Vector3i tri = triangles_.row(primIdx);
-        const Eigen::Vector3<S> p0 = positions_.row(tri[0]);
-        const Eigen::Vector3<S> p1 = positions_.row(tri[1]);
-        const Eigen::Vector3<S> p2 = positions_.row(tri[2]);
+  struct NodeElt {
+    SizeType nodeIdx;
+    S near_tVal;
+  };
 
-        S u;
-        S v;
-        S tOut;
-        Eigen::Vector3<S> itsPoint;
-        if (rayTriangleIntersect(ray.origin, ray.direction, p0, p1, p2, itsPoint, tOut, u, v) &&
-            tOut >= ray.minT && tOut <= maxT) {
-          // We don't update the maxT here because we want to intersect with all the triangles.
-          results.push_back({u, v, tOut, primIdx});
+  std::array<NodeElt, kMaxStackSize> nodeStack{};
+
+  // Start with root on the stack
+  nodeStack[0].nodeIdx = root_;
+  nodeStack[0].near_tVal = ray.minT;
+  SizeType stackSize = 1;
+
+  S closest_t = ray.maxT;
+  uint32_t closest_t_index = std::numeric_limits<uint32_t>::max();
+  Eigen::Vector3<S> closest_t_bary = Eigen::Vector3<S>::Zero();
+
+  while (stackSize != 0) {
+    // Pop the top of the stack
+    --stackSize;
+    const SizeType cur = nodeStack[stackSize].nodeIdx;
+    const S cur_min_t = nodeStack[stackSize].near_tVal;
+
+    if (cur_min_t >= closest_t) {
+      continue;
+    }
+
+    const auto& cur_node = nodes_[cur];
+
+    if (cur_node.isLeaf()) {
+      // Process leaf node - test triangles in triangle blocks
+      const SizeType triBlocksStart = cur_node.trianglesStart;
+      const SizeType triBlocksEnd = cur_node.trianglesEnd;
+
+      auto intersect_t = FloatP(std::numeric_limits<S>::max());
+      Vector3P intersect_bary;
+      auto intersect_index = UIntP(kInvalidTriangleIdx);
+
+      for (SizeType iBlock = triBlocksStart; iBlock < triBlocksEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        auto triIntersectRes =
+            intersectTriangle(ray, triBlock.triPos[0], triBlock.triPos[1], triBlock.triPos[2]);
+
+        auto mask = (triIntersectRes.first < intersect_t);
+        intersect_t = drjit::select(mask, triIntersectRes.first, intersect_t);
+        intersect_bary = drjit::select(mask, triIntersectRes.second, intersect_bary);
+        intersect_index = drjit::select(mask, triBlock.triIndex, intersect_index);
+      }
+
+      auto anyHit = (intersect_t < FloatP(closest_t));
+      if (!drjit::any(anyHit)) {
+        continue;
+      }
+
+      // Extract the closest hit from SIMD results
+      S min_t_cur = std::numeric_limits<S>::max();
+      int min_t_index = -1;
+      for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+        if (intersect_t[i] < min_t_cur && intersect_index[i] != kInvalidTriangleIdx) {
+          min_t_cur = intersect_t[i];
+          min_t_index = static_cast<int>(i);
         }
+      }
+
+      if (min_t_cur >= closest_t) {
+        continue;
+      }
+
+      // Update closest hit
+      closest_t = min_t_cur;
+      closest_t_index = static_cast<uint32_t>(intersect_index[min_t_index]);
+      for (int j = 0; j < 3; ++j) {
+        closest_t_bary[j] = intersect_bary[j][min_t_index];
+      }
+
+    } else {
+      // Process internal node - test bounding boxes
+      const auto [mask, tMin, tMax] =
+          intersectBBox(ray, cur_node.childBoxMin, cur_node.childBoxMax, ray.minT, closest_t);
+
+      // Missed all boxes
+      if (!drjit::any(mask)) {
+        continue;
+      }
+
+      // Add children to stack
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (!mask[i]) {
+          continue;
+        }
+
+        if (cur_node.children[i] == kInvalidNodeIdx) {
+          continue;
+        }
+
+        nodeStack[stackSize].nodeIdx = cur_node.children[i];
+        nodeStack[stackSize].near_tVal = tMin[i];
+        ++stackSize;
+      }
+    }
+  }
+
+  // Return result if we found a valid intersection
+  if (closest_t < ray.maxT && closest_t_index != std::numeric_limits<uint32_t>::max()) {
+    IntersectionResult<S> result;
+    result.triangleId = static_cast<int32_t>(closest_t_index);
+    result.hitDistance = closest_t;
+    result.hitPoint = ray.origin + closest_t * ray.direction;
+    result.baryCoords = closest_t_bary;
+    return result;
+  }
+
+  return std::nullopt;
+}
+
+template <typename S>
+std::vector<IntersectionResult<S>> TriBvh<S>::allHits(const Ray3<S>& ray) const {
+  std::vector<IntersectionResult<S>> results;
+
+  if (numTriangles_ == 0 || root_ == kInvalidNodeIdx) {
+    return results;
+  }
+
+  // Use explicit stack for traversal with optimized 8-way tree structure
+  const size_t kMaxStackSize = (TreeSplit - 1) * kMaxDepth + 1;
+
+  struct NodeElt {
+    SizeType nodeIdx;
+    S near_tVal;
+  };
+
+  std::array<NodeElt, kMaxStackSize> nodeStack{};
+
+  // Start with root on the stack
+  nodeStack[0].nodeIdx = root_;
+  nodeStack[0].near_tVal = ray.minT;
+  SizeType stackSize = 1;
+
+  // Note: Unlike closestHit, we don't update maxT during traversal
+  // We want to find ALL intersections within the ray bounds
+  const S segment_t = ray.maxT;
+
+  while (stackSize != 0) {
+    // Pop the top of the stack
+    --stackSize;
+    const SizeType cur = nodeStack[stackSize].nodeIdx;
+    const S cur_min_t = nodeStack[stackSize].near_tVal;
+
+    if (cur_min_t >= segment_t) {
+      continue;
+    }
+
+    const auto& cur_node = nodes_[cur];
+
+    if (cur_node.isLeaf()) {
+      // Process leaf node - test triangles in triangle blocks
+      const SizeType triBlocksStart = cur_node.trianglesStart;
+      const SizeType triBlocksEnd = cur_node.trianglesEnd;
+
+      for (SizeType iBlock = triBlocksStart; iBlock < triBlocksEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        auto triIntersectRes =
+            intersectTriangle(ray, triBlock.triPos[0], triBlock.triPos[1], triBlock.triPos[2]);
+
+        auto anyHit = (triIntersectRes.first < FloatP(segment_t));
+        if (!drjit::any(anyHit)) {
+          continue;
+        }
+
+        // Extract all valid hits from SIMD results
+        for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+          if (anyHit[i] && triBlock.triIndex[i] != kInvalidTriangleIdx) {
+            // Create intersection result for this hit
+            IntersectionResult<S> result;
+            result.triangleId = static_cast<int32_t>(triBlock.triIndex[i]);
+            result.hitDistance = triIntersectRes.first[i];
+            result.hitPoint = ray.origin + result.hitDistance * ray.direction;
+
+            // Extract barycentric coordinates
+            for (int j = 0; j < 3; ++j) {
+              result.baryCoords[j] = triIntersectRes.second[j][i];
+            }
+
+            results.push_back(result);
+          }
+        }
+      }
+
+    } else {
+      // Process internal node - test bounding boxes
+      const auto [mask, tMin, tMax] =
+          intersectBBox(ray, cur_node.childBoxMin, cur_node.childBoxMax, ray.minT, segment_t);
+
+      // Missed all boxes
+      if (!drjit::any(mask)) {
+        continue;
+      }
+
+      // Add children to stack
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (!mask[i]) {
+          continue;
+        }
+
+        if (cur_node.children[i] == kInvalidNodeIdx) {
+          continue;
+        }
+
+        nodeStack[stackSize].nodeIdx = cur_node.children[i];
+        nodeStack[stackSize].near_tVal = tMin[i];
+        ++stackSize;
+      }
+    }
+  }
+
+  // Sort results by hit distance (optional, but often expected)
+  std::sort(
+      results.begin(),
+      results.end(),
+      [](const IntersectionResult<S>& a, const IntersectionResult<S>& b) {
+        return a.hitDistance < b.hitDistance;
       });
 
-  std::vector<IntersectionResult<S>> intersections;
-  intersections.reserve(results.size());
-  for (const auto& result : results) {
-    const Eigen::Vector3<S> bary(1.0 - result.bary0 - result.bary1, result.bary0, result.bary1);
-    intersections.push_back(
-        {static_cast<int32_t>(result.triangleIdx),
-         result.t,
-         interpolatePosition(triangles_.row(result.triangleIdx), positions_, bary),
-         bary});
+  return results;
+}
+
+template <typename S>
+bool TriBvh<S>::anyHit(const Ray3<S>& ray) const {
+  if (numTriangles_ == 0 || root_ == kInvalidNodeIdx) {
+    return false;
   }
-  return intersections;
+
+  // Use explicit stack for traversal (similar to closestHit but with early exit)
+  const size_t kMaxStackSize = (TreeSplit - 1) * kMaxDepth + 1;
+
+  struct NodeElt {
+    SizeType nodeIdx;
+    S near_tVal;
+  };
+
+  std::array<NodeElt, kMaxStackSize> nodeStack{};
+
+  // Start with root on the stack
+  nodeStack[0].nodeIdx = root_;
+  nodeStack[0].near_tVal = ray.minT;
+  SizeType stackSize = 1;
+
+  while (stackSize != 0) {
+    // Pop the top of the stack
+    --stackSize;
+    const SizeType cur = nodeStack[stackSize].nodeIdx;
+    const S cur_min_t = nodeStack[stackSize].near_tVal;
+
+    if (cur_min_t >= ray.maxT) {
+      continue;
+    }
+
+    const auto& cur_node = nodes_[cur];
+
+    if (cur_node.isLeaf()) {
+      // Process leaf node - test triangles in triangle blocks
+      const SizeType triBlocksStart = cur_node.trianglesStart;
+      const SizeType triBlocksEnd = cur_node.trianglesEnd;
+
+      for (SizeType iBlock = triBlocksStart; iBlock < triBlocksEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        auto triIntersectRes =
+            intersectTriangle(ray, triBlock.triPos[0], triBlock.triPos[1], triBlock.triPos[2]);
+
+        auto anyHit = (triIntersectRes.first < FloatP(ray.maxT));
+        if (drjit::any(anyHit)) {
+          // Check if any of the hits are valid
+          for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+            if (anyHit[i] && triBlock.triIndex[i] != kInvalidTriangleIdx) {
+              return true; // Early exit on first valid hit
+            }
+          }
+        }
+      }
+
+    } else {
+      // Process internal node - test bounding boxes
+      const auto [mask, tMin, tMax] =
+          intersectBBox(ray, cur_node.childBoxMin, cur_node.childBoxMax, ray.minT, ray.maxT);
+
+      // Missed all boxes
+      if (!drjit::any(mask)) {
+        continue;
+      }
+
+      // Add children to stack
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (!mask[i]) {
+          continue;
+        }
+
+        if (cur_node.children[i] == kInvalidNodeIdx) {
+          continue;
+        }
+
+        nodeStack[stackSize].nodeIdx = cur_node.children[i];
+        nodeStack[stackSize].near_tVal = tMin[i];
+        ++stackSize;
+      }
+    }
+  }
+
+  return false; // No intersection found
 }
 
-template <typename S, size_t LeafCapacity>
-bool TriBvh<S, LeafCapacity>::anyHit(const Ray3<S>& ray) const {
-  return bvh_.rayQueryAnyHit(
-      ray.origin, ray.direction, ray.minT, ray.maxT, [this, &ray](const uint32_t primIdx) {
-        const Eigen::Vector3i tri = triangles_.row(primIdx);
-        const Eigen::Vector3<S> p0 = positions_.row(tri[0]);
-        const Eigen::Vector3<S> p1 = positions_.row(tri[1]);
-        const Eigen::Vector3<S> p2 = positions_.row(tri[2]);
+// SIMD point-to-bounding-box distance function - simplified using clamping
+template <typename S>
+typename TriBvh<S>::FloatSP TriBvh<S>::pointToBoxDistanceSquared(
+    const Eigen::Vector3<S>& query,
+    const Vector3SP& boxMin,
+    const Vector3SP& boxMax) const {
+  // Clamp query point to box bounds on each axis
+  Vector3SP queryP = Vector3SP(FloatSP(query[0]), FloatSP(query[1]), FloatSP(query[2]));
+  Vector3SP clampedPoint = Vector3SP(
+      drjit::clip(queryP[0], boxMin[0], boxMax[0]),
+      drjit::clip(queryP[1], boxMin[1], boxMax[1]),
+      drjit::clip(queryP[2], boxMin[2], boxMax[2]));
 
-        S u;
-        S v;
-        S tOut;
-        Eigen::Vector3<S> itsPoint;
-        return rayTriangleIntersect(ray.origin, ray.direction, p0, p1, p2, itsPoint, tOut, u, v) &&
-            tOut >= ray.minT && tOut <= ray.maxT;
-      });
+  // Compute squared distance between query point and clamped point
+  Vector3SP diff = queryP - clampedPoint;
+  return diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2];
 }
 
-template <typename S, size_t LeafCapacity>
-ClosestSurfacePointResult<S> TriBvh<S, LeafCapacity>::closestSurfacePoint(
-    const Eigen::Vector3<S>& query) const {
-  // If LeafCapacity is equal to the native SIMD width, we can vectorize.
-  if constexpr (LeafCapacity > 1 && LeafCapacity == kNativeLaneWidth<S>) {
-    WideVec3<S> wideQuery;
-    wideQuery[0] = query[0];
-    wideQuery[1] = query[1];
-    wideQuery[2] = query[2];
+// Scalar point-to-triangle distance function using proper axel projection
+template <typename S>
+std::tuple<S, Eigen::Vector3<S>, Eigen::Vector3<S>> TriBvh<S>::pointToTriangleDistanceSquaredScalar(
+    const Eigen::Vector3<S>& query,
+    const Eigen::Vector3<S>& v0,
+    const Eigen::Vector3<S>& v1,
+    const Eigen::Vector3<S>& v2) const {
+  Eigen::Vector3<S> closestPoint;
+  Eigen::Vector3<S> baryCoords;
 
-    // Note: We have to define wide int scalar depending on the native lane width of the
-    // floating point type (e.g. AVX = either 4 for doubles or 8 for floats)
-    using WideScalari = WideScalar<int32_t, kNativeLaneWidth<S>>;
-    return bvh_.queryClosestSurfacePointPacket(
-        query,
-        [this, &wideQuery](
-            const Eigen::Vector3<S>& /*query*/,
-            const uint32_t primCount,
-            const WideScalari& indices,
-            WideVec3<S>& projections,
-            WideVec3<S>& barycentrics,
-            WideScalar<S>& squaredDistances) {
-          // Is there a more efficient way to create this mask?
-          const auto mask = drjit::arange<WideScalari>(LeafCapacity) < primCount;
-          const auto v0Ind = drjit::gather<WideScalari>(triangles_.col(0).data(), indices, mask);
-          const auto v1Ind = drjit::gather<WideScalari>(triangles_.col(1).data(), indices, mask);
-          const auto v2Ind = drjit::gather<WideScalari>(triangles_.col(2).data(), indices, mask);
-          projectOnTriangle(
-              wideQuery,
-              drjit::gather<WideVec3<S>>(positions_.data(), v0Ind, mask),
-              drjit::gather<WideVec3<S>>(positions_.data(), v1Ind, mask),
-              drjit::gather<WideVec3<S>>(positions_.data(), v2Ind, mask),
-              projections,
-              &barycentrics);
-          squaredDistances = drjit::squared_norm(projections - wideQuery);
-        });
-  } else {
-    return bvh_.queryClosestSurfacePoint(
-        query,
-        [this](
-            const Eigen::Vector3<S>& query,
-            const uint32_t primIdx,
-            Eigen::Vector3<S>& projection,
-            Eigen::Vector3<S>& barycentric) {
-          const Eigen::Vector3i& face = triangles_.row(primIdx);
-          projectOnTriangle<S>(
-              query,
-              positions_.row(face(0)),
-              positions_.row(face(1)),
-              positions_.row(face(2)),
-              projection,
-              &barycentric);
-        });
+  // Use the proper axel projectOnTriangle function
+  projectOnTriangle(query, v0, v1, v2, closestPoint, &baryCoords);
+
+  // Compute squared distance
+  const S distSq = (query - closestPoint).squaredNorm();
+
+  return {distSq, closestPoint, baryCoords};
+}
+
+// SIMD point-to-triangle distance function using vectorized projectOnTriangle
+template <typename S>
+std::tuple<typename TriBvh<S>::FloatP, typename TriBvh<S>::Vector3P, typename TriBvh<S>::Vector3P>
+TriBvh<S>::pointToTriangleDistanceSquared(
+    const Eigen::Vector3<S>& query,
+    const Vector3P& v0,
+    const Vector3P& v1,
+    const Vector3P& v2) const {
+  // Create SIMD version of query point by broadcasting to all lanes
+  Vector3P queryP = Vector3P(FloatP(query.x()), FloatP(query.y()), FloatP(query.z()));
+
+  // Use vectorized projectOnTriangle function
+  Vector3P closestPoint;
+  Vector3P baryCoords;
+
+  // The vectorized projectOnTriangle function expects WideVec3<S> which is the same as our Vector3P
+  projectOnTriangle<S>(queryP, v0, v1, v2, closestPoint, &baryCoords);
+
+  // Compute squared distance using SIMD operations
+  Vector3P diff = queryP - closestPoint;
+  FloatP distSq = diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2];
+
+  return {distSq, closestPoint, baryCoords};
+}
+
+template <typename S>
+typename TriBvh<S>::ClosestSurfacePointResult TriBvh<S>::closestSurfacePoint(
+    const Eigen::Vector3<S>& query,
+    const std::optional<S>& maxDist) const {
+  ClosestSurfacePointResult result;
+  result.triangleIdx = kInvalidTriangleIdx;
+
+  if (numTriangles_ == 0 || root_ == kInvalidNodeIdx) {
+    return result;
+  }
+
+  // Use explicit stack for traversal (similar to ray intersection)
+  const size_t kMaxStackSize = (TreeSplit - 1) * kMaxDepth + 1;
+
+  struct NodeElt {
+    SizeType nodeIdx;
+    S minDistSq;
+  };
+
+  std::array<NodeElt, kMaxStackSize> nodeStack{};
+
+  // Start with root on the stack
+  nodeStack[0].nodeIdx = root_;
+  nodeStack[0].minDistSq = static_cast<S>(0);
+  SizeType stackSize = 1;
+
+  // Set initial closest distance to maxDist if specified, otherwise unlimited
+  S closestDistSq = maxDist.has_value()
+      ? maxDist.value() * maxDist.value() // Convert to squared distance
+      : std::numeric_limits<S>::max();
+  uint32_t closestTriangleIdx = kInvalidTriangleIdx;
+  Eigen::Vector3<S> closestPoint = query;
+  Eigen::Vector3<S> closestBaryCoords = Eigen::Vector3<S>::Zero();
+
+  while (stackSize != 0) {
+    // Pop the top of the stack
+    --stackSize;
+    const SizeType cur = nodeStack[stackSize].nodeIdx;
+    const S curMinDistSq = nodeStack[stackSize].minDistSq;
+
+    // Prune if this node can't contain a closer point
+    if (curMinDistSq >= closestDistSq) {
+      continue;
+    }
+
+    const auto& curNode = nodes_[cur];
+
+    if (curNode.isLeaf()) {
+      // Process leaf node - test triangles in triangle blocks
+      const SizeType triBlocksStart = curNode.trianglesStart;
+      const SizeType triBlocksEnd = curNode.trianglesEnd;
+
+      for (SizeType iBlock = triBlocksStart; iBlock < triBlocksEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        auto [distSqP, closestPointP, baryCoordsP] = pointToTriangleDistanceSquared(
+            query, triBlock.triPos[0], triBlock.triPos[1], triBlock.triPos[2]);
+
+        // Extract the closest result from SIMD
+        for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+          if (triBlock.triIndex[i] != kInvalidTriangleIdx && distSqP[i] <= closestDistSq) {
+            closestDistSq = distSqP[i];
+            closestTriangleIdx = static_cast<uint32_t>(triBlock.triIndex[i]);
+            closestPoint =
+                Eigen::Vector3<S>(closestPointP[0][i], closestPointP[1][i], closestPointP[2][i]);
+            closestBaryCoords =
+                Eigen::Vector3<S>(baryCoordsP[0][i], baryCoordsP[1][i], baryCoordsP[2][i]);
+          }
+        }
+      }
+
+    } else {
+      // Process internal node - test bounding boxes and add children to stack
+      const auto distSqToBoxes =
+          pointToBoxDistanceSquared(query, curNode.childBoxMin, curNode.childBoxMax);
+
+      // Add children to stack, sorted by distance (closest first)
+      std::array<std::pair<S, SizeType>, TreeSplit> childDistances;
+      int validChildren = 0;
+
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (curNode.children[i] != kInvalidNodeIdx && distSqToBoxes[i] < closestDistSq) {
+          childDistances[validChildren] = {distSqToBoxes[i], curNode.children[i]};
+          ++validChildren;
+        }
+      }
+
+      // Sort children by distance (closest first)
+      std::sort(
+          childDistances.begin(),
+          childDistances.begin() + validChildren,
+          [](const auto& a, const auto& b) { return a.first < b.first; });
+
+      // Add children to stack in reverse order (so closest is processed first)
+      for (int i = validChildren - 1; i >= 0; --i) {
+        nodeStack[stackSize].nodeIdx = childDistances[i].second;
+        nodeStack[stackSize].minDistSq = childDistances[i].first;
+        ++stackSize;
+      }
+    }
+  }
+
+  // Set up result - only return valid result if within maxDist (when specified)
+  if (closestTriangleIdx != kInvalidTriangleIdx) {
+    // If maxDist was specified, verify the result is within bounds
+    if (maxDist.has_value()) {
+      const S actualDist = std::sqrt(closestDistSq);
+      if (actualDist > maxDist.value()) {
+        // Result is beyond maxDist, return invalid result
+        result.triangleIdx = kInvalidTriangleIdx;
+        return result;
+      }
+    }
+
+    result.point = closestPoint;
+    result.triangleIdx = closestTriangleIdx;
+    result.baryCoords = closestBaryCoords;
+  }
+
+  return result;
+}
+
+template <typename S>
+size_t TriBvh<S>::getNodeCount() const {
+  return nodes_.size();
+}
+
+template <typename S>
+size_t TriBvh<S>::getPrimitiveCount() const {
+  return numTriangles_;
+}
+
+// Validation function for debugging tree construction
+template <typename S>
+void TriBvh<S>::validate(
+    const std::vector<Eigen::Vector3i>& triangles,
+    const std::vector<Eigen::Vector3<S>>& vertices) const {
+  if (numTriangles_ == 0) {
+    XR_CHECK(root_ == kInvalidNodeIdx, "Empty tree should have invalid root");
+    XR_CHECK(triangleBlocks_.empty(), "Empty tree should have no triangle blocks");
+    XR_CHECK(nodes_.empty(), "Empty tree should have no nodes");
+    return;
+  }
+
+  XR_CHECK(root_ != kInvalidNodeIdx, "Non-empty tree should have valid root");
+  XR_CHECK(root_ < nodes_.size(), "Root index should be valid");
+
+  // Validate that all triangles are accounted for
+  std::set<uint32_t> foundTriangles;
+
+  // Traverse all leaf nodes and collect triangle indices
+  std::function<void(SizeType)> validateNode = [&](SizeType nodeIdx) {
+    XR_CHECK(nodeIdx < nodes_.size(), "Node index {} out of bounds", nodeIdx);
+
+    const auto& node = nodes_[nodeIdx];
+
+    if (node.isLeaf()) {
+      // Validate leaf node
+      XR_CHECK(
+          node.trianglesStart != kInvalidTriangleBlockIdx,
+          "Leaf node should have valid triangle start");
+      XR_CHECK(
+          node.trianglesEnd != kInvalidTriangleBlockIdx,
+          "Leaf node should have valid triangle end");
+      XR_CHECK(node.trianglesStart <= node.trianglesEnd, "Invalid triangle range");
+      XR_CHECK(node.trianglesEnd <= triangleBlocks_.size(), "Triangle end out of bounds");
+
+      // Check all triangles in this leaf's blocks
+      for (SizeType iBlock = node.trianglesStart; iBlock < node.trianglesEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+
+        for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+          if (triBlock.triIndex[i] != kInvalidTriangleIdx) {
+            auto triIdx = static_cast<uint32_t>(triBlock.triIndex[i]);
+            XR_CHECK(triIdx < triangles.size(), "Triangle index {} out of bounds", triIdx);
+
+            // Check for duplicates
+            XR_CHECK(
+                foundTriangles.find(triIdx) == foundTriangles.end(),
+                "Duplicate triangle index {}",
+                triIdx);
+            foundTriangles.insert(triIdx);
+
+            // Validate triangle positions match input data
+            const auto& tri = triangles[triIdx];
+            for (int j = 0; j < 3; ++j) {
+              for (int k = 0; k < 3; ++k) {
+                S expected = vertices[tri[j]][k];
+                S actual = triBlock.triPos[j][k][i];
+                S diff = std::abs(expected - actual);
+                XR_CHECK(
+                    diff < static_cast<S>(1e-6),
+                    "Triangle {} vertex {} coord {} mismatch: expected {}, got {}",
+                    triIdx,
+                    j,
+                    k,
+                    expected,
+                    actual);
+              }
+            }
+          }
+        }
+      }
+    } else {
+      // Validate internal node
+      bool hasValidChild = false;
+      for (int i = 0; i < TreeSplit; ++i) {
+        if (node.children[i] != kInvalidNodeIdx) {
+          hasValidChild = true;
+          validateNode(node.children[i]);
+        }
+      }
+      XR_CHECK(hasValidChild, "Internal node should have at least one valid child");
+    }
+  };
+
+  validateNode(root_);
+
+  // Check that we found all triangles
+  XR_CHECK(
+      foundTriangles.size() == numTriangles_,
+      "Found {} triangles, expected {}",
+      foundTriangles.size(),
+      numTriangles_);
+
+  // Check that triangle indices are in expected range
+  for (uint32_t i = 0; i < numTriangles_; ++i) {
+    XR_CHECK(foundTriangles.find(i) != foundTriangles.end(), "Missing triangle index {}", i);
   }
 }
 
-template <typename S, size_t LeafCapacity>
-size_t TriBvh<S, LeafCapacity>::getNodeCount() const {
-  return bvh_.getNodeCount();
-}
+// Debug function to print tree statistics
+template <typename S>
+void TriBvh<S>::printTreeStats() const {
+  std::cout << "=== TriBvh Tree Statistics ===" << std::endl;
+  std::cout << "Triangles: " << numTriangles_ << std::endl;
+  std::cout << "Nodes: " << nodes_.size() << std::endl;
+  std::cout << "Triangle Blocks: " << triangleBlocks_.size() << std::endl;
+  std::cout << "Depth: " << depth_ << std::endl;
+  std::cout << "Root: " << root_ << std::endl;
+  std::cout << "SIMD Width: " << TriangleBlockSize << std::endl;
+  std::cout << "Tree Split: " << TreeSplit << std::endl;
 
-template <typename S, size_t LeafCapacity>
-size_t TriBvh<S, LeafCapacity>::getPrimitiveCount() const {
-  return bvh_.getPrimitiveCount();
+  if (numTriangles_ > 0) {
+    std::cout << "Bounding Box: [" << boundingBox_.min().transpose() << "] to ["
+              << boundingBox_.max().transpose() << "]" << std::endl;
+  }
+
+  // Count leaf vs internal nodes
+  size_t leafNodes = 0;
+  size_t internalNodes = 0;
+  size_t totalTrianglesInBlocks = 0;
+
+  for (const auto& node : nodes_) {
+    if (node.isLeaf()) {
+      leafNodes++;
+      // Count triangles in this leaf
+      for (SizeType iBlock = node.trianglesStart; iBlock < node.trianglesEnd; ++iBlock) {
+        const auto& triBlock = triangleBlocks_[iBlock];
+        for (uint32_t i = 0; i < TriangleBlockSize; ++i) {
+          if (triBlock.triIndex[i] != kInvalidTriangleIdx) {
+            totalTrianglesInBlocks++;
+          }
+        }
+      }
+    } else {
+      internalNodes++;
+    }
+  }
+
+  std::cout << "Leaf Nodes: " << leafNodes << std::endl;
+  std::cout << "Internal Nodes: " << internalNodes << std::endl;
+  std::cout << "Triangles in Blocks: " << totalTrianglesInBlocks << std::endl;
+
+  if (totalTrianglesInBlocks != numTriangles_) {
+    std::cout << "WARNING: Triangle count mismatch!" << std::endl;
+  }
+
+  std::cout << "==============================" << std::endl;
 }
 
 template class TriBvh<float>;
 template class TriBvh<double>;
-template class TriBvh<float, kNativeLaneWidth<float>>;
-template class TriBvh<double, kNativeLaneWidth<double>>;
 
 } // namespace axel

--- a/axel/axel/TriBvh.h
+++ b/axel/axel/TriBvh.h
@@ -7,35 +7,196 @@
 
 #pragma once
 
+#include <array>
 #include <optional>
 
 #ifndef AXEL_NO_DISPENSO
 #include <dispenso/parallel_for.h>
 #endif
 
+#include <drjit/array.h>
+#include <drjit/fwd.h>
+#include <drjit/packet.h>
+#include <gsl/span>
+
 #include "axel/Bvh.h"
 #include "axel/Ray.h"
+#include "axel/common/VectorizationTypes.h"
 
 namespace axel {
 
 inline constexpr double kDefaultBoundingBoxThickness{0.0};
 
-template <typename S, size_t LeafCapacity = 1>
+/**
+ * @brief High-performance triangle BVH with SIMD optimizations
+ *
+ * This implementation provides significant performance improvements through
+ * SIMD-optimized triangle processing and 8-way tree splits for improved
+ * cache efficiency and parallel processing.
+ *
+ * ## SIMD Optimization Strategy
+ *
+ * The core optimization comes from two key data structure changes:
+ *
+ * 1. **Triangle Blocks**: Triangles are packed into SIMD-aligned blocks where
+ *    each block contains 4-8 triangles (depending on scalar type). This enables
+ *    vectorized ray-triangle intersection tests across multiple triangles simultaneously.
+ *
+ * 2. **8-way Tree Nodes**: Each internal node has exactly 8 children, allowing
+ *    SIMD bounding box intersection tests to process all 8 children in parallel
+ *    using 256-bit SIMD instructions.
+ *
+ * ## Performance Benefits
+ *
+ * - **Ray Intersection**: Process 4-8 triangles per SIMD instruction
+ * - **Bounding Box Tests**: Process 8 child boxes per SIMD instruction
+ * - **Cache Efficiency**: 8-way splits reduce tree depth and improve locality
+ * - **Memory Layout**: SIMD-aligned data structures optimize memory access patterns
+ *
+ * @tparam S Scalar type (float or double). Note: double precision may have
+ *           reduced SIMD efficiency compared to float.
+ *
+ * Performance Notes:
+ * - Float precision: Optimal SIMD performance with native lane width
+ * - Double precision: Reduced SIMD width but maintains precision
+ * - 8-way tree splits provide better cache efficiency than binary trees
+ * - Triangle blocks are SIMD-aligned for optimal memory access
+ */
+template <typename S>
 class TriBvh {
  public:
   using Scalar = S;
+  using SizeType = uint32_t;
   using QueryBuffer = typename BvhBase<S>::QueryBuffer;
   using ClosestSurfacePointResult = ::axel::ClosestSurfacePointResult<S>;
 
+  // Compile-time scalar type validation
+  static_assert(
+      std::is_same_v<S, float> || std::is_same_v<S, double>,
+      "TriBvh only supports float and double scalar types");
+
+ private:
+  // SIMD type definitions for optimized triangle processing
+  // Using axel vectorization types for consistency with ray-triangle intersection
+  using FloatP = WideScalar<S, kNativeLaneWidth<S>>;
+  using IntP = drjit::Packet<int32_t, kNativeLaneWidth<S>>;
+  using UIntP = drjit::Packet<uint32_t, kNativeLaneWidth<S>>;
+  using Vector3P = WideVec3<S, kNativeLaneWidth<S>>;
+
+  // Tree-specific SIMD types for 8-way splits
+  static constexpr int TreeSplit = 8;
+  static constexpr int TriangleBlockSize = kNativeLaneWidth<S>;
+  using IntSP = drjit::Packet<int32_t, TreeSplit>;
+  using FloatSP = drjit::Packet<S, TreeSplit>;
+  using Vector3SP = drjit::Array<FloatSP, 3>;
+
+  // SIMD width information for debugging/profiling
+  static constexpr size_t SimdWidth = kNativeLaneWidth<S>;
+  static constexpr size_t NativeLaneWidth = kNativeLaneWidth<S>;
+
+  // Invalid index constants for better code readability
+  static constexpr uint32_t kInvalidNodeIdx = std::numeric_limits<uint32_t>::max();
+  static constexpr uint32_t kInvalidTriangleBlockIdx = std::numeric_limits<uint32_t>::max();
+
+  /**
+   * @brief Triangle storage optimized for SIMD operations
+   *
+   * To enable efficient SIMD processing, triangles are stored in blocks where each block
+   * contains exactly TriangleBlockSize triangles (typically 4-8 depending on scalar type).
+   * This allows vectorized operations across multiple triangles simultaneously.
+   *
+   * Memory Layout Example (for TriangleBlockSize = 4):
+   * triPos[0] = [v0x_tri0, v0x_tri1, v0x_tri2, v0x_tri3] (vertex 0, x-coordinates)
+   * triPos[1] = [v1x_tri0, v1x_tri1, v1x_tri2, v1x_tri3] (vertex 1, x-coordinates)
+   * triPos[2] = [v2x_tri0, v2x_tri1, v2x_tri2, v2x_tri3] (vertex 2, x-coordinates)
+   *
+   * Each triPos[i] is a Vector3P containing [x, y, z] SIMD vectors.
+   *
+   * Empty slots in incomplete blocks are filled with FAR_VALUE positions and
+   * INT32_MAX indices to ensure safe SIMD operations without branches.
+   */
+  struct TriangleBlock {
+    std::array<Vector3P, 3> triPos; // The three vertices of each triangle, SIMD-packed
+                                    // [vertex0_simd, vertex1_simd, vertex2_simd]
+    UIntP triIndex; // Triangle indices in SIMD format (unsigned for consistency)
+                    // [index0, index1, index2, index3, ...] up to TriangleBlockSize
+  };
+
+  /**
+   * @brief 8-way tree node optimized for SIMD bounding box tests
+   *
+   * Each internal node has exactly 8 children, corresponding to an octree-style spatial
+   * subdivision. This design enables SIMD processing of 8 bounding box intersection
+   * tests simultaneously using 256-bit SIMD instructions.
+   *
+   * The 8-way split provides several advantages:
+   * - SIMD efficiency: Process 8 box tests in parallel
+   * - Cache efficiency: Better spatial locality than binary trees
+   * - Reduced tree depth: Fewer levels to traverse
+   *
+   * Bounding boxes are stored as separate min/max SIMD vectors rather than
+   * Eigen::AlignedBox objects to avoid SIMD type instantiation issues.
+   */
+  struct Node {
+    Node(
+        const Vector3SP& bboxMin_in,
+        const Vector3SP& bboxMax_in,
+        const std::array<SizeType, TreeSplit>& children_in);
+
+    Node(SizeType trianglesStart_in, SizeType trianglesEnd_in);
+
+    // SIMD bounding boxes for the 8 children
+    // Stored as separate min/max vectors for SIMD compatibility
+    // childBoxMin[0] = [child0_minX, child1_minX, ..., child7_minX]
+    // childBoxMin[1] = [child0_minY, child1_minY, ..., child7_minY]
+    // childBoxMin[2] = [child0_minZ, child1_minZ, ..., child7_minZ]
+    Vector3SP childBoxMin;
+    Vector3SP childBoxMax;
+
+    // Indices of the 8 child nodes in the nodes_ array
+    // Missing/invalid children are marked with kInvalidNodeIdx
+    std::array<SizeType, TreeSplit> children{};
+
+    [[nodiscard]] bool isLeaf() const {
+      return trianglesStart != kInvalidTriangleBlockIdx;
+    }
+
+    // For leaf nodes: range of triangle blocks in triangleBlocks_ array
+    // These indices define which TriangleBlocks belong to this leaf
+    SizeType trianglesStart = kInvalidTriangleBlockIdx; // Start index (inclusive)
+    SizeType trianglesEnd = kInvalidTriangleBlockIdx; // End index (exclusive)
+  };
+
+ public:
   TriBvh() = default;
 
   /**
    * @brief Construct a new Bvh from the given positions and triangles. The constructor assumes
    * that the integrity of provided positions and triangles is checked beforehand.
+   * This is the backwards-compatible constructor that takes Eigen matrices.
    */
   explicit TriBvh(
-      Eigen::MatrixX3<S>&& positions,
-      Eigen::MatrixX3i&& triangles,
+      const Eigen::MatrixX3<S>& positions,
+      const Eigen::MatrixX3i& triangles,
+      const std::optional<S>& boundingBoxThickness = kDefaultBoundingBoxThickness);
+
+  /**
+   * @brief Construct a new Bvh from the given positions and triangles using gsl::span inputs.
+   * This constructor provides maximum flexibility by accepting spans, allowing BVH construction
+   * from both complete containers (std::vector, arrays) and subranges of existing data
+   * without requiring data copying or extraction.
+   *
+   * This is particularly useful when you have a large mesh but only want to build a BVH
+   * for a specific subset of triangles and vertices, or when working with std::vector inputs
+   * (which are automatically converted to spans).
+   *
+   * @param vertices Span of vertex positions (works with std::vector, arrays, subranges)
+   * @param triangles Span of triangle indices (indices must be valid within the vertices span)
+   * @param boundingBoxThickness Optional thickness to add to bounding boxes
+   */
+  explicit TriBvh(
+      gsl::span<const Eigen::Vector3<S>> vertices,
+      gsl::span<const Eigen::Vector3i> triangles,
       const std::optional<S>& boundingBoxThickness = kDefaultBoundingBoxThickness);
 
   /**
@@ -75,7 +236,18 @@ class TriBvh {
    */
   bool anyHit(const Ray3<S>& ray) const;
 
-  ClosestSurfacePointResult closestSurfacePoint(const Eigen::Vector3<S>& query) const;
+  /**
+   * @brief Find the closest surface point with optional maximum distance threshold for early exit.
+   * This optimization allows the search to exit early when we only care about nearby points.
+   *
+   * @param query The query point
+   * @param maxDist Maximum distance to search. Points further than this will be ignored.
+   *                Use std::nullopt (default) for unlimited search.
+   * @return ClosestSurfacePointResult with valid result only if found within maxDist
+   */
+  [[nodiscard]] ClosestSurfacePointResult closestSurfacePoint(
+      const Eigen::Vector3<S>& query,
+      const std::optional<S>& maxDist = std::nullopt) const;
 
   /**
    * @brief Returns the total number of internal nodes in the tree.
@@ -88,11 +260,72 @@ class TriBvh {
    */
   size_t getPrimitiveCount() const;
 
+  // Validation function for debugging tree construction
+  void validate(
+      const std::vector<Eigen::Vector3i>& triangles,
+      const std::vector<Eigen::Vector3<S>>& vertices) const;
+
+  // Debug function to print tree statistics
+  void printTreeStats() const;
+
  private:
-  // This memory layout is required for gather operations in vectorized code.
-  Eigen::Matrix<S, Eigen::Dynamic, 3, Eigen::RowMajor> positions_;
-  Eigen::MatrixX3i triangles_;
-  Bvh<S, LeafCapacity> bvh_;
+  // SIMD-optimized data structures for high-performance triangle processing
+  std::vector<TriangleBlock> triangleBlocks_;
+  std::vector<Node> nodes_;
+  SizeType root_ = kInvalidNodeIdx;
+  SizeType numTriangles_ = 0;
+  SizeType depth_ = 0;
+  Eigen::AlignedBox<S, 3> boundingBox_;
+
+  // Templated helper methods for tree building
+  template <typename TriangleContainer, typename VertexContainer>
+  std::pair<SizeType, Eigen::AlignedBox<S, 3>> split(
+      const TriangleContainer& triangles,
+      const VertexContainer& vertices,
+      std::vector<std::tuple<uint32_t, Eigen::Vector3<S>>>& triIndices,
+      SizeType start,
+      SizeType end,
+      SizeType depth,
+      S boundingBoxThickness);
+
+  // SIMD intersection helper methods for ray traversal
+  [[nodiscard]] std::tuple<typename IntSP::MaskType, FloatSP, FloatSP> intersectBBox(
+      const Ray3<S>& ray,
+      const Vector3SP& boxMin,
+      const Vector3SP& boxMax,
+      const S& t0,
+      const S& t1) const;
+
+  [[nodiscard]] std::pair<FloatP, Vector3P> intersectTriangle(
+      const Ray3<S>& ray,
+      const Vector3P& v0,
+      const Vector3P& v1,
+      const Vector3P& v2) const;
+
+  // SIMD helper methods for closest surface point queries
+  [[nodiscard]] FloatSP pointToBoxDistanceSquared(
+      const Eigen::Vector3<S>& query,
+      const Vector3SP& boxMin,
+      const Vector3SP& boxMax) const;
+
+  [[nodiscard]] std::tuple<S, Eigen::Vector3<S>, Eigen::Vector3<S>>
+  pointToTriangleDistanceSquaredScalar(
+      const Eigen::Vector3<S>& query,
+      const Eigen::Vector3<S>& v0,
+      const Eigen::Vector3<S>& v1,
+      const Eigen::Vector3<S>& v2) const;
+
+  [[nodiscard]] std::tuple<FloatP, Vector3P, Vector3P> pointToTriangleDistanceSquared(
+      const Eigen::Vector3<S>& query,
+      const Vector3P& v0,
+      const Vector3P& v1,
+      const Vector3P& v2) const;
+
+  // SIMD helper method for box query operations
+  [[nodiscard]] typename IntSP::MaskType intersectBoxWithBox(
+      const BoundingBox<S>& queryBox,
+      const Vector3SP& boxMin,
+      const Vector3SP& boxMax) const;
 };
 
 using TriBvhf = TriBvh<float>;
@@ -100,8 +333,6 @@ using TriBvhd = TriBvh<double>;
 
 extern template class TriBvh<float>;
 extern template class TriBvh<double>;
-extern template class TriBvh<float, kNativeLaneWidth<float>>;
-extern template class TriBvh<double, kNativeLaneWidth<double>>;
 
 template <typename Derived, typename F>
 void closestSurfacePoints(

--- a/axel/axel/math/RayBoxIntersection.cpp
+++ b/axel/axel/math/RayBoxIntersection.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "axel/math/RayBoxIntersection.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace axel {
+
+template <typename ScalarType>
+RayBoxIntersectionResult<ScalarType> intersectRayBox(
+    const Ray3<ScalarType>& ray,
+    const Eigen::Vector3<ScalarType>& boxMin,
+    const Eigen::Vector3<ScalarType>& boxMax) {
+  // Based on the proven implementation from BoundingBox.cpp intersects() method
+  // Reference:
+  // https://www.scratchapixel.com/lessons/3d-basic-rendering/minimal-ray-tracer-rendering-simple-shapes/ray-box-intersection
+
+  const Eigen::Vector3<ScalarType>& origin = ray.origin;
+  const Eigen::Vector3<ScalarType>& direction = ray.direction;
+
+  // X-axis intersection
+  ScalarType tmin = (boxMin.x() - origin.x()) / direction.x();
+  ScalarType tmax = (boxMax.x() - origin.x()) / direction.x();
+
+  if (tmin > tmax) {
+    std::swap(tmin, tmax);
+  }
+
+  // Y-axis intersection
+  ScalarType tymin = (boxMin.y() - origin.y()) / direction.y();
+  ScalarType tymax = (boxMax.y() - origin.y()) / direction.y();
+
+  if (tymin > tymax) {
+    std::swap(tymin, tymax);
+  }
+
+  // Check if ray misses the box in Y
+  if ((tmin > tymax) || (tymin > tmax)) {
+    return {false, ScalarType(0), ScalarType(0)};
+  }
+
+  if (tymin > tmin) {
+    tmin = tymin;
+  }
+
+  if (tymax < tmax) {
+    tmax = tymax;
+  }
+
+  // Z-axis intersection
+  ScalarType tzmin = (boxMin.z() - origin.z()) / direction.z();
+  ScalarType tzmax = (boxMax.z() - origin.z()) / direction.z();
+
+  if (tzmin > tzmax) {
+    std::swap(tzmin, tzmax);
+  }
+
+  // Check if ray misses the box in Z
+  if ((tmin > tzmax) || (tzmin > tmax)) {
+    return {false, ScalarType(0), ScalarType(0)};
+  }
+
+  if (tzmin > tmin) {
+    tmin = tzmin;
+  }
+
+  if (tzmax < tmax) {
+    tmax = tzmax;
+  }
+
+  // Now we have the intersection range [tmin, tmax] with the box
+  // Check if this range overlaps with the ray's parameter range [ray.minT, ray.maxT]
+
+  // Handle the case where ray.minT > ray.maxT (backwards ray)
+  const ScalarType actualMinT = std::min(ray.minT, ray.maxT);
+  const ScalarType actualMaxT = std::max(ray.minT, ray.maxT);
+
+  // Check if the intersection range overlaps with the ray parameter range
+  // Ranges [tmin, tmax] and [actualMinT, actualMaxT] overlap if:
+  // tmin <= actualMaxT && tmax >= actualMinT
+  if (tmin <= actualMaxT && tmax >= actualMinT) {
+    // There is an intersection within the ray's parameter range
+    return {true, tmin, tmax};
+  }
+
+  return {false, ScalarType(0), ScalarType(0)};
+}
+
+template <typename ScalarType, size_t SimdWidth>
+RayBoxIntersectionResult<
+    drjit::Packet<ScalarType, SimdWidth>,
+    typename drjit::Packet<ScalarType, SimdWidth>::MaskType>
+intersectRayBoxes(
+    const Ray3<ScalarType>& ray,
+    const drjit::Array<drjit::Packet<ScalarType, SimdWidth>, 3>& boxMin,
+    const drjit::Array<drjit::Packet<ScalarType, SimdWidth>, 3>& boxMax) {
+  using FloatP = drjit::Packet<ScalarType, SimdWidth>;
+  using MaskP = typename FloatP::MaskType;
+
+  const Eigen::Vector3<ScalarType>& origin = ray.origin;
+  const Eigen::Vector3<ScalarType>& direction = ray.direction;
+
+  // X-axis intersection
+  FloatP tmin = (boxMin[0] - FloatP(origin.x())) / FloatP(direction.x());
+  FloatP tmax = (boxMax[0] - FloatP(origin.x())) / FloatP(direction.x());
+
+  // Swap tmin and tmax if needed for X-axis
+  MaskP xSwapMask = tmin > tmax;
+  FloatP temp = drjit::select(xSwapMask, tmin, tmax);
+  tmin = drjit::select(xSwapMask, tmax, tmin);
+  tmax = temp;
+
+  // Y-axis intersection
+  FloatP tymin = (boxMin[1] - FloatP(origin.y())) / FloatP(direction.y());
+  FloatP tymax = (boxMax[1] - FloatP(origin.y())) / FloatP(direction.y());
+
+  // Swap tymin and tymax if needed for Y-axis
+  MaskP ySwapMask = tymin > tymax;
+  temp = drjit::select(ySwapMask, tymin, tymax);
+  tymin = drjit::select(ySwapMask, tymax, tymin);
+  tymax = temp;
+
+  // Check if ray misses the box in Y
+  MaskP yHits = (tmin <= tymax) & (tymin <= tmax);
+
+  // Update tmin and tmax based on Y intersection
+  tmin = drjit::select(tymin > tmin, tymin, tmin);
+  tmax = drjit::select(tymax < tmax, tymax, tmax);
+
+  // Z-axis intersection
+  FloatP tzmin = (boxMin[2] - FloatP(origin.z())) / FloatP(direction.z());
+  FloatP tzmax = (boxMax[2] - FloatP(origin.z())) / FloatP(direction.z());
+
+  // Swap tzmin and tzmax if needed for Z-axis
+  MaskP zSwapMask = tzmin > tzmax;
+  temp = drjit::select(zSwapMask, tzmin, tzmax);
+  tzmin = drjit::select(zSwapMask, tzmax, tzmin);
+  tzmax = temp;
+
+  // Check if ray misses the box in Z
+  MaskP zHits = (tmin <= tzmax) & (tzmin <= tmax);
+
+  // Update tmin and tmax based on Z intersection
+  tmin = drjit::select(tzmin > tmin, tzmin, tmin);
+  tmax = drjit::select(tzmax < tmax, tzmax, tmax);
+
+  // Now we have the intersection range [tmin, tmax] with each box
+  // Check if this range overlaps with the ray's parameter range [ray.minT, ray.maxT]
+
+  // Handle the case where ray.minT > ray.maxT (backwards ray)
+  const ScalarType actualMinT = std::min(ray.minT, ray.maxT);
+  const ScalarType actualMaxT = std::max(ray.minT, ray.maxT);
+
+  // Check if the intersection range overlaps with the ray parameter range
+  MaskP tRangeValid = (tmin <= FloatP(actualMaxT)) & (tmax >= FloatP(actualMinT));
+
+  // Combine all intersection tests
+  MaskP intersects = yHits & zHits & tRangeValid;
+
+  return {intersects, tmin, tmax};
+}
+
+// Explicit template instantiations for common types
+template RayBoxIntersectionResult<float> intersectRayBox<float>(
+    const Ray3<float>& ray,
+    const Eigen::Vector3<float>& boxMin,
+    const Eigen::Vector3<float>& boxMax);
+
+template RayBoxIntersectionResult<double> intersectRayBox<double>(
+    const Ray3<double>& ray,
+    const Eigen::Vector3<double>& boxMin,
+    const Eigen::Vector3<double>& boxMax);
+
+// SIMD instantiations for common widths using drjit::Array
+template RayBoxIntersectionResult<
+    drjit::Packet<float, 4>,
+    typename drjit::Packet<float, 4>::MaskType>
+intersectRayBoxes<float, 4>(
+    const Ray3<float>& ray,
+    const drjit::Array<drjit::Packet<float, 4>, 3>& boxMin,
+    const drjit::Array<drjit::Packet<float, 4>, 3>& boxMax);
+
+template RayBoxIntersectionResult<
+    drjit::Packet<float, 8>,
+    typename drjit::Packet<float, 8>::MaskType>
+intersectRayBoxes<float, 8>(
+    const Ray3<float>& ray,
+    const drjit::Array<drjit::Packet<float, 8>, 3>& boxMin,
+    const drjit::Array<drjit::Packet<float, 8>, 3>& boxMax);
+
+template RayBoxIntersectionResult<
+    drjit::Packet<double, 4>,
+    typename drjit::Packet<double, 4>::MaskType>
+intersectRayBoxes<double, 4>(
+    const Ray3<double>& ray,
+    const drjit::Array<drjit::Packet<double, 4>, 3>& boxMin,
+    const drjit::Array<drjit::Packet<double, 4>, 3>& boxMax);
+
+// TriBvh uses TreeSplit = 8 for both float and double, so we need width 8 for both
+template RayBoxIntersectionResult<
+    drjit::Packet<double, 8>,
+    typename drjit::Packet<double, 8>::MaskType>
+intersectRayBoxes<double, 8>(
+    const Ray3<double>& ray,
+    const drjit::Array<drjit::Packet<double, 8>, 3>& boxMin,
+    const drjit::Array<drjit::Packet<double, 8>, 3>& boxMax);
+
+template struct RayBoxIntersectionResult<
+    drjit::Packet<float, 4>,
+    typename drjit::Packet<float, 4>::MaskType>;
+
+template struct RayBoxIntersectionResult<
+    drjit::Packet<float, 8>,
+    typename drjit::Packet<float, 8>::MaskType>;
+
+template struct RayBoxIntersectionResult<
+    drjit::Packet<double, 4>,
+    typename drjit::Packet<double, 4>::MaskType>;
+
+template struct RayBoxIntersectionResult<
+    drjit::Packet<double, 8>,
+    typename drjit::Packet<double, 8>::MaskType>;
+
+} // namespace axel

--- a/axel/axel/math/RayBoxIntersection.h
+++ b/axel/axel/math/RayBoxIntersection.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "axel/Ray.h"
+
+#include <drjit/array.h>
+#include <drjit/packet.h>
+#include <Eigen/Core>
+#include <tuple>
+
+namespace axel {
+
+/**
+ * Templated result struct for ray-box intersection results.
+ * Provides named fields for better readability compared to std::tuple.
+ * Works for both scalar (MaskType = bool) and SIMD (MaskType = SIMD mask) cases.
+ */
+template <typename ScalarType, typename MaskType = bool>
+struct RayBoxIntersectionResult {
+  MaskType intersects; // True/mask if ray intersects the box within [ray.minT, ray.maxT]
+  ScalarType tMin; // Intersection entry distance(s)
+  ScalarType tMax; // Intersection exit distance(s)
+};
+
+/**
+ * SIMD ray-box intersection test using drjit::Array (Vector3SP) format.
+ * This function accepts drjit::Array<drjit::Packet<ScalarType, SimdWidth>, 3>
+ * which is commonly used in SIMD-optimized code as Vector3SP.
+ *
+ * Tests a single ray against multiple bounding boxes packed in SIMD vectors.
+ * Based on the proven scalar logic from BoundingBox.cpp but extended to handle
+ * ray parameter ranges (minT, maxT) and SIMD operations.
+ *
+ * @param ray The ray to test (origin, direction, minT, maxT)
+ * @param boxMin SIMD vector containing minimum corners of multiple boxes
+ * @param boxMax SIMD vector containing maximum corners of multiple boxes
+ * @return RayBoxIntersectionResult with named fields:
+ *   - intersects: SIMD mask indicating which boxes intersect the ray
+ *   - tMin: SIMD vector of intersection entry distances
+ *   - tMax: SIMD vector of intersection exit distances
+ */
+template <typename ScalarType, size_t SimdWidth>
+RayBoxIntersectionResult<
+    drjit::Packet<ScalarType, SimdWidth>,
+    typename drjit::Packet<ScalarType, SimdWidth>::MaskType>
+intersectRayBoxes(
+    const Ray3<ScalarType>& ray,
+    const drjit::Array<drjit::Packet<ScalarType, SimdWidth>, 3>& boxMin,
+    const drjit::Array<drjit::Packet<ScalarType, SimdWidth>, 3>& boxMax);
+
+/**
+ * Scalar ray-box intersection test with ray parameter range support.
+ * Based on the logic from BoundingBox.cpp with added minT/maxT handling.
+ *
+ * @param ray The ray to test
+ * @param boxMin Box minimum corner
+ * @param boxMax Box maximum corner
+ * @return RayBoxIntersectionResult with named fields:
+ *   - intersects: true if ray intersects the box within [ray.minT, ray.maxT]
+ *   - tMin: intersection entry distance
+ *   - tMax: intersection exit distance
+ */
+template <typename ScalarType>
+RayBoxIntersectionResult<ScalarType> intersectRayBox(
+    const Ray3<ScalarType>& ray,
+    const Eigen::Vector3<ScalarType>& boxMin,
+    const Eigen::Vector3<ScalarType>& boxMax);
+
+} // namespace axel

--- a/axel/axel/math/RayTriangleIntersection.cpp
+++ b/axel/axel/math/RayTriangleIntersection.cpp
@@ -10,6 +10,9 @@
 #include "axel/common/Constants.h"
 #include "axel/math/RayTriangleIntersection.h"
 
+#include <drjit/array.h>
+#include <drjit/packet.h>
+
 namespace axel {
 
 template <typename T>
@@ -119,5 +122,187 @@ template bool rayTriangleIntersect(
     const Eigen::Vector3<double>& p2,
     Eigen::Vector3<double>& intersectionPoint,
     double& tOut);
+
+template <typename T, size_t LaneWidth>
+WideMask<WideScalar<T, LaneWidth>> rayTriangleIntersectWide(
+    const Eigen::Vector3<T>& beginRay,
+    const Eigen::Vector3<T>& direction,
+    const WideVec3<T, LaneWidth>& p0,
+    const WideVec3<T, LaneWidth>& p1,
+    const WideVec3<T, LaneWidth>& p2,
+    WideVec3<T, LaneWidth>& intersectionPoint,
+    WideScalar<T, LaneWidth>& tOut,
+    WideScalar<T, LaneWidth>& u,
+    WideScalar<T, LaneWidth>& v) {
+  using WideScalarT = WideScalar<T, LaneWidth>;
+  using WideVec3T = WideVec3<T, LaneWidth>;
+  using WideMaskT = WideMask<WideScalarT>;
+
+  constexpr T kEpsilon = detail::eps<T>();
+
+  // Convert ray to SIMD format
+  const WideVec3T rayOrigin{
+      WideScalarT(beginRay.x()), WideScalarT(beginRay.y()), WideScalarT(beginRay.z())};
+  const WideVec3T rayDirection{
+      WideScalarT(direction.x()), WideScalarT(direction.y()), WideScalarT(direction.z())};
+
+  // Compute triangle edges (same as scalar version)
+  const WideVec3T v0v1 = p1 - p0;
+  const WideVec3T v0v2 = p2 - p0;
+
+  // Cross product: direction × v0v2
+  const WideVec3T pvec = drjit::cross(rayDirection, v0v2);
+
+  // Check for parallel ray and triangle (same logic as scalar version)
+  const WideScalarT pvecNorm = drjit::norm(pvec);
+  const WideMaskT notParallel = pvecNorm >= WideScalarT(kEpsilon);
+
+  // Early exit if all triangles are parallel
+  if (!drjit::any(notParallel)) {
+    u = WideScalarT(0);
+    v = WideScalarT(0);
+    tOut = WideScalarT(std::numeric_limits<T>::max());
+    intersectionPoint = rayOrigin;
+    return WideMaskT(false);
+  }
+
+  // Compute determinant
+  const WideScalarT det = drjit::dot(v0v1, pvec);
+
+  // Check for parallelism using normalized vectors (same as scalar version)
+  const WideVec3T v0v1_norm = drjit::normalize(v0v1);
+  const WideVec3T pvec_norm = drjit::normalize(pvec);
+  const WideScalarT det_norm = drjit::dot(v0v1_norm, pvec_norm);
+  const WideMaskT detValid = drjit::abs(det_norm) >= WideScalarT(kEpsilon);
+
+  const WideScalarT invDet = WideScalarT(1) / det;
+
+  // Compute tvec = rayOrigin - p0
+  const WideVec3T tvec = rayOrigin - p0;
+
+  // Compute u parameter
+  u = drjit::dot(tvec, pvec) * invDet;
+  const WideMaskT uValid = (u >= WideScalarT(-kEpsilon)) & (u <= WideScalarT(1 + kEpsilon));
+
+  // Compute qvec = tvec × v0v1
+  const WideVec3T qvec = drjit::cross(tvec, v0v1);
+
+  // Compute v parameter
+  v = drjit::dot(rayDirection, qvec) * invDet;
+  const WideMaskT vValid = (v >= WideScalarT(-kEpsilon)) & ((u + v) <= WideScalarT(1 + kEpsilon));
+
+  // Compute t parameter
+  tOut = drjit::dot(v0v2, qvec) * invDet;
+
+  // Compute intersection point
+  intersectionPoint = rayOrigin + tOut * rayDirection;
+
+  // Combine all validity checks
+  const WideMaskT valid = notParallel & detValid & uValid & vValid;
+
+  // Set invalid results to default values
+  u = drjit::select(valid, u, WideScalarT(0));
+  v = drjit::select(valid, v, WideScalarT(0));
+  tOut = drjit::select(valid, tOut, WideScalarT(std::numeric_limits<T>::max()));
+  intersectionPoint = drjit::select(valid, intersectionPoint, rayOrigin);
+
+  return valid;
+}
+
+template <typename T, size_t LaneWidth>
+WideMask<WideScalar<T, LaneWidth>> rayTriangleIntersectWide(
+    const Eigen::Vector3<T>& beginRay,
+    const Eigen::Vector3<T>& direction,
+    const WideVec3<T, LaneWidth>& p0,
+    const WideVec3<T, LaneWidth>& p1,
+    const WideVec3<T, LaneWidth>& p2,
+    WideVec3<T, LaneWidth>& intersectionPoint,
+    WideScalar<T, LaneWidth>& tOut) {
+  WideScalar<T, LaneWidth> u, v;
+  return rayTriangleIntersectWide<T, LaneWidth>(
+      beginRay, direction, p0, p1, p2, intersectionPoint, tOut, u, v);
+}
+
+// Explicit instantiations for common SIMD widths and default lane widths
+template WideMask<WideScalar<float, 4>> rayTriangleIntersectWide<float, 4>(
+    const Eigen::Vector3<float>&,
+    const Eigen::Vector3<float>&,
+    const WideVec3<float, 4>&,
+    const WideVec3<float, 4>&,
+    const WideVec3<float, 4>&,
+    WideVec3<float, 4>&,
+    WideScalar<float, 4>&,
+    WideScalar<float, 4>&,
+    WideScalar<float, 4>&);
+
+template WideMask<WideScalar<float, 8>> rayTriangleIntersectWide<float, 8>(
+    const Eigen::Vector3<float>&,
+    const Eigen::Vector3<float>&,
+    const WideVec3<float, 8>&,
+    const WideVec3<float, 8>&,
+    const WideVec3<float, 8>&,
+    WideVec3<float, 8>&,
+    WideScalar<float, 8>&,
+    WideScalar<float, 8>&,
+    WideScalar<float, 8>&);
+
+template WideMask<WideScalar<double, 2>> rayTriangleIntersectWide<double, 2>(
+    const Eigen::Vector3<double>&,
+    const Eigen::Vector3<double>&,
+    const WideVec3<double, 2>&,
+    const WideVec3<double, 2>&,
+    const WideVec3<double, 2>&,
+    WideVec3<double, 2>&,
+    WideScalar<double, 2>&,
+    WideScalar<double, 2>&,
+    WideScalar<double, 2>&);
+
+template WideMask<WideScalar<double, 4>> rayTriangleIntersectWide<double, 4>(
+    const Eigen::Vector3<double>&,
+    const Eigen::Vector3<double>&,
+    const WideVec3<double, 4>&,
+    const WideVec3<double, 4>&,
+    const WideVec3<double, 4>&,
+    WideVec3<double, 4>&,
+    WideScalar<double, 4>&,
+    WideScalar<double, 4>&,
+    WideScalar<double, 4>&);
+
+// Versions without barycentric coordinates
+template WideMask<WideScalar<float, 4>> rayTriangleIntersectWide<float, 4>(
+    const Eigen::Vector3<float>&,
+    const Eigen::Vector3<float>&,
+    const WideVec3<float, 4>&,
+    const WideVec3<float, 4>&,
+    const WideVec3<float, 4>&,
+    WideVec3<float, 4>&,
+    WideScalar<float, 4>&);
+
+template WideMask<WideScalar<float, 8>> rayTriangleIntersectWide<float, 8>(
+    const Eigen::Vector3<float>&,
+    const Eigen::Vector3<float>&,
+    const WideVec3<float, 8>&,
+    const WideVec3<float, 8>&,
+    const WideVec3<float, 8>&,
+    WideVec3<float, 8>&,
+    WideScalar<float, 8>&);
+
+template WideMask<WideScalar<double, 2>> rayTriangleIntersectWide<double, 2>(
+    const Eigen::Vector3<double>&,
+    const Eigen::Vector3<double>&,
+    const WideVec3<double, 2>&,
+    const WideVec3<double, 2>&,
+    const WideVec3<double, 2>&,
+    WideVec3<double, 2>&,
+    WideScalar<double, 2>&);
+
+template WideMask<WideScalar<double, 4>> rayTriangleIntersectWide<double, 4>(
+    const Eigen::Vector3<double>&,
+    const Eigen::Vector3<double>&,
+    const WideVec3<double, 4>&,
+    const WideVec3<double, 4>&,
+    const WideVec3<double, 4>&,
+    WideVec3<double, 4>&,
+    WideScalar<double, 4>&);
 
 } // namespace axel

--- a/axel/axel/math/RayTriangleIntersection.h
+++ b/axel/axel/math/RayTriangleIntersection.h
@@ -9,6 +9,8 @@
 
 #include <Eigen/Core>
 
+#include "axel/common/VectorizationTypes.h"
+
 namespace axel {
 
 template <typename T>
@@ -32,5 +34,49 @@ bool rayTriangleIntersect(
     T& tOut,
     T& u,
     T& v);
+
+/**
+ * @brief Wide vector version of ray-triangle intersection using Möller-Trumbore algorithm
+ *
+ * This function performs SIMD ray-triangle intersection tests using the same algorithm
+ * as the scalar version, ensuring consistent results across all lanes.
+ *
+ * @tparam T Scalar type (float or double)
+ * @tparam LaneWidth SIMD width (number of triangles to test simultaneously)
+ * @param beginRay Ray origin (scalar)
+ * @param direction Ray direction (scalar)
+ * @param p0 First vertices of triangles (wide vector)
+ * @param p1 Second vertices of triangles (wide vector)
+ * @param p2 Third vertices of triangles (wide vector)
+ * @param intersectionPoint Output intersection points (wide vector)
+ * @param tOut Output t parameters (wide vector)
+ * @param u Output u barycentric coordinates (wide vector)
+ * @param v Output v barycentric coordinates (wide vector)
+ * @return Wide mask indicating which triangles were hit
+ */
+template <typename T, size_t LaneWidth = kNativeLaneWidth<T>>
+WideMask<WideScalar<T, LaneWidth>> rayTriangleIntersectWide(
+    const Eigen::Vector3<T>& beginRay,
+    const Eigen::Vector3<T>& direction,
+    const WideVec3<T, LaneWidth>& p0,
+    const WideVec3<T, LaneWidth>& p1,
+    const WideVec3<T, LaneWidth>& p2,
+    WideVec3<T, LaneWidth>& intersectionPoint,
+    WideScalar<T, LaneWidth>& tOut,
+    WideScalar<T, LaneWidth>& u,
+    WideScalar<T, LaneWidth>& v);
+
+/**
+ * @brief Wide vector version without barycentric coordinates
+ */
+template <typename T, size_t LaneWidth = kNativeLaneWidth<T>>
+WideMask<WideScalar<T, LaneWidth>> rayTriangleIntersectWide(
+    const Eigen::Vector3<T>& beginRay,
+    const Eigen::Vector3<T>& direction,
+    const WideVec3<T, LaneWidth>& p0,
+    const WideVec3<T, LaneWidth>& p1,
+    const WideVec3<T, LaneWidth>& p2,
+    WideVec3<T, LaneWidth>& intersectionPoint,
+    WideScalar<T, LaneWidth>& tOut);
 
 } // namespace axel

--- a/axel/axel/math/test/RayBoxIntersectionTest.cpp
+++ b/axel/axel/math/test/RayBoxIntersectionTest.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axel/math/RayBoxIntersection.h"
+#include "axel/test/Helper.h"
+
+#include <perception/test_helpers/EigenChecks.h>
+
+namespace axel::test {
+namespace {
+
+template <typename T>
+struct RayBoxIntersectionTest : testing::Test {
+  using Type = T;
+};
+
+using ScalarTypes = testing::Types<float, double>;
+TYPED_TEST_SUITE(RayBoxIntersectionTest, ScalarTypes);
+
+TYPED_TEST(RayBoxIntersectionTest, BasicHit) {
+  using S = typename TestFixture::Type;
+
+  // Create a simple ray shooting towards +Z
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(0, 0, 0);
+  ray.direction = Eigen::Vector3<S>(0, 0, 1);
+  ray.minT = static_cast<S>(0.1);
+  ray.maxT = static_cast<S>(10.0);
+
+  // Create a box that the ray should hit
+  Eigen::Vector3<S> boxMin(-1, -1, 2);
+  Eigen::Vector3<S> boxMax(1, 1, 3);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  EXPECT_TRUE(result.intersects);
+  EXPECT_NEAR(result.tMin, static_cast<S>(2.0), static_cast<S>(1e-6));
+  EXPECT_NEAR(result.tMax, static_cast<S>(3.0), static_cast<S>(1e-6));
+}
+
+TYPED_TEST(RayBoxIntersectionTest, BasicMiss) {
+  using S = typename TestFixture::Type;
+
+  // Create a ray shooting towards +Z
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(0, 0, 0);
+  ray.direction = Eigen::Vector3<S>(0, 0, 1);
+  ray.minT = static_cast<S>(0.1);
+  ray.maxT = static_cast<S>(10.0);
+
+  // Create a box that the ray should miss (offset in X)
+  Eigen::Vector3<S> boxMin(2, -1, 2);
+  Eigen::Vector3<S> boxMax(3, 1, 3);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  EXPECT_FALSE(result.intersects);
+}
+
+TYPED_TEST(RayBoxIntersectionTest, NegativeMaxT) {
+  using S = typename TestFixture::Type;
+
+  // Test the failing case from TriBvhTest.cpp:
+  // Ray3<S>({0, 0, 0}, {0, 0, 1}, 0.0, -2.0)
+  // This creates a ray with origin=(0,0,0), direction=(0,0,1), maxT=0.0, minT=-2.0
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(0, 0, 0);
+  ray.direction = Eigen::Vector3<S>(0, 0, 1);
+  ray.maxT = static_cast<S>(0.0); // 3rd parameter
+  ray.minT = static_cast<S>(-2.0); // 4th parameter
+
+  // Create a box at z=-2 (same as the test triangle)
+  // Bounding Box: [-1  0 -2] to [ 1  1 -2]
+  Eigen::Vector3<S> boxMin(-1, 0, -2);
+  Eigen::Vector3<S> boxMax(1, 1, -2);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  EXPECT_TRUE(result.intersects) << "Ray with negative maxT should intersect box at z=-2";
+  EXPECT_NEAR(result.tMin, static_cast<S>(-2.0), static_cast<S>(1e-6));
+  EXPECT_NEAR(result.tMax, static_cast<S>(-2.0), static_cast<S>(1e-6));
+}
+
+TYPED_TEST(RayBoxIntersectionTest, RayTooShort) {
+  using S = typename TestFixture::Type;
+
+  // Create a ray that stops before reaching the box
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(0, 0, 0);
+  ray.direction = Eigen::Vector3<S>(0, 0, 1);
+  ray.minT = static_cast<S>(0.1);
+  ray.maxT = static_cast<S>(1.0); // Ray stops at t=1.0
+
+  // Create a box at z=2-3, which requires t=2.0 to reach
+  Eigen::Vector3<S> boxMin(-1, -1, 2);
+  Eigen::Vector3<S> boxMax(1, 1, 3);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  EXPECT_FALSE(result.intersects) << "Ray should not intersect box beyond its maxT";
+}
+
+TYPED_TEST(RayBoxIntersectionTest, RayStartsTooLate) {
+  using S = typename TestFixture::Type;
+
+  // Create a ray that starts after passing through the box
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(0, 0, 0);
+  ray.direction = Eigen::Vector3<S>(0, 0, 1);
+  ray.minT = static_cast<S>(5.0); // Ray starts at t=5.0
+  ray.maxT = static_cast<S>(10.0);
+
+  // Create a box at z=2-3, which is intersected at t=2.0-3.0
+  Eigen::Vector3<S> boxMin(-1, -1, 2);
+  Eigen::Vector3<S> boxMax(1, 1, 3);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  EXPECT_FALSE(result.intersects) << "Ray should not intersect box before its minT";
+}
+
+TYPED_TEST(RayBoxIntersectionTest, RayOriginInsideBox) {
+  using S = typename TestFixture::Type;
+
+  // Create a ray starting inside the box
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(0, 0, 0);
+  ray.direction = Eigen::Vector3<S>(0, 0, 1);
+  ray.minT = static_cast<S>(-1.0);
+  ray.maxT = static_cast<S>(1.0);
+
+  // Create a box containing the origin
+  Eigen::Vector3<S> boxMin(-2, -2, -2);
+  Eigen::Vector3<S> boxMax(2, 2, 2);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  EXPECT_TRUE(result.intersects) << "Ray starting inside box should intersect";
+  EXPECT_LE(result.tMin, static_cast<S>(0.0)) << "Entry should be at or before ray origin";
+  EXPECT_GE(result.tMax, static_cast<S>(0.0)) << "Exit should be at or after ray origin";
+}
+
+TYPED_TEST(RayBoxIntersectionTest, NegativeDirection) {
+  using S = typename TestFixture::Type;
+
+  // Create a ray shooting towards -Z
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(0, 0, 0);
+  ray.direction = Eigen::Vector3<S>(0, 0, -1);
+  ray.minT = static_cast<S>(0.1);
+  ray.maxT = static_cast<S>(10.0);
+
+  // Create a box in the negative Z direction
+  Eigen::Vector3<S> boxMin(-1, -1, -3);
+  Eigen::Vector3<S> boxMax(1, 1, -2);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  EXPECT_TRUE(result.intersects);
+  EXPECT_NEAR(result.tMin, static_cast<S>(2.0), static_cast<S>(1e-6));
+  EXPECT_NEAR(result.tMax, static_cast<S>(3.0), static_cast<S>(1e-6));
+}
+
+TYPED_TEST(RayBoxIntersectionTest, CompareWithBoundingBoxMethod) {
+  using S = typename TestFixture::Type;
+
+  // Test consistency with the BoundingBox.cpp intersects() method
+  Ray3<S> ray;
+  ray.origin = Eigen::Vector3<S>(1, 2, 3);
+  ray.direction = Eigen::Vector3<S>(-1, -1, -1).normalized();
+  ray.minT = static_cast<S>(0.0);
+  ray.maxT = static_cast<S>(100.0);
+
+  Eigen::Vector3<S> boxMin(0, 0, 0);
+  Eigen::Vector3<S> boxMax(5, 5, 5);
+
+  auto result = intersectRayBox(ray, boxMin, boxMax);
+
+  // Create equivalent BoundingBox and test
+  BoundingBox<S> bbox(boxMin, boxMax);
+  bool bboxIntersects = bbox.intersects(ray.origin, ray.direction);
+
+  EXPECT_EQ(result.intersects, bboxIntersects)
+      << "Our function should agree with BoundingBox.intersects() for basic cases";
+}
+
+} // namespace
+} // namespace axel::test

--- a/axel/axel/math/test/RayTriangleIntersectionTest.cpp
+++ b/axel/axel/math/test/RayTriangleIntersectionTest.cpp
@@ -9,12 +9,254 @@
 #include <perception/test_helpers/EigenChecks.h>
 
 #include "axel/common/Constants.h"
+#include "axel/common/VectorizationTypes.h"
 #include "axel/math/RayTriangleIntersection.h"
+
+#include <random>
 
 namespace axel::test {
 namespace {
 
 using ::axel::detail::eps;
+
+// Helper function to test both scalar and wide versions of ray-triangle intersection
+template <typename T>
+void testRayTriangleIntersectionBothVersions(
+    const Eigen::Vector3<T>& rayOrigin,
+    const Eigen::Vector3<T>& rayDirection,
+    const Eigen::Vector3<T>& v0,
+    const Eigen::Vector3<T>& v1,
+    const Eigen::Vector3<T>& v2,
+    bool expectedHit,
+    const std::string& testDescription = "") {
+  std::cout << "=== Testing both scalar and wide versions: " << testDescription
+            << " ===" << std::endl;
+  std::cout << "Ray: origin=" << rayOrigin.transpose() << " dir=" << rayDirection.transpose()
+            << std::endl;
+  std::cout << "Triangle: v0=" << v0.transpose() << " v1=" << v1.transpose()
+            << " v2=" << v2.transpose() << std::endl;
+
+  // Test scalar version
+  Eigen::Vector3<T> scalarHitPoint;
+  T scalarT, scalarU, scalarV;
+  bool scalarHit = rayTriangleIntersect(
+      rayOrigin, rayDirection, v0, v1, v2, scalarHitPoint, scalarT, scalarU, scalarV);
+
+  std::cout << "Scalar result: " << (scalarHit ? "HIT" : "MISS") << std::endl;
+  if (scalarHit) {
+    std::cout << "  t=" << scalarT << " u=" << scalarU << " v=" << scalarV
+              << " w=" << (1 - scalarU - scalarV) << std::endl;
+    std::cout << "  hitPoint=" << scalarHitPoint.transpose() << std::endl;
+  }
+
+  // Test wide version by filling a SIMD vector with random data and our test case
+  constexpr size_t LaneWidth = kNativeLaneWidth<T>;
+  constexpr size_t TestLane = 0; // Use first lane for our actual test case
+
+  // Create random number generator for filling other lanes
+  std::mt19937 rng(42); // Fixed seed for reproducibility
+  std::uniform_real_distribution<T> dist(-10.0, 10.0);
+
+  // Create wide vectors for triangles
+  WideVec3<T, LaneWidth> wideV0, wideV1, wideV2;
+  for (int axis = 0; axis < 3; ++axis) {
+    // Set the test case in the first lane
+    wideV0[axis][TestLane] = v0[axis];
+    wideV1[axis][TestLane] = v1[axis];
+    wideV2[axis][TestLane] = v2[axis];
+
+    // Fill other lanes with random triangles
+    for (size_t lane = 1; lane < LaneWidth; ++lane) {
+      wideV0[axis][lane] = dist(rng);
+      wideV1[axis][lane] = dist(rng);
+      wideV2[axis][lane] = dist(rng);
+    }
+  }
+
+  // Test wide version
+  WideVec3<T, LaneWidth> wideHitPoint;
+  WideScalar<T, LaneWidth> wideT, wideU, wideV;
+  auto wideHitMask = rayTriangleIntersectWide<T, LaneWidth>(
+      rayOrigin, rayDirection, wideV0, wideV1, wideV2, wideHitPoint, wideT, wideU, wideV);
+
+  bool wideHit = wideHitMask[TestLane];
+  std::cout << "Wide result: " << (wideHit ? "HIT" : "MISS") << std::endl;
+  if (wideHit) {
+    std::cout << "  t=" << wideT[TestLane] << " u=" << wideU[TestLane] << " v=" << wideV[TestLane]
+              << " w=" << (1 - wideU[TestLane] - wideV[TestLane]) << std::endl;
+    std::cout << "  hitPoint=(" << wideHitPoint[0][TestLane] << ", " << wideHitPoint[1][TestLane]
+              << ", " << wideHitPoint[2][TestLane] << ")" << std::endl;
+  }
+
+  // Verify both versions agree on hit/miss
+  EXPECT_EQ(scalarHit, wideHit) << "Scalar and wide versions disagree on hit/miss for "
+                                << testDescription;
+  EXPECT_EQ(expectedHit, scalarHit)
+      << "Scalar result doesn't match expected for " << testDescription;
+
+  // If both hit, verify they produce the same results
+  if (scalarHit && wideHit) {
+    EXPECT_NEAR(scalarT, wideT[TestLane], eps<T>())
+        << "t parameter mismatch for " << testDescription;
+    EXPECT_NEAR(scalarU, wideU[TestLane], eps<T>())
+        << "u parameter mismatch for " << testDescription;
+    EXPECT_NEAR(scalarV, wideV[TestLane], eps<T>())
+        << "v parameter mismatch for " << testDescription;
+
+    Eigen::Vector3<T> wideHitPointExtracted(
+        wideHitPoint[0][TestLane], wideHitPoint[1][TestLane], wideHitPoint[2][TestLane]);
+    EXPECT_EIGEN_MATRIX_NEAR(scalarHitPoint, wideHitPointExtracted, eps<T>())
+        << "Hit point mismatch for " << testDescription;
+  }
+
+  std::cout << "Both versions agree: " << (scalarHit == wideHit ? "YES" : "NO") << std::endl;
+  std::cout << std::endl;
+}
+
+// Helper function to test multiple triangles with SIMD (unique from Wide test)
+template <typename T>
+void testMultipleTriangles(
+    const Eigen::Vector3<T>& rayOrigin,
+    const Eigen::Vector3<T>& rayDirection,
+    const std::vector<std::array<Eigen::Vector3<T>, 3>>& triangles,
+    const std::vector<bool>& expectedHits,
+    const std::string& testDescription = "") {
+  constexpr size_t Width = 4; // Test with width 4 for simplicity
+  using WideScalarT = WideScalar<T, Width>;
+  using WideVec3T = WideVec3<T, Width>;
+  using WideMaskT = WideMask<WideScalarT>;
+
+  std::cout << "=== Testing multiple triangles: " << testDescription << " ===" << std::endl;
+
+  // Test each triangle individually with scalar version
+  std::vector<bool> scalarHits(triangles.size());
+  std::vector<T> scalarTs(triangles.size());
+  std::vector<T> scalarUs(triangles.size());
+  std::vector<T> scalarVs(triangles.size());
+  std::vector<Eigen::Vector3<T>> scalarHitPoints(triangles.size());
+
+  for (size_t i = 0; i < triangles.size(); ++i) {
+    scalarHits[i] = rayTriangleIntersect(
+        rayOrigin,
+        rayDirection,
+        triangles[i][0],
+        triangles[i][1],
+        triangles[i][2],
+        scalarHitPoints[i],
+        scalarTs[i],
+        scalarUs[i],
+        scalarVs[i]);
+  }
+
+  // Pack triangles into SIMD format
+  WideVec3T p0, p1, p2;
+  for (int i = 0; i < 3; ++i) {
+    p0[i] = WideScalarT(0);
+    p1[i] = WideScalarT(0);
+    p2[i] = WideScalarT(0);
+  }
+
+  const size_t numTris = std::min(triangles.size(), static_cast<size_t>(Width));
+  for (size_t i = 0; i < numTris; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      p0[j][i] = triangles[i][0][j];
+      p1[j][i] = triangles[i][1][j];
+      p2[j][i] = triangles[i][2][j];
+    }
+  }
+
+  // Test wide version
+  WideVec3T wideHitPoint;
+  WideScalarT wideT, wideU, wideV;
+  WideMaskT wideHit = rayTriangleIntersectWide<T, Width>(
+      rayOrigin, rayDirection, p0, p1, p2, wideHitPoint, wideT, wideU, wideV);
+
+  // Compare results
+  for (size_t i = 0; i < numTris; ++i) {
+    EXPECT_EQ(scalarHits[i], wideHit[i]) << "Hit/miss mismatch for triangle " << i;
+    if (i < expectedHits.size()) {
+      EXPECT_EQ(expectedHits[i], scalarHits[i]) << "Expected hit mismatch for triangle " << i;
+    }
+
+    if (scalarHits[i] && wideHit[i]) {
+      EXPECT_NEAR(scalarTs[i], wideT[i], static_cast<T>(1e-6))
+          << "T parameter mismatch for triangle " << i;
+      EXPECT_NEAR(scalarUs[i], wideU[i], static_cast<T>(1e-6))
+          << "U parameter mismatch for triangle " << i;
+      EXPECT_NEAR(scalarVs[i], wideV[i], static_cast<T>(1e-6))
+          << "V parameter mismatch for triangle " << i;
+
+      for (int j = 0; j < 3; ++j) {
+        EXPECT_NEAR(scalarHitPoints[i][j], wideHitPoint[j][i], static_cast<T>(1e-6))
+            << "Hit point mismatch for triangle " << i << " component " << j;
+      }
+    }
+  }
+
+  std::cout << "Multiple triangles test completed" << std::endl;
+}
+
+// Overloaded version without barycentric coordinates
+template <typename T>
+void testRayTriangleIntersectionBothVersionsNoBary(
+    const Eigen::Vector3<T>& rayOrigin,
+    const Eigen::Vector3<T>& rayDirection,
+    const Eigen::Vector3<T>& v0,
+    const Eigen::Vector3<T>& v1,
+    const Eigen::Vector3<T>& v2,
+    bool expectedHit,
+    const std::string& testDescription = "") {
+  std::cout << "=== Testing both versions (no bary): " << testDescription << " ===" << std::endl;
+
+  // Test scalar version
+  Eigen::Vector3<T> scalarHitPoint;
+  T scalarT;
+  bool scalarHit =
+      rayTriangleIntersect(rayOrigin, rayDirection, v0, v1, v2, scalarHitPoint, scalarT);
+
+  // Test wide version
+  constexpr size_t LaneWidth = kNativeLaneWidth<T>;
+  constexpr size_t TestLane = 0;
+
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<T> dist(-10.0, 10.0);
+
+  WideVec3<T, LaneWidth> wideV0, wideV1, wideV2;
+  for (int axis = 0; axis < 3; ++axis) {
+    wideV0[axis][TestLane] = v0[axis];
+    wideV1[axis][TestLane] = v1[axis];
+    wideV2[axis][TestLane] = v2[axis];
+
+    for (size_t lane = 1; lane < LaneWidth; ++lane) {
+      wideV0[axis][lane] = dist(rng);
+      wideV1[axis][lane] = dist(rng);
+      wideV2[axis][lane] = dist(rng);
+    }
+  }
+
+  WideVec3<T, LaneWidth> wideHitPoint;
+  WideScalar<T, LaneWidth> wideT;
+  auto wideHitMask = rayTriangleIntersectWide<T, LaneWidth>(
+      rayOrigin, rayDirection, wideV0, wideV1, wideV2, wideHitPoint, wideT);
+
+  bool wideHit = wideHitMask[TestLane];
+
+  // Verify both versions agree
+  EXPECT_EQ(scalarHit, wideHit) << "Scalar and wide versions disagree on hit/miss for "
+                                << testDescription;
+  EXPECT_EQ(expectedHit, scalarHit)
+      << "Scalar result doesn't match expected for " << testDescription;
+
+  if (scalarHit && wideHit) {
+    EXPECT_NEAR(scalarT, wideT[TestLane], eps<T>())
+        << "t parameter mismatch for " << testDescription;
+
+    Eigen::Vector3<T> wideHitPointExtracted(
+        wideHitPoint[0][TestLane], wideHitPoint[1][TestLane], wideHitPoint[2][TestLane]);
+    EXPECT_EIGEN_MATRIX_NEAR(scalarHitPoint, wideHitPointExtracted, eps<T>())
+        << "Hit point mismatch for " << testDescription;
+  }
+}
 
 TEST(RayTriangleIntersectionTest, Basic) {
   Eigen::Vector3d collisionPoint;
@@ -129,6 +371,348 @@ TEST(RaytracingUtilsTest, rayTriangleIntersect_noHit) {
       Eigen::Vector3d(12.5, 5., 2.5),
       hitPoint,
       t));
+}
+
+TEST(RayTriangleIntersectionTest, RayQuery_AnyHits_Simple_FailingCase) {
+  // This test reproduces the exact failing case from TriBvhTest::RayQuery_AnyHits_Simple
+  // Triangle vertices from the failing test case
+  Eigen::Vector3d v0(-1., 0., -2.0);
+  Eigen::Vector3d v1(+1., 0., -2.0);
+  Eigen::Vector3d v2(+0., 1., -2.0);
+
+  // Ray from the failing test case
+  Eigen::Vector3d rayOrigin(0., 0., 0.);
+  Eigen::Vector3d rayDirection(0., 0., -1.);
+
+  // The ray shoots straight down from origin (0,0,0) towards (0,0,-1)
+  // The triangle is at z=-2, so the ray should hit at t=2.0 at point (0,0,-2)
+  // Triangle spans from (-1,0,-2) to (1,0,-2) along x-axis at y=0
+  // and has a third vertex at (0,1,-2)
+  // The point (0,0,-2) should be on the bottom edge of this triangle
+
+  // Use our helper function to test both scalar and wide versions
+  testRayTriangleIntersectionBothVersions<double>(
+      rayOrigin, rayDirection, v0, v1, v2, true, "RayQuery_AnyHits_Simple failing case");
+}
+
+TEST(RayTriangleIntersectionTest, NegativeT_BackwardsRay) {
+  // Test the specific backward ray case from TriBvhTest
+  // This tests if we can detect intersections with negative t values
+
+  // Triangle at z=-2
+  Eigen::Vector3d v0(-1., 0., -2.0);
+  Eigen::Vector3d v1(+1., 0., -2.0);
+  Eigen::Vector3d v2(+0., 1., -2.0);
+
+  // Ray shooting towards +Z from origin, but we want to intersect behind origin
+  Eigen::Vector3d rayOrigin(0., 0., 0.);
+  Eigen::Vector3d rayDirection(0., 0., 1.); // towards +Z
+
+  std::cout << "=== Testing backwards ray intersection ===" << std::endl;
+  std::cout << "Triangle at z=-2, ray shoots towards +Z from origin" << std::endl;
+  std::cout << "Expected intersection at t=-2 (behind ray origin)" << std::endl;
+
+  Eigen::Vector3d hitPoint;
+  double t = NAN, u = NAN, v = NAN;
+  bool hit = rayTriangleIntersect(rayOrigin, rayDirection, v0, v1, v2, hitPoint, t, u, v);
+
+  std::cout << "Ray-triangle intersection result: " << (hit ? "HIT" : "MISS") << std::endl;
+  if (hit) {
+    std::cout << "  t=" << t << " (should be -2)" << std::endl;
+    std::cout << "  hitPoint=" << hitPoint.transpose() << " (should be (0, 0, -2))" << std::endl;
+    std::cout << "  u=" << u << " v=" << v << " w=" << (1 - u - v) << std::endl;
+
+    // Verify the intersection is correct
+    EXPECT_NEAR(t, -2.0, eps<double>()) << "Ray should intersect at t=-2";
+    EXPECT_NEAR(hitPoint.z(), -2.0, eps<double>()) << "Hit point should be at z=-2";
+    EXPECT_NEAR(hitPoint.x(), 0.0, eps<double>()) << "Hit point should be at x=0";
+    EXPECT_NEAR(hitPoint.y(), 0.0, eps<double>()) << "Hit point should be at y=0";
+
+    // Verify barycentric coordinates (on bottom edge, so v=0, u+w=1)
+    EXPECT_NEAR(v, 0.0, eps<double>()) << "Should be on bottom edge (v=0)";
+    EXPECT_NEAR(u + (1 - u - v), 1.0, eps<double>()) << "Barycentric coordinates should sum to 1";
+  }
+
+  // The basic ray-triangle intersection should find the hit at t=-2
+  EXPECT_TRUE(hit) << "Ray-triangle intersection should detect backward intersection";
+
+  // This demonstrates that our ray-triangle intersection DOES support negative t values
+  // So the issue must be in how the BVH applies the ray.minT/maxT constraints
+}
+
+TEST(RayTriangleIntersectionTest, BVH_RayParameterSimulation) {
+  // This test simulates how the BVH constructs and uses the ray parameters
+  // to understand why the test Ray3<S>({0, 0, 0}, {0, 0, 1}, 0.0, -2.0) fails
+
+  std::cout << "=== Simulating BVH ray parameter usage ===" << std::endl;
+
+  // Triangle at z=-2 (same as failing test)
+  Eigen::Vector3d v0(-1., 0., -2.0);
+  Eigen::Vector3d v1(+1., 0., -2.0);
+  Eigen::Vector3d v2(+0., 1., -2.0);
+
+  // Simulate the Ray3 constructor call: Ray3<S>({0, 0, 0}, {0, 0, 1}, 0.0, -2.0)
+  // According to Ray.h constructor: Ray3(origin, direction, maxT, minT)
+  Eigen::Vector3d rayOrigin(0., 0., 0.);
+  Eigen::Vector3d rayDirection(0., 0., 1.);
+  double maxT = 0.0;
+  double minT = -2.0;
+
+  std::cout << "Ray parameters:" << std::endl;
+  std::cout << "  origin: " << rayOrigin.transpose() << std::endl;
+  std::cout << "  direction: " << rayDirection.transpose() << std::endl;
+  std::cout << "  minT: " << minT << std::endl;
+  std::cout << "  maxT: " << maxT << std::endl;
+  std::cout << "  Valid t range: [" << minT << ", " << maxT << "]" << std::endl;
+
+  // Test raw ray-triangle intersection (no t filtering)
+  Eigen::Vector3d hitPoint;
+  double t = NAN, u = NAN, v = NAN;
+  bool hit = rayTriangleIntersect(rayOrigin, rayDirection, v0, v1, v2, hitPoint, t, u, v);
+
+  std::cout << "Raw intersection result: " << (hit ? "HIT" : "MISS") << std::endl;
+  if (hit) {
+    std::cout << "  t=" << t << std::endl;
+    std::cout << "  hitPoint=" << hitPoint.transpose() << std::endl;
+  }
+
+  // Simulate BVH t-range filtering (like in TriBvh::intersectTriangle line 608)
+  bool tInRange = (t >= minT) && (t <= maxT);
+  bool validHit = hit && tInRange;
+
+  std::cout << "BVH t-range check:" << std::endl;
+  std::cout << "  t >= minT: " << t << " >= " << minT << " = " << (t >= minT) << std::endl;
+  std::cout << "  t <= maxT: " << t << " <= " << maxT << " = " << (t <= maxT) << std::endl;
+  std::cout << "  tInRange: " << tInRange << std::endl;
+  std::cout << "  Final valid hit: " << validHit << std::endl;
+
+  // The basic intersection should work
+  EXPECT_TRUE(hit) << "Basic ray-triangle intersection should succeed";
+
+  if (hit) {
+    EXPECT_NEAR(t, -2.0, eps<double>()) << "Intersection should be at t=-2";
+
+    // The key test: t=-2 should be within range [-2, 0]
+    EXPECT_TRUE(tInRange) << "t=" << t << " should be within range [" << minT << ", " << maxT
+                          << "]";
+    EXPECT_TRUE(validHit) << "Ray should be valid after BVH-style t-range filtering";
+  }
+}
+
+TEST(RayTriangleIntersectionTest, ScalarAndWideConsistency_BasicHit) {
+  // Test a simple hit case with both scalar and wide versions
+  Eigen::Vector3f rayOrigin(1.f, 1.f, 1.f);
+  Eigen::Vector3f rayDirection(0.f, 1.f, 0.f);
+  Eigen::Vector3f v0(0.f, 5.f, 0.f);
+  Eigen::Vector3f v1(5.f, 5.f, 0.f);
+  Eigen::Vector3f v2(2.5f, 5.f, 2.5f);
+
+  testRayTriangleIntersectionBothVersions<float>(
+      rayOrigin, rayDirection, v0, v1, v2, true, "Basic hit case");
+}
+
+TEST(RayTriangleIntersectionTest, ScalarAndWideConsistency_BasicMiss) {
+  // Test a simple miss case with both scalar and wide versions
+  Eigen::Vector3f rayOrigin(1.f, 1.f, 1.f);
+  Eigen::Vector3f rayDirection(0.f, 1.f, 0.f);
+  Eigen::Vector3f v0(10.f, 5.f, 0.f);
+  Eigen::Vector3f v1(10.f, 15.f, 0.f);
+  Eigen::Vector3f v2(12.5f, 5.f, 2.5f);
+
+  testRayTriangleIntersectionBothVersions<float>(
+      rayOrigin, rayDirection, v0, v1, v2, false, "Basic miss case");
+}
+
+TEST(RayTriangleIntersectionTest, ScalarAndWideConsistency_EdgeCases) {
+  // Test various edge cases to ensure scalar and wide versions agree
+
+  // Case 1: Ray parallel to triangle plane
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(0., 0., 0.), // origin
+      Eigen::Vector3d(1., 0., 0.), // direction parallel to triangle
+      Eigen::Vector3d(-1., 0., 1.), // triangle vertices (in plane z=1)
+      Eigen::Vector3d(1., 0., 1.),
+      Eigen::Vector3d(0., 1., 1.),
+      false,
+      "Ray parallel to triangle plane");
+
+  // Case 2: Ray hits triangle edge
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(0.5, 0., 0.), // origin
+      Eigen::Vector3d(0., 0., 1.), // direction towards triangle
+      Eigen::Vector3d(0., 0., 2.), // triangle vertices
+      Eigen::Vector3d(1., 0., 2.),
+      Eigen::Vector3d(0.5, 1., 2.),
+      true,
+      "Ray hits triangle edge");
+
+  // Case 3: Ray hits triangle vertex
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(0., 0., 0.), // origin
+      Eigen::Vector3d(0., 0., 1.), // direction towards vertex
+      Eigen::Vector3d(0., 0., 2.), // triangle vertices (ray hits first vertex)
+      Eigen::Vector3d(1., 0., 2.),
+      Eigen::Vector3d(0., 1., 2.),
+      true,
+      "Ray hits triangle vertex");
+
+  // Case 4: Ray passes very close to triangle but misses
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(1.001, 0., 0.), // origin slightly outside triangle projection
+      Eigen::Vector3d(0., 0., 1.), // direction towards triangle plane
+      Eigen::Vector3d(-1., -1., 2.), // triangle vertices
+      Eigen::Vector3d(1., -1., 2.),
+      Eigen::Vector3d(0., 1., 2.),
+      false,
+      "Ray passes very close but misses");
+
+  // Case 5: Degenerate triangle (all points collinear)
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(0., 0., 0.), // origin
+      Eigen::Vector3d(0., 0., 1.), // direction
+      Eigen::Vector3d(0., 0., 2.), // degenerate triangle (all points on a line)
+      Eigen::Vector3d(1., 0., 2.),
+      Eigen::Vector3d(2., 0., 2.),
+      false,
+      "Degenerate triangle (collinear points)");
+}
+
+TEST(RayTriangleIntersectionTest, ScalarAndWideConsistency_NoBarycentricVersion) {
+  // Test the version without barycentric coordinates
+
+  testRayTriangleIntersectionBothVersionsNoBary<float>(
+      Eigen::Vector3f(1.f, 1.f, 1.f), // origin
+      Eigen::Vector3f(0.f, 1.f, 0.f), // direction
+      Eigen::Vector3f(0.f, 5.f, 0.f), // triangle vertices
+      Eigen::Vector3f(5.f, 5.f, 0.f),
+      Eigen::Vector3f(2.5f, 5.f, 2.5f),
+      true,
+      "No barycentric version - hit case");
+
+  testRayTriangleIntersectionBothVersionsNoBary<float>(
+      Eigen::Vector3f(1.f, 1.f, 1.f), // origin
+      Eigen::Vector3f(0.f, 1.f, 0.f), // direction
+      Eigen::Vector3f(10.f, 5.f, 0.f), // triangle vertices (miss)
+      Eigen::Vector3f(10.f, 15.f, 0.f),
+      Eigen::Vector3f(12.5f, 5.f, 2.5f),
+      false,
+      "No barycentric version - miss case");
+}
+
+TEST(RayTriangleIntersectionTest, ScalarAndWideConsistency_PrecisionTests) {
+  // Test cases that might reveal precision differences between scalar and wide versions
+
+  // Case 1: Very small triangle
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(0., 0., 0.),
+      Eigen::Vector3d(0., 0., 1.),
+      Eigen::Vector3d(-1e-6, -1e-6, 1.),
+      Eigen::Vector3d(1e-6, -1e-6, 1.),
+      Eigen::Vector3d(0., 1e-6, 1.),
+      true,
+      "Very small triangle");
+
+  // Case 2: Triangle far from origin
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(1e6, 1e6, 1e6),
+      Eigen::Vector3d(0., 0., 1.),
+      Eigen::Vector3d(1e6 - 1., 1e6 - 1., 1e6 + 100.),
+      Eigen::Vector3d(1e6 + 1., 1e6 - 1., 1e6 + 100.),
+      Eigen::Vector3d(1e6, 1e6 + 1., 1e6 + 100.),
+      true,
+      "Triangle far from origin");
+
+  // Case 3: Nearly parallel ray and triangle
+  double nearParallel = 1e-10;
+  testRayTriangleIntersectionBothVersions<double>(
+      Eigen::Vector3d(0., 0., 0.),
+      Eigen::Vector3d(1., 0., nearParallel), // Almost parallel to z=0 plane
+      Eigen::Vector3d(-1., -1., 1e6 * nearParallel), // Triangle in plane with tiny z
+      Eigen::Vector3d(1., -1., 1e6 * nearParallel),
+      Eigen::Vector3d(0., 1., 1e6 * nearParallel),
+      false,
+      "Nearly parallel ray and triangle"); // Corrected: nearly parallel should miss
+}
+
+// Tests from the original Wide test file that add unique coverage
+TEST(RayTriangleIntersectionTest, MultipleTriangles_SimdPacking) {
+  // Test multiple triangles packed into SIMD format (from original Wide test)
+
+  std::vector<std::array<Eigen::Vector3<float>, 3>> triangles = {
+      // Triangle 0: Should hit
+      {Eigen::Vector3f(-1, -1, 2), Eigen::Vector3f(1, -1, 2), Eigen::Vector3f(0, 1, 2)},
+      // Triangle 1: Should miss (too far to the side)
+      {Eigen::Vector3f(5, -1, 2), Eigen::Vector3f(7, -1, 2), Eigen::Vector3f(6, 1, 2)},
+      // Triangle 2: Should hit
+      {Eigen::Vector3f(-0.5f, -0.5f, 3),
+       Eigen::Vector3f(0.5f, -0.5f, 3),
+       Eigen::Vector3f(0, 0.5f, 3)},
+      // Triangle 3: Should miss (behind ray origin)
+      {Eigen::Vector3f(-1, -1, -1), Eigen::Vector3f(1, -1, -1), Eigen::Vector3f(0, 1, -1)}};
+
+  std::vector<bool> expectedHits = {
+      true, false, true, true}; // Triangle 3 actually hits (ray goes through z=0 to z=-1)
+
+  Eigen::Vector3f rayOrigin(0, 0, 0);
+  Eigen::Vector3f rayDirection(0, 0, 1);
+
+  testMultipleTriangles<float>(
+      rayOrigin, rayDirection, triangles, expectedHits, "Mixed hit/miss triangles");
+}
+
+TEST(RayTriangleIntersectionTest, EdgeCases_SimdConsistency) {
+  // Test edge cases with SIMD to ensure consistency (from original Wide test)
+
+  std::vector<std::array<Eigen::Vector3<double>, 3>> edgeCaseTriangles = {
+      // Degenerate triangle (all points collinear)
+      {Eigen::Vector3d(0, 0, 2), Eigen::Vector3d(1, 0, 2), Eigen::Vector3d(2, 0, 2)},
+      // Very small triangle
+      {Eigen::Vector3d(-0.001, -0.001, 2),
+       Eigen::Vector3d(0.001, -0.001, 2),
+       Eigen::Vector3d(0, 0.001, 2)},
+      // Triangle with one very acute angle
+      {Eigen::Vector3d(-10, 0, 2), Eigen::Vector3d(10, 0, 2), Eigen::Vector3d(0, 0.001, 2)},
+      // Normal triangle for comparison
+      {Eigen::Vector3d(-1, -1, 2), Eigen::Vector3d(1, -1, 2), Eigen::Vector3d(0, 1, 2)}};
+
+  std::vector<bool> expectedHits = {
+      false, true, true, true}; // Triangle 2 (acute angle) actually hits at the centroid
+
+  Eigen::Vector3d rayOrigin(0, 0, 0);
+  Eigen::Vector3d rayDirection(0, 0, 1);
+
+  testMultipleTriangles<double>(
+      rayOrigin, rayDirection, edgeCaseTriangles, expectedHits, "Edge case triangles");
+}
+
+TEST(RayTriangleIntersectionTest, RandomTriangles_StressTest) {
+  // Stress test with random triangles (adapted from original Wide test)
+
+  std::mt19937 rng(42); // Fixed seed for reproducibility
+  std::uniform_real_distribution<double> dist(-10.0, 10.0);
+
+  const int numTests = 50; // Reduced from 100 for faster execution
+
+  for (int test = 0; test < numTests; ++test) {
+    // Generate random triangles (up to 4 for SIMD width)
+    std::vector<std::array<Eigen::Vector3<double>, 3>> triangles;
+    triangles.reserve(4);
+    for (int i = 0; i < 4; ++i) {
+      triangles.push_back(
+          {Eigen::Vector3d(dist(rng), dist(rng), dist(rng)),
+           Eigen::Vector3d(dist(rng), dist(rng), dist(rng)),
+           Eigen::Vector3d(dist(rng), dist(rng), dist(rng))});
+    }
+
+    // Generate random ray
+    Eigen::Vector3d rayOrigin(dist(rng), dist(rng), dist(rng));
+    Eigen::Vector3d rayDirection = Eigen::Vector3d(dist(rng), dist(rng), dist(rng)).normalized();
+
+    std::vector<bool> expectedHits; // Don't specify expected hits for random test
+
+    testMultipleTriangles<double>(
+        rayOrigin, rayDirection, triangles, expectedHits, "Random test " + std::to_string(test));
+  }
 }
 
 } // namespace

--- a/axel/axel/test/TriBvhTest.cpp
+++ b/axel/axel/test/TriBvhTest.cpp
@@ -9,6 +9,7 @@
 
 #include "axel/TriBvh.h"
 #include "axel/common/Constants.h"
+#include "axel/math/RayTriangleIntersection.h"
 #include "axel/test/Helper.h"
 
 #include <igl/AABB.h>
@@ -26,16 +27,65 @@ using ::testing::Not;
 using ::testing::SizeIs;
 using ::testing::UnorderedElementsAre;
 
+// Sphere generation parameters used in tests
 template <typename S>
-constexpr SphereMeshParameters<S> kSphereParams{3.0, 64, 64};
+constexpr SphereMeshParameters<S> getSphereParams() {
+  return SphereMeshParameters<S>{3.0, 64, 64};
+}
 
 using ScalarTypes = testing::Types<float, double>;
 
-template <typename S, size_t LeafCapacity>
-TriBvh<S, LeafCapacity> makeBvh(const MeshData<S>& meshData) {
+// Brute force box query implementation for validation
+template <typename S>
+std::vector<uint32_t> bruteForceBoxQuery(
+    const BoundingBox<S>& queryBox,
+    const Eigen::MatrixX3<S>& positions,
+    const Eigen::MatrixX3i& triangles) {
+  std::vector<uint32_t> results;
+
+  for (int triIdx = 0; triIdx < triangles.rows(); ++triIdx) {
+    // Compute triangle bounding box
+    Eigen::AlignedBox<S, 3> triangleBBox;
+    for (int vertIdx = 0; vertIdx < 3; ++vertIdx) {
+      const int posIdx = triangles(triIdx, vertIdx);
+      triangleBBox.extend(positions.row(posIdx).transpose());
+    }
+
+    // Test intersection with query box
+    if (queryBox.aabb.intersects(triangleBBox)) {
+      results.push_back(static_cast<uint32_t>(triIdx));
+    }
+  }
+
+  // Sort results for comparison
+  std::sort(results.begin(), results.end());
+  return results;
+}
+
+template <typename S>
+TriBvh<S> makeBvh(const MeshData<S>& meshData) {
   auto pos = meshData.positions;
   auto tris = meshData.triangles;
-  return TriBvh<S, LeafCapacity>{std::move(pos), std::move(tris), 0.0};
+
+  // Store original data for validation
+  std::vector<Eigen::Vector3<S>> vertices;
+  vertices.reserve(pos.rows());
+  for (int i = 0; i < pos.rows(); ++i) {
+    vertices.emplace_back(pos.row(i));
+  }
+
+  std::vector<Eigen::Vector3i> triangleList;
+  triangleList.reserve(tris.rows());
+  for (int i = 0; i < tris.rows(); ++i) {
+    triangleList.emplace_back(tris.row(i));
+  }
+
+  auto bvh = TriBvh<S>{std::move(pos), std::move(tris), 0.0};
+
+  // Validate BVH construction for test correctness
+  bvh.validate(triangleList, vertices);
+
+  return bvh;
 }
 
 template <typename T>
@@ -46,10 +96,451 @@ struct TriBvhTest : testing::Test {
 
 TYPED_TEST_SUITE(TriBvhTest, ScalarTypes);
 
+TYPED_TEST(TriBvhTest, EmptyTree) {
+  using S = typename TestFixture::Type;
+
+  // Test both constructors with empty input
+  {
+    // Test Eigen matrix constructor with empty matrices
+    Eigen::MatrixX3<S> emptyPositions(0, 3);
+    Eigen::MatrixX3i emptyTriangles(0, 3);
+
+    TriBvh<S> bvh(emptyPositions, emptyTriangles);
+
+    // Verify empty tree properties
+    EXPECT_EQ(bvh.getPrimitiveCount(), 0);
+    EXPECT_EQ(bvh.getNodeCount(), 0);
+
+    // Verify validation works for empty tree
+    std::vector<Eigen::Vector3<S>> emptyVertices;
+    std::vector<Eigen::Vector3i> emptyTriangleList;
+    EXPECT_NO_THROW(bvh.validate(emptyTriangleList, emptyVertices));
+
+    // Test ray queries on empty tree
+    Ray3<S> testRay(Eigen::Vector3<S>(0, 0, 0), Eigen::Vector3<S>(1, 0, 0));
+
+    EXPECT_FALSE(bvh.anyHit(testRay));
+    EXPECT_EQ(bvh.closestHit(testRay), std::nullopt);
+    EXPECT_THAT(bvh.allHits(testRay), IsEmpty());
+    EXPECT_THAT(bvh.lineHits(testRay), IsEmpty());
+
+    // Test box queries on empty tree
+    BoundingBox<S> testBox;
+    testBox.aabb =
+        Eigen::AlignedBox<S, 3>(Eigen::Vector3<S>(-1, -1, -1), Eigen::Vector3<S>(1, 1, 1));
+
+    EXPECT_THAT(bvh.boxQuery(testBox), IsEmpty());
+
+    typename TriBvh<S>::QueryBuffer buffer;
+    EXPECT_EQ(bvh.boxQuery(testBox, buffer), 0);
+
+    // Test closest surface point on empty tree
+    auto result = bvh.closestSurfacePoint(Eigen::Vector3<S>(0, 0, 0));
+    EXPECT_EQ(result.triangleIdx, kInvalidTriangleIdx);
+
+    // Test with maxDist parameter
+    auto resultWithMaxDist = bvh.closestSurfacePoint(Eigen::Vector3<S>(0, 0, 0), S(10.0));
+    EXPECT_EQ(resultWithMaxDist.triangleIdx, kInvalidTriangleIdx);
+  }
+
+  {
+    // Test std::vector constructor with empty vectors
+    std::vector<Eigen::Vector3<S>> emptyVertices;
+    std::vector<Eigen::Vector3i> emptyTriangles;
+
+    TriBvh<S> bvh(emptyVertices, emptyTriangles);
+
+    // Verify empty tree properties
+    EXPECT_EQ(bvh.getPrimitiveCount(), 0);
+    EXPECT_EQ(bvh.getNodeCount(), 0);
+
+    // Verify validation works for empty tree
+    EXPECT_NO_THROW(bvh.validate(emptyTriangles, emptyVertices));
+
+    // Test ray queries on empty tree
+    Ray3<S> testRay(Eigen::Vector3<S>(0, 0, 0), Eigen::Vector3<S>(1, 0, 0));
+
+    EXPECT_FALSE(bvh.anyHit(testRay));
+    EXPECT_EQ(bvh.closestHit(testRay), std::nullopt);
+    EXPECT_THAT(bvh.allHits(testRay), IsEmpty());
+    EXPECT_THAT(bvh.lineHits(testRay), IsEmpty());
+
+    // Test closest surface point on empty tree
+    auto result = bvh.closestSurfacePoint(Eigen::Vector3<S>(0, 0, 0));
+    EXPECT_EQ(result.triangleIdx, kInvalidTriangleIdx);
+  }
+
+  // Test that printTreeStats doesn't crash on empty tree
+  {
+    std::vector<Eigen::Vector3<S>> emptyVertices;
+    std::vector<Eigen::Vector3i> emptyTriangles;
+    TriBvh<S> bvh(emptyVertices, emptyTriangles);
+
+    std::cout << "=== Testing printTreeStats on empty tree ===" << std::endl;
+    EXPECT_NO_THROW(bvh.printTreeStats());
+  }
+}
+
+TYPED_TEST(TriBvhTest, BoxQuery) {
+  using S = typename TestFixture::Type;
+
+  // Create simple test geometry - a cube made of triangles
+  Eigen::MatrixX3<S> positions(8, 3);
+  positions.row(0) = Eigen::Vector3<S>(-1, -1, -1); // Bottom face
+  positions.row(1) = Eigen::Vector3<S>(1, -1, -1);
+  positions.row(2) = Eigen::Vector3<S>(1, 1, -1);
+  positions.row(3) = Eigen::Vector3<S>(-1, 1, -1);
+  positions.row(4) = Eigen::Vector3<S>(-1, -1, 1); // Top face
+  positions.row(5) = Eigen::Vector3<S>(1, -1, 1);
+  positions.row(6) = Eigen::Vector3<S>(1, 1, 1);
+  positions.row(7) = Eigen::Vector3<S>(-1, 1, 1);
+
+  // Create 12 triangles (2 per face of cube)
+  Eigen::MatrixX3i triangles(12, 3);
+  // Bottom face (z = -1)
+  triangles.row(0) = Eigen::Vector3i(0, 1, 2);
+  triangles.row(1) = Eigen::Vector3i(0, 2, 3);
+  // Top face (z = 1)
+  triangles.row(2) = Eigen::Vector3i(4, 6, 5);
+  triangles.row(3) = Eigen::Vector3i(4, 7, 6);
+  // Front face (y = -1)
+  triangles.row(4) = Eigen::Vector3i(0, 5, 1);
+  triangles.row(5) = Eigen::Vector3i(0, 4, 5);
+  // Back face (y = 1)
+  triangles.row(6) = Eigen::Vector3i(3, 2, 6);
+  triangles.row(7) = Eigen::Vector3i(3, 6, 7);
+  // Left face (x = -1)
+  triangles.row(8) = Eigen::Vector3i(0, 3, 7);
+  triangles.row(9) = Eigen::Vector3i(0, 7, 4);
+  // Right face (x = 1)
+  triangles.row(10) = Eigen::Vector3i(1, 5, 6);
+  triangles.row(11) = Eigen::Vector3i(1, 6, 2);
+
+  const TriBvh<S> bvh{std::move(positions), std::move(triangles), S(0.0)};
+
+  // Test 1: Query box that completely contains the cube (should return all triangles)
+  {
+    BoundingBox<S> largeBox;
+    largeBox.aabb =
+        Eigen::AlignedBox<S, 3>(Eigen::Vector3<S>(-2, -2, -2), Eigen::Vector3<S>(2, 2, 2));
+
+    auto results = bvh.boxQuery(largeBox);
+
+    EXPECT_EQ(results.size(), 12); // Should find all 12 triangles
+
+    // Check that all triangle indices are valid and unique
+    std::set<uint32_t> uniqueResults(results.begin(), results.end());
+    EXPECT_EQ(uniqueResults.size(), 12);
+    for (uint32_t i = 0; i < 12; ++i) {
+      EXPECT_TRUE(uniqueResults.find(i) != uniqueResults.end());
+    }
+  }
+
+  // Test 2: Query box that intersects only part of the cube
+  {
+    BoundingBox<S> partialBox;
+    partialBox.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(-0.5, -0.5, -0.5),
+        Eigen::Vector3<S>(0.5, 0.5, 2)); // Extends beyond cube in +Z only
+
+    auto results = bvh.boxQuery(partialBox);
+
+    EXPECT_GT(results.size(), 0); // Should find some triangles
+    EXPECT_LE(results.size(), 12); // But not necessarily all
+
+    // All returned indices should be valid
+    for (uint32_t idx : results) {
+      EXPECT_LT(idx, 12);
+    }
+  }
+
+  // Test 3: Query box that doesn't intersect the cube at all
+  {
+    BoundingBox<S> missBox;
+    missBox.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(10, 10, 10), Eigen::Vector3<S>(11, 11, 11)); // Far away from cube
+
+    auto results = bvh.boxQuery(missBox);
+
+    EXPECT_EQ(results.size(), 0); // Should find no triangles
+  }
+
+  // Test 4: Very small query box inside the cube
+  {
+    BoundingBox<S> smallBox;
+    smallBox.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(-0.1, -0.1, -0.1),
+        Eigen::Vector3<S>(0.1, 0.1, 0.1)); // Tiny box at center
+
+    auto results = bvh.boxQuery(smallBox);
+
+    // All returned indices should be valid
+    for (uint32_t idx : results) {
+      EXPECT_LT(idx, 12);
+    }
+  }
+
+  // Test 5: Test the buffer-based boxQuery method
+  {
+    BoundingBox<S> testBox;
+    testBox.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(-1.5, -1.5, -1.5), Eigen::Vector3<S>(1.5, 1.5, 1.5));
+
+    typename TriBvh<S>::QueryBuffer buffer;
+    uint32_t hitCount = bvh.boxQuery(testBox, buffer);
+
+    EXPECT_GT(hitCount, 0);
+    EXPECT_LE(hitCount, std::min<uint32_t>(12, buffer.size()));
+
+    // Check that buffer contains valid triangle indices
+    for (uint32_t i = 0; i < hitCount; ++i) {
+      EXPECT_LT(buffer[i], 12);
+    }
+
+    // Compare with vector-based method
+    auto vectorResults = bvh.boxQuery(testBox);
+    if (vectorResults.size() <= buffer.size()) {
+      // If all results fit in buffer, they should match
+      EXPECT_EQ(hitCount, vectorResults.size());
+    } else {
+      // Buffer should be full
+      EXPECT_EQ(hitCount, buffer.size());
+    }
+  }
+}
+
+TYPED_TEST(TriBvhTest, BoxQuerySphere) {
+  using S = typename TestFixture::Type;
+
+  // Test with a more complex geometry (sphere)
+  auto sphere = generateSphere(getSphereParams<S>());
+  const TriBvh<S> bvh{std::move(sphere.positions), std::move(sphere.triangles), S(0.0)};
+
+  std::cout << "=== BoxQuery Sphere Tests ===" << std::endl;
+  std::cout << "Sphere triangles: " << bvh.getPrimitiveCount() << std::endl;
+
+  // Test 1: Query box that should contain the entire sphere
+  {
+    BoundingBox<S> largeBox;
+    largeBox.aabb =
+        Eigen::AlignedBox<S, 3>(Eigen::Vector3<S>(-5, -5, -5), Eigen::Vector3<S>(5, 5, 5));
+
+    auto results = bvh.boxQuery(largeBox);
+    std::cout << "Large sphere box query returned " << results.size() << " triangles" << std::endl;
+
+    EXPECT_EQ(results.size(), bvh.getPrimitiveCount()); // Should find all triangles
+  }
+
+  // Test 2: Query box that intersects only part of the sphere
+  {
+    BoundingBox<S> partialBox;
+    partialBox.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(-2.5, -2.5, -2.5),
+        Eigen::Vector3<S>(2.5, 2.5, 2.5)); // Box that reaches sphere surface
+
+    auto results = bvh.boxQuery(partialBox);
+    std::cout << "Partial sphere box query returned " << results.size() << " triangles"
+              << std::endl;
+
+    EXPECT_GT(results.size(), 0); // Should find some triangles
+    EXPECT_LT(results.size(), bvh.getPrimitiveCount()); // But not all
+  }
+
+  // Test 3: Query box at sphere surface
+  {
+    BoundingBox<S> surfaceBox;
+    surfaceBox.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(2.5, -0.5, -0.5),
+        Eigen::Vector3<S>(3.5, 0.5, 0.5)); // Box at sphere surface
+
+    auto results = bvh.boxQuery(surfaceBox);
+    std::cout << "Surface sphere box query returned " << results.size() << " triangles"
+              << std::endl;
+
+    EXPECT_GT(results.size(), 0); // Should find triangles at the surface
+  }
+
+  // Test 4: Query box outside the sphere
+  {
+    BoundingBox<S> outsideBox;
+    outsideBox.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(10, 10, 10), Eigen::Vector3<S>(11, 11, 11)); // Far from sphere
+
+    auto results = bvh.boxQuery(outsideBox);
+    std::cout << "Outside sphere box query returned " << results.size() << " triangles"
+              << std::endl;
+
+    EXPECT_EQ(results.size(), 0); // Should find no triangles
+  }
+}
+
+TYPED_TEST(TriBvhTest, BoxQueryBruteForceComparison) {
+  using S = typename TestFixture::Type;
+
+  // Create a more complex test geometry - a cube made of triangles
+  Eigen::MatrixX3<S> positions(8, 3);
+  positions.row(0) = Eigen::Vector3<S>(-1, -1, -1); // Bottom face
+  positions.row(1) = Eigen::Vector3<S>(1, -1, -1);
+  positions.row(2) = Eigen::Vector3<S>(1, 1, -1);
+  positions.row(3) = Eigen::Vector3<S>(-1, 1, -1);
+  positions.row(4) = Eigen::Vector3<S>(-1, -1, 1); // Top face
+  positions.row(5) = Eigen::Vector3<S>(1, -1, 1);
+  positions.row(6) = Eigen::Vector3<S>(1, 1, 1);
+  positions.row(7) = Eigen::Vector3<S>(-1, 1, 1);
+
+  // Create 12 triangles (2 per face of cube)
+  Eigen::MatrixX3i triangles(12, 3);
+  // Bottom face (z = -1)
+  triangles.row(0) = Eigen::Vector3i(0, 1, 2);
+  triangles.row(1) = Eigen::Vector3i(0, 2, 3);
+  // Top face (z = 1)
+  triangles.row(2) = Eigen::Vector3i(4, 6, 5);
+  triangles.row(3) = Eigen::Vector3i(4, 7, 6);
+  // Front face (y = -1)
+  triangles.row(4) = Eigen::Vector3i(0, 5, 1);
+  triangles.row(5) = Eigen::Vector3i(0, 4, 5);
+  // Back face (y = 1)
+  triangles.row(6) = Eigen::Vector3i(3, 2, 6);
+  triangles.row(7) = Eigen::Vector3i(3, 6, 7);
+  // Left face (x = -1)
+  triangles.row(8) = Eigen::Vector3i(0, 3, 7);
+  triangles.row(9) = Eigen::Vector3i(0, 7, 4);
+  // Right face (x = 1)
+  triangles.row(10) = Eigen::Vector3i(1, 5, 6);
+  triangles.row(11) = Eigen::Vector3i(1, 6, 2);
+
+  // Keep copies for brute force comparison
+  const Eigen::MatrixX3<S> originalPositions = positions;
+  const Eigen::MatrixX3i originalTriangles = triangles;
+
+  const TriBvh<S> bvh{std::move(positions), std::move(triangles), S(0.0)};
+
+  std::cout << "=== BoxQuery Brute Force Comparison Tests ===" << std::endl;
+  std::cout << "Total triangles: " << bvh.getPrimitiveCount() << std::endl;
+
+  // Test multiple query boxes of different sizes and positions
+  std::vector<BoundingBox<S>> testBoxes;
+
+  // Test case 1: Box that contains entire geometry
+  {
+    BoundingBox<S> box;
+    box.aabb = Eigen::AlignedBox<S, 3>(Eigen::Vector3<S>(-2, -2, -2), Eigen::Vector3<S>(2, 2, 2));
+    testBoxes.push_back(box);
+  }
+
+  // Test case 2: Box that intersects part of the geometry
+  {
+    BoundingBox<S> box;
+    box.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(-0.5, -0.5, -0.5), Eigen::Vector3<S>(1.5, 1.5, 1.5));
+    testBoxes.push_back(box);
+  }
+
+  // Test case 3: Box that doesn't intersect geometry
+  {
+    BoundingBox<S> box;
+    box.aabb = Eigen::AlignedBox<S, 3>(Eigen::Vector3<S>(5, 5, 5), Eigen::Vector3<S>(6, 6, 6));
+    testBoxes.push_back(box);
+  }
+
+  // Test case 4: Small box at corner
+  {
+    BoundingBox<S> box;
+    box.aabb =
+        Eigen::AlignedBox<S, 3>(Eigen::Vector3<S>(0.8, 0.8, 0.8), Eigen::Vector3<S>(1.2, 1.2, 1.2));
+    testBoxes.push_back(box);
+  }
+
+  // Test case 5: Box that clips one face
+  {
+    BoundingBox<S> box;
+    box.aabb = Eigen::AlignedBox<S, 3>(
+        Eigen::Vector3<S>(-2, -0.2, -0.2), Eigen::Vector3<S>(-0.8, 0.2, 0.2));
+    testBoxes.push_back(box);
+  }
+
+  for (size_t testIdx = 0; testIdx < testBoxes.size(); ++testIdx) {
+    const auto& queryBox = testBoxes[testIdx];
+
+    std::cout << "\n--- Test Case " << (testIdx + 1) << " ---" << std::endl;
+    std::cout << "Query box: [" << queryBox.aabb.min().transpose() << "] to ["
+              << queryBox.aabb.max().transpose() << "]" << std::endl;
+
+    // Get BVH results (sorted)
+    auto bvhResults = bvh.boxQuery(queryBox);
+    std::sort(bvhResults.begin(), bvhResults.end());
+
+    // Get brute force results (already sorted)
+    auto bruteForceResults = bruteForceBoxQuery(queryBox, originalPositions, originalTriangles);
+
+    std::cout << "BVH results: " << bvhResults.size() << " triangles";
+    if (!bvhResults.empty()) {
+      std::cout << " [";
+      for (size_t i = 0; i < std::min<size_t>(5, bvhResults.size()); ++i) {
+        if (i > 0) {
+          std::cout << ", ";
+        }
+        std::cout << bvhResults[i];
+      }
+      if (bvhResults.size() > 5) {
+        std::cout << ", ...";
+      }
+      std::cout << "]";
+    }
+    std::cout << std::endl;
+
+    std::cout << "Brute force results: " << bruteForceResults.size() << " triangles";
+    if (!bruteForceResults.empty()) {
+      std::cout << " [";
+      for (size_t i = 0; i < std::min<size_t>(5, bruteForceResults.size()); ++i) {
+        if (i > 0) {
+          std::cout << ", ";
+        }
+        std::cout << bruteForceResults[i];
+      }
+      if (bruteForceResults.size() > 5) {
+        std::cout << ", ...";
+      }
+      std::cout << "]";
+    }
+    std::cout << std::endl;
+
+    // Compare results
+    EXPECT_EQ(bvhResults.size(), bruteForceResults.size())
+        << "Test case " << (testIdx + 1) << ": Result count mismatch";
+    EXPECT_EQ(bvhResults, bruteForceResults)
+        << "Test case " << (testIdx + 1) << ": Results don't match";
+
+    // Also test the buffer-based method
+    typename TriBvh<S>::QueryBuffer buffer;
+    uint32_t bufferHitCount = bvh.boxQuery(queryBox, buffer);
+
+    std::cout << "Buffer method returned: " << bufferHitCount << " triangles" << std::endl;
+
+    if (bvhResults.size() <= buffer.size()) {
+      // All results should fit in buffer
+      EXPECT_EQ(bufferHitCount, bvhResults.size())
+          << "Test case " << (testIdx + 1) << ": Buffer count mismatch";
+
+      // Check that buffer contents match (need to sort buffer results)
+      std::vector<uint32_t> bufferResults(buffer.begin(), buffer.begin() + bufferHitCount);
+      std::sort(bufferResults.begin(), bufferResults.end());
+      EXPECT_EQ(bufferResults, bvhResults)
+          << "Test case " << (testIdx + 1) << ": Buffer results don't match";
+    } else {
+      // Buffer should be full
+      EXPECT_EQ(bufferHitCount, buffer.size())
+          << "Test case " << (testIdx + 1) << ": Buffer should be full";
+    }
+  }
+
+  std::cout << "\nAll brute force comparison tests completed!" << std::endl;
+}
+
 TYPED_TEST(TriBvhTest, rayHitsAny) {
   using S = typename TestFixture::Type;
 
-  auto sphere = generateSphere(kSphereParams<S>);
+  auto sphere = generateSphere(getSphereParams<S>());
   const Eigen::Index triangleCount{sphere.triangles.rows()};
   constexpr S kThickness{1e-2};
   const TriBvh<S> bvh{std::move(sphere.positions), std::move(sphere.triangles), kThickness};
@@ -83,7 +574,7 @@ TYPED_TEST(TriBvhTest, rayHitsAny) {
 TYPED_TEST(TriBvhTest, rayHitsClosest) {
   using S = typename TestFixture::Type;
 
-  auto sphere = generateSphere(kSphereParams<S>);
+  auto sphere = generateSphere(getSphereParams<S>());
   const TriBvh<S> bvh{std::move(sphere.positions), std::move(sphere.triangles)};
 
   // Hits.
@@ -112,7 +603,7 @@ TYPED_TEST(TriBvhTest, rayHitsClosest) {
 TYPED_TEST(TriBvhTest, rayAllHits) {
   using S = typename TestFixture::Type;
 
-  auto sphere = generateSphere(kSphereParams<S>);
+  auto sphere = generateSphere(getSphereParams<S>());
   rotate(
       sphere,
       (Eigen::AngleAxis<S>(M_PI / 13, Eigen::Vector3<S>::UnitX()) *
@@ -157,7 +648,7 @@ TYPED_TEST(TriBvhTest, differentThickness) {
   const Eigen::Vector3<S> dir{0.0, 0.0, -1.0};
 
   // Thick BVH has its bboxes expanded by 1 unit. The given ray parameters will hit through that.
-  auto s1 = generateSphere(kSphereParams<S>);
+  auto s1 = generateSphere(getSphereParams<S>());
   auto s2 = s1;
   const TriBvh<S> bvhWithThickness{std::move(s1.positions), std::move(s1.triangles), 1.0};
   EXPECT_THAT(bvhWithThickness.lineHits(Ray3<S>(org, dir)), Not(IsEmpty()));
@@ -174,7 +665,7 @@ TYPED_TEST(TriBvhTest, differentThickness) {
 TYPED_TEST(TriBvhTest, ClosestSurfacePoint_SameResultsAsIgl) {
   using S = typename TestFixture::Type;
 
-  auto sphere = generateSphere(kSphereParams<S>);
+  auto sphere = generateSphere(getSphereParams<S>());
   const Eigen::MatrixX<S> positions = sphere.positions;
   const Eigen::MatrixXi faces = sphere.triangles;
 
@@ -214,14 +705,13 @@ TYPED_TEST(TriBvhTest, ClosestSurfacePoint_SameResultsAsIgl) {
     }
   };
 
-  checkQueries(makeBvh<S, 1>(sphere));
-  checkQueries(makeBvh<S, kNativeLaneWidth<S>>(sphere));
+  checkQueries(makeBvh<S>(sphere));
 }
 
 TYPED_TEST(TriBvhTest, ClosestSurfacePoint_ExpectZeroDistFromMeshPoints) {
   using S = typename TestFixture::Type;
 
-  auto sphere = generateSphere(kSphereParams<S>);
+  auto sphere = generateSphere(getSphereParams<S>());
 
   const Eigen::MatrixX3<S> queryPoints = sphere.positions;
   const TriBvh<S> bvh{std::move(sphere.positions), std::move(sphere.triangles), detail::eps<S>()};
@@ -249,7 +739,7 @@ TYPED_TEST(TriBvhTest, ClosestSurfacePoint_ExpectZeroDistFromMeshPoints) {
 TYPED_TEST(TriBvhTest, ClosestSurfacePoints_SameResultsAsIgl) {
   using S = typename TestFixture::Type;
 
-  auto sphere = generateSphere(kSphereParams<S>);
+  auto sphere = generateSphere(getSphereParams<S>());
   const Eigen::MatrixX<S> positions = sphere.positions;
   const Eigen::MatrixXi faces = sphere.triangles;
 
@@ -338,6 +828,240 @@ TYPED_TEST(TriBvhTest, RayQuery_AnyHits_Simple) {
 
   // Ray shoots "backwards" with direction inverted and hits with minDist.
   EXPECT_TRUE(bvh.anyHit(Ray3<S>({0, 0, 0}, {0, 0, 1}, 0.0, -2.0)));
+}
+
+// Test SIMD ray-triangle intersection directly
+TYPED_TEST(TriBvhTest, SimdRayTriangleIntersection) {
+  using S = typename TestFixture::Type;
+
+  // Create a simple triangle for testing - make it easier to hit
+  Eigen::Vector3<S> v0(-1, -1, 2); // Triangle at z=2
+  Eigen::Vector3<S> v1(1, -1, 2);
+  Eigen::Vector3<S> v2(0, 1, 2);
+
+  // Create a single triangle mesh
+  Eigen::MatrixX3<S> positions(3, 3);
+  positions.row(0) = v0;
+  positions.row(1) = v1;
+  positions.row(2) = v2;
+
+  Eigen::MatrixX3i triangles(1, 3);
+  triangles.row(0) = Eigen::Vector3i(0, 1, 2);
+
+  // Create BVH to access SIMD intersection function
+  TriBvh<S> bvh(std::move(positions), std::move(triangles), 0.0);
+
+  // Test ray that should definitely hit the triangle
+  axel::Ray3<S> hitRay;
+  hitRay.origin = Eigen::Vector3<S>(0, 0, 0); // Shoot from origin
+  hitRay.direction = Eigen::Vector3<S>(0, 0, 1); // Towards +Z
+  hitRay.minT = static_cast<S>(0.001);
+  hitRay.maxT = static_cast<S>(10);
+
+  std::cout << "=== Testing SIMD Ray-Triangle Intersection ===" << std::endl;
+  std::cout << "Triangle vertices:" << std::endl;
+  std::cout << "  v0: " << v0.transpose() << std::endl;
+  std::cout << "  v1: " << v1.transpose() << std::endl;
+  std::cout << "  v2: " << v2.transpose() << std::endl;
+  std::cout << "Ray: origin=" << hitRay.origin.transpose()
+            << " dir=" << hitRay.direction.transpose() << " minT=" << hitRay.minT
+            << " maxT=" << hitRay.maxT << std::endl;
+
+  // Test with scalar ray-triangle intersection first
+  S u, v, t;
+  Eigen::Vector3<S> hitPoint;
+  bool scalarHit =
+      axel::rayTriangleIntersect(hitRay.origin, hitRay.direction, v0, v1, v2, hitPoint, t, u, v);
+
+  std::cout << "Scalar intersection: " << (scalarHit ? "HIT" : "MISS") << std::endl;
+  if (scalarHit) {
+    std::cout << "  t=" << t << " u=" << u << " v=" << v << std::endl;
+    std::cout << "  w=" << (1 - u - v) << std::endl;
+    std::cout << "  hitPoint=" << hitPoint.transpose() << std::endl;
+    std::cout << "  Expected hitPoint=" << (hitRay.origin + t * hitRay.direction).transpose()
+              << std::endl;
+  }
+
+  // Now test BVH intersection
+  auto bvhResult = bvh.closestHit(hitRay);
+  std::cout << "BVH intersection: " << (bvhResult.has_value() ? "HIT" : "MISS") << std::endl;
+  if (bvhResult.has_value()) {
+    std::cout << "  triangleId=" << bvhResult->triangleId << std::endl;
+    std::cout << "  hitDistance=" << bvhResult->hitDistance << std::endl;
+    std::cout << "  hitPoint=" << bvhResult->hitPoint.transpose() << std::endl;
+    std::cout << "  baryCoords=" << bvhResult->baryCoords.transpose() << std::endl;
+  }
+
+  // They should both hit
+  EXPECT_TRUE(scalarHit);
+  EXPECT_TRUE(bvhResult.has_value());
+
+  if (scalarHit && bvhResult.has_value()) {
+    EXPECT_NEAR(t, bvhResult->hitDistance, static_cast<S>(1e-5));
+    EXPECT_EIGEN_MATRIX_NEAR(hitPoint, bvhResult->hitPoint, static_cast<S>(1e-5));
+  }
+}
+
+// Test ray that should miss
+TYPED_TEST(TriBvhTest, SimdRayTriangleMiss) {
+  using S = typename TestFixture::Type;
+
+  // Create a simple triangle for testing
+  Eigen::Vector3<S> v0(-1, 0, -2);
+  Eigen::Vector3<S> v1(1, 0, -2);
+  Eigen::Vector3<S> v2(0, 1, -2);
+
+  // Create a single triangle mesh
+  Eigen::MatrixX3<S> positions(3, 3);
+  positions.row(0) = v0;
+  positions.row(1) = v1;
+  positions.row(2) = v2;
+
+  Eigen::MatrixX3i triangles(1, 3);
+  triangles.row(0) = Eigen::Vector3i(0, 1, 2);
+
+  // Create BVH to access SIMD intersection function
+  TriBvh<S> bvh(std::move(positions), std::move(triangles), 0.0);
+
+  // Test ray that should miss the triangle (shoots to the side)
+  axel::Ray3<S> missRay;
+  missRay.origin = Eigen::Vector3<S>(2, 0, 0); // Outside triangle projection
+  missRay.direction = Eigen::Vector3<S>(0, 0, -1);
+  missRay.minT = static_cast<S>(0.001);
+  missRay.maxT = static_cast<S>(10);
+
+  std::cout << "=== Testing SIMD Ray-Triangle Miss ===" << std::endl;
+  std::cout << "Ray: origin=" << missRay.origin.transpose()
+            << " dir=" << missRay.direction.transpose() << std::endl;
+
+  // Test with scalar ray-triangle intersection first
+  S u, v, t;
+  Eigen::Vector3<S> hitPoint;
+  bool scalarHit =
+      axel::rayTriangleIntersect(missRay.origin, missRay.direction, v0, v1, v2, hitPoint, t, u, v);
+
+  std::cout << "Scalar intersection: " << (scalarHit ? "HIT" : "MISS") << std::endl;
+
+  // Now test BVH intersection
+  auto bvhResult = bvh.closestHit(missRay);
+  std::cout << "BVH intersection: " << (bvhResult.has_value() ? "HIT" : "MISS") << std::endl;
+
+  // Both should miss
+  EXPECT_FALSE(scalarHit);
+  EXPECT_FALSE(bvhResult.has_value());
+}
+
+TYPED_TEST(TriBvhTest, ClosestSurfacePoint_MaxDistanceTest) {
+  using S = typename TestFixture::Type;
+
+  // Create a simple triangle mesh - single triangle at known location
+  Eigen::MatrixX3<S> positions(3, 3);
+  positions.row(0) = Eigen::Vector3<S>(-1, 0, 0);
+  positions.row(1) = Eigen::Vector3<S>(1, 0, 0);
+  positions.row(2) = Eigen::Vector3<S>(0, 1, 0);
+
+  Eigen::MatrixX3i triangles(1, 3);
+  triangles.row(0) = Eigen::Vector3i(0, 1, 2);
+
+  const TriBvh<S> bvh{std::move(positions), std::move(triangles), 0.0};
+
+  // Query point at a known distance from the triangle
+  // Place query point above the triangle center at distance = 2.0
+  const Eigen::Vector3<S> queryPoint(0, S(1.0 / 3.0), 2);
+
+  // Calculate the expected closest point on the triangle (should be at the centroid)
+  const Eigen::Vector3<S> expectedClosestPoint(0, S(1.0 / 3.0), 0);
+  const S expectedDistance = 2.0;
+
+  std::cout << "=== Testing maxDist parameter ===" << std::endl;
+  std::cout << "Query point: " << queryPoint.transpose() << std::endl;
+  std::cout << "Expected closest point: " << expectedClosestPoint.transpose() << std::endl;
+  std::cout << "Expected distance: " << expectedDistance << std::endl;
+
+  // Test 1: Unlimited search (should find the point)
+  {
+    auto result = bvh.closestSurfacePoint(queryPoint);
+    std::cout << "Unlimited search result:" << std::endl;
+    if (result.triangleIdx != kInvalidTriangleIdx) {
+      std::cout << "  Found triangle: " << result.triangleIdx << std::endl;
+      std::cout << "  Closest point: " << result.point.transpose() << std::endl;
+      std::cout << "  Distance: " << (queryPoint - result.point).norm() << std::endl;
+      EXPECT_NE(result.triangleIdx, kInvalidTriangleIdx);
+      EXPECT_EIGEN_MATRIX_NEAR(result.point, expectedClosestPoint, 1e-6);
+      EXPECT_NEAR((queryPoint - result.point).norm(), expectedDistance, 1e-6);
+    } else {
+      std::cout << "  No result found" << std::endl;
+      FAIL() << "Unlimited search should find the triangle";
+    }
+  }
+
+  // Test 2: maxDist larger than actual distance (should find the point)
+  {
+    const S largeMaxDist = expectedDistance + 1.0; // 3.0
+    auto result = bvh.closestSurfacePoint(queryPoint, largeMaxDist);
+    std::cout << "Large maxDist (" << largeMaxDist << ") result:" << std::endl;
+    if (result.triangleIdx != kInvalidTriangleIdx) {
+      std::cout << "  Found triangle: " << result.triangleIdx << std::endl;
+      std::cout << "  Closest point: " << result.point.transpose() << std::endl;
+      std::cout << "  Distance: " << (queryPoint - result.point).norm() << std::endl;
+      EXPECT_NE(result.triangleIdx, kInvalidTriangleIdx);
+      EXPECT_EIGEN_MATRIX_NEAR(result.point, expectedClosestPoint, 1e-6);
+      EXPECT_NEAR((queryPoint - result.point).norm(), expectedDistance, 1e-6);
+    } else {
+      std::cout << "  No result found" << std::endl;
+      FAIL() << "Search with large maxDist should find the triangle";
+    }
+  }
+
+  // Test 3: maxDist smaller than actual distance (should NOT find the point)
+  {
+    const S smallMaxDist = expectedDistance - 0.5; // 1.5
+    auto result = bvh.closestSurfacePoint(queryPoint, smallMaxDist);
+    std::cout << "Small maxDist (" << smallMaxDist << ") result:" << std::endl;
+    if (result.triangleIdx != kInvalidTriangleIdx) {
+      std::cout << "  Found triangle: " << result.triangleIdx << std::endl;
+      std::cout << "  Closest point: " << result.point.transpose() << std::endl;
+      std::cout << "  Distance: " << (queryPoint - result.point).norm() << std::endl;
+      FAIL() << "Search with small maxDist should NOT find the triangle";
+    } else {
+      std::cout << "  No result found (as expected)" << std::endl;
+      EXPECT_EQ(result.triangleIdx, kInvalidTriangleIdx);
+    }
+  }
+
+  // Test 4: maxDist exactly equal to actual distance (should find the point)
+  {
+    const S exactMaxDist = expectedDistance;
+    auto result = bvh.closestSurfacePoint(queryPoint, exactMaxDist);
+    std::cout << "Exact maxDist (" << exactMaxDist << ") result:" << std::endl;
+    if (result.triangleIdx != kInvalidTriangleIdx) {
+      std::cout << "  Found triangle: " << result.triangleIdx << std::endl;
+      std::cout << "  Closest point: " << result.point.transpose() << std::endl;
+      std::cout << "  Distance: " << (queryPoint - result.point).norm() << std::endl;
+      EXPECT_NE(result.triangleIdx, kInvalidTriangleIdx);
+      EXPECT_EIGEN_MATRIX_NEAR(result.point, expectedClosestPoint, 1e-6);
+      EXPECT_NEAR((queryPoint - result.point).norm(), expectedDistance, 1e-6);
+    } else {
+      std::cout << "  No result found" << std::endl;
+      FAIL() << "Search with exact maxDist should find the triangle";
+    }
+  }
+
+  // Test 5: maxDist very small (should NOT find the point)
+  {
+    const S tinyMaxDist = 0.1;
+    auto result = bvh.closestSurfacePoint(queryPoint, tinyMaxDist);
+    std::cout << "Tiny maxDist (" << tinyMaxDist << ") result:" << std::endl;
+    if (result.triangleIdx != kInvalidTriangleIdx) {
+      std::cout << "  Found triangle: " << result.triangleIdx << std::endl;
+      std::cout << "  Closest point: " << result.point.transpose() << std::endl;
+      std::cout << "  Distance: " << (queryPoint - result.point).norm() << std::endl;
+      FAIL() << "Search with tiny maxDist should NOT find the triangle";
+    } else {
+      std::cout << "  No result found (as expected)" << std::endl;
+      EXPECT_EQ(result.triangleIdx, kInvalidTriangleIdx);
+    }
+  }
 }
 
 } // namespace

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -3032,6 +3032,7 @@ This is used e.g. to swap one character's hand skeleton with another.
   m.def(
       "find_closest_points",
       &findClosestPoints,
+      py::call_guard<py::gil_scoped_release>(),
       R"(For each point in the points_source tensor, find the closest point in the points_target tensor.  This version of find_closest points supports both 2- and 3-dimensional point sets.
 
 :param points_source: [nBatch x nPoints x dim] tensor of source points (dim must be 2 or 3).
@@ -3048,6 +3049,7 @@ This is used e.g. to swap one character's hand skeleton with another.
   m.def(
       "find_closest_points",
       &findClosestPointsWithNormals,
+      py::call_guard<py::gil_scoped_release>(),
       R"(For each point in the points_source tensor, find the closest point in the points_target tensor whose normal is compatible (n_source . n_target > max_normal_dot).
 Using the normal is a good way to avoid certain kinds of bad matches, such as matching the front of the body against depth values from the back of the body.
 
@@ -3071,6 +3073,7 @@ Using the normal is a good way to avoid certain kinds of bad matches, such as ma
   m.def(
       "find_closest_points_on_mesh",
       &findClosestPointsOnMesh,
+      py::call_guard<py::gil_scoped_release>(),
       R"(For each point in the points_source tensor, find the closest point in the target mesh.
 
   :param points_source: [nBatch x nPoints x 3] tensor of source points.

--- a/pymomentum/tensor_momentum/tensor_kd_tree.cpp
+++ b/pymomentum/tensor_momentum/tensor_kd_tree.cpp
@@ -328,7 +328,7 @@ void findClosestPointsOnMesh_imp(
     at::Tensor result_points,
     at::Tensor result_face_index,
     at::Tensor result_barycentric) {
-  using TriBvh = typename axel::TriBvh<S, axel::kNativeLaneWidth<S>>;
+  using TriBvh = typename axel::TriBvh<S>;
 
   const int64_t nSrcPts = points_source.size(0);
   const int64_t nTgtVertices = vertices_target.size(0);


### PR DESCRIPTION
Summary:
The current TriBvh has a few specific limitations that bother me:
1. It's not _really_ simd code, because it does most operations without simd and then only tries to assemble simd triangles with a big gather() operation at the end.  It would be much more efficient if data was actually stored packed in simd primitives.
2. It's annoying to construct a tri_bvh because it takes a very unusual data structures that aren't actually used anywhere in momentum (Eigen::MatrixX3 instead of the std::vector<<Eigen::Vector3f>> that momentum::Mesh uses, which means constructing a TriBvh for a momentum Character requires a bunch of boilerplate code).  
3. It lacks an early exit for closest_point functionality based on distance, even though most closest point use cases only care if the query point is actually close (they don't need to distinguish between 1 meter and 10 meters).  This is more important than you'd think because when you're doing a distance query and you use a point which is say 1 meter away from the mesh, it will end up looking at large chunks of the bbox hierarchy since all the bboxes are roughly the same distance away (by vector norm), but if you use a query point which is right next to the mesh it only needs to look at a relatively small number of triangles. 

This should be a solveable problem.  I think the original issue here is that we are trying really hard to make TriBvh use the "regular" bvh class.  However IMO in this case we should instead be optimizing for the triangle use case, because there are many more use cases for triangles specifically than for any other kind of thing you'd store in a bounding box hierarchy.  So instead, let's specialize on triangles, and store the actual triangles in the leafs in SIMD-length blocks.  This will let us quickly process the triangles 8 at a time, and gives us a nice ~2x speedup.  Also, since we're repacking the triangles anyway, we no longer need to rely on taking the input arguments as std::move(), and allows us to support multiple possible input types.

Reviewed By: jeongseok-meta, FallenShard

Differential Revision: D82481416


