### PR TITLE
Enable Docusaurus editor for website

### DIFF
--- a/momentum/website/docusaurus.config.js
+++ b/momentum/website/docusaurus.config.js
@@ -53,6 +53,7 @@ const {fbContent, fbInternalOnly} = require('docusaurus-plugin-internaldocs-fb/i
         gtag: {
           trackingID: 'G-NQKPMTK7XB',
         },
+        enableEditor: true,
       }),
     ],
   ],


### PR DESCRIPTION
Summary: Enable inline editing functionality for Momentum documentation by adding `enableEditor: true` to the Docusaurus preset configuration. For more details on this feature, see https://www.internalfb.com/intern/staticdocs/staticdocs/docs/setup/5-plugin/

Differential Revision: D84373444


