### PR TITLE
store and load character name in gltf

### DIFF
--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -171,6 +171,7 @@ void compareCollisionGeometry(
 }
 
 void compareChars(const Character& refChar, const Character& character, const bool withMesh) {
+  ASSERT_EQ(refChar.name, character.name);
   const auto& refJoints = refChar.skeleton.joints;
   const auto& joints = character.skeleton.joints;
   ASSERT_EQ(refJoints.size(), joints.size());


### PR DESCRIPTION
Summary: Currently the character name field is lost when storing a gltf file. This will actually make sure it can be stored and loaded to enable identifying characters by the name string rather than by the filename.

Reviewed By: jeongseok-meta

Differential Revision: D83853609


