### PR TITLE
Convert maxThreads parameter from size_t to uint32_t in character solver classes

### DIFF
--- a/momentum/character_solver/collision_error_function_stateless.cpp
+++ b/momentum/character_solver/collision_error_function_stateless.cpp
@@ -21,7 +21,7 @@ CollisionErrorFunctionStatelessT<T>::CollisionErrorFunctionStatelessT(
     const Skeleton& skel,
     const ParameterTransform& pt,
     const CollisionGeometry& cg,
-    size_t /*unused*/)
+    uint32_t /*unused*/)
     : SkeletonErrorFunctionT<T>(skel, pt), collisionGeometry(cg) {
   updateCollisionPairs();
 }
@@ -29,7 +29,7 @@ CollisionErrorFunctionStatelessT<T>::CollisionErrorFunctionStatelessT(
 template <typename T>
 CollisionErrorFunctionStatelessT<T>::CollisionErrorFunctionStatelessT(
     const Character& character,
-    size_t /*maxThreads*/)
+    uint32_t /*maxThreads*/)
     : CollisionErrorFunctionStatelessT(
           character.skeleton,
           character.parameterTransform,

--- a/momentum/character_solver/collision_error_function_stateless.h
+++ b/momentum/character_solver/collision_error_function_stateless.h
@@ -29,9 +29,9 @@ class CollisionErrorFunctionStatelessT : public SkeletonErrorFunctionT<T> {
       const Skeleton& skel,
       const ParameterTransform& pt,
       const CollisionGeometry& cg,
-      size_t maxThreads = 1);
+      uint32_t maxThreads = 1);
 
-  explicit CollisionErrorFunctionStatelessT(const Character& character, size_t maxThreads = 1);
+  explicit CollisionErrorFunctionStatelessT(const Character& character, uint32_t maxThreads = 1);
 
   [[nodiscard]] double getError(const ModelParametersT<T>& params, const SkeletonStateT<T>& state)
       final;

--- a/momentum/character_solver/simd_normal_error_function.cpp
+++ b/momentum/character_solver/simd_normal_error_function.cpp
@@ -107,12 +107,12 @@ void SimdNormalConstraints::clearConstraints() {
 SimdNormalErrorFunction::SimdNormalErrorFunction(
     const Skeleton& skel,
     const ParameterTransform& pt,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SkeletonErrorFunction(skel, pt), maxThreads_(maxThreads) {
   constraints_ = nullptr;
 }
 
-SimdNormalErrorFunction::SimdNormalErrorFunction(const Character& character, size_t maxThreads)
+SimdNormalErrorFunction::SimdNormalErrorFunction(const Character& character, uint32_t maxThreads)
     : SimdNormalErrorFunction(character.skeleton, character.parameterTransform, maxThreads) {}
 
 double SimdNormalErrorFunction::getError(

--- a/momentum/character_solver/simd_normal_error_function.h
+++ b/momentum/character_solver/simd_normal_error_function.h
@@ -77,7 +77,7 @@ class SimdNormalErrorFunction : public SkeletonErrorFunction {
   explicit SimdNormalErrorFunction(
       const Skeleton& skel,
       const ParameterTransform& pt,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   /// @param maxThreads An optional parameter that specifies the maximum number of threads to be
   /// used with dispenso::parallel_for. If this parameter is set to zero, the function will run in
@@ -85,7 +85,7 @@ class SimdNormalErrorFunction : public SkeletonErrorFunction {
   /// maximum allowable size of a uint32_t, which is also the default for dispenso.
   explicit SimdNormalErrorFunction(
       const Character& character,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   [[nodiscard]] double getError(const ModelParameters& params, const SkeletonState& state) final;
 
@@ -116,7 +116,7 @@ class SimdNormalErrorFunction : public SkeletonErrorFunction {
   // constraints to use
   const SimdNormalConstraints* constraints_;
 
-  size_t maxThreads_;
+  uint32_t maxThreads_;
 };
 
 #ifdef MOMENTUM_ENABLE_AVX
@@ -129,11 +129,11 @@ class SimdNormalErrorFunctionAVX : public SimdNormalErrorFunction {
   explicit SimdNormalErrorFunctionAVX(
       const Skeleton& skel,
       const ParameterTransform& pt,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max())
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max())
       : SimdNormalErrorFunction(skel, pt, maxThreads) {}
   explicit SimdNormalErrorFunctionAVX(
       const Character& character,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max())
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max())
       : SimdNormalErrorFunction(character, maxThreads) {}
 
   double getJacobian(

--- a/momentum/character_solver/simd_plane_error_function.cpp
+++ b/momentum/character_solver/simd_plane_error_function.cpp
@@ -94,12 +94,12 @@ void SimdPlaneConstraints::clearConstraints() {
 SimdPlaneErrorFunction::SimdPlaneErrorFunction(
     const Skeleton& skel,
     const ParameterTransform& pt,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SkeletonErrorFunction(skel, pt), maxThreads_(maxThreads) {
   constraints_ = nullptr;
 }
 
-SimdPlaneErrorFunction::SimdPlaneErrorFunction(const Character& character, size_t maxThreads)
+SimdPlaneErrorFunction::SimdPlaneErrorFunction(const Character& character, uint32_t maxThreads)
     : SimdPlaneErrorFunction(character.skeleton, character.parameterTransform, maxThreads) {
   // Do nothing
 }
@@ -465,12 +465,14 @@ inline double __vectorcall sum8(const __m256 x) {
 SimdPlaneErrorFunctionAVX::SimdPlaneErrorFunctionAVX(
     const Skeleton& skel,
     const ParameterTransform& pt,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SimdPlaneErrorFunction(skel, pt, maxThreads) {
   // Do nothing
 }
 
-SimdPlaneErrorFunctionAVX::SimdPlaneErrorFunctionAVX(const Character& character, size_t maxThreads)
+SimdPlaneErrorFunctionAVX::SimdPlaneErrorFunctionAVX(
+    const Character& character,
+    uint32_t maxThreads)
     : SimdPlaneErrorFunction(character, maxThreads) {
   // Do nothing
 }

--- a/momentum/character_solver/simd_plane_error_function.h
+++ b/momentum/character_solver/simd_plane_error_function.h
@@ -76,7 +76,7 @@ class SimdPlaneErrorFunction : public SkeletonErrorFunction {
   explicit SimdPlaneErrorFunction(
       const Skeleton& skel,
       const ParameterTransform& pt,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   /// @param maxThreads An optional parameter that specifies the maximum number of threads to be
   /// used with dispenso::parallel_for. If this parameter is set to zero, the function will run in
@@ -84,7 +84,7 @@ class SimdPlaneErrorFunction : public SkeletonErrorFunction {
   /// maximum allowable size of a uint32_t, which is also the default for dispenso.
   explicit SimdPlaneErrorFunction(
       const Character& character,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   [[nodiscard]] double getError(const ModelParameters& params, const SkeletonState& state) override;
 
@@ -113,7 +113,7 @@ class SimdPlaneErrorFunction : public SkeletonErrorFunction {
   // constraints to use
   const SimdPlaneConstraints* constraints_;
 
-  size_t maxThreads_;
+  uint32_t maxThreads_;
 };
 
 #ifdef MOMENTUM_ENABLE_AVX
@@ -126,11 +126,11 @@ class SimdPlaneErrorFunctionAVX : public SimdPlaneErrorFunction {
   explicit SimdPlaneErrorFunctionAVX(
       const Skeleton& skel,
       const ParameterTransform& pt,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   explicit SimdPlaneErrorFunctionAVX(
       const Character& character,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   [[nodiscard]] double getError(const ModelParameters& params, const SkeletonState& state) final;
 

--- a/momentum/character_solver/simd_position_error_function.cpp
+++ b/momentum/character_solver/simd_position_error_function.cpp
@@ -91,12 +91,14 @@ void SimdPositionConstraints::clearConstraints() {
 SimdPositionErrorFunction::SimdPositionErrorFunction(
     const Skeleton& skel,
     const ParameterTransform& pt,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SkeletonErrorFunction(skel, pt), maxThreads_(maxThreads) {
   constraints_ = nullptr;
 }
 
-SimdPositionErrorFunction::SimdPositionErrorFunction(const Character& character, size_t maxThreads)
+SimdPositionErrorFunction::SimdPositionErrorFunction(
+    const Character& character,
+    uint32_t maxThreads)
     : SimdPositionErrorFunction(character.skeleton, character.parameterTransform, maxThreads) {
   // Do nothing
 }
@@ -514,14 +516,14 @@ inline double __vectorcall sum8(const __m256 x) {
 SimdPositionErrorFunctionAVX::SimdPositionErrorFunctionAVX(
     const Skeleton& skel,
     const ParameterTransform& pt,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SimdPositionErrorFunction(skel, pt, maxThreads) {
   // Do nothing
 }
 
 SimdPositionErrorFunctionAVX::SimdPositionErrorFunctionAVX(
     const Character& character,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SimdPositionErrorFunction(character, maxThreads) {
   // Do nothing
 }

--- a/momentum/character_solver/simd_position_error_function.h
+++ b/momentum/character_solver/simd_position_error_function.h
@@ -77,7 +77,7 @@ class SimdPositionErrorFunction : public SkeletonErrorFunction {
   explicit SimdPositionErrorFunction(
       const Skeleton& skel,
       const ParameterTransform& pt,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   /// @param maxThreads An optional parameter that specifies the maximum number of threads to be
   /// used with dispenso::parallel_for. If this parameter is set to zero, the function will run in
@@ -85,7 +85,7 @@ class SimdPositionErrorFunction : public SkeletonErrorFunction {
   /// maximum allowable size of a uint32_t, which is also the default for dispenso.
   explicit SimdPositionErrorFunction(
       const Character& character,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   [[nodiscard]] double getError(const ModelParameters& params, const SkeletonState& state) override;
 
@@ -114,7 +114,7 @@ class SimdPositionErrorFunction : public SkeletonErrorFunction {
   // constraints to use
   const SimdPositionConstraints* constraints_;
 
-  size_t maxThreads_;
+  uint32_t maxThreads_;
 };
 
 #ifdef MOMENTUM_ENABLE_AVX
@@ -127,11 +127,11 @@ class SimdPositionErrorFunctionAVX : public SimdPositionErrorFunction {
   explicit SimdPositionErrorFunctionAVX(
       const Skeleton& skel,
       const ParameterTransform& pt,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   explicit SimdPositionErrorFunctionAVX(
       const Character& character,
-      size_t maxThreads = std::numeric_limits<uint32_t>::max());
+      uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   double getError(const ModelParameters& params, const SkeletonState& state) final;
 

--- a/momentum/character_solver/vertex_error_function.cpp
+++ b/momentum/character_solver/vertex_error_function.cpp
@@ -36,7 +36,7 @@ template <typename T>
 VertexErrorFunctionT<T>::VertexErrorFunctionT(
     const Character& character_in,
     VertexConstraintType type,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SkeletonErrorFunctionT<T>(character_in.skeleton, character_in.parameterTransform),
       character_(character_in),
       constraintType_(type),

--- a/momentum/character_solver/vertex_error_function.h
+++ b/momentum/character_solver/vertex_error_function.h
@@ -47,7 +47,7 @@ class VertexErrorFunctionT : public SkeletonErrorFunctionT<T> {
   explicit VertexErrorFunctionT(
       const Character& character,
       VertexConstraintType type = VertexConstraintType::Position,
-      size_t maxThreads = 0);
+      uint32_t maxThreads = 0);
   virtual ~VertexErrorFunctionT() override;
 
   [[nodiscard]] double getError(
@@ -146,7 +146,7 @@ class VertexErrorFunctionT : public SkeletonErrorFunctionT<T> {
 
   const VertexConstraintType constraintType_;
 
-  size_t maxThreads_;
+  uint32_t maxThreads_;
 
   void updateMeshes(const ModelParametersT<T>& modelParameters, const SkeletonStateT<T>& state);
 };

--- a/momentum/character_solver/vertex_projection_error_function.cpp
+++ b/momentum/character_solver/vertex_projection_error_function.cpp
@@ -30,7 +30,7 @@ namespace momentum {
 template <typename T>
 VertexProjectionErrorFunctionT<T>::VertexProjectionErrorFunctionT(
     const Character& character_in,
-    size_t maxThreads)
+    uint32_t maxThreads)
     : SkeletonErrorFunctionT<T>(character_in.skeleton, character_in.parameterTransform),
       character_(character_in),
       maxThreads_(maxThreads) {

--- a/momentum/character_solver/vertex_projection_error_function.h
+++ b/momentum/character_solver/vertex_projection_error_function.h
@@ -33,7 +33,7 @@ struct VertexProjectionConstraintT {
 template <typename T>
 class VertexProjectionErrorFunctionT : public SkeletonErrorFunctionT<T> {
  public:
-  explicit VertexProjectionErrorFunctionT(const Character& character, size_t maxThreads = 0);
+  explicit VertexProjectionErrorFunctionT(const Character& character, uint32_t maxThreads = 0);
   ~VertexProjectionErrorFunctionT() override;
 
   [[nodiscard]] double getError(
@@ -110,7 +110,7 @@ class VertexProjectionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   std::unique_ptr<MeshT<T>>
       posedMesh_; // The posed mesh after the skeleton transforms have been applied.
 
-  size_t maxThreads_;
+  uint32_t maxThreads_;
 
   T _nearClip = 1.0f;
 };


### PR DESCRIPTION
Summary: This change standardizes the maxThreads parameter type across multiple character solver error function classes from `size_t` to `uint32_t` for improved consistency and portability.

Differential Revision: D83483161


