### PR TITLE
More detailed error report in marker tracking

### DIFF
--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -1233,6 +1233,8 @@ std::pair<float, float> getLocatorError(
   // go over all frames and pose the locators and compute the error
   double error = 0.0;
   double maxError = 0.0;
+  size_t frameNum = 0.0;
+  std::string markerName = "";
   for (size_t iFrame = 0; iFrame < numFrames; ++iFrame) {
     const auto jointParams = pt.apply(motion.col(iFrame));
     state.set(jointParams, character.skeleton, false);
@@ -1261,7 +1263,11 @@ std::pair<float, float> getLocatorError(
       const Vector3f diff = locatorPos - jMarker.pos.cast<float>();
       const float markerError = diff.norm();
       frameError += markerError;
-      maxError = std::max(maxError, static_cast<double>(markerError));
+      if (markerError > maxError) {
+        maxError = markerError;
+        frameNum = iFrame;
+        markerName = jMarker.name;
+      }
       validMarkers++;
     }
 
@@ -1269,6 +1275,7 @@ std::pair<float, float> getLocatorError(
       error += frameError / validMarkers;
     }
   }
+  MT_LOGI("Max marker error: {} at frame {} for marker {}", maxError, frameNum, markerName);
   return {static_cast<float>(error / numFrames), static_cast<float>(maxError)};
 }
 

--- a/momentum/marker_tracking/process_markers.cpp
+++ b/momentum/marker_tracking/process_markers.cpp
@@ -58,7 +58,7 @@ Eigen::MatrixXf processMarkers(
   Eigen::MatrixXf finalMotion = trackPosesPerframe(inputData, character, identity, trackingConfig);
 
   if (trackingConfig.debug) {
-    auto errors = getLocatorError(markerData, finalMotion, character);
+    auto errors = getLocatorError(inputData, finalMotion, character);
     MT_LOGI("Average marker error: {}", errors.first);
     MT_LOGI("Max marker error: {}", errors.second);
   }


### PR DESCRIPTION
Summary:
Report the marker name and frame number with the max error for debugging.

Fixed a bug in computing error statistics when the tracked motion is a sub-sequence of the input.

Differential Revision: D78504120


