### PR TITLE
use character name when loading marker file

### DIFF
--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -171,6 +171,7 @@ void compareCollisionGeometry(
 }
 
 void compareChars(const Character& refChar, const Character& character, const bool withMesh) {
+  ASSERT_EQ(refChar.name, character.name);
   const auto& refJoints = refChar.skeleton.joints;
   const auto& joints = character.skeleton.joints;
   ASSERT_EQ(refJoints.size(), joints.size());


### PR DESCRIPTION
Summary:
When loading a c3d file for marker tracking, first try to find an actor with the name of the character instead of just taking the first appearing actor.

This will allow processing multiple c3d files with multiple actors without splitting them apart in other tools before if we have an actor calibration for each of them.

Reviewed By: jeongseok-meta

Differential Revision: D83858851


