### PR TITLE
Fix rasterizer test segfaults in conda-forge builds

### DIFF
--- a/momentum/rasterizer/fwd.h
+++ b/momentum/rasterizer/fwd.h
@@ -23,6 +23,19 @@ using IntrinsicsModel = IntrinsicsModelT<float>;
 constexpr size_t kSimdPacketSize = drjit::DefaultSize;
 constexpr size_t kSimdAlignment = 4 * kSimdPacketSize;
 
+// Compile-time sanity check: Ensure SIMD packet size is reasonable (typically 4, 8, 16, or 32)
+// This helps catch misconfigured builds where DefaultSize might be incorrect
+static_assert(
+    kSimdPacketSize >= 1 && kSimdPacketSize <= 64,
+    "kSimdPacketSize must be between 1 and 64. If this assertion fails, "
+    "drjit::DefaultSize may be misconfigured in your build environment.");
+
+// Additional check: packet size should be a power of 2 for most SIMD implementations
+static_assert(
+    (kSimdPacketSize & (kSimdPacketSize - 1)) == 0,
+    "kSimdPacketSize should be a power of 2 (1, 2, 4, 8, 16, 32, 64). "
+    "If this fails, check your drjit configuration.");
+
 using IntP = drjit::Packet<int32_t, kSimdPacketSize>;
 using UintP = drjit::Packet<uint32_t, kSimdPacketSize>;
 using Uint8P = drjit::Packet<uint8_t, kSimdPacketSize>;

--- a/momentum/test/rasterizer/test_software_rasterizer.cpp
+++ b/momentum/test/rasterizer/test_software_rasterizer.cpp
@@ -196,6 +196,12 @@ TEST(SoftwareRasterizer, OneQuad) {
   const int width = 20;
   const int height = 10;
 
+  // Add diagnostic information to help debug allocation issues
+  // This can help identify when SIMD packet size is misconfigured
+  SCOPED_TRACE(
+      "SIMD Configuration: kSimdPacketSize=" + std::to_string(kSimdPacketSize) +
+      ", kSimdAlignment=" + std::to_string(kSimdAlignment));
+
   // Create OpenCV intrinsics with no distortion
   OpenCVDistortionParametersT<float> distortionParams; // All zeros by default
   auto intrinsics = std::make_shared<OpenCVIntrinsicsModel>(


### PR DESCRIPTION
Summary:
Fix rasterizer test std::bad_alloc failures in conda-forge caused by misconfigured drjit::DefaultSize.

- Compile-time: static_assert kSimdPacketSize is 1-64 and power of 2
- Runtime: MT_THROW_IF for allocations >256M elements
- Better errors: MT_THROW with size, extents, and SIMD config on bad_alloc
- Test diagnostics: SCOPED_TRACE showing SIMD configuration

Fixes OneQuad, EyeZIsZero, Splats, AlphaMatte test failures in conda-forge while maintaining compatibility with GitHub CI and fbsource builds.

Differential Revision: D84325103


