### PR TITLE
Update API doc for renderer and torch modules

### DIFF
--- a/pymomentum/doc/backend.rst
+++ b/pymomentum/doc/backend.rst
@@ -6,11 +6,8 @@ pymomentum.backend
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 pymomentum.backend.skel\_state\_backend module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 
 .. automodule:: pymomentum.backend.skel_state_backend
    :members:
@@ -18,7 +15,7 @@ pymomentum.backend.skel\_state\_backend module
    :show-inheritance:
 
 pymomentum.backend.trs\_backend module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 
 .. automodule:: pymomentum.backend.trs_backend
    :members:
@@ -26,7 +23,7 @@ pymomentum.backend.trs\_backend module
    :show-inheritance:
 
 pymomentum.backend.utils module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 .. automodule:: pymomentum.backend.utils
    :members:

--- a/pymomentum/doc/gpu_character.rst
+++ b/pymomentum/doc/gpu_character.rst
@@ -1,7 +1,0 @@
-pymomentum.gpu_character
-========================
-
-.. automodule:: pymomentum.gpu_character
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/pymomentum/doc/index.rst
+++ b/pymomentum/doc/index.rst
@@ -9,8 +9,9 @@ Welcome to PyMomentum
    quaternion
    skel_state
    trs
+   backend
    solver
    solver2
    marker_tracking
-   backend
-   gpu_character
+   torch
+   renderer

--- a/pymomentum/doc/renderer.rst
+++ b/pymomentum/doc/renderer.rst
@@ -1,0 +1,7 @@
+pymomentum.renderer
+===================
+
+.. automodule:: pymomentum.renderer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pymomentum/doc/torch.rst
+++ b/pymomentum/doc/torch.rst
@@ -1,0 +1,31 @@
+pymomentum.torch
+================
+
+.. automodule:: pymomentum.torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pymomentum.torch.character
+--------------------------
+
+.. automodule:: pymomentum.torch.character
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pymomentum.torch.parameter_limits
+----------------------------------
+
+.. automodule:: pymomentum.torch.parameter_limits
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pymomentum.torch.utility
+------------------------
+
+.. automodule:: pymomentum.torch.utility
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Summary:
Update pymomentum documentation to reflect new module structure:
- Add renderer.rst for new renderer module
- Add torch.rst for torch module (character, parameter_limits, utility)
- Remove gpu_character.rst (deprecated, replaced by torch.rst)
- Reorder index.rst logically based on BUCK dependency order
- Update backend.rst formatting for consistency

Differential Revision: D84123746


