### PR TITLE
Fix GitHub builds

### DIFF
--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -134,6 +134,18 @@ solver2_sources = [
     "solver2/solver2_utility.cpp",
 ]
 
+quaternion_sources = [
+    "quaternion.py",
+]
+
+skel_state_sources = [
+    "skel_state.py",
+]
+
+trs_sources = [
+    "trs.py",
+]
+
 marker_tracking_public_headers = [
 ]
 
@@ -149,7 +161,6 @@ marker_tracking_extensions_sources = [
 ]
 
 gpu_character_sources = [
-    "torch/__init__.py",
     "torch/character.py",
     "torch/parameter_limits.py",
     "torch/utility.py",

--- a/pymomentum/test/__init__.py
+++ b/pymomentum/test/__init__.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the


### PR DESCRIPTION
## Summary

* Removed `pymomentum/torch/__init__.py` and its CMake reference to prevent the local `torch/` directory from shadowing the PyTorch package, resolving import conflicts where `import torch` would incorrectly resolve to the local directory instead of PyTorch.
* Added missing build variables for quaternion, skel_state, trs
* Added missing `test/__init__.py`

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

```
pixi run test
pixi run test_py
```
