### PR TITLE
pymomentum: new skel_state_backend for pytorch-based FK

### DIFF
--- a/pymomentum/backend/skel_state_backend.py
+++ b/pymomentum/backend/skel_state_backend.py
@@ -1,0 +1,391 @@
+# pyre-strict
+from typing import List, Tuple
+
+import torch as th
+
+from pymomentum import quaternion, skel_state, trs
+from pymomentum.backend.trs_backend import unpose_from_global_joint_state
+
+
+@th.jit.script
+def get_local_momentum_state_from_joint_params(
+    joint_params: th.Tensor,
+    joint_offset: th.Tensor,
+    joint_quat_rotation: th.Tensor,
+) -> th.Tensor:
+    """
+    calculate local momentum joint state from joint parameters.
+
+    Args:
+        joint_params: (B, J, 7), the momentum per-joint params
+        joint_offset: (J, 3) per-joint pre-offset
+        joint_quat_rotation: (J, 4) per-joint pre-rotation
+
+    Returns:
+        local_joint_state: (B, J, 8)
+    """
+    t = joint_offset[None, :] + joint_params[:, :, :3]
+    q = quaternion.multiply(
+        joint_quat_rotation[None],
+        quaternion.euler_xyz_to_quaternion(joint_params[:, :, 3:6]),
+    )
+    s = th.exp2(joint_params[:, :, 6:])
+
+    return th.cat([t, q, s], dim=-1)
+
+
+@th.jit.script
+def fk_from_local_momentum_state_impl(
+    local_joint_state: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+    save_intermediate_results: bool = True,
+    use_double_precision: bool = True,
+) -> Tuple[th.Tensor, List[th.Tensor]]:
+    """
+    same as fk_from_local_state, but for momentum
+
+    TODO: need to re-verify if double precision is needed
+
+    Args:
+        local_joint_state (th.Tensor): (B, J, 8)
+        prefix_mul_indices (List[th.Tensor]): the prefix multiplication indices
+        save_intermediate_results (bool, optional): save intermediate results for backward.
+            Defaults to True.
+
+    Returns:
+        global_joint_state (th.Tensor): (B, J, 8)
+        intermediate_results (List[th.Tensor]): intermediate results for backward
+    """
+    dtype = local_joint_state.dtype
+    intermediate_results: List[th.Tensor] = []
+    if use_double_precision:
+        global_joint_state = local_joint_state.clone().double()
+    else:
+        global_joint_state = local_joint_state.clone()
+    for prefix_mul_index in prefix_mul_indices:
+        source = prefix_mul_index[0]
+        target = prefix_mul_index[1]
+
+        state1 = global_joint_state.index_select(-2, target)
+        state2 = global_joint_state.index_select(-2, source)
+
+        if save_intermediate_results:
+            intermediate_results.append(state2.clone())
+
+        global_joint_state.index_copy_(-2, source, skel_state.multiply(state1, state2))
+
+    return (global_joint_state.to(dtype), intermediate_results)
+
+
+def fk_from_local_momentum_state_no_grad(
+    local_joint_state: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+    save_intermediate_results: bool = True,
+    use_double_precision: bool = True,
+) -> Tuple[th.Tensor, List[th.Tensor]]:
+    """just for compatibility"""
+    with th.no_grad():
+        outputs = fk_from_local_momentum_state_impl(
+            local_joint_state,
+            prefix_mul_indices,
+            save_intermediate_results=save_intermediate_results,
+            use_double_precision=use_double_precision,
+        )
+    return outputs
+
+
+# @th.jit.script
+def fk_from_local_momentum_state_backprop(
+    global_joint_state: th.Tensor,
+    grad_global_joint_state: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+    intermediate_results: List[th.Tensor],
+    use_double_precision: bool = True,
+) -> th.Tensor:
+    """
+    same as fk_from_local_state_backprop, but for momentum
+
+    TODO: need to re-verify if double precision is needed
+
+    Args:
+        global_joint_state (th.Tensor): (B, J, 8)
+        grad_global_joint_state (th.Tensor): (B, J, 8)
+        prefix_mul_indices (List[th.Tensor]): the prefix multiplication indices
+        intermediate_results (List[th.Tensor]): intermediate results from fk forward
+
+    Returns:
+        grad_local_joint_state (th.Tensor): (B, J, 8)
+    """
+    dtype = global_joint_state.dtype
+    if use_double_precision:
+        grad_local_joint_state = grad_global_joint_state.clone().double()
+        global_joint_state = global_joint_state.clone().double()
+    else:
+        grad_local_joint_state = grad_global_joint_state.clone()
+        global_joint_state = global_joint_state.clone()
+
+    for prefix_mul_index, state_source_original in list(
+        zip(prefix_mul_indices, intermediate_results)
+    )[::-1]:
+        source = prefix_mul_index[0]
+        target = prefix_mul_index[1]
+
+        state_target = global_joint_state.index_select(-2, target)
+
+        # forward
+        # This is for checking that the numerical error is in the safe
+        # range, but it's not completely abnormal to see large numerical
+        # error during backpropagation at the beginning of training.
+        # state_source = global_joint_state[:, source]
+        # state_source_expect = sim3_multiplication(
+        #     state_target, state_source_original
+        # )
+        # assert th.allclose(
+        #     state_source, state_source_expect, atol=1e-5, rtol=1e-5
+        # )
+
+        # backward
+        grad_target_accum, grad_source_original = skel_state.multiply_backprop(
+            state1=state_target,
+            state2=state_source_original,
+            grad_state=grad_local_joint_state.index_select(-2, source),
+        )
+
+        # setup the reduced gradients
+        grad_local_joint_state.index_copy_(-2, source, grad_source_original)
+        grad_local_joint_state.index_add_(-2, target, grad_target_accum)
+        # setup the reduced KC
+        global_joint_state.index_copy_(-2, source, state_source_original)
+
+    return grad_local_joint_state.to(dtype)
+
+
+class ForwardKinematicsFromLocalMomentumStateJIT(th.autograd.Function):
+    @staticmethod
+    # pyre-ignore[14]
+    def forward(
+        local_joint_state: th.Tensor,
+        prefix_mul_indices: List[th.Tensor],
+    ) -> Tuple[th.Tensor, List[th.Tensor]]:
+        return fk_from_local_momentum_state_no_grad(
+            local_joint_state,
+            prefix_mul_indices,
+        )
+
+    @staticmethod
+    # pyre-ignore[14]
+    # pyre-ignore[2]
+    def setup_context(ctx, inputs, outputs) -> None:
+        (
+            _,
+            prefix_mul_indices,
+        ) = inputs
+        (
+            global_joint_state,
+            intermediate_results,
+        ) = outputs
+        # need to clone as it's modified in-place
+        ctx.save_for_backward(global_joint_state.clone())
+        ctx.intermediate_results = intermediate_results
+        ctx.prefix_mul_indices = prefix_mul_indices
+
+    @staticmethod
+    # pyre-ignore[14]
+    def backward(
+        # pyre-ignore[2]
+        ctx,
+        grad_global_joint_state: th.Tensor,
+        _0,
+    ) -> Tuple[th.Tensor, None]:
+        (global_joint_state,) = ctx.saved_tensors
+
+        intermediate_results = ctx.intermediate_results
+        prefix_mul_indices = ctx.prefix_mul_indices
+
+        grad_local_state = fk_from_local_momentum_state_backprop(
+            global_joint_state,
+            grad_global_joint_state,
+            prefix_mul_indices,
+            intermediate_results,
+        )
+        return grad_local_state, None
+
+
+def fk_from_local_momentum_state(
+    local_joint_state: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+) -> th.Tensor:
+    """
+    Wrap FK as a function.
+    Args:
+        local_joint_state (th.Tensor): (B, J, 8) local joint state
+        prefix_mul_indices (List[th.Tensor]): the prefix multiplication indices
+    """
+
+    if th.jit.is_tracing() or th.jit.is_scripting():
+        global_joint_state, _ = fk_from_local_momentum_state_impl(
+            local_joint_state, prefix_mul_indices
+        )
+        return global_joint_state
+    else:
+        global_joint_state, _ = ForwardKinematicsFromLocalMomentumStateJIT.apply(
+            local_joint_state,
+            prefix_mul_indices,
+        )
+        return global_joint_state
+
+
+@th.jit.script
+def skinning_from_momentum_state(
+    template: th.Tensor,
+    global_joint_state: th.Tensor,
+    binded_joint_state_inv: th.Tensor,
+    skin_indices_flattened: th.Tensor,
+    skin_weights_flattened: th.Tensor,
+    vert_indices_flattened: th.Tensor,
+) -> th.Tensor:
+    """
+    same as skinning(), but for momentum
+    Args:
+        template (th.Tensor): (B, V, 3)
+        global_joint_state (th.Tensor): (B, J, 8)
+        binded_joint_state (th.Tensor): (B, J, 8)
+        skin_indices_flattened: (N, ) LBS skinning nbr joint indices
+        skin_weights_flattened: (N, ) LBS skinning nbr joint weights
+        vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
+    Returns:
+        skinned (th.Tensor): (B, V, 3)
+    """
+    assert template.shape[-1] == 3
+    while template.ndim < global_joint_state.ndim:
+        template = template.unsqueeze(0)
+
+    template = template.expand(
+        list(global_joint_state.shape[:-2]) + list(template.shape[-2:])
+    )
+
+    joint_state = skel_state.multiply(
+        global_joint_state,
+        binded_joint_state_inv,
+    )
+
+    skinned = th.zeros_like(template)
+    skinned = skinned.index_add(
+        -2,
+        vert_indices_flattened,
+        skel_state.transform_points(
+            th.index_select(joint_state, -2, skin_indices_flattened),
+            th.index_select(template, -2, vert_indices_flattened),
+        )
+        * skin_weights_flattened[None, :, None],
+    )
+    return skinned
+
+
+@th.jit.script
+def skinning_oriented_points_from_momentum_state(
+    means: th.Tensor,
+    quaternions: th.Tensor,
+    global_joint_state: th.Tensor,
+    binded_joint_state_inv: th.Tensor,
+    skin_indices_flattened: th.Tensor,
+    skin_weights_flattened: th.Tensor,
+    vert_indices_flattened: th.Tensor,
+) -> tuple[th.Tensor, th.Tensor]:
+    """
+    same as skinning_from_momentum_state(), but for gaussians
+    for the orientation we use lerp of rotation matrices to match
+    Args:
+        means (th.Tensor): (B, V, 3)
+        quaternions (th.Tensor): (B, V, 4)
+        global_joint_state (th.Tensor): (B, J, 8)
+        binded_joint_state (th.Tensor): (B, J, 8)
+        skin_indices_flattened: (N, ) LBS skinning nbr joint indices
+        skin_weights_flattened: (N, ) LBS skinning nbr joint weights
+        vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
+    Returns:
+        skinned_means (th.Tensor): (B, V, 3)
+        skinned_quaternions (th.Tensor): (B, V, 4)
+    """
+    assert means.shape[-1] == 3
+    assert quaternions.shape[-1] == 4
+    while means.ndim < global_joint_state.ndim:
+        means = means.unsqueeze(0)
+
+    means = means.expand(list(global_joint_state.shape[:-2]) + list(means.shape[-2:]))
+
+    joint_state = skel_state.multiply(
+        global_joint_state,
+        binded_joint_state_inv,
+    )
+
+    sim3_transforms = th.index_select(joint_state, -2, skin_indices_flattened)
+    t, q, s = skel_state.split(sim3_transforms)
+    r = quaternion.to_rotation_matrix(q)
+
+    means_flattened = th.index_select(means, -2, vert_indices_flattened)
+
+    skinned_means = th.zeros_like(means)
+    skinned_means = skinned_means.index_add(
+        -2,
+        vert_indices_flattened,
+        (s * quaternion.rotate_vector(q, means_flattened) + t)
+        * skin_weights_flattened[None, :, None],
+    )
+
+    lerp_rotations = th.zeros(
+        quaternions.shape[:-1] + (3, 3),
+        dtype=quaternions.dtype,
+        device=quaternions.device,
+    )
+    lerp_rotations = lerp_rotations.index_add(
+        -3,
+        vert_indices_flattened,
+        r * skin_weights_flattened[None, :, None, None],
+    )
+    lerp_quaternions = quaternion.from_rotation_matrix(lerp_rotations)
+    lerp_quaternions = quaternion.normalize(lerp_quaternions)
+    skinned_quaternions = quaternion.multiply_assume_normalized(
+        quaternions, lerp_quaternions
+    )
+    return skinned_means, skinned_quaternions
+
+
+def unpose_from_momentum_global_joint_state(
+    verts: th.Tensor,
+    global_joint_state: th.Tensor,
+    binded_joint_state_inv: th.Tensor,
+    skin_indices_flattened: th.Tensor,
+    skin_weights_flattened: th.Tensor,
+    vert_indices_flattened: th.Tensor,
+    with_high_precision: bool = True,
+) -> th.Tensor:
+    """
+    The inverse function of skinning().
+    WARNING: the precision is low...
+
+    Args:
+        verts: [batch_size, num_verts, 3]
+        global_joint_state (th.Tensor): (B, J, 8)
+        binded_joint_state (th.Tensor): (J, 8)
+        skin_indices_flattened: (N, ) LBS skinning nbr joint indices
+        skin_weights_flattened: (N, ) LBS skinning nbr joint weights
+        vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
+        with_high_precision: if True, use high precision solver (LDLT),
+            but requires a cuda device sync
+    """
+    t, r, s = trs.from_skeleton_state(global_joint_state)
+    t0, r0, _ = trs.from_skeleton_state(binded_joint_state_inv)
+
+    return unpose_from_global_joint_state(
+        verts,
+        t,
+        r,
+        s,
+        t0,
+        r0,
+        skin_indices_flattened,
+        skin_weights_flattened,
+        vert_indices_flattened,
+        with_high_precision,
+    )

--- a/pymomentum/backend/trs_backend.py
+++ b/pymomentum/backend/trs_backend.py
@@ -1,0 +1,739 @@
+# pyre-strict
+from typing import List, Tuple
+
+import torch as th
+from pymomentum import trs
+
+
+@th.jit.script
+def fk_from_local_state_impl(
+    local_state_t: th.Tensor,
+    local_state_r: th.Tensor,
+    local_state_s: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+    save_intermediate_results: bool = True,
+    use_double_precision: bool = True,
+) -> Tuple[
+    th.Tensor, th.Tensor, th.Tensor, List[Tuple[th.Tensor, th.Tensor, th.Tensor]]
+]:
+    """
+    just a vanilla forward kinematics with PyTorch, but utilizing prefix multiplication.
+
+    given $y=sRx+t$
+
+    we have FK:
+    sg = sp * sl
+    rg = rp * rl
+    tg = tp + sp * rp * tl
+    where
+    - sp, rp, tp are the parent global state
+    - sl, rl, tl are the local state
+    - sg, rg, tg are the global state
+
+    WARNING: this function is not differentiable.
+    """
+    dtype = local_state_t.dtype
+    with th.no_grad():
+        if use_double_precision:
+            joint_state_t = local_state_t.clone().double()
+            joint_state_r = local_state_r.clone().double()
+            joint_state_s = local_state_s.clone().double()
+        else:
+            joint_state_t = local_state_t.clone()
+            joint_state_r = local_state_r.clone()
+            joint_state_s = local_state_s.clone()
+
+    intermediate_results: List[Tuple[th.Tensor, th.Tensor, th.Tensor]] = []
+
+    for prefix_mul_index in prefix_mul_indices:
+        source = prefix_mul_index[0]
+        target = prefix_mul_index[1]
+
+        s1 = joint_state_s[:, target]
+        r1 = joint_state_r[:, target]
+        t1 = joint_state_t[:, target]
+
+        s2 = joint_state_s[:, source]
+        r2 = joint_state_r[:, source]
+        t2 = joint_state_t[:, source]
+
+        if save_intermediate_results:
+            intermediate_results.append(
+                (
+                    t2.clone(),
+                    r2.clone(),
+                    s2.clone(),
+                )
+            )
+
+        t3, r3, s3 = trs.multiply((t1, r1, s1), (t2, r2, s2))
+
+        joint_state_s[:, source] = s3
+        joint_state_r[:, source] = r3
+        joint_state_t[:, source] = t3
+
+    return (
+        joint_state_t.to(dtype),
+        joint_state_r.to(dtype),
+        joint_state_s.to(dtype),
+        intermediate_results,
+    )
+
+
+@th.jit.script
+def fk_from_local_state_no_grad(
+    local_state_t: th.Tensor,
+    local_state_r: th.Tensor,
+    local_state_s: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+    save_intermediate_results: bool = True,
+    use_double_precision: bool = True,
+) -> Tuple[
+    th.Tensor, th.Tensor, th.Tensor, List[Tuple[th.Tensor, th.Tensor, th.Tensor]]
+]:
+    with th.no_grad():
+        outputs = fk_from_local_state_impl(
+            local_state_t,
+            local_state_r,
+            local_state_s,
+            prefix_mul_indices,
+            save_intermediate_results=save_intermediate_results,
+            use_double_precision=use_double_precision,
+        )
+    return outputs
+
+
+@th.jit.script
+def ik_from_global_state(
+    global_state_t: th.Tensor,
+    global_state_r: th.Tensor,
+    global_state_s: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+    use_double_precision: bool = True,
+) -> Tuple[th.Tensor, th.Tensor, th.Tensor]:
+    dtype = global_state_t.dtype
+
+    if use_double_precision:
+        local_state_t = global_state_t.clone().double()
+        local_state_r = global_state_r.clone().double()
+        local_state_s = global_state_s.clone().double()
+    else:
+        local_state_t = global_state_t.clone()
+        local_state_r = global_state_r.clone()
+        local_state_s = global_state_s.clone()
+
+    # Compose the inverse of the FK transforms, in reverse order.
+    for prefix_mul_index in prefix_mul_indices[::-1]:
+        joint = prefix_mul_index[0]
+        parent = prefix_mul_index[1]
+
+        s1 = local_state_s[:, parent].reciprocal()
+        r1 = trs.rotmat_inverse(local_state_r[:, parent])
+        t1 = local_state_t[:, parent]
+
+        s2 = local_state_s[:, joint]
+        r2 = local_state_r[:, joint]
+        t2 = local_state_t[:, joint]
+
+        local_state_s[:, joint] = s1 * s2
+        local_state_r[:, joint] = trs.rotmat_multiply(r1, r2)
+        local_state_t[:, joint] = trs.rotmat_rotate_vector(r1, (t2 - t1) * s1)
+
+    return (
+        local_state_t.to(dtype),
+        local_state_r.to(dtype),
+        local_state_s.to(dtype),
+    )
+
+
+@th.jit.script
+def fk_from_local_state_backprop(
+    joint_state_t: th.Tensor,
+    joint_state_r: th.Tensor,
+    joint_state_s: th.Tensor,
+    grad_joint_state_t: th.Tensor,
+    grad_joint_state_r: th.Tensor,
+    grad_joint_state_s: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+    intermediate_results: List[Tuple[th.Tensor, th.Tensor, th.Tensor]],
+    use_double_precision: bool = True,
+) -> Tuple[th.Tensor, th.Tensor, th.Tensor]:
+    r"""
+    The backward pass of fk_from_local_state_no_grad.
+
+    during backprop, we have
+    \partial L/\partial tl_i = \sum_j \partial L/\partial tg_j * \partial tg_j/\partial tl_i
+    \partial L/\partial sl_i = \sum_j \partial L/\partial tg_j * \partial tg_j/\partial sl_i + \sum_j \partial L/\partial sg_j * \partial tg_j/\partial sl_i
+    \partial L/\partial rl_i = \sum_j \partial L/\partial tg_j * \partial tg_j/\partial rl_i + \sum_j \partial L/\partial rg_j * \partial tg_j/\partial rl_i
+
+    however, if we naively do this, sum_j is very expensive (and the jacobian is very sparse).
+
+    consider how we do prefix multiplication during forward:
+    assume the chain order is [0, 1, 2, 3]
+
+    forward (source <- target)
+
+    level 0: [1, 3] <- [0, 2]
+    now the chain is [0, 01, 2, 23]
+
+    level 1: [2, 3] <- [1, 1]
+    now the chain is [0, 01, 012, 0123]
+
+    now consider backward, for level 0 we need to cast
+    {
+        g(s1), g(s1s2), g(s1s2s3), g(s1s2s3s4);
+        g(R1), g(R1R2), g(R1R2R3), g(R1R2R3R4);
+        g(t1), g(t1+s1R1t2), g(s1+s1R2t2+s1R1s2R2t3), ...
+    }
+    into
+    {
+        g(s1), g(s1s2), g(s3), g(s3s4);
+        g(R1), g(R1R2), g(R3), g(R3R4);
+        g(t1), g(t1+s1R1t2), g(t3), g(t3+s3R3t4)
+    }
+    which is actually in reverse order of forward levels.
+    """
+    dtype = joint_state_t.dtype
+    if use_double_precision:
+        grad_local_state_t = grad_joint_state_t.clone().double()
+        grad_local_state_r = grad_joint_state_r.clone().double()
+        grad_local_state_s = grad_joint_state_s.clone().double()
+        joint_state_t = joint_state_t.clone().double()
+        joint_state_r = joint_state_r.clone().double()
+        joint_state_s = joint_state_s.clone().double()
+    else:
+        grad_local_state_t = grad_joint_state_t.clone()
+        grad_local_state_r = grad_joint_state_r.clone()
+        grad_local_state_s = grad_joint_state_s.clone()
+        joint_state_t = joint_state_t.clone()
+        joint_state_r = joint_state_r.clone()
+        joint_state_s = joint_state_s.clone()
+
+    # instead of calculating the original s, r and t from global state
+    # we just load them via forward intermediate results
+    for prefix_mul_index, (t, r, s) in list(
+        zip(prefix_mul_indices, intermediate_results)
+    )[::-1]:
+        source = prefix_mul_index[0]
+        target = prefix_mul_index[1]
+
+        grad_s2 = grad_local_state_s[:, source]
+        grad_r2 = grad_local_state_r[:, source]
+        grad_t2 = grad_local_state_t[:, source]
+
+        # the corresponding global state
+        sg1 = joint_state_s[:, target]
+        rg1 = joint_state_r[:, target]
+
+        # TODO: maybe we should better formulate this function
+        # similar to pymomentum_state.py
+
+        # backward accumulation on the reduced child state (source)
+        # (translate torch.einsum as explicit summations to improve speed)
+        grad_s = sg1 * grad_s2
+        # original: grad_t = sg1 * th.einsum("bjyx,bjy->bjx", rg1, grad_t2)
+        grad_t = sg1 * (rg1 * grad_t2[..., None]).sum(dim=2)
+        # original: grad_r = th.einsum("bjyx,bjyz->bjxz", rg1, grad_r2)
+        grad_r = (rg1[:, :, :, :, None] * grad_r2[:, :, :, None, :]).sum(dim=2)
+
+        # backward accumulation on the ancestor state (target)
+        # original: grad_s1_accum = th.einsum("bjxy,bjy,bjx->bj", rg1, t, grad_t2)[
+        #     :, :, None
+        # ]
+        grad_s1_accum = (
+            (rg1 * t[:, :, None, :] * grad_t2[:, :, :, None])
+            .sum(dim=3)
+            .sum(dim=2, keepdim=True)
+        )
+        grad_s1_accum = grad_s1_accum + s * grad_s2
+
+        # original: grad_r1_accum = th.einsum("bjxy,bjzy->bjxz", grad_r2, r)
+        # original: grad_r1_accum = grad_r1_accum + th.einsum(
+        #     "bj,bjx,bjy->bjxy",
+        #     sg1[:, :, 0],
+        #     grad_t2,
+        #     t,
+        # )
+        grad_r1_accum = (grad_r2[:, :, :, None, :] * r[:, :, None, :, :]).sum(dim=4)
+        grad_r1_accum = (
+            grad_r1_accum + (sg1 * grad_t2)[:, :, :, None] * t[:, :, None, :]
+        )
+
+        grad_t1_accum = grad_t2
+
+        # setup the reduced gradients
+        grad_local_state_t[:, source] = grad_t
+        grad_local_state_r[:, source] = grad_r
+        grad_local_state_s[:, source] = grad_s
+
+        grad_local_state_t.index_add_(1, target, grad_t1_accum)
+        grad_local_state_r.index_add_(1, target, grad_r1_accum)
+        grad_local_state_s.index_add_(1, target, grad_s1_accum)
+
+        # setup the reduced KC
+        joint_state_t[:, source] = t
+        joint_state_r[:, source] = r
+        joint_state_s[:, source] = s
+
+    return (
+        grad_local_state_t.to(dtype),
+        grad_local_state_r.to(dtype),
+        grad_local_state_s.to(dtype),
+    )
+
+
+class ForwardKinematicsFromLocalTransformationJIT(th.autograd.Function):
+    @staticmethod
+    # pyre-ignore[14]
+    def forward(
+        local_state_t: th.Tensor,
+        local_state_r: th.Tensor,
+        local_state_s: th.Tensor,
+        prefix_mul_indices: List[th.Tensor],
+    ) -> Tuple[
+        th.Tensor, th.Tensor, th.Tensor, List[Tuple[th.Tensor, th.Tensor, th.Tensor]]
+    ]:
+        return fk_from_local_state_no_grad(
+            local_state_t,
+            local_state_r,
+            local_state_s,
+            prefix_mul_indices,
+        )
+
+    @staticmethod
+    # pyre-ignore[14]
+    # pyre-ignore[2]
+    def setup_context(ctx, inputs, outputs) -> None:
+        (
+            _,
+            _,
+            _,
+            prefix_mul_indices,
+        ) = inputs
+        (
+            joint_state_t,
+            joint_state_r,
+            joint_state_s,
+            intermediate_results,
+        ) = outputs
+        # need to clone as it's modified in-place
+        ctx.save_for_backward(
+            joint_state_t.clone(),
+            joint_state_r.clone(),
+            joint_state_s.clone(),
+        )
+        ctx.intermediate_results = intermediate_results
+        ctx.prefix_mul_indices = prefix_mul_indices
+
+    @staticmethod
+    # pyre-ignore[14]
+    def backward(
+        # pyre-ignore[2]
+        ctx,
+        grad_joint_state_t: th.Tensor,
+        grad_joint_state_r: th.Tensor,
+        grad_joint_state_s: th.Tensor,
+        _0,
+    ) -> Tuple[th.Tensor, th.Tensor, th.Tensor, None]:
+        (
+            joint_state_t,
+            joint_state_r,
+            joint_state_s,
+        ) = ctx.saved_tensors
+
+        intermediate_results = ctx.intermediate_results
+        prefix_mul_indices = ctx.prefix_mul_indices
+
+        (
+            grad_local_state_t,
+            grad_local_state_r,
+            grad_local_state_s,
+        ) = fk_from_local_state_backprop(
+            joint_state_t,
+            joint_state_r,
+            joint_state_s,
+            grad_joint_state_t,
+            grad_joint_state_r,
+            grad_joint_state_s,
+            prefix_mul_indices,
+            intermediate_results,
+        )
+        return (grad_local_state_t, grad_local_state_r, grad_local_state_s, None)
+
+
+def fk_from_local_state(
+    local_state_t: th.Tensor,
+    local_state_r: th.Tensor,
+    local_state_s: th.Tensor,
+    prefix_mul_indices: List[th.Tensor],
+) -> Tuple[th.Tensor, th.Tensor, th.Tensor]:
+    """
+    wrap FK as a function.
+    """
+    if th.jit.is_tracing() or th.jit.is_scripting():
+        (
+            joint_state_t,
+            joint_state_r,
+            joint_state_s,
+            _,
+        ) = fk_from_local_state_impl(
+            local_state_t,
+            local_state_r,
+            local_state_s,
+            prefix_mul_indices,
+        )
+    else:
+        (
+            joint_state_t,
+            joint_state_r,
+            joint_state_s,
+            _,
+        ) = ForwardKinematicsFromLocalTransformationJIT.apply(
+            local_state_t,
+            local_state_r,
+            local_state_s,
+            prefix_mul_indices,
+        )
+    return (
+        joint_state_t,
+        joint_state_r,
+        joint_state_s,
+    )
+
+
+def fk_from_local_state_forward_only(
+    local_state_t: th.Tensor,
+    local_state_r: th.Tensor,
+    local_state_s: th.Tensor,
+    prefix_mul_indices: list[th.Tensor],
+) -> tuple[th.Tensor, th.Tensor, th.Tensor]:
+    """
+    wrap FK as a function.
+    """
+    (
+        joint_state_t,
+        joint_state_r,
+        joint_state_s,
+        _,
+    ) = ForwardKinematicsFromLocalTransformationJIT.forward(
+        local_state_t,
+        local_state_r,
+        local_state_s,
+        prefix_mul_indices,
+    )
+    return (
+        joint_state_t,
+        joint_state_r,
+        joint_state_s,
+    )
+
+
+@th.jit.script
+def skinning(
+    template: th.Tensor,
+    t: th.Tensor,
+    r: th.Tensor,
+    s: th.Tensor,
+    t0: th.Tensor,
+    r0: th.Tensor,
+    skin_indices_flattened: th.Tensor,
+    skin_weights_flattened: th.Tensor,
+    vert_indices_flattened: th.Tensor,
+) -> th.Tensor:
+    r"""
+    LBS skinning formula as is in lbs_pytorch:
+    https://ghe.oculus-rep.com/ydong142857/lbs_pytorch
+
+    TODO: we might want to change skinning to double precision
+    with current float32 formulation the numerical error is bigger than 1e-3 level
+    (but smaller than 1e-2 level)
+
+    Basically,
+    y_i = \sum_j w_ij (s_j * r_j * (r0_j * x_i + t0_j) + t_j)
+    where \sum_j w_ij = 1, \forall i
+
+    Args:
+        template: (B, V, 3) LBS template
+        t: (B, J, 3) Translation of the joints
+        r: (B, J, 3, 3) Rotation of the joints
+        s: (B, J, 1) Scale of the joints
+        t0: (J, 3) Translation of inverse bind pose
+        r0: (J, 3, 3) Rotation of inverse bind pose
+        (for our setting, s0 == 1)
+        skin_indices_flattened: (N, ) LBS skinning nbr joint indices
+        skin_weights_flattened: (N, ) LBS skinning nbr joint weights
+        vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
+
+    Returns:
+        skinned: (B, V, 3) Skinned mesh
+    """
+    batch_size = t.shape[0]
+    if template.shape[0] != batch_size:
+        template = template[None, ...].expand(batch_size, -1, -1)
+
+    sr = s[:, :, :, None] * r
+    A = trs.rotmat_multiply(sr, r0[None])
+    b = trs.rotmat_rotate_vector(sr, t0[None]) + t
+
+    skinned = th.zeros_like(template)
+    skinned = skinned.index_add(
+        1,
+        vert_indices_flattened,
+        (
+            trs.rotmat_rotate_vector(
+                th.index_select(A, 1, skin_indices_flattened),
+                th.index_select(template, 1, vert_indices_flattened),
+            )
+            + th.index_select(b, 1, skin_indices_flattened)
+        )
+        * skin_weights_flattened[None, :, None],
+    )
+    return skinned
+
+
+@th.jit.script
+def multi_topology_skinning(
+    template: th.Tensor,
+    t: th.Tensor,
+    r: th.Tensor,
+    s: th.Tensor,
+    t0: th.Tensor,
+    r0: th.Tensor,
+    skin_indices_flattened: th.Tensor,
+    skin_weights_flattened: th.Tensor,
+    vert_indices_flattened: th.Tensor,
+) -> th.Tensor:
+    r"""
+    LBS skinning formula as is in lbs_pytorch:
+    https://ghe.oculus-rep.com/ydong142857/lbs_pytorch
+
+    The difference here is that we assume that the flattened indices are for multiple
+    topologies. So vert_indices_flattened needs to flattened with the batch dimension.
+
+    TODO: we might want to change skinning to double precision
+    with current float32 formulation the numerical error is bigger than 1e-3 level
+    (but smaller than 1e-2 level)
+
+    Basically,
+    y_i = \sum_j w_ij (s_j * r_j * (r0_j * x_i + t0_j) + t_j)
+    where \sum_j w_ij = 1, \forall i
+
+    Args:
+        template: (B, V, 3) LBS template
+        t: (B, J, 3) Translation of the joints
+        r: (B, J, 3, 3) Rotation of the joints
+        s: (B, J, 1) Scale of the joints
+        t0: (J, 3) Translation of inverse bind pose
+        r0: (J, 3, 3) Rotation of inverse bind pose
+        (for our setting, s0 == 1)
+        skin_indices_flattened: (N, ) LBS skinning nbr joint indices
+        skin_weights_flattened: (N, ) LBS skinning nbr joint weights
+        vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
+
+    Returns:
+        skinned: (B, V, 3) Skinned mesh
+    """
+    batch_size = t.shape[0]
+    if template.shape[0] != batch_size:
+        template = template[None, ...].expand(batch_size, -1, -1)
+
+    sr = s[:, :, :, None] * r
+    A = trs.rotmat_multiply(sr, r0[None])
+    b = trs.rotmat_rotate_vector(sr, t0[None]) + t
+
+    # If multi_topology is True, then index on the 0th dimension of A and b
+    # because we assume that the skin indices are flattened to index into different
+    # vertex indices in each sample of the batch.
+
+    skinning_A = th.index_select(
+        A.view(A.shape[0] * A.shape[1], A.shape[2], A.shape[3]),
+        0,
+        skin_indices_flattened,
+    )
+
+    skinning_b = th.index_select(
+        b.view(b.shape[0] * b.shape[1], b.shape[2]), 0, skin_indices_flattened
+    )
+
+    skinning_verts = th.index_select(
+        template.view(template.shape[0] * template.shape[1], template.shape[2]),
+        0,
+        vert_indices_flattened,
+    )
+
+    skinned = th.zeros_like(template).view(
+        template.shape[0] * template.shape[1], template.shape[2]
+    )
+    skinned = skinned.index_add(
+        0,
+        vert_indices_flattened,
+        (trs.rotmat_rotate_vector(skinning_A, skinning_verts) + skinning_b)
+        * skin_weights_flattened[..., None],
+    )
+    return skinned.view(template.shape[0], template.shape[1], template.shape[2])
+
+
+def unpose_from_global_joint_state(
+    verts: th.Tensor,
+    t: th.Tensor,
+    r: th.Tensor,
+    s: th.Tensor,
+    t0: th.Tensor,
+    r0: th.Tensor,
+    skin_indices_flattened: th.Tensor,
+    skin_weights_flattened: th.Tensor,
+    vert_indices_flattened: th.Tensor,
+    with_high_precision: bool = True,
+) -> th.Tensor:
+    """
+    The inverse function of skinning().
+    WARNING: the precision is low...
+
+    Args:
+        verts: [batch_size, num_verts, 3]
+        t: (B, J, 3) Translation of the joints
+        r: (B, J, 3, 3) Rotation of the joints
+        s: (B, J, 1) Scale of the joints
+        t0: (J, 3) Translation of inverse bind pose
+        r0: (J, 3, 3) Rotation of inverse bind pose
+        skin_indices_flattened: (N, ) LBS skinning nbr joint indices
+        skin_weights_flattened: (N, ) LBS skinning nbr joint weights
+        vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
+        with_high_precision: if True, use high precision solver (LDLT),
+            but requires a cuda device sync
+    """
+    dtype = verts.dtype
+    device = verts.device
+
+    sr = s[:, :, :, None] * r
+    A = trs.rotmat_multiply(sr, r0[None])
+    b = trs.rotmat_rotate_vector(sr, t0[None]) + t
+
+    fused_A = th.zeros(verts.shape + (3,), dtype=dtype, device=device)
+    fused_b = th.zeros(verts.shape, dtype=dtype, device=device)
+    fused_A = fused_A.index_add_(
+        1,
+        vert_indices_flattened,
+        th.index_select(
+            A,
+            1,
+            skin_indices_flattened,
+        )
+        * skin_weights_flattened[None, :, None, None],
+    )
+    fused_b = fused_b.index_add_(
+        1,
+        vert_indices_flattened,
+        th.index_select(
+            b,
+            1,
+            skin_indices_flattened,
+        )
+        * skin_weights_flattened[None, :, None],
+    )
+
+    if with_high_precision:
+        # th.linalg.solve is not aware of the condition number
+        # let's use LDLT decomposition
+        ATA = th.einsum("bvyx,bvyz->bvxz", fused_A, fused_A)
+        ATb = th.einsum("bvyx,bvy->bvx", fused_A, verts - fused_b)
+
+        # ldl_factor_ex is very slow on GPU
+        LD, pivots, _ = th.linalg.ldl_factor_ex(ATA.cpu())
+        unposed_mesh = th.linalg.ldl_solve(LD, pivots, ATb[..., None].cpu())[..., 0]
+
+        unposed_mesh = unposed_mesh.to(ATA.device)
+    else:
+        unposed_mesh = th.linalg.solve(fused_A, verts - fused_b)
+
+    return unposed_mesh
+
+
+@th.jit.script
+def get_local_state_from_joint_params(
+    joint_params: th.Tensor,
+    joint_offset: th.Tensor,
+    joint_rotation: th.Tensor,
+    joint_parents: th.Tensor | None = None,
+    allow_inverse_kinematic_chain: bool = False,
+) -> Tuple[th.Tensor, th.Tensor, th.Tensor]:
+    """
+    calculate local joint state from joint parameters.
+
+    Args:
+        joint_params: [batch_size, num_joints, 7] or [batch_size, num_joints * 7]
+        joint_offset: [num_joints, 3]
+        joint_rotation: [num_joints, 3, 3]
+        allow_inverse_kinematic_chain: if set to True, this hints that the kinematic
+            chain might be reversed (e.g. from wrist to root). This leads to a few
+            changes in assumption. One of the major difference is that the root joint
+            always has identity [0, I, 1] transformation.
+
+    Returns:
+        local_state_t: [batch_size, num_joints, 3]
+        local_state_r: [batch_size, num_joints, 3, 3]
+        local_state_s: [batch_size, num_joints, 1]
+    """
+    if len(joint_params.shape) == 2:
+        # reshape joint_params as (batch_size, num_joints, 7)
+        joint_params = joint_params.view(joint_params.shape[0], -1, 7)
+
+    # the vanilla conversion
+    local_state_t = joint_params[:, :, :3] + joint_offset[None, :]
+    local_state_r = trs.rotmat_multiply(
+        joint_rotation[None], trs.rotmat_from_euler_xyz(joint_params[:, :, 3:6])
+    )
+    local_state_s = th.exp2(joint_params[:, :, 6:])
+
+    if allow_inverse_kinematic_chain:
+        assert joint_parents is not None
+        assert len(joint_parents.shape) == 1
+        device = joint_parents.device
+        root_joint = th.where(joint_parents == -1)[0]
+        inversed_joints = th.where(
+            joint_parents
+            > th.arange(0, len(joint_parents), dtype=th.long, device=device)
+        )[0]
+        inversed_joint_parents = joint_parents[inversed_joints]
+
+        # create a new node so the autograd does not fail
+        (
+            _local_state_t,
+            _local_state_r,
+            _local_state_s,
+        ) = (
+            local_state_t.clone(),
+            local_state_r.clone(),
+            local_state_s.clone(),
+        )
+
+        # for the inverse joints
+        # the order needs to be inversed
+        (
+            _local_state_t[:, inversed_joints],
+            _local_state_r[:, inversed_joints],
+            _local_state_s[:, inversed_joints],
+        ) = trs.inverse(
+            (
+                local_state_t[:, inversed_joint_parents],
+                local_state_r[:, inversed_joint_parents],
+                local_state_s[:, inversed_joint_parents],
+            )
+        )
+
+        # set new root joint to identity
+        _local_state_t[:, root_joint] = 0
+        _local_state_r[:, root_joint] = th.eye(3, device=device)[None]
+        _local_state_s[:, root_joint] = 1
+
+        (
+            local_state_t,
+            local_state_r,
+            local_state_s,
+        ) = (
+            _local_state_t,
+            _local_state_r,
+            _local_state_s,
+        )
+
+    return local_state_t, local_state_r, local_state_s

--- a/pymomentum/backend/utils.py
+++ b/pymomentum/backend/utils.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Backend Utility Functions for PyMomentum
+=========================================
+
+This module provides utility functions that are specific to backend operations
+and were previously available in real_lbs_pytorch but are now implemented
+within pymomentum for the backend porting effort.
+"""
+
+# pyre-strict
+
+from typing import List, Tuple
+
+import numpy as np
+
+import torch
+
+
+def calc_fk_prefix_multiplication_indices(
+    joint_parents: torch.Tensor,
+) -> List[torch.Tensor]:
+    """
+    Calculate prefix multiplication indices for forward kinematics.
+
+    This function computes the indices needed for efficient prefix multiplication
+    during forward kinematics computation. The algorithm builds kinematic chains
+    for each joint and determines the multiplication order for parallel processing.
+
+    :parameter joint_parents: Parent joint index for each joint. For root joint, its parent is -1.
+    :type joint_parents: torch.Tensor
+    :return: List of prefix multiplication indices per level. For each level,
+             index[0] is the source and index[1] is the target indices.
+    :rtype: List[torch.Tensor]
+    """
+    device = joint_parents.device
+    nr_joints = len(joint_parents)
+    # get the kinematic chain per joint
+    kc_joints = []
+    for idx_joint in range(nr_joints):
+        kc = [idx_joint]
+        while joint_parents[idx_joint] >= 0:
+            idx_joint = int(joint_parents[idx_joint])
+            kc.append(idx_joint)
+        kc_joints.append(kc[::-1])
+
+    # get the multiplication target per joint per level
+    prefix_mul_indices = []
+    while True:
+        level = len(prefix_mul_indices)
+        source = []
+        target = []
+        for kc in kc_joints:
+            idx = len(kc) - 1
+            current_bit = (idx >> level) & 1
+            if current_bit:
+                source.append(kc[idx])
+                target.append(kc[((idx >> level) << level) - 1])
+        if source:
+            prefix_mul_indices.append(
+                torch.from_numpy(np.array([source, target])).long().to(device)
+            )
+        else:
+            break
+
+    return prefix_mul_indices
+
+
+def flatten_skinning_weights_and_indices(
+    skin_weights: torch.Tensor, skin_indices: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Decompress LBS skinning weights and indices into flattened arrays.
+
+    This function takes the typical (V, 8) sparse representation of skinning weights
+    and indices and converts them into flattened arrays by removing zero weights,
+    making them suitable for efficient skinning computation.
+
+    :parameter skin_weights: Skinning weights tensor of shape (V, 8).
+    :type skin_weights: torch.Tensor
+    :parameter skin_indices: Skinning joint indices tensor of shape (V, 8).
+    :type skin_indices: torch.Tensor
+    :return: Tuple of (skin_indices_flattened, skin_weights_flattened, vert_indices_flattened).
+    :rtype: Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    """
+    nr_vertices, nr_nbrs = skin_indices.shape
+    device = skin_indices.device
+
+    mask = skin_weights.flatten() > 1e-5
+
+    skin_indices_flattened = skin_indices.clone().flatten()[mask]
+    skin_weights_flattened = skin_weights.clone().flatten()[mask]
+    vert_indices_flattened = (
+        torch.arange(nr_vertices, dtype=torch.long, device=device)[:, None]
+        .repeat(1, nr_nbrs)
+        .clone()
+        .flatten()[mask]
+    )
+
+    return skin_indices_flattened, skin_weights_flattened, vert_indices_flattened

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -141,6 +141,8 @@ trs_sources = [
 
 backend_sources = [
     "backend/__init__.py",
+    "backend/trs_backend.py",
+    "backend/utils.py",
 ]
 
 marker_tracking_public_headers = [

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -142,6 +142,7 @@ trs_sources = [
 backend_sources = [
     "backend/__init__.py",
     "backend/trs_backend.py",
+    "backend/skel_state_backend.py",
     "backend/utils.py",
 ]
 


### PR DESCRIPTION
Summary: This is a backend for doing forward kinematics and skinning with pure pytorch operations.  This is just the raw implementation, actually using it will come in follow-up diffs.

Reviewed By: hzsydy, jeongseok-meta

Differential Revision: D83222360
