### PR TITLE
Fix flaky character_test by using fixed random seeds

### DIFF
--- a/momentum/test/character/character_helpers.cpp
+++ b/momentum/test/character/character_helpers.cpp
@@ -55,10 +55,11 @@ Eigen::MatrixX<T> randomMatrix(Eigen::Index nRows, Eigen::Index nCols) {
 // hardcoded locators for test character
 [[nodiscard]] LocatorList createDefaultLocatorList(size_t numJoints) {
   LocatorList result;
+  momentum::Random<> rng(10001);
   for (int i = 0; i < numJoints; ++i) {
     Locator loc;
     loc.parent = i;
-    loc.offset = Eigen::Vector3f::Random();
+    loc.offset = rng.uniform<Eigen::Vector3f>(-1.0f, 1.0f);
     loc.name = "l" + std::to_string(i);
     result.push_back(loc);
   }

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -20,6 +20,7 @@
 #include "momentum/character/skin_weights.h"
 #include "momentum/math/constants.h"
 #include "momentum/math/mesh.h"
+#include "momentum/math/random.h"
 #include "momentum/test/character/character_helpers.h"
 #include "momentum/test/helpers/expect_throw.h"
 
@@ -29,6 +30,8 @@ using namespace momentum;
 class CharacterUtilityTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    Random<>::GetSingleton().setSeed(42);
+
     // Create test characters with different numbers of joints
     character = createTestCharacter<float>(5);
     smallCharacter = createTestCharacter<float>(3);


### PR DESCRIPTION
Summary:
The CharacterUtilityTest.TransformCharacter test was [failing](https://github.com/facebookresearch/momentum/actions/runs/18413273590/job/52470860848) intermittently on GitHub Actions due to non-deterministic random number generation:

```
[ RUN      ] CharacterUtilityTest.TransformCharacter
/home/runner/work/momentum/momentum/momentum/test/character/character_utility_test.cpp:160: Failure
Value of: meshTransformed->normals[0].isApprox(expectedNormal)
  Actual: false
Expected: true

[  FAILED  ] CharacterUtilityTest.TransformCharacter (0 ms)
```

Fixed by setting a fixed seed for the global random number generator in the test fixture and replacing Eigen's Random() with a seeded RNG in test helper functions.

Differential Revision: D84366206


