### PR TITLE
Add quaternion normalization to to_matrix.

### DIFF
--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -119,12 +119,16 @@ def multiply_assume_normalized(q1: torch.Tensor, q2: torch.Tensor) -> torch.Tens
     """
     check(q1)
     check(q2)
-    r1, v1 = split(q1)
-    r2, v2 = split(q2)
-    assert q1.size() == q2.size(), "Expected matching quaternion dimensions."
-    r_res = r1 * r2 - (v1 * v2).sum(-1, keepdim=True)
-    v_res = r1.expand_as(v2) * v2 + r2.expand_as(v1) * v1 + torch.cross(v1, v2, -1)
-    return torch.cat((v_res, r_res), -1)
+
+    x1, y1, z1, w1 = q1.unbind(-1)
+    x2, y2, z2, w2 = q2.unbind(-1)
+
+    x = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
+    y = w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2
+    z = w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
+    w = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
+
+    return torch.stack((x, y, z, w), dim=-1)
 
 
 def normalize(q: torch.Tensor) -> torch.Tensor:

--- a/pymomentum/test/test_trs.py
+++ b/pymomentum/test/test_trs.py
@@ -5,13 +5,67 @@
 
 # pyre-strict
 
+import math
 import unittest
+
+import pymomentum.quaternion as pym_quaternion
+import pymomentum.skel_state as pym_skel_state
 
 import pymomentum.trs as pym_trs
 import torch
 
 
 class TestTRS(unittest.TestCase):
+    def _rotation_x(self, angle: float) -> torch.Tensor:
+        """Create rotation matrix around X-axis."""
+        c, s = math.cos(angle), math.sin(angle)
+        return torch.tensor([[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]])
+
+    def _rotation_y(self, angle: float) -> torch.Tensor:
+        """Create rotation matrix around Y-axis."""
+        c, s = math.cos(angle), math.sin(angle)
+        return torch.tensor([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+
+    def _rotation_z(self, angle: float) -> torch.Tensor:
+        """Create rotation matrix around Z-axis."""
+        c, s = math.cos(angle), math.sin(angle)
+        return torch.tensor([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+
+    def _quat_from_axis_angle(self, axis: torch.Tensor, angle: float) -> torch.Tensor:
+        """Create quaternion from axis-angle representation using pymomentum.quaternion."""
+        # Normalize the axis and scale by the angle to create axis-angle vector
+        axis_normalized = axis / torch.norm(axis)
+        axis_angle = axis_normalized * angle
+        return pym_quaternion.from_axis_angle(axis_angle)
+
+    def _random_skel_states(
+        self,
+        sz: int,
+    ) -> torch.Tensor:
+        # [sz, 3
+        trans: torch.Tensor = torch.normal(
+            mean=0,
+            std=4,
+            size=(sz, 3),
+            dtype=torch.float64,
+            requires_grad=True,
+        )
+
+        rot: torch.Tensor = pym_quaternion.normalize(
+            torch.normal(
+                mean=0,
+                std=4,
+                size=(sz, 4),
+                dtype=torch.float64,
+                requires_grad=True,
+            )
+        )
+
+        scale: torch.Tensor = torch.rand(
+            size=(sz, 1), dtype=torch.float64, requires_grad=True
+        )
+        return torch.cat([trans, rot, scale], -1)
+
     def test_from_translation(self) -> None:
         """Test creating TRS from translation vector."""
         translation = torch.tensor([1.0, 2.0, 3.0])
@@ -98,36 +152,40 @@ class TestTRS(unittest.TestCase):
 
     def test_multiply(self) -> None:
         """Test multiplying two TRS transforms."""
-        # Create first transform: translation only
+        # Create first transform: 90-degree rotation around Z axis and translation
+        rotation_z_90 = self._rotation_z(math.pi / 2)
         t1 = torch.tensor([1.0, 0.0, 0.0])
-        trs1 = pym_trs.from_translation(t1)
+        trs1 = pym_trs.multiply(
+            pym_trs.from_rotation_matrix(rotation_z_90), pym_trs.from_translation(t1)
+        )
 
-        # Create second transform: scale only
+        # Create second transform: 45-degree rotation around X axis and scale
+        rotation_x_45 = self._rotation_x(math.pi / 4)
         s2 = torch.tensor([2.0])
-        trs2 = pym_trs.from_scale(s2)
+        trs2 = pym_trs.multiply(
+            pym_trs.from_rotation_matrix(rotation_x_45), pym_trs.from_scale(s2)
+        )
 
         # Multiply transforms
-        t_result, r_result, s_result = pym_trs.multiply(trs1, trs2)
-
-        # Check that rotation is still identity
-        self.assertTrue(torch.allclose(r_result, torch.eye(3)))
+        _, r_result, s_result = pym_trs.multiply(trs1, trs2)
 
         # Check that scale is 2.0
         self.assertTrue(torch.allclose(s_result, torch.tensor([2.0])))
 
-        # For TRS1 * TRS2, the translation should be t1 + R1 * (s1 * t2)
-        # t1 = [1,0,0], R1 = I, s1 = 1, t2 = [0,0,0]
-        # So result should be [1,0,0] + I * (1 * [0,0,0]) = [1,0,0]
-        expected_translation = torch.tensor([1.0, 0.0, 0.0])
-        self.assertTrue(torch.allclose(t_result, expected_translation))
+        # Check that rotation is composition of both rotations
+        expected_rotation = torch.matmul(rotation_z_90, rotation_x_45)
+        self.assertTrue(torch.allclose(r_result, expected_rotation, atol=1e-6))
 
     def test_inverse(self) -> None:
         """Test inverting a TRS transform."""
-        # Create a transform with translation and scale
+        # Create a transform with rotation around Y axis, translation, and scale
+        rotation_y_60 = self._rotation_y(math.pi / 3)  # 60 degrees
         t = torch.tensor([2.0, 4.0, 6.0])
         s = torch.tensor([2.0])
+
         trs_original = pym_trs.multiply(
-            pym_trs.from_translation(t), pym_trs.from_scale(s)
+            pym_trs.from_rotation_matrix(rotation_y_60),
+            pym_trs.multiply(pym_trs.from_translation(t), pym_trs.from_scale(s)),
         )
 
         # Compute inverse
@@ -144,17 +202,25 @@ class TestTRS(unittest.TestCase):
 
     def test_transform_points(self) -> None:
         """Test transforming points with TRS transform."""
-        # Create a simple translation transform
+        # Create a transform with 90-degree rotation around Z-axis, translation, and scale
+        # Using direct construction instead of multiplication
+        rotation_z_90 = self._rotation_z(math.pi / 2)
         translation = torch.tensor([1.0, 2.0, 3.0])
-        trs_trans = pym_trs.from_translation(translation)
+        scale = torch.tensor([2.0])
 
-        # Transform a point
-        points = torch.tensor([[0.0, 0.0, 0.0]])
-        transformed = pym_trs.transform_points(trs_trans, points)
+        # Create TRS directly with all components
+        trs_transform = (translation, rotation_z_90, scale)
 
-        # Should be translated by [1, 2, 3]
-        expected = torch.tensor([[1.0, 2.0, 3.0]])
-        self.assertTrue(torch.allclose(transformed, expected))
+        # Transform a point at [1, 0, 0]
+        points = torch.tensor([[1.0, 0.0, 0.0]])
+        transformed = pym_trs.transform_points(trs_transform, points)
+
+        # Order is Scale->Rotate->Translate:
+        # Point [1,0,0] scaled by 2: [2,0,0]
+        # [2,0,0] rotated 90° around Z: [0,2,0]
+        # [0,2,0] translated by [1,2,3]: [1,4,3]
+        expected = torch.tensor([[1.0, 4.0, 3.0]])
+        self.assertTrue(torch.allclose(transformed, expected, atol=1e-6))
 
     def test_transform_points_invalid_shape(self) -> None:
         """Test that transform_points raises error for invalid point shapes."""
@@ -172,12 +238,13 @@ class TestTRS(unittest.TestCase):
 
     def test_to_matrix(self) -> None:
         """Test converting TRS transform to 4x4 matrix."""
-        # Create a TRS with translation and scale
+        # Create a TRS directly with 45-degree rotation around X, translation, and scale
+        rotation_x_45 = self._rotation_x(math.pi / 4)
         translation = torch.tensor([1.0, 2.0, 3.0])
         scale = torch.tensor([2.0])
-        trs_transform = pym_trs.multiply(
-            pym_trs.from_translation(translation), pym_trs.from_scale(scale)
-        )
+
+        # Create TRS directly with all components
+        trs_transform = (translation, rotation_x_45, scale)
 
         # Convert to matrix
         matrix = pym_trs.to_matrix(trs_transform)
@@ -186,9 +253,9 @@ class TestTRS(unittest.TestCase):
         self.assertEqual(matrix.shape, (4, 4))
 
         # Check that it matches expected structure
-        # Top-left 3x3 should be scaled identity matrix
-        expected_linear = torch.eye(3) * 2.0
-        self.assertTrue(torch.allclose(matrix[:3, :3], expected_linear))
+        # Top-left 3x3 should be scaled rotation matrix
+        expected_linear = rotation_x_45 * 2.0
+        self.assertTrue(torch.allclose(matrix[:3, :3], expected_linear, atol=1e-6))
 
         # Right column should be translation
         self.assertTrue(torch.allclose(matrix[:3, 3], translation))
@@ -199,39 +266,41 @@ class TestTRS(unittest.TestCase):
 
     def test_from_matrix(self) -> None:
         """Test converting 4x4 matrix to TRS transform."""
-        # Create a 4x4 matrix manually
-        matrix = torch.tensor(
-            [
-                [2.0, 0.0, 0.0, 1.0],
-                [0.0, 2.0, 0.0, 2.0],
-                [0.0, 0.0, 2.0, 3.0],
-                [0.0, 0.0, 0.0, 1.0],
-            ]
-        )
+        # Create a 4x4 matrix with a 90-degree rotation around Z axis, scale, and translation
+        rotation_z_90 = self._rotation_z(math.pi / 2)
+        scale = 2.0
+        translation = torch.tensor([1.0, 2.0, 3.0])
+
+        # Build matrix manually: R*S for top-left 3x3, translation in top-right column
+        matrix = torch.zeros(4, 4)
+        matrix[:3, :3] = rotation_z_90 * scale
+        matrix[:3, 3] = translation
+        matrix[3, 3] = 1.0
 
         # Convert to TRS
         t, r, s = pym_trs.from_matrix(matrix)
 
         # Check translation
-        expected_translation = torch.tensor([1.0, 2.0, 3.0])
-        self.assertTrue(torch.allclose(t, expected_translation))
+        self.assertTrue(torch.allclose(t, translation, atol=1e-6))
 
-        # Check rotation (should be identity)
-        expected_rotation = torch.eye(3)
-        self.assertTrue(torch.allclose(r, expected_rotation, atol=1e-6))
+        # Check rotation (should be 90-degree rotation around Z)
+        self.assertTrue(torch.allclose(r, rotation_z_90, atol=1e-6))
 
         # Check scale
-        expected_scale = torch.tensor([2.0])
+        expected_scale = torch.tensor([scale])
         self.assertTrue(torch.allclose(s, expected_scale, atol=1e-6))
 
     def test_matrix_roundtrip(self) -> None:
         """Test that to_matrix and from_matrix are inverse operations."""
-        # Create a random TRS transform
+        # Create a TRS transform with 30-degree rotation around arbitrary axis, translation, and scale
+        axis = torch.tensor([1.0, 2.0, 3.0])
+        quat = self._quat_from_axis_angle(axis, math.pi / 6)  # 30 degrees
         translation = torch.tensor([1.5, -2.3, 0.7])
         scale = torch.tensor([1.8])
-        trs_original = pym_trs.multiply(
-            pym_trs.from_translation(translation), pym_trs.from_scale(scale)
-        )
+
+        # Create transform using the skeleton state approach since we have quaternion
+        skeleton_state = torch.cat([translation, quat, scale])
+        trs_original = pym_trs.from_skeleton_state(skeleton_state)
 
         # Convert to matrix and back
         matrix = pym_trs.to_matrix(trs_original)
@@ -352,30 +421,30 @@ class TestTRS(unittest.TestCase):
         trs1 = pym_trs.from_translation(torch.tensor([0.0, 1.0, 0.0]))
 
         # Test slerp at t=0 should return trs0
-        t_interp_0, r_interp_0, s_interp_0 = pym_trs.slerp(
-            trs0, trs1, torch.tensor([0.0])
-        )
+        t_interp_0, _, _ = pym_trs.slerp(trs0, trs1, torch.tensor([0.0]))
         expected_t0 = torch.tensor([1.0, 0.0, 0.0])
         self.assertTrue(torch.allclose(t_interp_0, expected_t0, atol=1e-6))
 
         # Test slerp at t=1 should return trs1
-        t_interp_1, r_interp_1, s_interp_1 = pym_trs.slerp(
-            trs0, trs1, torch.tensor([1.0])
-        )
+        t_interp_1, _, _ = pym_trs.slerp(trs0, trs1, torch.tensor([1.0]))
         expected_t1 = torch.tensor([0.0, 1.0, 0.0])
         self.assertTrue(torch.allclose(t_interp_1, expected_t1, atol=1e-6))
 
     def test_slerp_midpoint(self) -> None:
         """Test slerp at t=0.5."""
-        # Create two TRS transforms with different translation and scale
-        trs0 = pym_trs.multiply(
-            pym_trs.from_translation(torch.tensor([0.0, 0.0, 0.0])),
-            pym_trs.from_scale(torch.tensor([1.0])),
-        )
-        trs1 = pym_trs.multiply(
-            pym_trs.from_translation(torch.tensor([2.0, 4.0, 6.0])),
-            pym_trs.from_scale(torch.tensor([3.0])),
-        )
+        # Create two TRS transforms with different rotations, translation, and scale
+        quat0 = self._quat_from_axis_angle(
+            torch.tensor([0.0, 0.0, 1.0]), 0.0
+        )  # Identity
+        quat1 = self._quat_from_axis_angle(
+            torch.tensor([1.0, 0.0, 0.0]), math.pi / 2
+        )  # 90° around X
+
+        state0 = torch.cat([torch.tensor([0.0, 0.0, 0.0]), quat0, torch.tensor([1.0])])
+        state1 = torch.cat([torch.tensor([2.0, 4.0, 6.0]), quat1, torch.tensor([3.0])])
+
+        trs0 = pym_trs.from_skeleton_state(state0)
+        trs1 = pym_trs.from_skeleton_state(state1)
 
         # Interpolate at midpoint
         t_interp, r_interp, s_interp = pym_trs.slerp(trs0, trs1, torch.tensor([0.5]))
@@ -388,16 +457,30 @@ class TestTRS(unittest.TestCase):
         expected_s = torch.tensor([2.0])  # (1+3)/2
         self.assertTrue(torch.allclose(s_interp, expected_s, atol=1e-6))
 
-        # Rotation should still be identity (since both inputs have identity rotation)
-        self.assertTrue(torch.allclose(r_interp, torch.eye(3), atol=1e-6))
+        # Rotation should be interpolated between identity and 90° X rotation
+        self.assertFalse(torch.allclose(r_interp, torch.eye(3), atol=1e-2))
 
     def test_blend_equal_weights(self) -> None:
         """Test blending with equal weights."""
-        # Create three TRS transforms
+        # Create three TRS transforms with different rotations
+        quat1 = self._quat_from_axis_angle(
+            torch.tensor([1.0, 0.0, 0.0]), math.pi / 6
+        )  # 30° around X
+        quat2 = self._quat_from_axis_angle(
+            torch.tensor([0.0, 1.0, 0.0]), math.pi / 4
+        )  # 45° around Y
+        quat3 = self._quat_from_axis_angle(
+            torch.tensor([0.0, 0.0, 1.0]), math.pi / 3
+        )  # 60° around Z
+
+        state1 = torch.cat([torch.tensor([1.0, 0.0, 0.0]), quat1, torch.tensor([1.0])])
+        state2 = torch.cat([torch.tensor([0.0, 1.0, 0.0]), quat2, torch.tensor([1.0])])
+        state3 = torch.cat([torch.tensor([0.0, 0.0, 1.0]), quat3, torch.tensor([1.0])])
+
         trs_list = [
-            pym_trs.from_translation(torch.tensor([1.0, 0.0, 0.0])),
-            pym_trs.from_translation(torch.tensor([0.0, 1.0, 0.0])),
-            pym_trs.from_translation(torch.tensor([0.0, 0.0, 1.0])),
+            pym_trs.from_skeleton_state(state1),
+            pym_trs.from_skeleton_state(state2),
+            pym_trs.from_skeleton_state(state3),
         ]
 
         # Blend with equal weights (should use default equal weights)
@@ -407,8 +490,8 @@ class TestTRS(unittest.TestCase):
         expected_t = torch.tensor([1.0 / 3, 1.0 / 3, 1.0 / 3])
         self.assertTrue(torch.allclose(t_blend, expected_t, atol=1e-6))
 
-        # Rotation should be identity (all inputs have identity)
-        self.assertTrue(torch.allclose(r_blend, torch.eye(3), atol=1e-6))
+        # Rotation should NOT be identity since we're blending different rotations
+        self.assertFalse(torch.allclose(r_blend, torch.eye(3), atol=1e-2))
 
         # Scale should be 1 (all inputs have scale 1)
         expected_s = torch.tensor([1.0])
@@ -416,19 +499,32 @@ class TestTRS(unittest.TestCase):
 
     def test_blend_custom_weights(self) -> None:
         """Test blending with custom weights."""
-        # Create two TRS transforms
+        # Create two TRS transforms with different rotations
+        quat1 = self._quat_from_axis_angle(
+            torch.tensor([0.0, 0.0, 1.0]), math.pi / 2
+        )  # 90° around Z
+        quat2 = self._quat_from_axis_angle(
+            torch.tensor([1.0, 0.0, 0.0]), math.pi / 3
+        )  # 60° around X
+
+        state1 = torch.cat([torch.tensor([0.0, 0.0, 0.0]), quat1, torch.tensor([1.0])])
+        state2 = torch.cat([torch.tensor([4.0, 0.0, 0.0]), quat2, torch.tensor([1.0])])
+
         trs_list = [
-            pym_trs.from_translation(torch.tensor([0.0, 0.0, 0.0])),
-            pym_trs.from_translation(torch.tensor([4.0, 0.0, 0.0])),
+            pym_trs.from_skeleton_state(state1),
+            pym_trs.from_skeleton_state(state2),
         ]
 
         # Blend with custom weights [0.25, 0.75]
         weights = torch.tensor([0.25, 0.75])
-        t_blend, r_blend, s_blend = pym_trs.blend(trs_list, weights)
+        t_blend, r_blend, _ = pym_trs.blend(trs_list, weights)
 
         # Translation should be weighted average: 0.25*[0,0,0] + 0.75*[4,0,0] = [3,0,0]
         expected_t = torch.tensor([3.0, 0.0, 0.0])
         self.assertTrue(torch.allclose(t_blend, expected_t, atol=1e-6))
+
+        # Rotation should be a weighted blend of the two different rotations
+        self.assertFalse(torch.allclose(r_blend, torch.eye(3), atol=1e-2))
 
     def test_blend_single_transform(self) -> None:
         """Test that blending a single transform returns the transform itself."""
@@ -447,6 +543,40 @@ class TestTRS(unittest.TestCase):
             pym_trs.blend([])
 
         self.assertIn("Cannot blend empty list of transforms", str(context.exception))
+
+    def test_batched_skeleton_state_equivalence(self) -> None:
+        """Test that batched operations produce equivalent results through different paths."""
+        # Create batched skeleton states with different rotations and transformations
+        batch_size = 3
+
+        skel_state1 = self._random_skel_states(sz=(batch_size))
+        skel_state2 = self._random_skel_states(sz=(batch_size))
+        skel_state_final = pym_skel_state.multiply(skel_state1, skel_state2)
+        mat1 = pym_skel_state.to_matrix(skel_state_final)
+
+        trs1 = pym_trs.from_skeleton_state(skel_state1)
+        trs2 = pym_trs.from_skeleton_state(skel_state2)
+        trs_final = pym_trs.multiply(trs1, trs2)
+        mat2 = pym_trs.to_matrix(trs_final)
+
+        self.assertTrue(torch.allclose(mat1, mat2))
+
+    def test_transform_points_skel_state_equivalence(self) -> None:
+        """Test that batched operations produce equivalent results through different paths."""
+        # Create batched skeleton states with different rotations and transformations
+        torch.manual_seed(1002389)
+
+        batch_size = 3
+
+        skel_state = self._random_skel_states(sz=(batch_size))
+        trs = pym_trs.from_skeleton_state(skel_state)
+
+        points = torch.randn(batch_size, 3)
+
+        transformed1 = pym_skel_state.transform_points(skel_state, points)
+        transformed2 = pym_trs.transform_points(trs, points)
+
+        self.assertTrue(torch.allclose(transformed1, transformed2))
 
 
 if __name__ == "__main__":

--- a/pymomentum/trs.py
+++ b/pymomentum/trs.py
@@ -495,3 +495,41 @@ def rotmat_rotate_vector(r: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
     :rtype: torch.Tensor
     """
     return torch.einsum("...ij,...j->...i", r, v)
+
+
+def rotmat_from_euler_xyz(euler: torch.Tensor) -> torch.Tensor:
+    """
+    Create rotation matrices from XYZ Euler angles.
+
+    This function converts XYZ Euler angles to rotation matrices using the
+    ZYX rotation order (also known as Tait-Bryan angles). The rotation is
+    applied as follows: first around the X-axis, then Y-axis, then Z-axis.
+
+    :parameter euler: Euler angles of shape [..., 3] where the last dimension
+                      contains [rx, ry, rz] rotations in radians.
+    :type euler: torch.Tensor
+    :return: Rotation matrices of shape [..., 3, 3].
+    :rtype: torch.Tensor
+    """
+    cos_angles = torch.cos(euler)
+    sin_angles = torch.sin(euler)
+
+    cx, cy, cz = cos_angles.unbind(-1)
+    sx, sy, sz = sin_angles.unbind(-1)
+
+    result = torch.stack(
+        [
+            cy * cz,
+            -cx * sz + sx * sy * cz,
+            sx * sz + cx * sy * cz,
+            cy * sz,
+            cx * cz + sx * sy * sz,
+            -sx * cz + cx * sy * sz,
+            -sy,
+            sx * cy,
+            cx * cy,
+        ],
+        dim=-1,
+    )
+    result_shape = result.shape[:-1] + (3, 3)
+    return result.view(result_shape)


### PR DESCRIPTION
Summary: This is basically D82989411 but for this function.  It turns out to be important for the TRS backend derivatives to be correct.

Reviewed By: jeongseok-meta

Differential Revision: D83222361


