### PR TITLE
Move to arvr (28/n: renderer)

### DIFF
--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -169,3 +169,16 @@ gpu_character_sources = [
 character_manager_sources = [
     "character_manager/character_manager_pybind.cpp",
 ]
+
+renderer_public_headers = [
+    "renderer/mesh_processing.h",
+    "renderer/momentum_render.h",
+    "renderer/software_rasterizer.h",
+]
+
+renderer_sources = [
+    "renderer/mesh_processing.cpp",
+    "renderer/momentum_render.cpp",
+    "renderer/renderer_pybind.cpp",
+    "renderer/software_rasterizer.cpp",
+]

--- a/pymomentum/renderer/mesh_processing.cpp
+++ b/pymomentum/renderer/mesh_processing.cpp
@@ -1,0 +1,99 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "pymomentum/renderer/mesh_processing.h"
+
+#include <momentum/rasterizer/geometry.h>
+
+#include <stdexcept>
+
+namespace pymomentum {
+
+std::tuple<RowMatrixf, RowMatrixf, RowMatrixi, RowMatrixf, RowMatrixi> subdivideMesh(
+    RowMatrixf vertices,
+    RowMatrixf normals,
+    RowMatrixi triangles,
+    std::optional<RowMatrixf> textureCoords,
+    std::optional<RowMatrixi> textureTriangles,
+    int levels,
+    float max_edge_length) {
+  if (levels <= 0) {
+    throw std::runtime_error("Expected levels >= 1");
+  }
+
+  if (levels > 5) {
+    throw std::runtime_error(
+        "Too many levels, exiting to avoid excessive computation/memory usage");
+  }
+
+  for (int i = 0; i < levels; ++i) {
+    if (vertices.cols() != 3) {
+      throw std::runtime_error("Expected n x 3 vertices");
+    }
+
+    if (normals.cols() != 3) {
+      throw std::runtime_error("Expected n x 3 normals");
+    }
+
+    if (vertices.rows() != normals.rows()) {
+      throw std::runtime_error("number of vertices does not match number of normals");
+    }
+
+    if (triangles.cols() != 3) {
+      throw std::runtime_error("Expected n x 3 triangles");
+    }
+
+    if (!textureTriangles.has_value()) {
+      textureTriangles = triangles;
+    }
+
+    if (textureTriangles->cols() != 3) {
+      throw std::runtime_error("Expected n x 3 texture_triangles");
+    }
+
+    if (!textureCoords.has_value()) {
+      textureCoords = RowMatrixf::Zero(vertices.rows(), 2);
+    }
+
+    if (textureCoords->cols() != 2) {
+      throw std::runtime_error("Expected n x 2 texture_coords");
+    }
+
+    if (triangles.minCoeff() < 0 || triangles.maxCoeff() >= vertices.rows()) {
+      throw std::runtime_error(
+          "Invalid triangle index; expected all triangle indices to be within [0, nVerts)");
+    }
+
+    if (textureTriangles->minCoeff() < 0 || textureTriangles->maxCoeff() >= textureCoords->rows()) {
+      throw std::runtime_error(
+          "Invalid texture_triangles index; expected all texture_triangles indices to be within [0, nTextureCoords)");
+    }
+
+    const auto nVertOrig = vertices.rows();
+    const auto nTrianglesOrig = triangles.rows();
+
+    if (triangles.maxCoeff() >= nVertOrig || triangles.minCoeff() < 0) {
+      throw std::runtime_error("Invalid triangle");
+    }
+
+    float maxEdgeLengthCur = 0;
+    for (int iTri = 0; iTri < nTrianglesOrig; ++iTri) {
+      for (int j = 0; j < 3; ++j) {
+        const int vi = triangles(iTri, j);
+        const int vj = triangles(iTri, (j + 1) % 3);
+        maxEdgeLengthCur = std::max(maxEdgeLengthCur, (vertices.row(vi) - vertices.row(vj)).norm());
+      }
+    }
+
+    if (max_edge_length != 0 && maxEdgeLengthCur < max_edge_length) {
+      break;
+    }
+
+    std::tie(vertices, normals, triangles, textureCoords, textureTriangles) =
+        momentum::rasterizer::subdivideMeshNoSmoothing(
+            vertices, normals, triangles, *textureCoords, *textureTriangles, max_edge_length);
+  }
+
+  return {vertices, normals, triangles, *textureCoords, *textureTriangles};
+}
+
+} // namespace pymomentum

--- a/pymomentum/renderer/mesh_processing.h
+++ b/pymomentum/renderer/mesh_processing.h
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <Eigen/Core>
+
+#include <optional>
+
+namespace pymomentum {
+
+using RowMatrixf = Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+using RowMatrixi = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+std::tuple<RowMatrixf, RowMatrixf, RowMatrixi, RowMatrixf, RowMatrixi> subdivideMesh(
+    RowMatrixf vertices,
+    RowMatrixf normals,
+    RowMatrixi triangles,
+    std::optional<RowMatrixf> textureCoords,
+    std::optional<RowMatrixi> textureTriangles,
+    int levels,
+    float max_edge_length);
+
+} // namespace pymomentum

--- a/pymomentum/renderer/momentum_render.cpp
+++ b/pymomentum/renderer/momentum_render.cpp
@@ -1,0 +1,377 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "pymomentum/renderer/momentum_render.h"
+
+#include "pymomentum/tensor_momentum/tensor_parameter_transform.h"
+#include "pymomentum/tensor_utility/tensor_utility.h"
+
+#include <momentum/character/character.h>
+#include <momentum/character/linear_skinning.h>
+#include <momentum/character/parameter_transform.h>
+#include <momentum/character/skeleton_state.h>
+#include <momentum/character/skin_weights.h>
+#include <momentum/math/mesh.h>
+
+#include <momentum/rasterizer/camera.h>
+
+#include <dispenso/parallel_for.h> // @manual
+#include <Eigen/Core>
+
+#include <string.h>
+
+namespace pymomentum {
+
+// Build a camera to look at an object:
+// cameraUpWorld: world-space camera up-vector.
+// cameraLookAtWorld: world-space direction where camera looks at.
+// aimCenterWorld: world-space point the camera looks at
+// distanceToAimCenter: distance of the camera to the location of the aim,
+//   aimCenterWorld.
+// Note: if cameraUpWorld is not orthogonal to cameraLookAtWorld, the function
+// will fix it, as long as cameraUpWorld is not parallel to cameraLookAtWorld.
+momentum::rasterizer::Camera makeOutsideInCamera(
+    const Eigen::Vector3f& cameraUpWorld,
+    const Eigen::Vector3f& cameraLookAtWorld,
+    const Eigen::Vector3f& aimCenterWorld,
+    const float distanceToAimCenter,
+    const int imageHeight_pixels,
+    const int imageWidth_pixels,
+    const float focal_length_mm = 50) {
+  // In openCV eye coords,
+  //    z points _into_ the frame
+  //    x points to frame right
+  //    y points _down_
+  Eigen::Matrix3f eyeToWorldRotation = Eigen::Matrix3f::Identity();
+  // To ensure the matrix is a rotation, we need to orthogonalize the two input
+  // vectors:
+  const Eigen::Vector3f sideDirection = cameraLookAtWorld.cross(cameraUpWorld);
+  const Eigen::Vector3f cameraUpWorldOrtho = sideDirection.cross(cameraLookAtWorld);
+  eyeToWorldRotation.col(1) = -cameraUpWorldOrtho.normalized();
+  eyeToWorldRotation.col(2) = cameraLookAtWorld.normalized();
+  eyeToWorldRotation.col(0) = eyeToWorldRotation.col(1).cross(eyeToWorldRotation.col(2));
+  // make sure I got the ordering right
+  assert(eyeToWorldRotation.determinant() > 0);
+
+  Eigen::Affine3f worldToEyeXF = Eigen::Affine3f::Identity();
+
+  // To go from world to eye, we
+  //   1. translate the object to the origin.
+  //   2. rotate the object according to the inverse of eye-to-world rotation.
+  //   3. translate the object back (in eye space) along negative z.
+  worldToEyeXF.translate(distanceToAimCenter * Eigen::Vector3f::UnitZ());
+  worldToEyeXF.rotate(eyeToWorldRotation.transpose());
+  worldToEyeXF.translate(-aimCenterWorld);
+
+  // "normal" lens is a 50mm lens on a 35mm camera body:
+  const float film_width_mm = 36.0f;
+  const float focal_length_pixels = (focal_length_mm / film_width_mm) * (double)imageWidth_pixels;
+
+  std::cout << "focal length pixels: " << focal_length_pixels << std::endl;
+
+  // Create a PinholeIntrinsicsModel
+  auto intrinsicsModel = std::make_shared<momentum::rasterizer::PinholeIntrinsicsModel>(
+      imageWidth_pixels, imageHeight_pixels, focal_length_pixels, focal_length_pixels);
+
+  std::cout << "fx: " << intrinsicsModel->fx() << std::endl;
+
+  // Create and return the camera with the intrinsics model and transform
+  return momentum::rasterizer::Camera(intrinsicsModel, worldToEyeXF);
+}
+
+momentum::rasterizer::Camera frameMesh(
+    const momentum::rasterizer::Camera& cam_in,
+    const momentum::Character& character,
+    gsl::span<const momentum::SkeletonState> skelStates) {
+  const float min_z = 5;
+  std::vector<Eigen::Vector3f> positions;
+  for (const auto& s : skelStates) {
+    if (character.mesh && character.skinWeights) {
+      for (const auto& p : momentum::applySSD(
+               character.inverseBindPose, *character.skinWeights, character.mesh->vertices, s)) {
+        positions.push_back(p);
+      }
+    } else {
+      for (const auto& js : s.jointState) {
+        positions.push_back(js.translation());
+      }
+    }
+  }
+
+  return cam_in.framePoints(positions, min_z, 0.05f);
+}
+
+momentum::rasterizer::Camera makeOutsideInCameraForBody(
+    const momentum::Character& character,
+    gsl::span<const momentum::SkeletonState> skelStates,
+    const int imageHeight_pixels,
+    const int imageWidth_pixels,
+    const float focalLength_mm,
+    bool horizontal,
+    float cameraAngle) {
+  // Center on the mid-spine (to get a good view of the upper body) rather than
+  // the root (which is down in the pelvis).
+  // For hand models, center on the wrist.
+  std::vector<const char*> possibleRoots = {
+      "b_spine3", "c_spine3", "spineUpper_joint", "b_l_wrist", "b_r_wrist", "l_wrist", "r_wrist"};
+
+  const auto spineJoint = [&]() -> size_t {
+    for (const auto& r : possibleRoots) {
+      auto id = character.skeleton.getJointIdByName(r);
+      if (id != momentum::kInvalidIndex) {
+        return id;
+      }
+    }
+
+    std::ostringstream oss;
+    oss << "Unable to locate appropriate root joint.  Options are {";
+    for (const auto& r : possibleRoots) {
+      oss << r << ", ";
+    }
+    oss << "}";
+    throw std::runtime_error(oss.str());
+  }();
+
+  std::vector<momentum::TransformT<double>> spineLocalToWorldTransforms;
+  for (size_t i = 0; i < skelStates.size(); ++i) {
+    const auto& jointState = skelStates[i].jointState.at(spineJoint);
+    spineLocalToWorldTransforms.emplace_back(
+        jointState.translation().cast<double>(), jointState.rotation().cast<double>());
+  }
+  const std::vector<double> weights(skelStates.size(), 1.0 / skelStates.size());
+  const auto blendedTransform = momentum::blendTransforms(
+      gsl::span<const momentum::TransformT<double>>(spineLocalToWorldTransforms),
+      gsl::span<const double>(weights));
+  const Eigen::Affine3f spineLocalToWorldXF = blendedTransform.toAffine3().cast<float>();
+
+  const Eigen::Vector3f body_center_world_cm = spineLocalToWorldXF.translation();
+  const float cameraDistanceToBody_cm = 2.5f * 100; // 2.5 meters away.
+
+  // in spine-local coords,
+  //   x points up
+  //   y points forward
+  //   z points to the body's left
+
+  Eigen::Vector3f body_forward_world = spineLocalToWorldXF.linear() * Eigen::Vector3f::UnitY();
+  Eigen::Vector3f camera_forward_world = -body_forward_world;
+
+  // If `horizontal`, we place the camera horizontally, with camera up vector
+  // facing upward. We assume the world Y axis points upward.
+  // Otherwise, the camera is placed perpendicular to the spine direction.
+  Eigen::Vector3f camera_up_world;
+
+  if (horizontal) {
+    camera_up_world = Eigen::Vector3f::UnitY();
+    camera_forward_world[1] = 0.0;
+    camera_forward_world = camera_forward_world.normalized();
+    if (camera_forward_world.norm() < 1e-5) {
+      // The horizontal camera placement is degenerate. Revert back to the
+      // original placement.
+      camera_forward_world = -body_forward_world;
+      camera_up_world = spineLocalToWorldXF.linear() * Eigen::Vector3f::UnitX();
+      camera_up_world = camera_up_world.normalized();
+    }
+  } else {
+    camera_up_world = spineLocalToWorldXF.linear() * Eigen::Vector3f::UnitX();
+    camera_up_world = camera_up_world.normalized();
+  }
+
+  if (cameraAngle != 0.0) {
+    // Rotate camera_forward_world around camera_up_world by `cameraAngle` (rad
+    // unit)
+    camera_forward_world = Eigen::AngleAxisf(cameraAngle, camera_up_world) * camera_forward_world;
+  }
+
+  auto result = makeOutsideInCamera(
+      camera_up_world,
+      camera_forward_world,
+      body_center_world_cm,
+      cameraDistanceToBody_cm,
+      imageHeight_pixels,
+      imageWidth_pixels,
+      focalLength_mm);
+
+  return frameMesh(result, character, skelStates);
+}
+
+std::vector<momentum::rasterizer::Camera> buildCamerasForBody(
+    const momentum::Character& character,
+    at::Tensor jointParameters,
+    int imageHeight,
+    int imageWidth,
+    float focalLength_mm,
+    bool horizontal,
+    float cameraAngle) {
+  jointParameters = flattenJointParameters(character, jointParameters);
+
+  // If the user passes in a tensor of dimension [n x nJointParams] we assume
+  // the n refers to the batch dimension, and add the nFrames dimension of 1
+  // so it becomes [batchSize x 1 x nJointParams].
+  // If the tensor is [nJointParams], we will add the nFrames dimension of 1
+  // so it becomes [1 x nJointParams].
+  if (jointParameters.ndimension() < 3) {
+    jointParameters = jointParameters.unsqueeze(-2);
+  }
+
+  const int nFramesBinding = -1;
+
+  TensorChecker checker("buildCamerasForBody");
+  jointParameters = checker.validateAndFixTensor(
+      jointParameters,
+      "jointParameters",
+      {nFramesBinding, (int)character.parameterTransform.numJointParameters()},
+      {"nFrames", "nJointParams"},
+      at::kFloat,
+      true,
+      false);
+
+  const auto nBatch = checker.getBatchSize();
+  std::vector<momentum::rasterizer::Camera> result(nBatch);
+
+  for (int64_t iBatch = 0; iBatch < nBatch; ++iBatch) {
+    at::Tensor sequence_cur = jointParameters.select(0, iBatch);
+
+    const auto nFrames = sequence_cur.size(0);
+    std::vector<momentum::SkeletonState> skelStates;
+    skelStates.reserve(nFrames);
+    for (int64_t iFrame = 0; iFrame < nFrames; ++iFrame) {
+      at::Tensor jointParameters_cur = sequence_cur.select(0, iFrame);
+      skelStates.emplace_back(toEigenMap<float>(jointParameters_cur), character.skeleton);
+    }
+
+    result[iBatch] = makeOutsideInCameraForBody(
+        character, skelStates, imageHeight, imageWidth, focalLength_mm, horizontal, cameraAngle);
+  } // end for iBatch
+
+  return result;
+}
+
+template <typename T2, typename T1>
+std::vector<Eigen::Vector3<T2>> castVector(const std::vector<Eigen::Vector3<T1>>& vec) {
+  std::vector<Eigen::Vector3<T2>> result;
+  result.reserve(vec.size());
+  for (const auto& v : vec) {
+    result.push_back(v.template cast<T2>());
+  }
+  return result;
+}
+
+Eigen::Matrix<int, Eigen::Dynamic, 3, Eigen::RowMajor> triangulate(
+    const Eigen::VectorXi& faceIndices,
+    const Eigen::VectorXi& faceOffsets) {
+  std::vector<int32_t> triangleIndices;
+  const size_t numPolygons = faceOffsets.size() - 1;
+  for (size_t iFace = 0; iFace < numPolygons; ++iFace) {
+    const auto faceBegin = faceOffsets(iFace);
+    const auto faceEnd = faceOffsets(iFace + 1);
+    const auto nv = faceEnd - faceBegin;
+    if (nv < 3) {
+      throw std::runtime_error(
+          (fmt::format("Invalid face with {} indices; expected at least 3.", nv)));
+    }
+    for (size_t j = 1; j < (nv - 1); ++j) {
+      triangleIndices.push_back(faceIndices(faceBegin));
+      triangleIndices.push_back(faceIndices(faceBegin + j));
+      triangleIndices.push_back(faceIndices(faceBegin + j + 1));
+    }
+  }
+
+  const size_t numTris = triangleIndices.size() / 3;
+  Eigen::Matrix<int, Eigen::Dynamic, 3, Eigen::RowMajor> result(numTris, 3);
+  for (size_t iTri = 0; iTri < numTris; iTri++) {
+    result(iTri, 0) = triangleIndices[iTri * 3 + 0];
+    result(iTri, 1) = triangleIndices[iTri * 3 + 1];
+    result(iTri, 2) = triangleIndices[iTri * 3 + 2];
+  }
+  return result;
+}
+
+std::vector<momentum::rasterizer::Camera>
+buildCamerasForHand(at::Tensor wristTransformation, int imageHeight, int imageWidth) {
+  TensorChecker checker("buildCamerasForHand");
+  wristTransformation = checker.validateAndFixTensor(
+      wristTransformation,
+      "wristTransformation",
+      {4, 4},
+      {"nTransformMatrixRows", "nTransformMatrixCols"},
+      at::kFloat,
+      true,
+      false);
+
+  const auto nBatch = checker.getBatchSize();
+  std::vector<momentum::rasterizer::Camera> result(nBatch);
+  momentum::SkeletonState skelState;
+
+  for (int64_t iBatch = 0; iBatch < nBatch; ++iBatch) {
+    // in spine-local coords,
+    //   x points up
+    //   y points forward
+    //   z points to the hand's left
+    Eigen::Affine3f wristLocalToWorldXF = Eigen::Affine3f::Identity();
+    const Eigen::Vector3f hand_up_world = wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitY();
+    const Eigen::Vector3f hand_forward_world =
+        -1.0 * wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitZ();
+
+    at::Tensor wristtranslation_mm =
+        wristTransformation.select(0, iBatch).select(1, iBatch).slice(0, 0, 3).contiguous();
+    const Eigen::Vector3f hand_center_world_cm = toEigenMap<float>(wristtranslation_mm) * 0.1;
+
+    const float cameraDistanceToHand_cm = 0.5f * 100; // 0.5 meters away.
+    const Eigen::Vector3f& camera_up_world = hand_up_world;
+    const Eigen::Vector3f camera_forward_world = -hand_forward_world;
+
+    result[iBatch] = makeOutsideInCamera(
+        camera_up_world,
+        camera_forward_world,
+        hand_center_world_cm,
+        cameraDistanceToHand_cm,
+        imageHeight,
+        imageWidth);
+  } // end for iBatch
+
+  return result;
+}
+
+std::vector<momentum::rasterizer::Camera>
+buildCamerasForHandSurface(at::Tensor wristTransformation, int imageHeight, int imageWidth) {
+  TensorChecker checker("buildCamerasForHand");
+  wristTransformation = checker.validateAndFixTensor(
+      wristTransformation,
+      "wristTransformation",
+      {4, 4},
+      {"nTransformMatrixRows", "nTransformMatrixCols"},
+      at::kFloat,
+      true,
+      false);
+
+  const auto nBatch = checker.getBatchSize();
+  std::vector<momentum::rasterizer::Camera> result(nBatch);
+  momentum::SkeletonState skelState;
+
+  for (int64_t iBatch = 0; iBatch < nBatch; ++iBatch) {
+    // in spine-local coords,
+    //   x points up
+    //   y points forward
+    //   z points to the hand's left
+    Eigen::Affine3f wristLocalToWorldXF = Eigen::Affine3f::Identity();
+    const Eigen::Vector3f hand_up_world = wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitY();
+    const Eigen::Vector3f hand_forward_world =
+        -1.0 * wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitZ();
+
+    const Eigen::Vector3f hand_center_world_cm = wristLocalToWorldXF.translation();
+    const float cameraDistanceToHand_cm = 0.5f * 100; // 0.5 meters away.
+    const Eigen::Vector3f& camera_up_world = hand_up_world;
+    const Eigen::Vector3f camera_forward_world = -hand_forward_world;
+
+    result[iBatch] = makeOutsideInCamera(
+        camera_up_world,
+        camera_forward_world,
+        hand_center_world_cm,
+        cameraDistanceToHand_cm,
+        imageHeight,
+        imageWidth);
+  } // end for iBatch
+
+  return result;
+}
+
+} // namespace pymomentum

--- a/pymomentum/renderer/momentum_render.h
+++ b/pymomentum/renderer/momentum_render.h
@@ -1,0 +1,47 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <momentum/character/character.h>
+#include <momentum/rasterizer/camera.h>
+
+#include <ATen/ATen.h>
+
+#include <memory>
+#include <vector>
+
+namespace pymomentum {
+
+// Returned camera is in cm unit.
+std::vector<momentum::rasterizer::Camera> buildCamerasForBodyJoints(
+    at::Tensor jointLocalToWorldTransforms,
+    int spineJointIndexToOrientCamera,
+    int imageHeight,
+    int imageWidth);
+
+// Build a vector of cameras that roughly face the body (default: facing the
+// front of the body). If horizontal is true, the cameras are placed
+// horizontally, assuming the Y axis is the world up direction. Returned camera
+// is in cm unit.
+// cameraAngle: control from what angle the camera looks at the body. Default:
+// 0, looking at the front. Pi/2: looking at the body left side.
+std::vector<momentum::rasterizer::Camera> buildCamerasForBody(
+    const momentum::Character& character,
+    at::Tensor jointParameters,
+    int imageHeight,
+    int imageWidth,
+    float focalLength_mm,
+    bool horizontal,
+    float cameraAngle = 0.0f);
+
+Eigen::Matrix<int, Eigen::Dynamic, 3, Eigen::RowMajor> triangulate(
+    const Eigen::VectorXi& faceIndices,
+    const Eigen::VectorXi& faceOffsets);
+
+std::vector<momentum::rasterizer::Camera>
+buildCamerasForHand(at::Tensor wristTransformation, int imageHeight, int imageWidth);
+
+std::vector<momentum::rasterizer::Camera>
+buildCamerasForHandSurface(at::Tensor wristTransformation, int imageHeight, int imageWidth);
+
+} // namespace pymomentum

--- a/pymomentum/renderer/renderer_pybind.cpp
+++ b/pymomentum/renderer/renderer_pybind.cpp
@@ -1,0 +1,1411 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <pymomentum/renderer/mesh_processing.h>
+#include <pymomentum/renderer/momentum_render.h>
+#include <pymomentum/renderer/software_rasterizer.h>
+#include <pymomentum/tensor_momentum/tensor_parameter_transform.h>
+#include <pymomentum/tensor_momentum/tensor_skeleton_state.h>
+
+#include <momentum/character/character.h>
+#include <momentum/character/skeleton_state.h>
+#include <momentum/rasterizer/camera.h>
+#include <momentum/rasterizer/rasterizer.h>
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <torch/csrc/utils/pybind.h>
+#include <torch/python.h>
+#include <Eigen/Core>
+
+#include <optional>
+
+namespace py = pybind11;
+namespace mm = momentum;
+
+using namespace pymomentum;
+
+PYBIND11_MODULE(renderer, m) {
+  // TODO more explanation
+  m.attr("__name__") = "pymomentum.renderer";
+  m.doc() = "Functions for rendering momentum models.";
+
+  pybind11::module_::import("torch"); // @dep=//caffe2:torch
+  pybind11::module_::import(
+      "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry
+
+  // Bind IntrinsicsModel and its derived classes
+  py::class_<
+      momentum::rasterizer::IntrinsicsModel,
+      std::shared_ptr<momentum::rasterizer::IntrinsicsModel>>(
+      m, "IntrinsicsModel", "Base class for camera intrinsics models")
+      .def_property_readonly(
+          "image_width",
+          &momentum::rasterizer::IntrinsicsModel::imageWidth,
+          "Width of the image in pixels")
+      .def_property_readonly(
+          "image_height",
+          &momentum::rasterizer::IntrinsicsModel::imageHeight,
+          "Height of the image in pixels")
+      .def_property_readonly(
+          "fx", &momentum::rasterizer::IntrinsicsModel::fx, "Focal length in x direction (pixels)")
+      .def_property_readonly(
+          "fy", &momentum::rasterizer::IntrinsicsModel::fy, "Focal length in y direction (pixels)")
+      .def(
+          "__repr__",
+          [](const momentum::rasterizer::IntrinsicsModel& self) {
+            return fmt::format(
+                "IntrinsicsModel(image_size=({}, {}), focal_length=({:.2f}, {:.2f}))",
+                self.imageWidth(),
+                self.imageHeight(),
+                self.fx(),
+                self.fy());
+          })
+      .def(
+          "project",
+          [](const momentum::rasterizer::IntrinsicsModel& intrinsics,
+             const py::array_t<float>& points) -> py::array_t<float> {
+            if (points.ndim() != 2 || points.shape(1) != 3) {
+              throw std::runtime_error("Expected a 2D array of shape (nPoints, 3)");
+            }
+
+            py::array_t<float> result(std::vector<ssize_t>{points.shape(0), 3});
+            auto res_acc = result.mutable_unchecked<2>();
+            auto pts_acc = points.unchecked<2>();
+
+            for (size_t i = 0; i < points.shape(0); i += momentum::rasterizer::kSimdPacketSize) {
+              momentum::rasterizer::FloatP px, py, pz;
+              auto nPtsCur = std::min(momentum::rasterizer::kSimdPacketSize, points.shape(0) - i);
+              for (int k = 0; k < nPtsCur; ++k) {
+                px[k] = pts_acc(i + k, 0);
+                py[k] = pts_acc(i + k, 1);
+                pz[k] = pts_acc(i + k, 2);
+              }
+
+              const auto [res, valid] =
+                  intrinsics.project(momentum::rasterizer::Vector3fP(px, py, pz));
+
+              for (int k = 0; k < nPtsCur; ++k) {
+                res_acc(i + k, 0) = res.x()[k];
+                res_acc(i + k, 1) = res.y()[k];
+                res_acc(i + k, 2) = res.z()[k];
+              }
+            }
+            return result;
+          },
+          R"(Project 3D points in camera space to 2D image coordinates.
+
+:param points: (N x 3) array of 3D points in camera coordinate space to project.
+:return: (N x 3) array of projected points where columns are [x, y, depth] in image coordinates.)",
+          py::arg("points"))
+      .def(
+          "upsample",
+          &momentum::rasterizer::IntrinsicsModel::upsample,
+          R"(Create a new intrinsics model upsampled by the given factor.
+
+:param factor: Upsampling factor (e.g., 2.0 doubles the resolution).
+:return: A new IntrinsicsModel instance with upsampled parameters.)",
+          py::arg("factor"))
+      .def(
+          "downsample",
+          &momentum::rasterizer::IntrinsicsModel::downsample,
+          R"(Create a new intrinsics model downsampled by the given factor.
+
+:param factor: Downsampling factor (e.g., 2.0 halves the resolution).
+:return: A new IntrinsicsModel instance with downsampled parameters.)",
+          py::arg("factor"))
+      .def(
+          "crop",
+          &momentum::rasterizer::IntrinsicsModel::crop,
+          R"(Create a new intrinsics model cropped to a sub-region of the image.
+
+:param top: Top offset in pixels.
+:param left: Left offset in pixels.
+:param width: New width in pixels after cropping.
+:param height: New height in pixels after cropping.
+:return: A new IntrinsicsModel instance with cropped parameters.)",
+          py::arg("top"),
+          py::arg("left"),
+          py::arg("width"),
+          py::arg("height"))
+      .def(
+          "resize",
+          &momentum::rasterizer::IntrinsicsModel::resize,
+          R"(Create a new intrinsics model resized to new image dimensions.
+
+:param image_width: New image width in pixels.
+:param image_height: New image height in pixels.
+:return: A new IntrinsicsModel instance with resized parameters.)",
+          py::arg("image_width"),
+          py::arg("image_height"));
+
+  py::class_<momentum::rasterizer::OpenCVDistortionParameters>(
+      m, "OpenCVDistortionParameters", "OpenCV distortion parameters")
+      .def(py::init<>(), "Initialize with default parameters (no distortion)")
+      .def_readwrite(
+          "k1",
+          &momentum::rasterizer::OpenCVDistortionParameters::k1,
+          "Radial distortion coefficient k1")
+      .def_readwrite(
+          "k2",
+          &momentum::rasterizer::OpenCVDistortionParameters::k2,
+          "Radial distortion coefficient k2")
+      .def_readwrite(
+          "k3",
+          &momentum::rasterizer::OpenCVDistortionParameters::k3,
+          "Radial distortion coefficient k3")
+      .def_readwrite(
+          "k4",
+          &momentum::rasterizer::OpenCVDistortionParameters::k4,
+          "Radial distortion coefficient k4")
+      .def_readwrite(
+          "k5",
+          &momentum::rasterizer::OpenCVDistortionParameters::k5,
+          "Radial distortion coefficient k5")
+      .def_readwrite(
+          "k6",
+          &momentum::rasterizer::OpenCVDistortionParameters::k6,
+          "Radial distortion coefficient k6")
+      .def_readwrite(
+          "p1",
+          &momentum::rasterizer::OpenCVDistortionParameters::p1,
+          "Tangential distortion coefficient p1")
+      .def_readwrite(
+          "p2",
+          &momentum::rasterizer::OpenCVDistortionParameters::p2,
+          "Tangential distortion coefficient p2")
+      .def_readwrite(
+          "p3",
+          &momentum::rasterizer::OpenCVDistortionParameters::p3,
+          "Tangential distortion coefficient p3")
+      .def_readwrite(
+          "p4",
+          &momentum::rasterizer::OpenCVDistortionParameters::p4,
+          "Tangential distortion coefficient p4")
+      .def("__repr__", [](const momentum::rasterizer::OpenCVDistortionParameters& self) {
+        return fmt::format(
+            "OpenCVDistortionParameters(k1={:.4f}, k2={:.4f}, k3={:.4f}, k4={:.4f}, k5={:.4f}, k6={:.4f}, p1={:.4f}, p2={:.4f}, p3={:.4f}, p4={:.4f})",
+            self.k1,
+            self.k2,
+            self.k3,
+            self.k4,
+            self.k5,
+            self.k6,
+            self.p1,
+            self.p2,
+            self.p3,
+            self.p4);
+      });
+
+  py::class_<
+      momentum::rasterizer::PinholeIntrinsicsModel,
+      momentum::rasterizer::IntrinsicsModel,
+      std::shared_ptr<momentum::rasterizer::PinholeIntrinsicsModel>>(
+      m, "PinholeIntrinsicsModel", "Pinhole camera intrinsics model without distortion")
+      .def(
+          py::init([](int32_t imageWidth,
+                      int32_t imageHeight,
+                      std::optional<float> fx,
+                      std::optional<float> fy,
+                      std::optional<float> cx,
+                      std::optional<float> cy) {
+            // Default focal length calculation: "normal" lens is a 50mm lens on
+            // a 35mm camera body
+            const float focal_length_cm = 5.0f;
+            const float film_width_cm = 3.6f;
+            const float default_focal_length_pixels =
+                (focal_length_cm / film_width_cm) * (float)imageWidth;
+
+            if (fx.has_value() != fy.has_value()) {
+              throw std::runtime_error("fx and fy must be both specified or both omitted");
+            }
+
+            if (cx.has_value() != cy.has_value()) {
+              throw std::runtime_error("cx and cy must be both specified or both omitted");
+            }
+
+            return std::make_shared<momentum::rasterizer::PinholeIntrinsicsModel>(
+                imageWidth,
+                imageHeight,
+                fx.value_or(default_focal_length_pixels),
+                fy.value_or(default_focal_length_pixels),
+                cx.value_or(imageWidth / 2.0f),
+                cy.value_or(imageHeight / 2.0f));
+          }),
+          R"(Create a pinhole camera model with specified focal lengths and image dimensions.
+
+:param image_width: Width of the image in pixels.
+:param image_height: Height of the image in pixels.
+:param fx: Focal length in x direction (pixels). Defaults to computed value based on 50mm equivalent lens.
+:param fy: Focal length in y direction (pixels). Defaults to computed value based on 50mm equivalent lens.
+:param cx: Principal point x-coordinate (pixels). Defaults to image center if not provided.
+:param cy: Principal point y-coordinate (pixels). Defaults to image center if not provided.
+:return: A new PinholeIntrinsicsModel instance.)",
+          py::arg("image_width"),
+          py::arg("image_height"),
+          py::arg("fx") = std::nullopt,
+          py::arg("fy") = std::nullopt,
+          py::arg("cx") = std::nullopt,
+          py::arg("cy") = std::nullopt)
+      .def_property_readonly(
+          "cx",
+          &momentum::rasterizer::PinholeIntrinsicsModel::cx,
+          "Principal point x-coordinate (pixels)")
+      .def_property_readonly(
+          "cy",
+          &momentum::rasterizer::PinholeIntrinsicsModel::cy,
+          "Principal point y-coordinate (pixels)")
+      .def("__repr__", [](const momentum::rasterizer::PinholeIntrinsicsModel& self) {
+        return fmt::format(
+            "PinholeIntrinsicsModel(image_size=({}, {}), fx={:.2f}, fy={:.2f}, cx={:.2f}, cy={:.2f})",
+            self.imageWidth(),
+            self.imageHeight(),
+            self.fx(),
+            self.fy(),
+            self.cx(),
+            self.cy());
+      });
+
+  py::class_<
+      momentum::rasterizer::OpenCVIntrinsicsModel,
+      momentum::rasterizer::IntrinsicsModel,
+      std::shared_ptr<momentum::rasterizer::OpenCVIntrinsicsModel>>(
+      m, "OpenCVIntrinsicsModel", "OpenCV camera intrinsics model with distortion")
+      .def(
+          py::init(
+              [](int32_t imageWidth,
+                 int32_t imageHeight,
+                 std::optional<float> fx,
+                 std::optional<float> fy,
+                 std::optional<float> cx,
+                 std::optional<float> cy,
+                 std::optional<momentum::rasterizer::OpenCVDistortionParameters> distortionParams) {
+                // Default focal length calculation: "normal" lens is a 50mm
+                // lens on a 35mm camera body
+                const float focal_length_cm = 5.0f;
+                const float film_width_cm = 3.6f;
+                const float default_focal_length_pixels =
+                    (focal_length_cm / film_width_cm) * (float)imageWidth;
+                return std::make_shared<momentum::rasterizer::OpenCVIntrinsicsModel>(
+                    imageWidth,
+                    imageHeight,
+                    fx.value_or(default_focal_length_pixels),
+                    fy.value_or(default_focal_length_pixels),
+                    cx.value_or(imageWidth / 2.0f),
+                    cy.value_or(imageHeight / 2.0f),
+                    distortionParams.value_or(momentum::rasterizer::OpenCVDistortionParameters{}));
+              }),
+          R"(Create an OpenCV camera model with specified parameters and optional distortion.
+
+:param image_width: Width of the image in pixels.
+:param image_height: Height of the image in pixels.
+:param fx: Focal length in x direction (pixels).
+:param fy: Focal length in y direction (pixels).
+:param cx: Principal point x-coordinate (pixels).
+:param cy: Principal point y-coordinate (pixels).
+:param distortion_params: Optional OpenCV distortion parameters. Defaults to no distortion if not provided.
+:return: A new OpenCVIntrinsicsModel instance.)",
+          py::arg("image_width"),
+          py::arg("image_height"),
+          py::arg("fx"),
+          py::arg("fy"),
+          py::arg("cx"),
+          py::arg("cy"),
+          py::arg("distortion_params") = std::nullopt)
+      .def_property_readonly(
+          "cx",
+          &momentum::rasterizer::OpenCVIntrinsicsModel::cx,
+          "Principal point x-coordinate (pixels)")
+      .def_property_readonly(
+          "cy",
+          &momentum::rasterizer::OpenCVIntrinsicsModel::cy,
+          "Principal point y-coordinate (pixels)")
+      .def("__repr__", [](const momentum::rasterizer::OpenCVIntrinsicsModel& self) {
+        return fmt::format(
+            "OpenCVIntrinsicsModel(image_size=({}, {}), fx={:.2f}, fy={:.2f}, cx={:.2f}, cy={:.2f})",
+            self.imageWidth(),
+            self.imageHeight(),
+            self.fx(),
+            self.fy(),
+            self.cx(),
+            self.cy());
+      });
+
+  // Bind Camera class
+  py::class_<momentum::rasterizer::Camera>(m, "Camera", "Camera for rendering")
+      .def(
+          py::init([](std::shared_ptr<const momentum::rasterizer::IntrinsicsModel> intrinsics,
+                      const std::optional<Eigen::Matrix4f>& eye_from_world) {
+            return momentum::rasterizer::Camera(
+                intrinsics, Eigen::Affine3f(eye_from_world.value_or(Eigen::Matrix4f::Identity())));
+          }),
+          R"(Create a camera with specified intrinsics and pose.
+
+:param intrinsics_model: Camera intrinsics model defining focal length, principal point, and image dimensions.
+:param eye_from_world: Optional 4x4 transformation matrix from world space to camera/eye space. Defaults to identity matrix if not provided.
+:return: A new Camera instance with the specified intrinsics and pose.)",
+          py::arg("intrinsics_model"),
+          py::arg("eye_from_world") = std::nullopt)
+      .def(
+          "__repr__",
+          [](const momentum::rasterizer::Camera& self) {
+            Eigen::Vector3f position = self.eyeFromWorld().inverse().translation();
+            return fmt::format(
+                "Camera(image_size=({}, {}), focal_length=({:.2f}, {:.2f}), position=({:.2f}, {:.2f}, {:.2f}))",
+                self.imageWidth(),
+                self.imageHeight(),
+                self.fx(),
+                self.fy(),
+                position.x(),
+                position.y(),
+                position.z());
+          })
+      .def_property_readonly(
+          "image_width", &momentum::rasterizer::Camera::imageWidth, "Width of the image in pixels")
+      .def_property_readonly(
+          "image_height",
+          &momentum::rasterizer::Camera::imageHeight,
+          "Height of the image in pixels")
+      .def_property_readonly(
+          "fx", &momentum::rasterizer::Camera::fx, "Focal length in x direction (pixels)")
+      .def_property_readonly(
+          "fy", &momentum::rasterizer::Camera::fy, "Focal length in y direction (pixels)")
+      .def_property_readonly(
+          "intrinsics_model",
+          &momentum::rasterizer::Camera::intrinsicsModel,
+          "The camera's intrinsics model")
+      .def_property(
+          "T_eye_from_world",
+          [](const momentum::rasterizer::Camera& self) -> Eigen::Matrix4f {
+            return self.eyeFromWorld().matrix();
+          },
+          [](momentum::rasterizer::Camera& self, const Eigen::Matrix4f& value) {
+            self.setEyeFromWorld(Eigen::Affine3f(value));
+          },
+          "Transform from world space to camera/eye space")
+      .def_property(
+          "T_world_from_eye",
+          [](const momentum::rasterizer::Camera& self) -> Eigen::Matrix4f {
+            return self.worldFromEye().matrix();
+          },
+          [](momentum::rasterizer::Camera& self, const Eigen::Matrix4f& value) {
+            self.setEyeFromWorld(Eigen::Affine3f(value));
+          },
+          "Transform from world space to camera/eye space")
+      .def_property_readonly(
+          "center_of_projection",
+          [](const momentum::rasterizer::Camera& self) -> Eigen::Vector3f {
+            return (self.eyeFromWorld().inverse().translation()).eval();
+          },
+          "Position of the camera center in world space")
+      .def(
+          "look_at",
+          [](const momentum::rasterizer::Camera& self,
+             const Eigen::Vector3f& position,
+             const std::optional<Eigen::Vector3f>& target,
+             const std::optional<Eigen::Vector3f>& up) {
+            return self.lookAt(
+                position,
+                target.value_or(Eigen::Vector3f::Zero()),
+                up.value_or(Eigen::Vector3f::UnitY()));
+          },
+          R"(Position the camera to look at a specific target point.
+
+:param position: 3D position where the camera should be placed.
+:param target: 3D point the camera should look at. Defaults to origin (0,0,0) if not provided.
+:param up: Up vector for camera orientation. Defaults to (0,1,0) if not provided.
+:return: A new Camera instance positioned to look at the target.)",
+          py::arg("position"),
+          py::arg("target") = std::nullopt,
+          py::arg("up") = std::nullopt)
+      .def(
+          "frame",
+          [](const momentum::rasterizer::Camera& self,
+             const py::array_t<float>& points,
+             float min_z,
+             float edge_padding) -> momentum::rasterizer::Camera {
+            if (points.ndim() != 2 || points.shape(1) != 3) {
+              throw std::runtime_error("Expected a 2D array of shape (nPoints, 3)");
+            }
+
+            // Convert py::array_t<float> to std::vector<Eigen::Vector3f>
+            std::vector<Eigen::Vector3f> eigenPoints;
+            eigenPoints.reserve(points.shape(0));
+
+            auto pts_acc = points.unchecked<2>();
+            for (size_t i = 0; i < points.shape(0); ++i) {
+              eigenPoints.emplace_back(pts_acc(i, 0), pts_acc(i, 1), pts_acc(i, 2));
+            }
+
+            return self.framePoints(eigenPoints, min_z, edge_padding);
+          },
+          R"(Adjust the camera position to ensure all specified points are in view.
+
+:param points: (N x 3) array of 3D points that should be visible in the camera view.
+:param min_z: Minimum distance from camera to maintain. Defaults to 0.1.
+:param edge_padding: Padding factor to add around the points as a fraction of the image size. Defaults to 0.05.
+:return: A new Camera instance positioned to frame all the specified points.)",
+          py::arg("points"),
+          py::arg("min_z") = 0.1f,
+          py::arg("edge_padding") = 0.05f)
+      .def_property_readonly(
+          "world_space_principle_axis",
+          [](const momentum::rasterizer::Camera& self) -> Eigen::Vector3f {
+            // The principle axis is the direction the camera is looking
+            // In camera space, this is the positive Z axis (0, 0, 1)
+            Eigen::Vector3f cameraSpacePrincipalAxis = Eigen::Vector3f::UnitZ();
+            return (self.worldFromEye().linear() * cameraSpacePrincipalAxis).eval();
+          },
+          "Camera world-space principal axis (direction the camera is looking)")
+      .def(
+          "upsample",
+          [](const momentum::rasterizer::Camera& self, float factor) {
+            return momentum::rasterizer::Camera(
+                self.intrinsicsModel()->upsample(factor), self.eyeFromWorld());
+          },
+          R"(Create a new camera with upsampled resolution by the given factor.
+
+:param factor: Upsampling factor (e.g., 2.0 doubles the resolution).
+:return: A new Camera instance with upsampled intrinsics and same pose.)",
+          py::arg("factor"))
+      .def(
+          "crop",
+          [](const momentum::rasterizer::Camera& self,
+             int32_t top,
+             int32_t left,
+             int32_t width,
+             int32_t height) { return self.crop(top, left, width, height); },
+          R"(Create a new camera with cropped image region.
+
+:param top: Top offset in pixels.
+:param left: Left offset in pixels.
+:param width: New width in pixels after cropping.
+:param height: New height in pixels after cropping.
+:return: A new Camera instance with cropped intrinsics and same pose.)",
+          py::arg("top"),
+          py::arg("left"),
+          py::arg("width"),
+          py::arg("height"))
+      .def(
+          "project",
+          [](const momentum::rasterizer::Camera& self,
+             const py::array_t<float>& world_points) -> py::array_t<float> {
+            if (world_points.ndim() != 2 || world_points.shape(1) != 3) {
+              throw std::runtime_error("Expected a 2D array of shape (nPoints, 3)");
+            }
+
+            py::array_t<float> result(std::vector<ssize_t>{world_points.shape(0), 3});
+            auto res_acc = result.mutable_unchecked<2>();
+            auto pts_acc = world_points.unchecked<2>();
+
+            for (size_t i = 0; i < world_points.shape(0); ++i) {
+              // Extract world point
+              Eigen::Vector3f world_pt(pts_acc(i, 0), pts_acc(i, 1), pts_acc(i, 2));
+
+              // Use the camera's project method directly
+              auto [projected_pt, is_valid] = self.project(world_pt);
+
+              res_acc(i, 0) = projected_pt.x();
+              res_acc(i, 1) = projected_pt.y();
+              res_acc(i, 2) = projected_pt.z();
+            }
+            return result;
+          },
+          R"(Project 3D points from world space to 2D image coordinates.
+
+:param world_points: (N x 3) array of 3D points in world coordinate space to project.
+:return: (N x 3) array of projected points where columns are [x, y, depth] in image coordinates.)",
+          py::arg("world_points"))
+      .def(
+          "unproject",
+          [](const momentum::rasterizer::Camera& self,
+             const py::array_t<float>& image_points) -> py::array_t<float> {
+            if (image_points.ndim() != 2 || image_points.shape(1) != 3) {
+              throw std::runtime_error(
+                  "Expected image_points to be a 2D array of shape (nPoints, 3)");
+            }
+
+            py::array_t<float> result(std::vector<ssize_t>{image_points.shape(0), 3});
+            auto res_acc = result.mutable_unchecked<2>();
+            auto img_acc = image_points.unchecked<2>();
+
+            for (size_t i = 0; i < image_points.shape(0); ++i) {
+              // Create 3D image point (u, v, z)
+              const Eigen::Vector3f image_point(img_acc(i, 0), img_acc(i, 1), img_acc(i, 2));
+
+              // Use the camera's unproject method to get world coordinates
+              // directly
+              auto [world_pt, is_valid] = self.unproject(image_point);
+
+              res_acc(i, 0) = world_pt.x();
+              res_acc(i, 1) = world_pt.y();
+              res_acc(i, 2) = world_pt.z();
+            }
+            return result;
+          },
+          R"(Unproject 3D image coordinates to 3D points in world space.
+
+:param image_points: (N x 3) array of 3D points in image coordinates [x, y, depth].
+:return: (N x 3) array of 3D points in world coordinate space.)",
+          py::arg("image_points"));
+
+  py::class_<momentum::rasterizer::PhongMaterial>(
+      m,
+      "PhongMaterial",
+      "A Phong shading material model with diffuse, specular, and emissive components. "
+      "Supports both solid colors and texture maps for realistic surface rendering. "
+      "The Phong model provides smooth shading with controllable highlights and surface properties.")
+      .def_property(
+          "diffuse_color",
+          [](const momentum::rasterizer::PhongMaterial& mat) { return mat.diffuseColor; },
+          [](momentum::rasterizer::PhongMaterial& mat, const Eigen::Vector3f& color) {
+            mat.diffuseColor = color;
+          })
+      .def_property(
+          "specular_color",
+          [](const momentum::rasterizer::PhongMaterial& mat) { return mat.specularColor; },
+          [](momentum::rasterizer::PhongMaterial& mat, const Eigen::Vector3f& color) {
+            mat.specularColor = color;
+          })
+      .def_property(
+          "emissive_color",
+          [](const momentum::rasterizer::PhongMaterial& mat) { return mat.emissiveColor; },
+          [](momentum::rasterizer::PhongMaterial& mat, const Eigen::Vector3f& color) {
+            mat.emissiveColor = color;
+          })
+      .def_property(
+          "specular_exponent",
+          [](const momentum::rasterizer::PhongMaterial& mat) { return mat.specularExponent; },
+          [](momentum::rasterizer::PhongMaterial& mat, const float exponent) {
+            mat.specularExponent = exponent;
+          })
+      .def(py::init<>())
+      .def(
+          py::init(&pymomentum::createPhongMaterial),
+          R"(Create a Phong material with customizable properties.
+
+          :param diffuse_color: RGB diffuse color values (0-1 range)
+          :param specular_color: RGB specular color values (0-1 range)
+          :param specular_exponent: Specular highlight sharpness
+          :param emissive_color: RGB emissive color values (0-1 range)
+          :param diffuse_texture: Optional diffuse texture as a numpy array
+          :param emissive_texture: Optional emissive texture as a numpy array
+          )",
+          py::arg("diffuse_color") = std::optional<Eigen::Vector3f>{},
+          py::arg("specular_color") = std::optional<Eigen::Vector3f>{},
+          py::arg("specular_exponent") = std::optional<float>{},
+          py::arg("emissive_color") = std::optional<Eigen::Vector3f>{},
+          py::arg("diffuse_texture") = std::optional<py::array_t<float>>{},
+          py::arg("emissive_texture") = std::optional<py::array_t<float>>{})
+      .def("__repr__", [](const momentum::rasterizer::PhongMaterial& self) {
+        return fmt::format(
+            "PhongMaterial(diffuse=({:.2f}, {:.2f}, {:.2f}), specular=({:.2f}, {:.2f}, {:.2f}), exponent={:.2f}, emissive=({:.2f}, {:.2f}, {:.2f}))",
+            self.diffuseColor.x(),
+            self.diffuseColor.y(),
+            self.diffuseColor.z(),
+            self.specularColor.x(),
+            self.specularColor.y(),
+            self.specularColor.z(),
+            self.specularExponent,
+            self.emissiveColor.x(),
+            self.emissiveColor.y(),
+            self.emissiveColor.z());
+      });
+
+  py::enum_<momentum::rasterizer::LightType>(m, "LightType", "Type of light to use in rendering.")
+      .value("Ambient", momentum::rasterizer::LightType::Ambient)
+      .value("Directional", momentum::rasterizer::LightType::Directional)
+      .value("Point", momentum::rasterizer::LightType::Point);
+  py::class_<momentum::rasterizer::Light>(
+      m,
+      "Light",
+      "A light source for 3D rendering supporting point, directional, and ambient lighting. "
+      "Point lights emit from a specific position, directional lights simulate distant sources "
+      "like the sun, and ambient lights provide uniform illumination from all directions.")
+      .def(py::init<>())
+      .def_property(
+          "position",
+          [](const momentum::rasterizer::Light& light) { return light.position; },
+          [](momentum::rasterizer::Light& light, const Eigen::Vector3f& position) {
+            light.position = position;
+          })
+      .def_property(
+          "color",
+          [](const momentum::rasterizer::Light& light) { return light.color; },
+          [](momentum::rasterizer::Light& light, const Eigen::Vector3f& color) {
+            light.color = color;
+          })
+      .def_property(
+          "type",
+          [](const momentum::rasterizer::Light& light) { return light.type; },
+          [](momentum::rasterizer::Light& light, const momentum::rasterizer::LightType& type) {
+            light.type = type;
+          })
+      .def(
+          "__repr__",
+          [](const momentum::rasterizer::Light& self) {
+            std::string typeStr;
+            switch (self.type) {
+              case momentum::rasterizer::LightType::Ambient:
+                typeStr = "Ambient";
+                break;
+              case momentum::rasterizer::LightType::Directional:
+                typeStr = "Directional";
+                break;
+              case momentum::rasterizer::LightType::Point:
+                typeStr = "Point";
+                break;
+            }
+            return fmt::format(
+                "Light(type={}, position=({:.2f}, {:.2f}, {:.2f}), color=({:.2f}, {:.2f}, {:.2f}))",
+                typeStr,
+                self.position.x(),
+                self.position.y(),
+                self.position.z(),
+                self.color.x(),
+                self.color.y(),
+                self.color.z());
+          })
+      .def_static(
+          "create_point_light",
+          [](const Eigen::Vector3f& position, std::optional<Eigen::Vector3f>& color) {
+            return momentum::rasterizer::createPointLight(
+                position, color.value_or(Eigen::Vector3f::Ones()));
+          },
+          py::arg("position"),
+          py::arg("color") = std::optional<Eigen::Vector3f>{})
+      .def_static(
+          "create_directional_light",
+          [](const Eigen::Vector3f& direction, std::optional<Eigen::Vector3f>& color) {
+            return momentum::rasterizer::createDirectionalLight(
+                direction, color.value_or(Eigen::Vector3f::Ones()));
+          },
+          py::arg("direction"),
+          py::arg("color") = std::optional<Eigen::Vector3f>{})
+      .def_static(
+          "create_ambient_light",
+          [](const std::optional<Eigen::Vector3f>& color) {
+            return momentum::rasterizer::createAmbientLight(
+                color.value_or(Eigen::Vector3f::Ones()));
+          },
+          py::arg("color") = std::optional<Eigen::Vector3f>{})
+      .def(
+          "transform",
+          [](const momentum::rasterizer::Light& light, const Eigen::Matrix4f& xf) {
+            return momentum::rasterizer::transformLight(light, Eigen::Affine3f(xf));
+          },
+          "Transform the light using the passed-in transform.",
+          py::arg("xf"));
+
+  m.def(
+      "build_cameras_for_body",
+      &buildCamerasForBody,
+      R"(Build a batched vector of cameras that roughly face the body (default: face the front of the body).  If you pass in multiple frames of animation, the camera will ensure all frames are visible.
+
+:param character: Character to use.
+:param jointParameters: torch.Tensor of size (nBatch x [nFrames] x nJointParameters) or size (nJointParameters); can be computed from the modelParameters using :math:`ParameterTransform.apply`.
+:param imageHeight: Height of the target image.
+:param imageWidth: Width of the target image.
+:param focalLength_mm: 35mm-equivalent focal length; e.g. focalLength=50 corresponds to a "normal" lens.
+:param horizontal: whether the cameras are placed horizontally, assuming the Y axis is the world up direction.
+:param camera_angle: what direction the camera looks at the body. default: 0, looking at front of body. pi/2: at left side of body.
+:return: List of cameras, one for each element of the batch.)",
+      py::arg("character"),
+      py::arg("joint_parameters"),
+      py::arg("image_height"),
+      py::arg("image_width"),
+      py::arg("focal_length_mm") = 50.0f,
+      py::arg("horizontal") = false,
+      py::arg("camera_angle") = 0.0f);
+
+  m.def(
+      "build_cameras_for_hand",
+      &buildCamerasForHand,
+      R"(Build a vector of cameras that roughly face inward from the front of the hand.
+
+:param wristTransformation: Wrist transformation.
+:param imageHeight: Height of the target image.
+:param imageWidth: Width of the target image.
+:return: List of cameras, one for each element of the batch.)",
+      py::arg("wrist_transformation"),
+      py::arg("image_height"),
+      py::arg("image_width"));
+
+  m.def(
+      "build_cameras_for_hand_surface",
+      &buildCamerasForHandSurface,
+      R"(Build a vector of cameras that face over the plane.
+
+:param imageHeight: Height of the target image.
+:param imageWidth: Width of the target image.
+:return: List of cameras, one for each element of the batch.)",
+      py::arg("wrist_transformation"),
+      py::arg("image_height"),
+      py::arg("image_width"));
+
+  m.def(
+      "triangulate",
+      &triangulate,
+      R"(triangulate the polygon mesh.
+
+:param faceOffests: numpy.ndarray defining the starting and end points of each polygon
+:param facesIndices: numpy.ndarray of the face indicies to vertex
+)",
+      py::arg("face_indices"),
+      py::arg("face_offsets"));
+
+  m.def(
+      "subdivide_mesh",
+      &subdivideMesh,
+      R"(Subdivide the triangle mesh.
+
+:param vertices: n x 3 numpy.ndarray of vertex positions.
+:param normals: n x 3 numpy.ndarray of vertex normals.
+:param triangles: n x 3 numpy.ndarray of triangles.
+:param texture_coordinates: n x numpy.ndarray or texture coordinates.
+:param texture_triangles: n x numpy.ndarray or texture triangles (see :mesh:`rasterize_mesh` for more details).).
+:param levels: Maximum levels to subdivide (default = 1)
+:param max_edge_length: Stop subdividing when the longest edge is shorter than this length.
+:return: A tuple [vertices, normals, triangles, texture_coordinates, texture_triangles].
+)",
+      py::arg("vertices"),
+      py::arg("normals"),
+      py::arg("triangles"),
+      py::arg("texture_coordinates") = std::optional<RowMatrixf>{},
+      py::arg("texture_triangles") = std::optional<RowMatrixi>{},
+      py::arg("levels") = 1,
+      py::arg("max_edge_length") = 0);
+
+  m.def(
+      "rasterize_mesh",
+      &rasterizeMesh,
+      R"(Rasterize the triangle mesh using the passed-in camera onto a given RGB+depth buffer.  Uses an optimized cross-platform SIMD implementation.
+
+Notes:
+
+* You can rasterize multiple meshes to the same depth buffer by calling this function multiple times.
+* To simplify the SIMD implementation, the width of the depth buffer must be a multiple of 8.  If you want to render a resolution that is not a multiple of 8, allocate an appropriately padded depth buffer (e.g. using :meth:`create_rasterizer_buffers`) and then extract the smaller image at the end.
+
+:param vertex_positions: (nVert x 3) Tensor of vertex positions.
+:param vertex_normals: (nVert x 3) Tensor of vertex normals.
+:param triangles: (nVert x 3) Tensor of triangles.
+:param camera: Camera to render from.
+:param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+:param material: Material to render with (assumes solid color for now).
+:param texture_coordinates: Texture coordinates used with the mesh, indexed by texture_triangles (if present) or triangles otherwise.
+:param texture_triangles: Triangles in texture coordinate space.  Must have the same number of triangles as the triangles input and is assumed to match the regular triangles input if not present.  This allows discontinuities in the texture map without needing to break up the mesh.
+:param per_vertex_diffuse_color: A per-vertex diffuse color to use instead of the material's diffuse color.
+:param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+:param back_face_culling: Enable back-face culling (speeds up the render).
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param surface_normals_buffer: Buffer to render eye-space surface normals to; can be reused for multiple renders.  Should have dimensions [height x width x 3].
+:param vertex_index_buffer: Optional buffer to rasterize the vertex indices to.  Useful for e.g. computing parts.
+:param triangle_index_buffer: Optional buffer to rasterize the triangle indices to.  Useful for e.g. computing parts.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+)",
+      py::arg("vertex_positions"),
+      py::arg("vertex_normals"),
+      py::arg("triangles"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::kw_only(),
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("vertex_index_buffer") = std::optional<at::Tensor>{},
+      py::arg("triangle_index_buffer") = std::optional<at::Tensor>{},
+      py::arg("material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::arg("texture_coordinates") = std::optional<at::Tensor>{},
+      py::arg("texture_triangles") = std::optional<at::Tensor>{},
+      py::arg("per_vertex_diffuse_color") = std::optional<at::Tensor>{},
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("back_face_culling") = true,
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{});
+
+  m.def(
+      "rasterize_wireframe",
+      &rasterizeWireframe,
+      R"(Rasterize the triangle mesh as a wireframe.
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param vertex_positions: (nVert x 3) Tensor of vertex positions.
+:param triangles: (nVert x 3) Tensor of triangles.
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param thickness: Thickness of the wireframe lines.
+:param color: Wireframe color.
+:param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+:param back_face_culling: Enable back-face culling (speeds up the render).
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+)",
+      py::arg("vertex_positions"),
+      py::arg("triangles"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::kw_only(),
+      py::arg("thickness") = 1.0f,
+      py::arg("color") = std::optional<Eigen::Vector3f>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("back_face_culling") = true,
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{});
+
+  m.def(
+      "rasterize_spheres",
+      &rasterizeSpheres,
+      R"(Rasterize spheres using the passed-in camera onto a given RGB+depth buffer.  Uses an optimized cross-platform SIMD implementation.
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param center: (nSpheres x 3) Tensor of sphere centers.
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param radius: (nSpheres) Optional Tensor of per-sphere radius values (defaults to 1).
+:param color: (nSpheres x 3) optional Tensor of per-sphere colors (defaults to using the passed-in material).
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+:param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+:param back_face_culling: Enable back-face culling (speeds up the render).
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+:param subdivision_level: How many subdivision levels; more levels means more triangles, smoother spheres, but slower rendering.
+)",
+      py::arg("center"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("radius") = std::optional<at::Tensor>{},
+      py::arg("color") = std::optional<at::Tensor>{},
+      py::arg("material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::kw_only(),
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("back_face_culling") = true,
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{},
+      py::arg("subdivision_level") = 2);
+
+  m.def(
+      "rasterize_camera_frustum",
+      &rasterizeCameraFrustum,
+      R"(Rasterize the camera frustum.
+
+:param camera_frustum: Camera frustum to render.
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param line_thickness: Thickness of the lines.
+:param distance: Distance to project the frustum out into space (defaults to 10cm).
+:param num_samples: Number of samples to use for computing the boundaries of the frustum (defaults to 20).
+:param color: Color to use for the frustum (defaults to white).
+:param model_matrix: Additional matrix to apply to the frustum.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something
+    else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.
+  )",
+      py::arg("camera_frustum"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::arg("line_thickness") = 1.0f,
+      py::arg("distance") = 10.0f,
+      py::arg("num_samples") = 20,
+      py::arg("color") = std::optional<Eigen::Vector3f>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{});
+
+  m.def(
+      "rasterize_cylinders",
+      &rasterizeCylinders,
+      R"(Rasterize cylinders using the passed-in camera onto a given RGB+depth buffer.  Uses an optimized cross-platform SIMD implementation.
+
+A cylinder is defined as extending from start_position to end_position with the radius provided by radius.
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param start_position: (nCylinders x 3) torch.Tensor of starting positions.
+:param end_position: (nCylinders x 3) torch.Tensor of ending positions.
+:param camera: Camera to render from.
+:param radius: (nSpheres) Optional tensor of per-cylinder radius values (defaults to 1).
+:param color: (nVert x 3) Optional Tensor of per-cylinder colors (defaults to using the material parameter).
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+:param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+:param back_face_culling: Enable back-face culling (speeds up the render).
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+:param length_subdivisions: How many subdivisions along length; longer cylinders may need more to avoid looking chunky.
+:param radius_subdivisions: How many subdivisions around cylinder radius; good values are between 16 and 64.
+)",
+      py::arg("start_position"),
+      py::arg("end_position"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("radius") = std::optional<at::Tensor>{},
+      py::arg("color") = std::optional<at::Tensor>{},
+      py::arg("material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::kw_only(),
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("back_face_culling") = true,
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{},
+      py::arg("length_subdivisions") = 16,
+      py::arg("radius_subdivisions") = 16);
+
+  m.def(
+      "rasterize_capsules",
+      &rasterizeCapsules,
+      R"(Rasterize capsules using the passed-in camera onto a given RGB+depth buffer.
+
+A capsule is defined as extending along the x axis in the local space defined by the transform.  It
+has two radius values, one for the start and end of the capsule, and the ends of the capsules are spheres.
+
+:param transformation: (nCapsules x 4 x 4) torch.Tensor of transformations from capsule-local space (oriented along the x axis) to world space.
+:param radius: (nCapsules x 2) torch.Tensor of per-capsule start and end radius values.
+:param length: (nCapsules) torch.Tensor of per-capsule length values.
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param surface_normals_buffer: Buffer to render eye-space surface normals to; can be reused for multiple renders.  Should have dimensions [height x width x 3].
+:param material: Material to render with (assumes solid color for now).
+:param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+:param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+:param cylinder_length_subdivisions: How many subdivisions along cylinder length; longer cylinders may need more to avoid looking chunky.
+:param cylinder_radius_subdivisions: How many subdivisions around cylinder radius; good values are between 16 and 64.
+  )",
+      py::arg("transformation"),
+      py::arg("radius"),
+      py::arg("length"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::kw_only(),
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{},
+      py::arg("cylinder_length_subdivisions") = 16,
+      py::arg("cylinder_radius_subdivisions") = 16);
+
+  m.def(
+      "rasterize_transforms",
+      &rasterizeTransforms,
+      R"(Rasterize a set of transforms as little frames using arrows.
+
+  :param transforms: (n x 4 x 4) torch.Tensor of transforms to render.
+  :param camera: Camera to render from.
+  :param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+  :param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+  :param surface_normals_buffer: Buffer to render eye-space surface normals to; can be reused for multiple renders.
+  :param scale: Scale of the arrows.
+  :param material: Material to render with.  If not specified, then red/green/blue are used for the x/y/z axes.
+  :param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+  :param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+  :param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+  :param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something
+      else and avoid depth fighting.  Defaults to 0.
+  :param image_offset: Offset by (x, y) pixels in image space.
+  :param length_subdivisions: How many subdivisions along length; longer cylinders may need more to avoid looking chunky.
+  :param radius_subdivisions: How many subdivisions around cylinder radius; good values are between 16 and 64. )",
+      py::arg("transforms"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::kw_only(),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("scale") = 1.0f,
+      py::arg("material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{},
+      py::arg("length_subdivisions") = 16,
+      py::arg("radius_subdivisions") = 16);
+
+  py::enum_<SkeletonStyle>(
+      m,
+      "SkeletonStyle",
+      R"(Rendering style options for skeleton visualization. Different styles are optimized for different use cases, "
+      "from technical debugging to publication-quality figures.)")
+      .value(
+          "Pipes",
+          SkeletonStyle::Pipes,
+          "Render joints as spheres with fixed-radius pipes connecting them. Useful when rendering a skeleton under a mesh.")
+      .value(
+          "Octahedrons",
+          SkeletonStyle::Octahedrons,
+          "Render joints as octahedrons. This gives much more sense of the joint orientations and is useful when rendering just the skeleton.")
+      .value(
+          "Lines",
+          SkeletonStyle::Lines,
+          "Render joints as lines. This would look nice in e.g. a paper figure. Note that all sizes are in pixels when this is used.");
+
+  m.def(
+      "rasterize_skeleton",
+      &rasterizeSkeleton,
+      R"(Rasterize the skeleton onto a given RGB+depth buffer by placing spheres at joints and connecting joints with cylinders.
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param character: :class:`pymomentum.geometry.Character` whose skeleton to rasterize.
+:param skeleton_state: State of the skeleton.
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param sphere_material: Material to use for spheres at joints.
+:param cylinder_material: Material to use for cylinders at joints.
+:param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+:param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+:param back_face_culling: Enable back-face culling (speeds up the render).
+:param active_joints: Bool tensor specifying which joints to render.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+:param sphere_radius: Radius for spheres at joints.
+:param cylinder_radius: Radius for cylinders between joints.
+:param sphere_subdivision_level: How many subdivision levels; more levels means more triangles, smoother spheres, but slower rendering.  Good values are between 1 and 3.
+:param cylinder_length_subdivisions: How many subdivisions along cylinder length; longer cylinders may need more to avoid looking chunky.
+:param cylinder_radius_subdivisions: How many subdivisions around cylinder radius; good values are between 16 and 64.
+)",
+      py::arg("character"),
+      py::arg("skeleton_state"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::kw_only(),
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("sphere_material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::arg("cylinder_material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("back_face_culling") = true,
+      py::arg("active_joints") = std::optional<at::Tensor>{},
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{},
+      py::arg("sphere_radius") = 2.0f,
+      py::arg("cylinder_radius") = 1.0f,
+      py::arg("sphere_subdivision_level") = 2,
+      py::arg("cylinder_length_subdivisions") = 16,
+      py::arg("cylinder_radius_subdivisions") = 16,
+      py::arg("style") = SkeletonStyle::Pipes);
+
+  m.def(
+      "rasterize_character",
+      &rasterizeCharacter,
+      R"(Rasterize the posed character using the passed-in camera onto a given RGB+depth buffer.  Uses an optimized cross-platform SIMD implementation.
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param character: :class:`pymomentum.geometry.Character` whose skeleton to rasterize.
+:param skeleton_state: State of the skeleton.
+:param camera: Camera to render from.
+:param material: Material to render with (assumes solid color for now).
+:param per_vertex_diffuse_color: A per-vertex diffuse color to use instead of the material's diffuse color.
+:param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+:param model_matrix: Additional matrix to apply to the model.  Unlike the camera transforms, it is allowed to have scaling and/or shearing.
+:param back_face_culling: Enable back-face culling (speeds up the render).
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param vertex_index_buffer: Optional buffer to rasterize the vertex indices to.  Useful for e.g. computing parts.
+:param triangle_index_buffer: Optional buffer to rasterize the triangle indices to.  Useful for e.g. computing parts.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+:param wireframe_color: If provided, color to use for the wireframe (defaults to no wireframe).
+)",
+      py::arg("character"),
+      py::arg("skeleton_state"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::kw_only(),
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("vertex_index_buffer") = std::optional<at::Tensor>{},
+      py::arg("triangle_index_buffer") = std::optional<at::Tensor>{},
+      py::arg("material") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::arg("per_vertex_diffuse_color") = std::optional<at::Tensor>{},
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("back_face_culling") = true,
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{},
+      py::arg("wireframe_color") = std::optional<Eigen::Vector3f>{});
+
+  m.def(
+      "rasterize_checkerboard",
+      &rasterizeCheckerboard,
+      R"(Rasterize a checkerboard floor in the x-z plane (with y up).
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param material1: Material to use for even checks.
+:param material2: Material to use for odd checks.
+:param lights: Lights to use in renderering, in world-space.  If none are given, a default light setup is used.
+:param model_matrix: Matrix to use to transform the plane from the origin.
+:param back_face_culling: Cull back-facing triangles.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+:param width: Width of the plane in x/z.
+:param num_checks: Number of checks in each axis.
+:param subdivisions: How much to divide up each check.
+)",
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::kw_only(),
+      py::arg("surface_normals_buffer") = std::optional<at::Tensor>{},
+      py::arg("material1") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::arg("material2") = std::optional<momentum::rasterizer::PhongMaterial>{},
+      py::arg("lights") = std::optional<std::vector<momentum::rasterizer::Light>>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("back_face_culling") = true,
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{},
+      py::arg("width") = 50.0f,
+      py::arg("num_checks") = 10,
+      py::arg("subdivisions") = 1);
+
+  m.def(
+      "rasterize_lines",
+      &rasterizeLines,
+      R"(Rasterize lines to the provided RGB and z buffers.
+
+The advantage of using rasterization to draw lines instead of just drawing them with e.g. opencv is that it will use the correct camera model and respect the z buffer.
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param positions: (nLines x 2 x 3) torch.Tensor of start/end positions.
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param width: Width of the lines, currently is the same across all lines.
+:param color: Line color, currently is shared across all lines.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+)",
+      py::arg("positions"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::kw_only(),
+      py::arg("thickness") = 1.0f,
+      py::arg("color") = std::optional<Eigen::Vector3f>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{});
+
+  m.def(
+      "rasterize_circles",
+      &rasterizeCircles,
+      R"(Rasterize circles to the provided RGB and z buffers.
+
+The advantage of using rasterization to draw circles instead of just drawing them with e.g. opencv is that it will use the correct camera model and respect the z buffer.
+
+See detailed notes under :meth:`rasterize_mesh`, above.
+
+:param positions: (nCircles x 3) torch.Tensor of circle centers.
+:param camera: Camera to render from.
+:param z_buffer: Z-buffer to render geometry onto; can be reused for multiple renders.
+:param rgb_buffer: RGB-buffer to render geometry onto; can be reused for multiple renders.
+:param line_thickness: Thickness of the circle outline.
+:param radius: Radius of the circle.
+:param line_color: Color of the outline, is transparent if not provided.
+:param fill_color: Line color, is transparent if not provided.
+:param near_clip: Clip any triangles closer than this depth.  Defaults to 0.1.
+:param depth_offset: Offset the depth values.  Nonzero values can be used to render something slightly in front of something else and avoid depth fighting.  Defaults to 0.
+:param image_offset: Offset by (x, y) pixels in image space.  Can be used to render e.g. two characters next to each other for comparison without needing to create a special camera.
+)",
+      py::arg("positions"),
+      py::arg("camera"),
+      py::arg("z_buffer"),
+      py::arg("rgb_buffer") = std::optional<at::Tensor>{},
+      py::kw_only(),
+      py::arg("line_thickness") = 1.0f,
+      py::arg("radius") = 3.0f,
+      py::arg("line_color") = std::optional<Eigen::Vector3f>{},
+      py::arg("fill_color") = std::optional<Eigen::Vector3f>{},
+      py::arg("model_matrix") = std::optional<Eigen::Matrix4f>{},
+      py::arg("near_clip") = 0.1f,
+      py::arg("depth_offset") = 0.0f,
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{});
+
+  // 2D rasterization functions that operate directly in image space
+  // without camera projection or z-buffer
+  m.def(
+      "rasterize_lines_2d",
+      &rasterizeLines2D,
+      R"(Rasterize lines directly in 2D image space without camera projection or z-buffer.
+
+:param positions: (nLines x 4) torch.Tensor of line start/end positions in image space [start_x, start_y, end_x, end_y].
+:param rgb_buffer: RGB-buffer to render geometry onto.
+:param thickness: Thickness of the lines.
+:param color: Line color.
+:param z_buffer: Optional Z-buffer to write zeros to for alpha matting.
+:param image_offset: Offset by (x, y) pixels in image space.
+)",
+      py::arg("positions"),
+      py::arg("rgb_buffer"),
+      py::arg("thickness") = 1.0f,
+      py::arg("color") = std::optional<Eigen::Vector3f>{},
+      py::arg("z_buffer") = std::optional<at::Tensor>{},
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{});
+
+  m.def(
+      "rasterize_circles_2d",
+      &rasterizeCircles2D,
+      R"(Rasterize circles directly in 2D image space without camera projection or z-buffer.
+
+:param positions: (nCircles x 2) torch.Tensor of circle centers in image space [x, y].
+:param rgb_buffer: RGB-buffer to render geometry onto.
+:param line_thickness: Thickness of the circle outline.
+:param radius: Radius of the circle.
+:param line_color: Color of the outline, is transparent if not provided.
+:param fill_color: Fill color, is transparent if not provided.
+:param z_buffer: Optional Z-buffer to write zeros to for alpha matting.
+:param image_offset: Offset by (x, y) pixels in image space.
+)",
+      py::arg("positions"),
+      py::arg("rgb_buffer"),
+      py::arg("line_thickness") = 1.0f,
+      py::arg("radius") = 3.0f,
+      py::arg("line_color") = std::optional<Eigen::Vector3f>{},
+      py::arg("fill_color") = std::optional<Eigen::Vector3f>{},
+      py::arg("z_buffer") = std::optional<at::Tensor>{},
+      py::arg("image_offset") = std::optional<Eigen::Vector2f>{});
+
+  m.def(
+      "create_z_buffer",
+      &createZBuffer,
+      R"(Creates a padded buffer suitable for rasterization.
+
+:param camera: Camera to render from.
+
+:return: A z_buffer torch.Tensor (height, padded_width) suitable for use in the :meth:`rasterize` function.
+)",
+      py::arg("camera"),
+      py::arg("far_clip") = FLT_MAX);
+
+  m.def(
+      "create_rgb_buffer",
+      &createRGBBuffer,
+      R"(Creates a padded RGB buffer suitable for rasterization.
+
+:param camera: Camera to render from.
+:param background_color: Background color, defaults to all-black (0, 0, 0).
+
+:return: A rgb_buffer torch.Tensor (height, padded_width, 3) suitable for use in the :meth:`rasterize` function. After rasterization, use `rgb_buffer[:, 0 : camera.image_width, :]` to get the rendered image.
+)",
+      py::arg("camera"),
+      py::arg("background_color") = std::optional<Eigen::Vector3f>{});
+
+  m.def(
+      "create_index_buffer",
+      &createIndexBuffer,
+      R"(Creates a padded RGB buffer suitable for storing triangle or vertex indices during rasterization.
+
+:param camera: Camera to render from.
+
+:return: An integer tensor (height, padded_width) suitable for passing in as an index buffer to the :meth:`rasterize` function.
+)",
+      py::arg("camera"));
+
+  m.def(
+      "alpha_matte",
+      &alphaMatte,
+      R"(Use alpha matting to overlay a rasterized image onto a background image.
+
+This function includes a few features which simplify using it with the rasterizer:
+1. Depth buffer is automatically converted to an alpha matte.
+2. Supersampled images are handled correctly: if your rgb_buffer is an integer multiple of the target image, it will automatically be smoothed and converted to fractional alpha.
+3. You can apply an additional global alpha on top of the per-pixel alpha.
+
+:param depth_buffer: A z-buffer as generated by :meth:`create_z_buffer`.
+:param rgb_buffer: An rgb_buffer as created by :meth:`create_rgb_buffer`.
+:param target_image: A target RGB image to overlay the rendered image onto.  Will be written in place.
+:param alpha: A global alpha between 0 and 1 to multiply the source image by.  Defaults to 1.
+)",
+      py::arg("depth_buffer"),
+      py::arg("rgb_buffer"),
+      py::arg("target_image"),
+      py::arg("alpha") = 1.0f);
+
+  m.def(
+      "create_shadow_projection_matrix",
+      [](const momentum::rasterizer::Light& light,
+         const std::optional<Eigen::Vector3f>& planeNormal_in,
+         const std::optional<Eigen::Vector3f>& planeOrigin_in) {
+        const Eigen::Vector3f planeNormal =
+            planeNormal_in.value_or(Eigen::Vector3f::UnitY()).normalized();
+        const Eigen::Vector3f planeOrigin = planeOrigin_in.value_or(Eigen::Vector3f::Zero());
+        const Eigen::Vector4f planeVec(
+            planeNormal.x(), planeNormal.y(), planeNormal.z(), -planeNormal.dot(planeOrigin));
+
+        Eigen::Vector4f lightVec = Eigen::Vector4f::Zero();
+        switch (light.type) {
+          case momentum::rasterizer::LightType::Directional:
+            lightVec =
+                Eigen::Vector4f(light.position.x(), light.position.y(), light.position.z(), 0.0f);
+            break;
+          case momentum::rasterizer::LightType::Point:
+            lightVec =
+                Eigen::Vector4f(light.position.x(), light.position.y(), light.position.z(), 1.0f);
+            break;
+          case momentum::rasterizer::LightType::Ambient:
+            throw std::runtime_error("Shadows not supported for ambient lights");
+        }
+
+        Eigen::Matrix4f shadowMat = lightVec.dot(planeVec) * Eigen::Matrix4f::Identity() -
+            (lightVec * planeVec.transpose());
+        return shadowMat;
+      },
+      R"(Create a modelview matrix that when passed to rasterize_mesh will project all the vertices to the passed-in plane.
+
+This is useful for rendering shadows using the classic projection shadows technique from OpenGL.
+
+:param light: The light to use to cast shadows.
+:param plane_normal: The normal vector of the plane (defaults to y-up, (0, 1, 0)).
+:param plane_origin: A point on the plane, defaults to the origin (0, 0, 0).
+
+:return: a 4x4 matrix that can be passed to the rasterizer function.)",
+      py::arg("light"),
+      py::arg("plane_normal") = std::optional<Eigen::Vector3f>{},
+      py::arg("plane_origin") = std::optional<Eigen::Vector3f>{});
+}

--- a/pymomentum/renderer/software_rasterizer.cpp
+++ b/pymomentum/renderer/software_rasterizer.cpp
@@ -1,0 +1,1656 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "pymomentum/renderer/software_rasterizer.h"
+
+#include "pymomentum/tensor_momentum/tensor_momentum_utility.h"
+#include "pymomentum/tensor_utility/tensor_utility.h"
+
+#include <momentum/character/character.h>
+#include <momentum/character/linear_skinning.h>
+#include <momentum/character/skeleton.h>
+#include <momentum/character/skeleton_state.h>
+#include <momentum/math/fwd.h>
+#include <momentum/math/mesh.h>
+
+#include <momentum/rasterizer/geometry.h>
+#include <momentum/rasterizer/image.h>
+#include <momentum/rasterizer/rasterizer.h>
+
+#include <drjit/packet.h>
+#include <fmt/format.h>
+#include <pybind11/pybind11.h>
+
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace py = pybind11;
+
+namespace pymomentum {
+
+namespace {
+
+template <typename T, size_t R>
+Kokkos::mdspan<T, Kokkos::dextents<std::ptrdiff_t, R>> make_mdspan(const at::Tensor& t) {
+  if (t.scalar_type() != toScalarType<T>()) {
+    throw std::runtime_error("Scalar type incorrect in mdspan conversion.");
+  }
+
+  if (t.dim() != R) {
+    throw std::runtime_error(fmt::format(
+        "Incorrect dimension in mdspan conversion; expected ndim={} but got {}",
+        R,
+        formatTensorSizes(t)));
+  }
+
+  if (!t.device().is_cpu()) {
+    throw std::runtime_error("Expected CPU tensor in mdspan conversion");
+  }
+
+  std::array<std::ptrdiff_t, R> extents{};
+  for (int64_t i = 0; i < t.dim(); ++i) {
+    extents[i] = t.size(i);
+  }
+
+  return Kokkos::mdspan<T, Kokkos::dextents<std::ptrdiff_t, R>>(t.data_ptr<T>(), extents);
+}
+
+template <typename T, size_t R>
+Kokkos::mdspan<T, Kokkos::dextents<std::ptrdiff_t, R>> make_mdspan(std::optional<at::Tensor> t) {
+  if (!t.has_value()) {
+    return Kokkos::mdspan<T, Kokkos::dextents<std::ptrdiff_t, R>>();
+  }
+
+  return make_mdspan<T, R>(t.value());
+}
+
+template <typename T, size_t R>
+Kokkos::mdspan<T, Kokkos::dextents<std::ptrdiff_t, R>> make_mdspan(const py::buffer_info& info) {
+  if (info.format != py::format_descriptor<T>::format()) {
+    throw std::runtime_error("Incorrect scalar format in Numpy array.");
+  }
+
+  if (info.ndim != R) {
+    throw std::runtime_error(fmt::format(
+        "Incorrect dimension in mdspan conversion; expected ndim={} but got {}",
+        R,
+        formatTensorSizes(info.shape)));
+  }
+
+  std::array<std::ptrdiff_t, R> extents{};
+  for (int64_t i = 0; i < R; ++i) {
+    extents.at(i) = info.shape.at(i);
+  }
+
+  return Kokkos::mdspan<T, Kokkos::dextents<std::ptrdiff_t, R>>(static_cast<T*>(info.ptr), extents);
+}
+
+std::tuple<
+    at::Tensor,
+    std::optional<at::Tensor>,
+    std::optional<at::Tensor>,
+    std::optional<at::Tensor>,
+    std::optional<at::Tensor>>
+validateRasterizerBuffers(
+    TensorChecker& checker,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer = {},
+    std::optional<at::Tensor> vertexIndexBuffer = {},
+    std::optional<at::Tensor> triangleIndexBuffer = {}) {
+  // Values chosen to not conflict with any other bound values:
+  const int widthBindingID = -2003;
+  const int heightBindingID = -2004;
+
+  const int32_t imageWidth = camera.imageWidth();
+  const int32_t imageHeight = camera.imageHeight();
+  const int32_t paddedWidth = momentum::rasterizer::padImageWidthForRasterizer(imageWidth);
+
+  zBuffer = checker.validateAndFixTensor(
+      zBuffer,
+      "zBuffer",
+      {heightBindingID, widthBindingID},
+      {"imageHeight", "imageWidth"},
+      at::kFloat,
+      true,
+      false);
+
+  if (rgbBuffer) {
+    *rgbBuffer = checker.validateAndFixTensor(
+        *rgbBuffer,
+        "rgbBuffer",
+        {heightBindingID, widthBindingID, 3},
+        {"imageHeight", "imageWidth", "rgb"},
+        at::kFloat,
+        true,
+        false);
+  }
+
+  if (surfaceNormalsBuffer) {
+    *surfaceNormalsBuffer = checker.validateAndFixTensor(
+        *surfaceNormalsBuffer,
+        "surfaceNormalsBuffer",
+        {heightBindingID, widthBindingID, 3},
+        {"imageHeight", "imageWidth", "rgb"},
+        at::kFloat,
+        true,
+        false);
+  }
+
+  if (vertexIndexBuffer) {
+    *vertexIndexBuffer = checker.validateAndFixTensor(
+        *vertexIndexBuffer,
+        "vertexIndexBuffer",
+        {heightBindingID, widthBindingID},
+        {"imageHeight", "imageWidth"},
+        at::kInt,
+        true,
+        false);
+  }
+
+  if (triangleIndexBuffer) {
+    *triangleIndexBuffer = checker.validateAndFixTensor(
+        *triangleIndexBuffer,
+        "triangleIndexBuffer",
+        {heightBindingID, widthBindingID},
+        {"imageHeight", "imageWidth"},
+        at::kInt,
+        true,
+        false);
+  }
+
+  const auto zBufferWidth = checker.getBoundValue(widthBindingID);
+  const auto zBufferHeight = checker.getBoundValue(heightBindingID);
+
+  // Write a custom error message rather than relying on the tensor checker so
+  // we can warn people about the padding requirement.
+  if (zBufferHeight != imageHeight || zBufferWidth != paddedWidth) {
+    throw std::runtime_error(fmt::format(
+        "Expected z buffer of size {} x {} but got {} x {}.  "
+        "Note that the width must be padded out to the nearest {} to ensure fast SIMD code.  ",
+        imageHeight,
+        paddedWidth,
+        zBufferHeight,
+        zBufferWidth,
+        momentum::rasterizer::kSimdPacketSize));
+  }
+
+  return {zBuffer, rgbBuffer, surfaceNormalsBuffer, vertexIndexBuffer, triangleIndexBuffer};
+}
+
+std::vector<momentum::rasterizer::Light> convertLightsToEyeSpace(
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const momentum::rasterizer::Camera& camera) {
+  if (!lights.has_value()) {
+    return {};
+  }
+
+  const Eigen::Affine3f worldToEyeXF = camera.worldFromEye();
+  std::vector<momentum::rasterizer::Light> result;
+  result.reserve(lights->size());
+  for (const auto& l : *lights) {
+    result.push_back(momentum::rasterizer::transformLight(l, worldToEyeXF));
+  }
+
+  return result;
+}
+
+} // namespace
+
+at::Tensor createZBuffer(const momentum::rasterizer::Camera& camera, float farClip) {
+  return at::full(
+      {camera.imageHeight(), momentum::rasterizer::padImageWidthForRasterizer(camera.imageWidth())},
+      farClip,
+      at::kFloat);
+}
+
+at::Tensor createRGBBuffer(
+    const momentum::rasterizer::Camera& camera,
+    std::optional<Eigen::Vector3f> bgColor) {
+  auto result = at::zeros(
+      {camera.imageHeight(),
+       momentum::rasterizer::padImageWidthForRasterizer(camera.imageWidth()),
+       3},
+      at::kFloat);
+
+  if (bgColor.has_value()) {
+    result.select(-1, 0) = bgColor->x();
+    result.select(-1, 1) = bgColor->y();
+    result.select(-1, 2) = bgColor->z();
+  }
+
+  return result;
+}
+
+at::Tensor createIndexBuffer(const momentum::rasterizer::Camera& camera) {
+  return at::full(
+      {camera.imageHeight(), momentum::rasterizer::padImageWidthForRasterizer(camera.imageWidth())},
+      -1,
+      at::kInt);
+}
+
+std::optional<at::Tensor> maybeSelect(std::optional<at::Tensor> tensor, int64_t index) {
+  if (!tensor) {
+    return {};
+  }
+
+  return tensor->select(0, index);
+}
+
+// rasterize with CameraData3d which considers distortion
+void rasterizeMesh(
+    at::Tensor positions,
+    std::optional<at::Tensor> normals,
+    at::Tensor triangles,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> vertexIndexBuffer,
+    std::optional<at::Tensor> triangleIndexBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<at::Tensor> textureCoordinates,
+    std::optional<at::Tensor> textureTriangles,
+    std::optional<at::Tensor> perVertexDiffuseColor,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const int nVertsBindingID = -1;
+  const int nTrisBindingID = -2;
+
+  TensorChecker checker("rasterize");
+  positions = checker.validateAndFixTensor(
+      positions, "positions", {nVertsBindingID, 3}, {"nVertices", "xyz"}, at::kFloat, true, false);
+
+  if (normals.has_value()) {
+    normals = checker.validateAndFixTensor(
+        normals.value(),
+        "normals",
+        {nVertsBindingID, 3},
+        {"nVertices", "xyz"},
+        at::kFloat,
+        true,
+        true);
+  }
+
+  triangles = checker.validateAndFixTensor(
+      triangles, "triangles", {nTrisBindingID, 3}, {"nTriangles", "xyz"}, at::kInt, true, false);
+
+  if (textureCoordinates.has_value()) {
+    textureCoordinates = checker.validateAndFixTensor(
+        textureCoordinates.value(),
+        "texture_coordinates",
+        {nVertsBindingID, 2},
+        {"nVerts", "uv"},
+        at::kFloat,
+        true,
+        false);
+  }
+
+  if (textureTriangles.has_value()) {
+    textureTriangles = checker.validateAndFixTensor(
+        textureTriangles.value(),
+        "triangles",
+        {nTrisBindingID, 3},
+        {"nTriangles", "xyz"},
+        at::kInt,
+        true,
+        false);
+  }
+
+  if (perVertexDiffuseColor.has_value()) {
+    perVertexDiffuseColor = checker.validateAndFixTensor(
+        perVertexDiffuseColor.value(),
+        "perVertexDiffuseColor",
+        {nVertsBindingID, 3},
+        {"nVerts", "rgb"},
+        at::kFloat,
+        true,
+        false);
+  }
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, vertexIndexBuffer, triangleIndexBuffer) =
+      validateRasterizerBuffers(
+          checker,
+          camera,
+          zBuffer,
+          rgbBuffer,
+          surfaceNormalsBuffer,
+          vertexIndexBuffer,
+          triangleIndexBuffer);
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel.
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    Eigen::VectorXf emptyTextureCoords;
+    Eigen::VectorXf emptyNormals;
+    Eigen::VectorXi emptyTextureTriangles;
+    Eigen::VectorXf emptyPerVertexDiffuseColor;
+    momentum::rasterizer::rasterizeMesh(
+        toEigenMap<float>(positions.select(0, iBatch)),
+        normals.has_value() ? toEigenMap<float>(normals->select(0, iBatch)) : emptyNormals,
+        toEigenMap<int>(triangles.select(0, iBatch)),
+        textureCoordinates.has_value() ? toEigenMap<float>(textureCoordinates->select(0, iBatch))
+                                       : emptyTextureCoords,
+        textureTriangles.has_value() ? toEigenMap<int32_t>(textureTriangles->select(0, iBatch))
+                                     : emptyTextureTriangles,
+        perVertexDiffuseColor.has_value()
+            ? toEigenMap<float>(perVertexDiffuseColor->select(0, iBatch))
+            : emptyPerVertexDiffuseColor,
+        camera,
+        modelMatrix.value_or(Eigen::Matrix4f::Identity()),
+        nearClip,
+        material.value_or(momentum::rasterizer::PhongMaterial{}),
+        make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+        make_mdspan<int, 2>(maybeSelect(vertexIndexBuffer, iBatch)),
+        make_mdspan<int, 2>(maybeSelect(triangleIndexBuffer, iBatch)),
+        lights_eye,
+        backfaceCulling,
+        depthOffset,
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+  }
+}
+
+void rasterizeWireframe(
+    at::Tensor positions,
+    at::Tensor triangles,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float thickness,
+    const std::optional<Eigen::Vector3f>& color,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const int nVertsBindingID = -1;
+  const int nTrisBindingID = -2;
+
+  TensorChecker checker("rasterize");
+  positions = checker.validateAndFixTensor(
+      positions, "positions", {nVertsBindingID, 3}, {"nVertices", "xyz"}, at::kFloat, true, false);
+
+  triangles = checker.validateAndFixTensor(
+      triangles, "triangles", {nTrisBindingID, 3}, {"nTriangles", "xyz"}, at::kInt, true, false);
+
+  std::tie(zBuffer, rgbBuffer, std::ignore, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, {}, {}, {});
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel.
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    Eigen::VectorXf emptyTextureCoords;
+    Eigen::VectorXi emptyTextureTriangles;
+    momentum::rasterizer::rasterizeWireframe(
+        toEigenMap<float>(positions.select(0, iBatch)),
+        toEigenMap<int>(triangles.select(0, iBatch)),
+        camera,
+        modelMatrix.value_or(Eigen::Matrix4f::Identity()),
+        nearClip,
+        color.value_or(Eigen::Vector3f{1, 1, 1}),
+        thickness,
+        make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+        backfaceCulling,
+        depthOffset,
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+  }
+}
+
+void rasterizeSpheres(
+    at::Tensor center,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> radius,
+    std::optional<at::Tensor> color,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix_in,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int subdivisionLevel) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  const int nSpheresBindingID = -1;
+
+  TensorChecker checker("rasterize");
+  center = checker.validateAndFixTensor(
+      center, "center", {nSpheresBindingID, 3}, {"nSpheres", "xyz"}, at::kFloat, true, false);
+
+  if (radius) {
+    *radius = checker.validateAndFixTensor(
+        *radius, "radius", {nSpheresBindingID}, {"nSpheres"}, at::kFloat, true, false);
+  }
+
+  if (color) {
+    *color = checker.validateAndFixTensor(
+        *color, "color", {nSpheresBindingID, 3}, {"nSpheres", "rgb"}, at::kFloat, true, false);
+  }
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, surfaceNormalsBuffer, {}, {});
+
+  const auto nSpheres = checker.getBoundValue(nSpheresBindingID);
+
+  const auto sphereMesh = momentum::rasterizer::makeSphere(subdivisionLevel);
+
+  const Eigen::Matrix4f modelMatrix = modelMatrix_in.value_or(Eigen::Matrix4f::Identity());
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto zBufferCur = zBuffer.select(0, iBatch);
+    auto rgbBufferCur = maybeSelect(rgbBuffer, iBatch);
+    auto centerCur = center.select(0, iBatch);
+    auto radiiCur = maybeSelect(radius, iBatch);
+    auto colorsCur = maybeSelect(color, iBatch);
+
+    for (int i = 0; i < nSpheres; ++i) {
+      const float radiusVal = radiiCur ? toEigenMap<float>(*radiiCur)(i) : 1.0f;
+      auto materialCur = material.value_or(momentum::rasterizer::PhongMaterial());
+      if (colorsCur) {
+        materialCur.diffuseColor = toEigenMap<float>(*colorsCur).segment<3>(3 * i);
+      }
+
+      Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+      transform.translate(toEigenMap<float>(centerCur).segment<3>(3 * i));
+      transform.scale(radiusVal);
+
+      momentum::rasterizer::rasterizeMesh(
+          sphereMesh,
+          camera,
+          modelMatrix * transform.matrix(),
+          nearClip,
+          materialCur,
+          make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+          {},
+          {},
+          lights_eye,
+          backfaceCulling,
+          depthOffset,
+          imageOffset.value_or(Eigen::Vector2f::Zero()));
+    }
+  }
+}
+
+void rasterizeCylinders(
+    at::Tensor start_position,
+    at::Tensor end_position,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> radius,
+    std::optional<at::Tensor> color,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix_in,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int lengthSubdivisions,
+    int radiusSubdivisions) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  const int nCylindersBindingID = -1;
+
+  TensorChecker checker("rasterize");
+  start_position = checker.validateAndFixTensor(
+      start_position,
+      "start_position",
+      {nCylindersBindingID, 3},
+      {"nCylinders", "xyz"},
+      at::kFloat,
+      true,
+      false);
+
+  end_position = checker.validateAndFixTensor(
+      end_position,
+      "end_position",
+      {nCylindersBindingID, 3},
+      {"nCylinders", "xyz"},
+      at::kFloat,
+      true,
+      false);
+
+  if (radius) {
+    *radius = checker.validateAndFixTensor(
+        *radius, "radius", {nCylindersBindingID}, {"nSpheres"}, at::kFloat, true, false);
+  }
+
+  if (color) {
+    *color = checker.validateAndFixTensor(
+        *color, "color", {nCylindersBindingID, 3}, {"nCylinders", "rgb"}, at::kFloat, true, false);
+  }
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, surfaceNormalsBuffer, {}, {});
+
+  const auto nCylinders = checker.getBoundValue(nCylindersBindingID);
+
+  const auto cylinderMesh =
+      momentum::rasterizer::makeCylinder(radiusSubdivisions, lengthSubdivisions);
+
+  const Eigen::Matrix4f modelMatrix = modelMatrix_in.value_or(Eigen::Matrix4f::Identity());
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto zBufferCur = zBuffer.select(0, iBatch);
+    auto rgbBufferCur = maybeSelect(rgbBuffer, iBatch);
+    auto startPosCur = start_position.select(0, iBatch);
+    auto endPosCur = end_position.select(0, iBatch);
+    auto radiusCur = maybeSelect(radius, iBatch);
+    auto colorCur = maybeSelect(color, iBatch);
+
+    for (int i = 0; i < nCylinders; ++i) {
+      const Eigen::Vector3f startPos = toEigenMap<float>(startPosCur).segment<3>(3 * i);
+      const Eigen::Vector3f endPos = toEigenMap<float>(endPosCur).segment<3>(3 * i);
+      const float radiusVal = radiusCur ? toEigenMap<float>(*radiusCur)(i) : 1.0f;
+      auto materialCur = material.value_or(momentum::rasterizer::PhongMaterial());
+      if (colorCur) {
+        materialCur.diffuseColor = toEigenMap<float>(*colorCur).segment<3>(3 * i);
+      }
+
+      const float length = (endPos - startPos).norm();
+      Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+      transform.translate(startPos);
+      transform.rotate(Eigen::Quaternionf::FromTwoVectors(
+          Eigen::Vector3f::UnitX(), (endPos - startPos).normalized()));
+      transform.scale(Eigen::Vector3f(length, radiusVal, radiusVal));
+
+      momentum::rasterizer::rasterizeMesh(
+          cylinderMesh,
+          camera,
+          modelMatrix * transform.matrix(),
+          nearClip,
+          materialCur,
+          make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+          {},
+          {},
+          lights_eye,
+          backfaceCulling,
+          depthOffset,
+          imageOffset.value_or(Eigen::Vector2f::Zero()));
+    }
+  }
+}
+
+void rasterizeCapsules(
+    at::Tensor transformation,
+    at::Tensor radius,
+    at::Tensor length,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix_in,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int cylinderLengthSubdivisions,
+    int cylinderRadiusSubdivisions) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  const int nCapsulesBindingId = -1;
+
+  TensorChecker checker("rasterize");
+  transformation = checker.validateAndFixTensor(
+      transformation,
+      "transformation",
+      {nCapsulesBindingId, 4, 4},
+      {"nCapsules", "rows", "cols"},
+      at::kFloat,
+      true,
+      false);
+
+  radius = checker.validateAndFixTensor(
+      radius,
+      "radius",
+      {nCapsulesBindingId, 2},
+      {"nCapsules", "startEnd"},
+      at::kFloat,
+      true,
+      false);
+
+  length = checker.validateAndFixTensor(
+      length, "length", {nCapsulesBindingId}, {"nCapsules"}, at::kFloat, true, false);
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, surfaceNormalsBuffer, {}, {});
+
+  const auto nCapsules = checker.getBoundValue(nCapsulesBindingId);
+
+  const Eigen::Matrix4f modelMatrix = modelMatrix_in.value_or(Eigen::Matrix4f::Identity());
+
+  // Capsules are closed surfaces so we might as well always cull:
+  const bool backfaceCulling = true;
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto zBufferCur = zBuffer.select(0, iBatch);
+    auto rgbBufferCur = maybeSelect(rgbBuffer, iBatch);
+    auto transformationCur = transformation.select(0, iBatch);
+    auto radiusCur = radius.select(0, iBatch);
+    auto lengthCur = length.select(0, iBatch);
+
+    for (int i = 0; i < nCapsules; ++i) {
+      const Eigen::Matrix4f transform =
+          toEigenMap<float>(transformationCur).segment<16>(16 * i).reshaped(4, 4).transpose();
+
+      const Eigen::Vector2f radiusVal = toEigenMap<float>(radiusCur).segment<2>(2 * i);
+      const float lengthVal = toEigenMap<float>(lengthCur)(i);
+
+      auto materialCur = material.value_or(momentum::rasterizer::PhongMaterial());
+
+      momentum::rasterizer::rasterizeMesh(
+          momentum::rasterizer::makeCapsule(
+              cylinderRadiusSubdivisions,
+              cylinderLengthSubdivisions,
+              radiusVal[0],
+              radiusVal[1],
+              lengthVal),
+          camera,
+          modelMatrix * transform.matrix(),
+          nearClip,
+          materialCur,
+          make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+          {},
+          {},
+          lights_eye,
+          backfaceCulling,
+          depthOffset,
+          imageOffset.value_or(Eigen::Vector2f::Zero()));
+    }
+  }
+}
+
+void rasterizeLines(
+    at::Tensor positions,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float width,
+    const std::optional<Eigen::Vector3f>& color,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const int nLinesBindingId = -1;
+
+  TensorChecker checker("rasterize");
+  positions = checker.validateAndFixTensor(
+      positions,
+      "positions",
+      {nLinesBindingId, 2, 3},
+      {"nLines", "start_end", "xyz"},
+      at::kFloat,
+      true,
+      false);
+
+  std::tie(zBuffer, rgbBuffer, std::ignore, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, {}, {}, {});
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto zBufferCur = zBuffer.select(0, iBatch);
+    auto rgbBufferCur = maybeSelect(rgbBuffer, iBatch);
+    auto positionsCur = positions.select(0, iBatch);
+
+    momentum::rasterizer::rasterizeLines(
+        toEigenMap<float>(positionsCur),
+        camera,
+        modelMatrix.value_or(Eigen::Matrix4f::Identity()),
+        nearClip,
+        color.value_or(Eigen::Vector3f::Ones()),
+        width,
+        make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+        depthOffset,
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+  }
+}
+
+void rasterizeCircles(
+    at::Tensor positions,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float lineThickness,
+    float radius,
+    const std::optional<Eigen::Vector3f>& lineColor,
+    std::optional<Eigen::Vector3f> fillColor,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const int nCirclesBindingId = -1;
+
+  TensorChecker checker("rasterize");
+  positions = checker.validateAndFixTensor(
+      positions, "positions", {nCirclesBindingId, 3}, {"nCircles", "xyz"}, at::kFloat, true, false);
+
+  // If no color is provided, use fill=white as default.
+  if (!lineColor.has_value() && !fillColor.has_value()) {
+    fillColor = Eigen::Vector3f::Ones();
+  }
+
+  std::tie(zBuffer, rgbBuffer, std::ignore, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, {}, {}, {});
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto positionsCur = positions.select(0, iBatch);
+
+    momentum::rasterizer::rasterizeCircles(
+        toEigenMap<float>(positionsCur),
+        camera,
+        modelMatrix.value_or(Eigen::Matrix4f::Identity()),
+        nearClip,
+        lineColor,
+        fillColor,
+        lineThickness,
+        radius,
+        make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+        depthOffset,
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+  }
+}
+
+void rasterizeSkeleton(
+    const momentum::Character& character,
+    at::Tensor skeletonState,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& jointMaterial,
+    const std::optional<momentum::rasterizer::PhongMaterial>& cylinderMaterial,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix_in,
+    bool backfaceCulling,
+    std::optional<at::Tensor> activeJoints_in,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    float sphereRadius,
+    float cylinderRadius,
+    int sphereSubdivisionLevel,
+    int cylinderLengthSubdivisions,
+    int cylinderRadiusSubdivisions,
+    SkeletonStyle style) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  TensorChecker checker("rasterize_skeleton");
+
+  skeletonState = checker.validateAndFixTensor(
+      skeletonState,
+      "skeletonState",
+      {(int)character.skeleton.joints.size(), 8},
+      {"nJoints", "pos+rot+scale"},
+      at::kFloat,
+      true,
+      false);
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, surfaceNormalsBuffer, {}, {});
+
+  const auto nJoints = character.skeleton.joints.size();
+
+  const Eigen::Matrix4f modelMatrix = modelMatrix_in.value_or(Eigen::Matrix4f::Identity());
+
+  std::vector<bool> activeJoints(nJoints);
+  if (activeJoints_in.has_value()) {
+    activeJoints =
+        tensorToJointSet(character.skeleton, *activeJoints_in, DefaultJointSet::ALL_ONES);
+  } else {
+    // Make all joints active except b_world, which we usually don't want to
+    // render because it's confusing:
+    for (size_t i = 0; i < character.skeleton.joints.size(); ++i) {
+      activeJoints[i] = (character.skeleton.joints[i].name != "body_world");
+    }
+  }
+
+  // Now construct the parent relationships:
+  std::vector<std::pair<size_t, size_t>> jointConnections;
+  for (size_t iJoint = 0; iJoint < character.skeleton.joints.size(); ++iJoint) {
+    if (!activeJoints[iJoint]) {
+      continue;
+    }
+
+    size_t grandparent = character.skeleton.joints[iJoint].parent;
+    while (grandparent != momentum::kInvalidIndex && !activeJoints[grandparent]) {
+      grandparent = character.skeleton.joints[grandparent].parent;
+    }
+
+    if (grandparent != momentum::kInvalidIndex) {
+      jointConnections.emplace_back(iJoint, grandparent);
+    }
+  }
+
+  momentum::rasterizer::Mesh jointMesh;
+  std::vector<Eigen::Vector3f> jointLines;
+  std::vector<Eigen::Vector3f> jointCircles;
+  momentum::rasterizer::Mesh sphereMesh;
+
+  if (style == SkeletonStyle::Octahedrons) {
+    std::tie(jointMesh, jointLines) = momentum::rasterizer::makeOctahedron(0.15, 0.1);
+    sphereMesh = momentum::rasterizer::makeSphere(sphereSubdivisionLevel);
+
+  } else if (style == SkeletonStyle::Lines) {
+    for (size_t i = 0; i < cylinderLengthSubdivisions; ++i) {
+      jointLines.emplace_back(i / float(cylinderLengthSubdivisions), 0, 0);
+      jointLines.emplace_back((i + 1) / float(cylinderLengthSubdivisions), 0, 0);
+    }
+    jointCircles.emplace_back(0, 0, 0);
+  } else {
+    sphereMesh = momentum::rasterizer::makeSphere(sphereSubdivisionLevel);
+    jointMesh =
+        momentum::rasterizer::makeCylinder(cylinderRadiusSubdivisions, cylinderLengthSubdivisions);
+  }
+
+  const float lineThickness =
+      (style == SkeletonStyle::Lines) ? std::max(1.0f, 2.0f * cylinderRadius) : 1.0f;
+  const float circleRadius = std::max(1.0f, sphereRadius);
+
+  const Eigen::Vector3f lineColor = (style == SkeletonStyle::Lines)
+      ? cylinderMaterial.value_or(momentum::rasterizer::PhongMaterial{}).diffuseColor
+      : Eigen::Vector3f::Constant(0.3f);
+  const Eigen::Vector3f circleColor =
+      jointMaterial.value_or(momentum::rasterizer::PhongMaterial{}).diffuseColor;
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto zBufferCur = zBuffer.select(0, iBatch);
+    auto rgbBufferCur = maybeSelect(rgbBuffer, iBatch);
+    auto skelStateCur = skeletonState.select(0, iBatch);
+
+    for (size_t jJoint = 0; jJoint < nJoints; ++jJoint) {
+      if (!activeJoints[jJoint]) {
+        continue;
+      }
+
+      Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+      transform.translate(toEigenMap<float>(skelStateCur).segment<3>(8 * jJoint));
+      transform.scale(sphereRadius);
+
+      if (!jointCircles.empty()) {
+        momentum::rasterizer::rasterizeCircles(
+            jointCircles,
+            camera,
+            modelMatrix * transform.matrix(),
+            nearClip,
+            lineColor,
+            circleColor,
+            0.5f * lineThickness,
+            circleRadius,
+            make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+            depthOffset,
+            imageOffset.value_or(Eigen::Vector2f::Zero()));
+      }
+
+      if (!sphereMesh.vertices.empty()) {
+        momentum::rasterizer::rasterizeMesh(
+            sphereMesh,
+            camera,
+            modelMatrix * transform.matrix(),
+            nearClip,
+            jointMaterial.value_or(momentum::rasterizer::PhongMaterial{}),
+            make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+            {},
+            {},
+            lights_eye,
+            backfaceCulling,
+            depthOffset,
+            imageOffset.value_or(Eigen::Vector2f::Zero()));
+      }
+    }
+
+    const auto skelStateMap = toEigenMap<float>(skelStateCur);
+
+    for (const auto& [childJoint, parentJoint] : jointConnections) {
+      const auto parentXF = momentum::Transform(
+          skelStateMap.segment<3>(8 * parentJoint),
+          Eigen::Quaternionf(skelStateMap.segment<4>(8 * parentJoint + 3)),
+          skelStateMap(8 * parentJoint + 7));
+
+      const auto childXF = momentum::Transform(
+          skelStateMap.segment<3>(8 * childJoint),
+          Eigen::Quaternionf(skelStateMap.segment<4>(8 * childJoint + 3)),
+          skelStateMap(8 * childJoint + 7));
+
+      const Eigen::Vector3f diff = childXF.translation - parentXF.translation;
+      const float length = diff.norm();
+      if (length < 1e-6) {
+        continue;
+      }
+
+      // x always points to the next joint, y and z axes are aligned
+      // to the local y and z axes of the parent joint where possible:
+      const Eigen::Vector3f xVec = diff.normalized();
+      Eigen::Vector3f yVec = (parentXF.toLinear() * Eigen::Vector3f::UnitY()).normalized();
+      Eigen::Vector3f zVec = (parentXF.toLinear() * Eigen::Vector3f::UnitZ()).normalized();
+      yVec = xVec.cross(zVec).normalized();
+      zVec = xVec.cross(yVec).normalized();
+
+      Eigen::Matrix3f rotMat = Eigen::Matrix3f::Identity();
+      rotMat.col(0) = xVec;
+      rotMat.col(1) = yVec;
+      rotMat.col(2) = zVec;
+
+      Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+      transform.translate(parentXF.translation);
+      transform.linear() = rotMat;
+
+      if (style == SkeletonStyle::Octahedrons) {
+        transform.scale(Eigen::Vector3f::Constant(length));
+      } else {
+        transform.scale(Eigen::Vector3f(length, cylinderRadius, cylinderRadius));
+      }
+
+      if (!jointMesh.vertices.empty()) {
+        momentum::rasterizer::rasterizeMesh(
+            jointMesh,
+            camera,
+            modelMatrix * transform.matrix(),
+            nearClip,
+            cylinderMaterial.value_or(momentum::rasterizer::PhongMaterial{}),
+            make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+            {},
+            {},
+            lights_eye,
+            backfaceCulling,
+            depthOffset,
+            imageOffset.value_or(Eigen::Vector2f::Zero()));
+      }
+
+      if (!jointLines.empty()) {
+        momentum::rasterizer::rasterizeLines(
+            jointLines,
+            camera,
+            modelMatrix * transform.matrix(),
+            nearClip,
+            lineColor,
+            lineThickness,
+            make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+            depthOffset - 0.001f,
+            imageOffset.value_or(Eigen::Vector2f::Zero()));
+      }
+    }
+  }
+}
+
+void rasterizeCharacter(
+    const momentum::Character& character,
+    at::Tensor skeletonState,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> vertexIndexBuffer,
+    std::optional<at::Tensor> triangleIndexBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<at::Tensor> perVertexDiffuseColor,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix_in,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    std::optional<Eigen::Vector3f> wireframeColor) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (!character.skinWeights || !character.mesh) {
+    throw std::runtime_error("Mesh is missing from character.");
+  }
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  TensorChecker checker("rasterize_character");
+
+  skeletonState = checker.validateAndFixTensor(
+      skeletonState,
+      "skeletonState",
+      {(int)character.skeleton.joints.size(), 8},
+      {"nJoints", "pos+rot+scale"},
+      at::kFloat,
+      true,
+      false);
+
+  if (perVertexDiffuseColor) {
+    perVertexDiffuseColor = checker.validateAndFixTensor(
+        *perVertexDiffuseColor,
+        "perVertexDiffuseColor",
+        {(int)character.mesh->vertices.size(), 3},
+        {"nVertices", "rgb"},
+        at::kFloat,
+        true,
+        false);
+  }
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, vertexIndexBuffer, triangleIndexBuffer) =
+      validateRasterizerBuffers(
+          checker,
+          camera,
+          zBuffer,
+          rgbBuffer,
+          surfaceNormalsBuffer,
+          vertexIndexBuffer,
+          triangleIndexBuffer);
+
+  const Eigen::Matrix4f modelMatrix = modelMatrix_in.value_or(Eigen::Matrix4f::Identity());
+
+  const auto nJoints = character.skeleton.joints.size();
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto zBufferCur = zBuffer.select(0, iBatch);
+    auto rgbBufferCur = maybeSelect(rgbBuffer, iBatch);
+    auto skelStateCur = skeletonState.select(0, iBatch);
+
+    std::vector<momentum::JointState> jointStates(character.skeleton.joints.size());
+    const auto skelStateMap = toEigenMap<float>(skelStateCur);
+    for (size_t jJoint = 0; jJoint < nJoints; ++jJoint) {
+      const auto tf = momentum::Transform(
+          skelStateMap.segment<3>(8 * jJoint),
+          Eigen::Quaternionf(skelStateMap.segment<4>(8 * jJoint + 3)),
+          skelStateMap(8 * jJoint + 7));
+
+      auto& js = jointStates.at(jJoint);
+      js.transform = tf;
+    }
+
+    momentum::Mesh posedMesh = *character.mesh;
+    momentum::applySSD(
+        character.inverseBindPose, *character.skinWeights, *character.mesh, jointStates, posedMesh);
+
+    // Don't trust the skinned normals:
+    posedMesh.updateNormals();
+
+    momentum::rasterizer::rasterizeMesh(
+        posedMesh.vertices,
+        posedMesh.normals,
+        posedMesh.faces,
+        posedMesh.texcoords,
+        posedMesh.texcoord_faces,
+        perVertexDiffuseColor.has_value()
+            ? toEigenMap<float>(perVertexDiffuseColor->select(0, iBatch))
+            : Eigen::VectorXf{},
+        camera,
+        modelMatrix,
+        nearClip,
+        material.value_or(momentum::rasterizer::PhongMaterial{}),
+        make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+        make_mdspan<int, 2>(maybeSelect(vertexIndexBuffer, iBatch)),
+        make_mdspan<int, 2>(maybeSelect(triangleIndexBuffer, iBatch)),
+        lights_eye,
+        backfaceCulling,
+        depthOffset,
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+
+    if (wireframeColor.has_value()) {
+      momentum::rasterizer::rasterizeWireframe(
+          posedMesh.vertices,
+          posedMesh.faces,
+          camera,
+          modelMatrix,
+          nearClip,
+          *wireframeColor,
+          1.0f,
+          make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+          backfaceCulling,
+          depthOffset - 0.001,
+          imageOffset.value_or(Eigen::Vector2f::Zero()));
+    }
+  }
+}
+
+void rasterizeCheckerboard(
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material1_in,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material2_in,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    float width,
+    int numChecks,
+    int subdivisions) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  if (numChecks <= 0) {
+    throw std::runtime_error("num_checks should be positive.");
+  }
+
+  if (width <= 0) {
+    throw std::runtime_error("width should be positive.");
+  }
+
+  if (subdivisions < 1) {
+    throw std::runtime_error("subdivisions should be positive.");
+  }
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  TensorChecker checker("rasterize_checkerboard");
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, surfaceNormalsBuffer, {}, {});
+
+  const auto& meshes = momentum::rasterizer::makeCheckerboard(width, numChecks, subdivisions);
+
+  // Simply white/gray scheme.  All-white or all-black tends to look bad in the
+  // render:
+  std::array<momentum::rasterizer::PhongMaterial, 2> materials = {
+      material1_in.value_or(momentum::rasterizer::PhongMaterial{Eigen::Vector3f(0.8f, 0.8f, 0.8f)}),
+      material2_in.value_or(
+          momentum::rasterizer::PhongMaterial{Eigen::Vector3f(0.5f, 0.5f, 0.5f)})};
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    for (int k = 0; k < 2; ++k) {
+      momentum::rasterizer::rasterizeMesh(
+          meshes[k],
+          camera,
+          modelMatrix.value_or(Eigen::Matrix4f::Identity()),
+          nearClip,
+          materials[k],
+          make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+          make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+          {},
+          {},
+          lights_eye,
+          backfaceCulling,
+          depthOffset,
+          imageOffset.value_or(Eigen::Vector2f::Zero()));
+    }
+  }
+}
+
+momentum::rasterizer::Tensor<float, 3> toFloatImage(const pybind11::array_t<const float>& img) {
+  if (img.ndim() != 3 || img.shape(2) != 3) {
+    throw std::runtime_error("Expected tensor shape height x width x 3 for RGB image.");
+  }
+
+  momentum::rasterizer::Tensor<float, 3> result(
+      {static_cast<std::ptrdiff_t>(img.shape(0)),
+       static_cast<std::ptrdiff_t>(img.shape(1)),
+       static_cast<std::ptrdiff_t>(img.shape(2))});
+  auto r = img.unchecked<3>(); // x must have ndim = 3; can be non-writable
+  for (py::ssize_t i = 0; i < r.shape(0); i++) {
+    for (py::ssize_t j = 0; j < r.shape(1); j++) {
+      for (py::ssize_t k = 0; k < r.shape(2); k++) {
+        result(i, j, k) = r(i, j, k);
+      }
+    }
+  }
+  return result;
+}
+
+momentum::rasterizer::PhongMaterial createPhongMaterial(
+    const std::optional<Eigen::Vector3f>& diffuseColor,
+    const std::optional<Eigen::Vector3f>& specularColor,
+    const std::optional<float>& specularExponent,
+    const std::optional<Eigen::Vector3f>& emissiveColor,
+    const std::optional<pybind11::array_t<const float>>& diffuseTexture,
+    const std::optional<pybind11::array_t<const float>>& emissiveTexture) {
+  momentum::rasterizer::PhongMaterial result;
+  result.diffuseColor = diffuseColor.value_or(Eigen::Vector3f::Ones());
+  result.specularColor = specularColor.value_or(Eigen::Vector3f::Zero());
+  result.specularExponent = specularExponent.value_or(10.0f);
+  result.emissiveColor = emissiveColor.value_or(Eigen::Vector3f::Zero());
+
+  if (diffuseTexture) {
+    result.diffuseTextureMap = toFloatImage(diffuseTexture.value());
+  }
+  if (emissiveTexture) {
+    result.emissiveTextureMap = toFloatImage(emissiveTexture.value());
+  }
+
+  return result;
+}
+
+void alphaMatte(
+    at::Tensor zBuffer,
+    at::Tensor rgbBuffer,
+    const pybind11::array& tgtRgbImage,
+    float alpha) {
+  TensorChecker checker("alpha_matte");
+
+  const int widthBindingID = -2003;
+  const int heightBindingID = -2004;
+
+  zBuffer = checker.validateAndFixTensor(
+      zBuffer,
+      "zBuffer",
+      {heightBindingID, widthBindingID},
+      {"imageHeight", "imageWidth"},
+      at::kFloat,
+      true,
+      false);
+
+  rgbBuffer = checker.validateAndFixTensor(
+      rgbBuffer,
+      "rgbBuffer",
+      {heightBindingID, widthBindingID, 3},
+      {"imageHeight", "imageWidth", "rgb"},
+      at::kFloat,
+      true,
+      false);
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    const auto tgtRgbImage_info = tgtRgbImage.request();
+    if (tgtRgbImage_info.format == py::format_descriptor<float>::format()) {
+      momentum::rasterizer::alphaMatte(
+          make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(rgbBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(tgtRgbImage_info),
+          alpha);
+    } else if (tgtRgbImage_info.format == py::format_descriptor<uint8_t>::format()) {
+      momentum::rasterizer::alphaMatte(
+          make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+          make_mdspan<float, 3>(rgbBuffer.select(0, iBatch)),
+          make_mdspan<uint8_t, 3>(tgtRgbImage_info),
+          alpha);
+    } else {
+      throw std::runtime_error("tgt_rgb_image must be a uint8 or float32 RGB array.");
+    }
+  }
+}
+
+void rasterizeCameraFrustum(
+    const momentum::rasterizer::Camera& frustumCamera,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float lineWidth,
+    float distance,
+    size_t numSamples,
+    const std::optional<Eigen::Vector3f>& color,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  if (lineWidth <= 0) {
+    throw std::runtime_error("line_width should be positive.");
+  }
+
+  if (numSamples <= 2) {
+    throw std::runtime_error("num_samples should be at least 3.");
+  }
+
+  if (distance <= 0) {
+    throw std::runtime_error("distance should be positive.");
+  }
+
+  TensorChecker checker("rasterize_camera_frustum");
+
+  std::tie(zBuffer, rgbBuffer, std::ignore, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, {}, {}, {});
+
+  const std::vector<Eigen::Vector3f> frustumLinesEye =
+      momentum::rasterizer::makeCameraFrustumLines(frustumCamera, distance, numSamples);
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (int64_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    momentum::rasterizer::rasterizeLines(
+        frustumLinesEye,
+        camera,
+        modelMatrix.value_or(Eigen::Matrix4f::Identity()) * frustumCamera.worldFromEye().matrix(),
+        nearClip,
+        color.value_or(Eigen::Vector3f::Ones()),
+        lineWidth,
+        make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+        make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+        depthOffset,
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+  }
+}
+
+void rasterizeLines2D(
+    at::Tensor positions,
+    at::Tensor rgbBuffer,
+    float thickness,
+    const std::optional<Eigen::Vector3f>& color,
+    std::optional<at::Tensor> zBuffer,
+    const std::optional<Eigen::Vector2f>& imageOffset) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  const int nLinesBindingId = -1;
+  const int heightBindingId = -2003;
+  const int widthBindingId = -2004;
+
+  TensorChecker checker("rasterize_lines_2d");
+  positions = checker.validateAndFixTensor(
+      positions,
+      "positions",
+      {nLinesBindingId, 2, 2},
+      {"nLines", "start_end", "xy"},
+      at::kFloat,
+      true,
+      false);
+
+  rgbBuffer = checker.validateAndFixTensor(
+      rgbBuffer,
+      "rgb_buffer",
+      {heightBindingId, widthBindingId, 3},
+      {"height", "width", "rgb"},
+      at::kFloat,
+      true,
+      false);
+
+  if (zBuffer.has_value()) {
+    zBuffer = checker.validateAndFixTensor(
+        *zBuffer,
+        "z_buffer",
+        {heightBindingId, widthBindingId},
+        {"height", "width"},
+        at::kFloat,
+        true,
+        false);
+  }
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto rgbBufferCur = rgbBuffer.select(0, iBatch);
+    auto positionsCur = positions.select(0, iBatch);
+    auto zBufferCur =
+        zBuffer.has_value() ? maybeSelect(zBuffer, iBatch) : std::optional<at::Tensor>{};
+
+    momentum::rasterizer::rasterizeLines2D(
+        toEigenMap<float>(positionsCur),
+        color.value_or(Eigen::Vector3f::Ones()),
+        thickness,
+        make_mdspan<float, 3>(rgbBufferCur),
+        make_mdspan<float, 2>(zBufferCur),
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+  }
+}
+
+void rasterizeCircles2D(
+    at::Tensor positions,
+    at::Tensor rgbBuffer,
+    float lineThickness,
+    float radius,
+    const std::optional<Eigen::Vector3f>& lineColor,
+    std::optional<Eigen::Vector3f> fillColor,
+    std::optional<at::Tensor> zBuffer,
+    const std::optional<Eigen::Vector2f>& imageOffset) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  const int nCirclesBindingId = -1;
+  const int heightBindingId = -2003;
+  const int widthBindingId = -2004;
+
+  TensorChecker checker("rasterize_circles_2d");
+  positions = checker.validateAndFixTensor(
+      positions, "positions", {nCirclesBindingId, 2}, {"nCircles", "xy"}, at::kFloat, true, false);
+
+  rgbBuffer = checker.validateAndFixTensor(
+      rgbBuffer,
+      "rgb_buffer",
+      {heightBindingId, widthBindingId, 3},
+      {"height", "width", "rgb"},
+      at::kFloat,
+      true,
+      false);
+
+  // If no color is provided, use fill=white as default.
+  if (!lineColor.has_value() && !fillColor.has_value()) {
+    fillColor = Eigen::Vector3f::Ones();
+  }
+
+  if (zBuffer.has_value()) {
+    zBuffer = checker.validateAndFixTensor(
+        *zBuffer,
+        "z_buffer",
+        {heightBindingId, widthBindingId},
+        {"height", "width"},
+        at::kFloat,
+        true,
+        false);
+  }
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (size_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto rgbBufferCur = rgbBuffer.select(0, iBatch);
+    auto positionsCur = positions.select(0, iBatch);
+    auto zBufferCur =
+        zBuffer.has_value() ? maybeSelect(zBuffer, iBatch) : std::optional<at::Tensor>{};
+
+    momentum::rasterizer::rasterizeCircles2D(
+        toEigenMap<float>(positionsCur),
+        lineColor,
+        fillColor,
+        lineThickness,
+        radius,
+        make_mdspan<float, 3>(rgbBufferCur),
+        make_mdspan<float, 2>(zBufferCur),
+        imageOffset.value_or(Eigen::Vector2f::Zero()));
+  }
+}
+
+void rasterizeTransforms(
+    at::Tensor transforms,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    float scale,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights_world,
+    const std::optional<Eigen::Matrix4f>& modelMatrix_in,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int lengthSubdivisions,
+    int radiusSubdivisions) {
+  drjit::scoped_flush_denormals flushDenorm(true);
+  pybind11::gil_scoped_release release;
+
+  if (nearClip <= 0) {
+    throw std::runtime_error("near_clip should be positive.");
+  }
+
+  const auto lights_eye = convertLightsToEyeSpace(std::move(lights_world), camera);
+
+  const int nTransformsBindingId = -1;
+
+  TensorChecker checker("rasterize");
+
+  transforms = checker.validateAndFixTensor(
+      transforms,
+      "transforms",
+      {nTransformsBindingId, 4, 4},
+      {"nTransforms", "rows", "cols"},
+      at::kFloat,
+      true,
+      false);
+
+  const float c1 = 1.0f;
+  const float c2 = 0.3f;
+  const bool backfaceCulling = true;
+
+  momentum::rasterizer::PhongMaterial materials[3] = {
+      material.value_or(momentum::rasterizer::PhongMaterial(Eigen::Vector3f(c1, c2, c2))),
+      material.value_or(momentum::rasterizer::PhongMaterial(Eigen::Vector3f(c2, c1, c2))),
+      material.value_or(momentum::rasterizer::PhongMaterial(Eigen::Vector3f(c2, c2, c1)))};
+
+  std::tie(zBuffer, rgbBuffer, surfaceNormalsBuffer, std::ignore, std::ignore) =
+      validateRasterizerBuffers(checker, camera, zBuffer, rgbBuffer, surfaceNormalsBuffer, {}, {});
+
+  const auto nTransforms = checker.getBoundValue(nTransformsBindingId);
+
+  const auto arrowMesh = momentum::rasterizer::makeArrow(
+      radiusSubdivisions, lengthSubdivisions, 0.05f, 0.2f, 0.4f, 0.6f);
+
+  const Eigen::Matrix4f modelMatrix = modelMatrix_in.value_or(Eigen::Matrix4f::Identity());
+
+  // We don't expect batched to be the common case, so don't try to process
+  // the batches in parallel
+  for (int64_t iBatch = 0; iBatch < checker.getBatchSize(); ++iBatch) {
+    auto zBufferCur = zBuffer.select(0, iBatch);
+    auto rgbBufferCur = maybeSelect(rgbBuffer, iBatch);
+
+    auto transformsCur = transforms.select(0, iBatch);
+    auto a = transformsCur.accessor<float, 3>();
+
+    for (int i = 0; i < nTransforms; ++i) {
+      const Eigen::Vector3f origin(a[i][0][3], a[i][1][3], a[i][2][3]);
+      for (int j = 0; j < 3; ++j) {
+        const Eigen::Vector3f col_j(a[i][0][j], a[i][1][j], a[i][2][j]);
+        const float length = col_j.norm();
+        if (length == 0) {
+          continue;
+        }
+
+        const auto& materialCur = materials[j];
+
+        Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+        transform.translate(origin);
+        transform.rotate(
+            Eigen::Quaternionf::FromTwoVectors(Eigen::Vector3f::UnitX(), col_j.normalized()));
+        transform.scale(scale * Eigen::Vector3f(length, length, length));
+
+        momentum::rasterizer::rasterizeMesh(
+            arrowMesh,
+            camera,
+            modelMatrix * transform.matrix(),
+            nearClip,
+            materialCur,
+            make_mdspan<float, 2>(zBuffer.select(0, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(rgbBuffer, iBatch)),
+            make_mdspan<float, 3>(maybeSelect(surfaceNormalsBuffer, iBatch)),
+            {},
+            {},
+            lights_eye,
+            backfaceCulling,
+            depthOffset,
+            imageOffset.value_or(Eigen::Vector2f::Zero()));
+      }
+    }
+  }
+}
+
+} // namespace pymomentum

--- a/pymomentum/renderer/software_rasterizer.h
+++ b/pymomentum/renderer/software_rasterizer.h
@@ -1,0 +1,272 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <momentum/character/character.h>
+
+#include <momentum/rasterizer/camera.h>
+#include <momentum/rasterizer/fwd.h>
+#include <momentum/rasterizer/rasterizer.h>
+
+#include <ATen/ATen.h>
+#include <pybind11/numpy.h>
+#include <Eigen/Geometry>
+#include <cfloat>
+
+#include <optional>
+
+namespace pymomentum {
+
+// A SIMD-based software rasterizer that supports the Nimble camera model
+// and per-pixel Phong shading/lighting.
+void rasterizeMesh(
+    at::Tensor positions,
+    std::optional<at::Tensor> normals,
+    at::Tensor triangles,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> vertexIndexBuffer,
+    std::optional<at::Tensor> triangleIndexBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<at::Tensor> textureCoordinates,
+    std::optional<at::Tensor> textureTriangles,
+    std::optional<at::Tensor> perVertexDiffuseColor,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset);
+
+void rasterizeWireframe(
+    at::Tensor positions,
+    at::Tensor triangles,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float width,
+    const std::optional<Eigen::Vector3f>& color,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset);
+
+void rasterizeSpheres(
+    at::Tensor center,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> radius,
+    std::optional<at::Tensor> color,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int subdivisionLevel);
+
+void rasterizeCylinders(
+    at::Tensor start_position,
+    at::Tensor end_position,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> radius,
+    std::optional<at::Tensor> color,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int lengthSubdivisions,
+    int radiusSubdivisions);
+
+void rasterizeCapsules(
+    at::Tensor transformation,
+    at::Tensor radius,
+    at::Tensor length,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int cylinderLengthSubdivisions,
+    int cylinderRadiusSubdivisions);
+
+enum class SkeletonStyle {
+  Octahedrons,
+  Pipes,
+  Lines,
+};
+
+void rasterizeSkeleton(
+    const momentum::Character& character,
+    at::Tensor skeletonState,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& jointMaterial,
+    const std::optional<momentum::rasterizer::PhongMaterial>& cylinderMaterial,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    std::optional<at::Tensor> activeJoints,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    float sphereRadius,
+    float cylinderRadius,
+    int sphereSubdivisionLevel,
+    int cylinderLengthSubdivisions,
+    int cylinderRadiusSubdivisions,
+    SkeletonStyle style);
+
+void rasterizeCharacter(
+    const momentum::Character& character,
+    at::Tensor skeletonState,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    std::optional<at::Tensor> vertexIndexBuffer,
+    std::optional<at::Tensor> triangleIndexBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<at::Tensor> perVertexDiffuseColor,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    std::optional<Eigen::Vector3f> wireframeColor);
+
+void rasterizeCheckerboard(
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material1,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material2,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    bool backfaceCulling,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    float width,
+    int numChecks,
+    int subdivisions);
+
+void rasterizeLines(
+    at::Tensor positions,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float width,
+    const std::optional<Eigen::Vector3f>& color,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset);
+
+void rasterizeCameraFrustum(
+    const momentum::rasterizer::Camera& frustumCamera,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float lineWidth,
+    float distance,
+    size_t numSamples,
+    const std::optional<Eigen::Vector3f>& color,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset);
+
+void rasterizeTransforms(
+    at::Tensor transforms,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    std::optional<at::Tensor> surfaceNormalsBuffer,
+    float scale,
+    const std::optional<momentum::rasterizer::PhongMaterial>& material,
+    std::optional<std::vector<momentum::rasterizer::Light>> lights,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset,
+    int lengthSubdivisions,
+    int radiusSubdivisions);
+
+void rasterizeCircles(
+    at::Tensor positions,
+    const momentum::rasterizer::Camera& camera,
+    at::Tensor zBuffer,
+    std::optional<at::Tensor> rgbBuffer,
+    float lineThickness,
+    float radius,
+    const std::optional<Eigen::Vector3f>& lineColor,
+    std::optional<Eigen::Vector3f> fillColor,
+    const std::optional<Eigen::Matrix4f>& modelMatrix,
+    float nearClip,
+    float depthOffset,
+    const std::optional<Eigen::Vector2f>& imageOffset);
+
+// 2D rasterization functions that operate directly in image space
+// without camera projection or z-buffer
+
+void rasterizeLines2D(
+    at::Tensor positions,
+    at::Tensor rgbBuffer,
+    float thickness,
+    const std::optional<Eigen::Vector3f>& color,
+    std::optional<at::Tensor> zBuffer,
+    const std::optional<Eigen::Vector2f>& imageOffset);
+
+void rasterizeCircles2D(
+    at::Tensor positions,
+    at::Tensor rgbBuffer,
+    float lineThickness,
+    float radius,
+    const std::optional<Eigen::Vector3f>& lineColor,
+    std::optional<Eigen::Vector3f> fillColor,
+    std::optional<at::Tensor> zBuffer,
+    const std::optional<Eigen::Vector2f>& imageOffset);
+
+at::Tensor createZBuffer(const momentum::rasterizer::Camera& camera, float far_clip = FLT_MAX);
+at::Tensor createRGBBuffer(
+    const momentum::rasterizer::Camera& camera,
+    std::optional<Eigen::Vector3f> bgColor);
+at::Tensor createIndexBuffer(const momentum::rasterizer::Camera& camera);
+
+momentum::rasterizer::PhongMaterial createPhongMaterial(
+    const std::optional<Eigen::Vector3f>& diffuseColor,
+    const std::optional<Eigen::Vector3f>& specularColor,
+    const std::optional<float>& specularExponent,
+    const std::optional<Eigen::Vector3f>& emissiveColor,
+    const std::optional<pybind11::array_t<const float>>& diffuseTexture,
+    const std::optional<pybind11::array_t<const float>>& emissiveTexture);
+
+void alphaMatte(
+    at::Tensor zBuffer,
+    at::Tensor rgbBuffer,
+    const pybind11::array& tgtRgbImage,
+    float alpha = 1.0f);
+
+} // namespace pymomentum

--- a/pymomentum/test/test_renderer.py
+++ b/pymomentum/test/test_renderer.py
@@ -1,0 +1,262 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import numpy as np
+
+import pymomentum.renderer as pym_renderer
+import torch
+from numpy.typing import NDArray
+
+
+class TestRendering(unittest.TestCase):
+    def test_lighting(self) -> None:
+        """Test that directional lighting works."""
+
+        image_width, image_height = 30, 30
+        camera = pym_renderer.Camera(
+            pym_renderer.PinholeIntrinsicsModel(
+                image_width=image_width,
+                image_height=image_height,
+            )
+        )
+
+        def rasterize_spheres_with_lights(
+            lights: list[pym_renderer.Light] | None,
+            camera_param: pym_renderer.Camera = camera,
+        ) -> torch.Tensor:
+            z_buffer = pym_renderer.create_z_buffer(camera_param)
+            rgb_buffer = pym_renderer.create_rgb_buffer(camera_param)
+
+            pym_renderer.rasterize_spheres(
+                center=torch.as_tensor([[0, 0, 20]], dtype=torch.float32),
+                lights=lights,
+                radius=torch.as_tensor([5], dtype=torch.float32),
+                camera=camera_param,
+                rgb_buffer=rgb_buffer,
+                z_buffer=z_buffer,
+            )
+            return rgb_buffer
+
+        def mean_absolute_difference(t1: torch.Tensor, t2: torch.Tensor) -> float:
+            return torch.mean(torch.abs(t1 - t2)).item()
+
+        default_lighting = rasterize_spheres_with_lights(None)
+        lights_at_camera = rasterize_spheres_with_lights(
+            [pym_renderer.Light.create_point_light(camera.center_of_projection)]
+        )
+        # pyre-fixme[6]: For 2nd argument expected `SupportsDunderLT[_T]` but got
+        #  `float`.
+        self.assertGreater(torch.mean(default_lighting), 0.15)
+        front_directional_lighting = rasterize_spheres_with_lights(
+            [
+                pym_renderer.Light.create_directional_light(
+                    camera.world_space_principle_axis
+                )
+            ]
+        )
+
+        # One light at the camera should be identical to the default lighting.
+        self.assertLess(
+            mean_absolute_difference(default_lighting, lights_at_camera), 1e-4
+        )
+        # Directional lighting is a bit different from a point light at the camera but
+        # should be pretty close.
+        self.assertLess(
+            mean_absolute_difference(default_lighting, front_directional_lighting), 0.05
+        )
+        self.assertGreater(
+            torch.mean(front_directional_lighting),
+            # pyre-fixme[6]: For 2nd argument expected `SupportsDunderLT[_T]` but
+            #  got `Tensor`.
+            torch.mean(default_lighting),
+        )
+
+        back_lighting = rasterize_spheres_with_lights(
+            [
+                pym_renderer.Light.create_directional_light(
+                    -camera.world_space_principle_axis
+                )
+            ]
+        )
+
+        # We should see very little light coming from the back:
+        self.assertLess(
+            mean_absolute_difference(back_lighting, torch.zeros_like(default_lighting)),
+            1e-4,
+        )
+
+        # All lighting should be from the left side:
+        left_lighting = rasterize_spheres_with_lights(
+            [
+                pym_renderer.Light.create_directional_light(
+                    np.asarray([1, 0, 0], dtype=np.float32)
+                )
+            ]
+        )
+        # pyre-fixme[6]: For 2nd argument expected `SupportsDunderLT[_T]` but got
+        #  `float`.
+        self.assertGreater(torch.mean(left_lighting[:, : image_width // 2]), 0.1)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsDunderGT[_T]` but got
+        #  `float`.
+        self.assertLess(torch.mean(left_lighting[:, image_width // 2 :]), 1e-5)
+
+        # All lighting should be from the right side:
+        right_lighting = rasterize_spheres_with_lights(
+            [
+                pym_renderer.Light.create_directional_light(
+                    np.asarray([-1, 0, 0], dtype=np.float32)
+                )
+            ]
+        )
+        # pyre-fixme[6]: For 2nd argument expected `SupportsDunderGT[_T]` but got
+        #  `float`.
+        self.assertLess(torch.mean(right_lighting[:, : image_width // 2]), 1e-5)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsDunderLT[_T]` but got
+        #  `float`.
+        self.assertGreater(torch.mean(right_lighting[:, image_width // 2 :]), 0.1)
+
+    def test_subdivide_uneven(self) -> None:
+        """Check that we can do uneven subdivision where only some edges are split."""
+
+        def _compute_area(
+            mesh_positions: NDArray[np.float32], triangles: NDArray[np.int32]
+        ) -> float:
+            v1 = mesh_positions[triangles[:, 1]] - mesh_positions[triangles[:, 0]]
+            v2 = mesh_positions[triangles[:, 2]] - mesh_positions[triangles[:, 0]]
+            cross_prod = np.cross(v1, v2)
+            return 0.5 * np.sum(np.linalg.norm(cross_prod, axis=-1))
+
+        def _compute_triangle_normals(
+            mesh_positions: NDArray[np.float32], triangles: NDArray[np.int32]
+        ) -> NDArray[np.float32]:
+            v1 = mesh_positions[triangles[:, 1]] - mesh_positions[triangles[:, 0]]
+            v2 = mesh_positions[triangles[:, 2]] - mesh_positions[triangles[:, 0]]
+            cross_prod = np.cross(v1, v2)
+            return cross_prod / np.linalg.norm(cross_prod, axis=-1, keepdims=True)
+
+        mesh_positions_orig = np.asarray([[0, 0, 0], [0.25, 0, 0], [0, 1, 0]])
+
+        mesh_normals_orig = np.asarray([[0, 0, 1]] * 3)
+        mesh_triangles_orig = np.asarray([[0, 1, 2]], dtype=np.int32)
+
+        self.assertAlmostEqual(
+            _compute_area(mesh_positions_orig, mesh_triangles_orig), 0.125
+        )
+
+        # Check basic invariants:
+        #   total area is unchanged
+        #   all triangles have the correct winding
+        def _check_invariants(
+            max_edge_length: float,
+            expected_triangles: int,
+            positions: NDArray[np.float32] = mesh_positions_orig,
+            normals: NDArray[np.float32] = mesh_normals_orig,
+            triangles: NDArray[np.int32] = mesh_triangles_orig,
+        ) -> None:
+            (
+                mesh_positions_subd,
+                mesh_normals_subd,
+                mesh_triangles_subd,
+                texture_coords_subd,
+                texture_triangles_subd,
+            ) = pym_renderer.subdivide_mesh(
+                positions,
+                normals,
+                triangles,
+                levels=1,
+                max_edge_length=max_edge_length,
+            )
+
+            self.assertEqual(mesh_triangles_subd.shape[0], expected_triangles)
+
+            # Since we didn't provide texture coords, should get just all-zeros texture coords:
+            self.assertTrue(np.array_equal(mesh_triangles_subd, texture_triangles_subd))
+            self.assertFalse(np.any(texture_coords_subd))
+
+            area_new = _compute_area(mesh_positions_subd, mesh_triangles_subd)
+            self.assertAlmostEqual(area_new, 0.125)
+
+            normals_new = _compute_triangle_normals(
+                mesh_positions_subd, mesh_triangles_subd
+            )
+            self.assertEqual(normals_new.shape[0], expected_triangles)
+            for i in range(normals_new.shape[0]):
+                self.assertLess(np.linalg.norm(normals_new[i] - normals[0]), 1e-3)
+
+        _check_invariants(10, 1)
+        _check_invariants(1.01, 2)
+        _check_invariants(0.99, 3)
+        _check_invariants(0.001, 4)
+
+    def test_shadow_projection_matrix_point_light(self) -> None:
+        """Check that the projection matrix actually projects points."""
+
+        points = np.asarray(
+            [[0, 0, 0], [0, 10, 0], [0, 0, 10], [0, 10, 10], [10, 20, 20]],
+            dtype=np.float32,
+        )
+
+        pos_light = pym_renderer.Light.create_point_light(
+            np.asarray([0, 50, 0], dtype=np.float32)
+        )
+        pos_proj_mat = pym_renderer.create_shadow_projection_matrix(pos_light)
+        plane_normal = np.asarray([0, 1, 0], dtype=np.float32)
+
+        for i in range(points.shape[0]):
+            p = np.concatenate([points[i, :], np.ones([1], dtype=np.float32)])
+            p_proj_unnormalized = np.matmul(pos_proj_mat, p)
+            p_proj_normalized = p_proj_unnormalized[0:3] / p_proj_unnormalized[3]
+
+            # vector pointing from p toward light:
+            light_vec = pos_light.position - p[0:3]
+            light_vec = light_vec / np.linalg.norm(light_vec)
+
+            # intersect with plane:
+            # (p + t * light_vec) . n = 0
+            # p . n = -(light_vec . n) * t
+            # Solve for t:
+            t = -np.dot(p[0:3], plane_normal) / np.dot(light_vec, plane_normal)
+            p_proj = p[0:3] + t * light_vec
+            self.assertTrue(np.allclose(p_proj, p_proj_normalized))
+
+    def test_shadow_projection_matrix_dir_light(self) -> None:
+        points = np.asarray(
+            [[0, 0, 0], [0, 10, 0], [0, 0, 10], [0, 10, 10], [10, 20, 20]],
+            dtype=np.float32,
+        )
+
+        dir_light = pym_renderer.Light.create_directional_light(
+            np.asarray([-1, -1, -2], dtype=np.float32)
+        )
+        plane_normal = np.asarray([0, 1, 0], dtype=np.float32)
+        plane_origin = np.asarray([0, -1, 0], dtype=np.float32)
+        plane_offset = np.dot(plane_normal, plane_origin)
+        dir_proj_mat = pym_renderer.create_shadow_projection_matrix(
+            dir_light, plane_normal=plane_normal, plane_origin=plane_origin
+        )
+
+        for i in range(points.shape[0]):
+            p = np.concatenate([points[i, :], np.ones([1], dtype=np.float32)])
+            p_proj_unnormalized = np.matmul(dir_proj_mat, p)
+            p_proj_normalized = p_proj_unnormalized[0:3] / p_proj_unnormalized[3]
+
+            # vector pointing from p toward light:
+            light_vec = dir_light.position
+            light_vec = light_vec / np.linalg.norm(light_vec)
+
+            # intersect with plane:
+            # (p + t * light_vec) . n = plane_offset
+            # t * (light_vec . n) = plane_offset - (p . n)
+            # Solve for t:
+            t = (plane_offset - np.dot(p[0:3], plane_normal)) / np.dot(
+                light_vec, plane_normal
+            )
+            p_proj = p[0:3] + t * light_vec
+            self.assertTrue(np.allclose(p_proj, p_proj_normalized))
+            self.assertAlmostEqual(p_proj[1], -1)


### PR DESCRIPTION
Summary:
## Context
Refactoring the codebase to move from fbcode to arvr, enabling library use in both repos.

For users:

* In fbcode, minimal impact. Update buck target path from `fbcode/pymomentum` to `arvr/libraries/pymomentum` in BUCK (include paths and code remain the same).

* In arvr, some pymomentum features may be temporarily disabled or use fallback implementation due to pytorch package limitations in arvr.

## This Diff

* Move `renderer` to `arvr/libraries/pymomentum/` with minor code formatting changes (arvr mode is **not** yet supported)
* Create alias target in the original location to delay updating references until the final diff.

Differential Revision: D84090986
