### PR TITLE
axel: hole filling code for SDF.

### DIFF
--- a/axel/axel/math/MeshHoleFilling.cpp
+++ b/axel/axel/math/MeshHoleFilling.cpp
@@ -1,0 +1,593 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "axel/math/MeshHoleFilling.h"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace axel {
+
+namespace {
+
+using Edge = std::pair<Index, Index>;
+
+// Simple hash for edge pairs - custom hash struct to avoid std::hash<std::pair> issues
+struct EdgePairHash {
+  std::size_t operator()(const std::pair<Index, Index>& edge) const {
+    return std::hash<Index>{}(edge.first) ^ (std::hash<Index>{}(edge.second) << 1);
+  }
+};
+
+using EdgeCountMap = std::unordered_map<std::pair<Index, Index>, size_t, EdgePairHash>;
+
+/**
+ * Build edge-to-triangle count map for hole detection.
+ * Much more efficient than storing full triangle lists - we only need counts.
+ */
+EdgeCountMap buildEdgeCountMap(gsl::span<const Eigen::Vector3i> triangles) {
+  EdgeCountMap edgeCountMap;
+
+  for (const auto& triangle : triangles) {
+    // Add three edges of the triangle
+    const std::array<Edge, 3> edges = {
+        {{triangle[0], triangle[1]}, {triangle[1], triangle[2]}, {triangle[2], triangle[0]}}};
+
+    for (const auto& edge : edges) {
+      // Normalize edge orientation (smaller index first)
+      const auto normalizedEdge =
+          std::make_pair(std::min(edge.first, edge.second), std::max(edge.first, edge.second));
+
+      // Simply increment the count - much more efficient than storing triangle IDs
+      edgeCountMap[normalizedEdge]++;
+    }
+  }
+
+  return edgeCountMap;
+}
+
+/**
+ * Find boundary edges (edges that belong to only one triangle).
+ */
+std::vector<std::pair<Index, Index>> findBoundaryEdges(const EdgeCountMap& edgeCountMap) {
+  std::vector<std::pair<Index, Index>> boundaryEdges;
+
+  for (const auto& [edge, count] : edgeCountMap) {
+    if (count == 1) {
+      // This edge belongs to only one triangle, so it's a boundary edge
+      boundaryEdges.push_back(edge);
+    }
+  }
+
+  return boundaryEdges;
+}
+
+/**
+ * Group boundary edges into connected hole loops.
+ */
+std::vector<std::vector<std::pair<Index, Index>>> groupBoundaryEdgesIntoLoops(
+    const std::vector<std::pair<Index, Index>>& boundaryEdges) {
+  if (boundaryEdges.empty()) {
+    return {};
+  }
+
+  // Build adjacency map for vertices
+  std::unordered_map<Index, std::vector<Index>> vertexEdgeMap;
+  for (size_t i = 0; i < boundaryEdges.size(); ++i) {
+    const auto& edge = boundaryEdges[i];
+    vertexEdgeMap[edge.first].push_back(static_cast<Index>(i));
+    vertexEdgeMap[edge.second].push_back(static_cast<Index>(i));
+  }
+
+  std::vector<std::vector<std::pair<Index, Index>>> loops;
+  std::vector<bool> usedEdges(boundaryEdges.size(), false);
+
+  for (size_t startEdgeIdx = 0; startEdgeIdx < boundaryEdges.size(); ++startEdgeIdx) {
+    if (usedEdges[startEdgeIdx]) {
+      continue;
+    }
+
+    std::vector<std::pair<Index, Index>> currentLoop;
+
+    // Start new loop
+    size_t currentEdgeIdx = startEdgeIdx;
+    Index currentVertex = boundaryEdges[startEdgeIdx].first;
+
+    do {
+      usedEdges[currentEdgeIdx] = true;
+      currentLoop.push_back(boundaryEdges[currentEdgeIdx]);
+
+      // Find next edge
+      const auto& currentEdge = boundaryEdges[currentEdgeIdx];
+      currentVertex = (currentVertex == currentEdge.first) ? currentEdge.second : currentEdge.first;
+
+      // Find next unused edge connected to currentVertex
+      size_t nextEdgeIdx = SIZE_MAX;
+      for (const auto edgeIdx : vertexEdgeMap[currentVertex]) {
+        if (!usedEdges[edgeIdx] && edgeIdx != currentEdgeIdx) {
+          nextEdgeIdx = edgeIdx;
+          break;
+        }
+      }
+
+      if (nextEdgeIdx == SIZE_MAX) {
+        break; // End of loop
+      }
+
+      currentEdgeIdx = nextEdgeIdx;
+
+    } while (currentEdgeIdx != startEdgeIdx && !usedEdges[currentEdgeIdx]);
+
+    if (!currentLoop.empty()) {
+      loops.push_back(std::move(currentLoop));
+    }
+  }
+
+  return loops;
+}
+
+/**
+ * Fill a single hole using advancing front method.
+ */
+template <typename ScalarType>
+HoleFillingResult fillSingleHole(
+    const HoleBoundary& hole,
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices) {
+  HoleFillingResult result;
+
+  if (hole.vertices.size() < 3) {
+    return result; // Cannot fill holes with less than 3 vertices
+  }
+
+  // For very small holes (triangles), just create one triangle
+  if (hole.vertices.size() == 3) {
+    result.newTriangles.emplace_back(hole.vertices[0], hole.vertices[1], hole.vertices[2]);
+    result.success = true;
+    return result;
+  }
+
+  // For small to medium holes, use improved centroid-based triangulation
+  if (hole.vertices.size() <= 8) {
+    // Compute a better centroid position
+    Eigen::Vector3<ScalarType> centroid = Eigen::Vector3<ScalarType>::Zero();
+    for (const auto vertexIdx : hole.vertices) {
+      centroid += vertices[vertexIdx];
+    }
+    centroid /= static_cast<ScalarType>(hole.vertices.size());
+
+    // Adjust centroid position to be slightly inside the hole for better triangle quality
+    // Find the normal of the hole plane (average of cross products)
+    Eigen::Vector3<ScalarType> holeNormal = Eigen::Vector3<ScalarType>::Zero();
+    for (size_t i = 0; i < hole.vertices.size(); ++i) {
+      const size_t nextI = (i + 1) % hole.vertices.size();
+      const auto& p1 = vertices[hole.vertices[i]];
+      const auto& p2 = vertices[hole.vertices[nextI]];
+      const auto edge1 = p1 - centroid;
+      const auto edge2 = p2 - centroid;
+      holeNormal += edge1.cross(edge2).normalized();
+    }
+
+    if (holeNormal.norm() > ScalarType{1e-6}) {
+      holeNormal.normalize();
+      // Move centroid slightly along the normal to improve triangle quality
+      const ScalarType offset = static_cast<ScalarType>(0.1) * hole.radius;
+      centroid += offset * holeNormal;
+    }
+
+    // Add centroid as new vertex
+    result.newVertices.push_back(centroid.template cast<float>());
+    const auto centroidIdx = static_cast<Index>(vertices.size()); // Index in combined mesh
+
+    // Create triangles from centroid to boundary edges with proper winding
+    for (size_t i = 0; i < hole.vertices.size(); ++i) {
+      const size_t nextI = (i + 1) % hole.vertices.size();
+
+      const Index v1 = hole.vertices[i];
+      const Index v2 = hole.vertices[nextI];
+
+      // Create triangle with consistent winding order
+      result.newTriangles.emplace_back(v1, v2, centroidIdx);
+    }
+
+    result.success = true;
+    return result;
+  }
+
+  // For larger holes, use improved ear clipping with better ear detection
+  std::vector<Index> remainingVertices = hole.vertices;
+
+  while (remainingVertices.size() > 3) {
+    bool foundEar = false;
+    auto bestEarQuality = ScalarType{-1};
+    size_t bestEarIndex = 0;
+
+    // Find the best ear (most convex, best triangle quality)
+    for (size_t i = 0; i < remainingVertices.size(); ++i) {
+      const size_t prevI = (i + remainingVertices.size() - 1) % remainingVertices.size();
+      const size_t nextI = (i + 1) % remainingVertices.size();
+
+      const Index vi1 = remainingVertices[prevI];
+      const Index vi2 = remainingVertices[i];
+      const Index vi3 = remainingVertices[nextI];
+
+      // Check if this forms a valid ear
+      const auto& p1 = vertices[vi1];
+      const auto& p2 = vertices[vi2];
+      const auto& p3 = vertices[vi3];
+
+      const Eigen::Vector3<ScalarType> edge1 = p2 - p1;
+      const Eigen::Vector3<ScalarType> edge2 = p3 - p2;
+      const Eigen::Vector3<ScalarType> crossProd = edge1.cross(edge2);
+
+      // Check if triangle is valid and convex
+      if (crossProd.norm() > ScalarType{1e-6}) {
+        // Calculate triangle quality (avoid very thin triangles)
+        const auto edge3 = p1 - p3;
+        const ScalarType area = crossProd.norm() * ScalarType{0.5};
+        const ScalarType perimeter = edge1.norm() + edge2.norm() + edge3.norm();
+        const ScalarType quality = area / (perimeter * perimeter); // Higher is better
+
+        // Check if no other vertices are inside this triangle
+        bool isEar = true;
+        for (size_t j = 0; j < remainingVertices.size(); ++j) {
+          if (j == prevI || j == i || j == nextI) {
+            continue;
+          }
+
+          const auto& testPoint = vertices[remainingVertices[j]];
+          // Simple point-in-triangle test using barycentric coordinates
+          const Eigen::Vector3<ScalarType> v0 = p3 - p1;
+          const Eigen::Vector3<ScalarType> v1 = p2 - p1;
+          const Eigen::Vector3<ScalarType> v2 = testPoint - p1;
+
+          const ScalarType dot00 = v0.dot(v0);
+          const ScalarType dot01 = v0.dot(v1);
+          const ScalarType dot02 = v0.dot(v2);
+          const ScalarType dot11 = v1.dot(v1);
+          const ScalarType dot12 = v1.dot(v2);
+
+          const ScalarType invDenom = ScalarType{1} / (dot00 * dot11 - dot01 * dot01);
+          const ScalarType u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+          const ScalarType v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+
+          if (u >= 0 && v >= 0 && u + v <= 1) {
+            isEar = false;
+            break;
+          }
+        }
+
+        if (isEar && quality > bestEarQuality) {
+          bestEarQuality = quality;
+          bestEarIndex = i;
+          foundEar = true;
+        }
+      }
+    }
+
+    if (foundEar) {
+      const size_t prevI = (bestEarIndex + remainingVertices.size() - 1) % remainingVertices.size();
+      const size_t nextI = (bestEarIndex + 1) % remainingVertices.size();
+
+      result.newTriangles.emplace_back(
+          remainingVertices[prevI], remainingVertices[bestEarIndex], remainingVertices[nextI]);
+
+      remainingVertices.erase(remainingVertices.begin() + bestEarIndex);
+    } else {
+      // Fallback: just create a triangle from first three vertices
+      if (remainingVertices.size() >= 3) {
+        result.newTriangles.emplace_back(
+            remainingVertices[0], remainingVertices[1], remainingVertices[2]);
+        remainingVertices.erase(remainingVertices.begin() + 1);
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Add final triangle
+  if (remainingVertices.size() == 3) {
+    result.newTriangles.emplace_back(
+        remainingVertices[0], remainingVertices[1], remainingVertices[2]);
+  }
+
+  result.success = !result.newTriangles.empty();
+  return result;
+}
+
+/**
+ * Compute hole center and radius from boundary vertices.
+ */
+template <typename ScalarType>
+std::pair<Eigen::Vector3<ScalarType>, ScalarType> computeHoleGeometry(
+    const std::vector<Index>& boundaryVertices,
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices);
+
+/**
+ * Apply Laplacian smoothing to newly added vertices.
+ */
+template <typename ScalarType>
+void smoothHoleFilledRegion(
+    std::vector<Eigen::Vector3<ScalarType>>& vertices,
+    gsl::span<const Eigen::Vector3i> triangles,
+    const std::unordered_set<Index>& newVertexIndices,
+    Index iterations,
+    ScalarType factor);
+
+} // anonymous namespace
+
+// ================================================================================================
+// HOLE DETECTION
+// ================================================================================================
+
+std::vector<HoleBoundary> detectMeshHoles(
+    gsl::span<const Eigen::Vector3f> vertices,
+    gsl::span<const Eigen::Vector3i> triangles) {
+  const auto edgeCountMap = buildEdgeCountMap(triangles);
+  const auto boundaryEdges = findBoundaryEdges(edgeCountMap);
+  const auto edgeLoops = groupBoundaryEdgesIntoLoops(boundaryEdges);
+
+  std::vector<HoleBoundary> holes;
+  holes.reserve(edgeLoops.size());
+
+  for (const auto& loop : edgeLoops) {
+    if (loop.empty()) {
+      continue;
+    }
+
+    HoleBoundary hole;
+    hole.edges = loop;
+
+    // Extract ordered vertex list from edge loop
+    std::unordered_set<Index> visitedVertices;
+    hole.vertices.reserve(loop.size());
+
+    // Start with first edge
+    hole.vertices.push_back(loop[0].first);
+    hole.vertices.push_back(loop[0].second);
+    visitedVertices.insert(loop[0].first);
+    visitedVertices.insert(loop[0].second);
+
+    // Follow the loop
+    Index currentVertex = loop[0].second;
+    for (size_t i = 1; i < loop.size(); ++i) {
+      // Find next edge that starts with currentVertex
+      for (const auto& edge : loop) {
+        if (edge.first == currentVertex &&
+            visitedVertices.find(edge.second) == visitedVertices.end()) {
+          hole.vertices.push_back(edge.second);
+          visitedVertices.insert(edge.second);
+          currentVertex = edge.second;
+          break;
+        } else if (
+            edge.second == currentVertex &&
+            visitedVertices.find(edge.first) == visitedVertices.end()) {
+          hole.vertices.push_back(edge.first);
+          visitedVertices.insert(edge.first);
+          currentVertex = edge.first;
+          break;
+        }
+      }
+    }
+
+    // Compute hole geometry
+    const auto [center, radius] = computeHoleGeometry(hole.vertices, vertices);
+    hole.center = center;
+    hole.radius = radius;
+
+    holes.push_back(std::move(hole));
+  }
+
+  return holes;
+}
+
+// ================================================================================================
+// HOLE FILLING IMPLEMENTATION
+// ================================================================================================
+
+// ================================================================================================
+// DETAIL IMPLEMENTATIONS
+// ================================================================================================
+
+namespace {
+
+template <typename ScalarType>
+std::pair<Eigen::Vector3<ScalarType>, ScalarType> computeHoleGeometry(
+    const std::vector<Index>& boundaryVertices,
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices) {
+  if (boundaryVertices.empty()) {
+    return {Eigen::Vector3<ScalarType>::Zero(), ScalarType{0}};
+  }
+
+  // Compute centroid
+  Eigen::Vector3<ScalarType> center = Eigen::Vector3<ScalarType>::Zero();
+  for (const auto vertexIdx : boundaryVertices) {
+    center += vertices[vertexIdx];
+  }
+  center /= static_cast<ScalarType>(boundaryVertices.size());
+
+  // Compute average distance to center (rough radius estimate)
+  auto radius = ScalarType{0};
+  for (const auto vertexIdx : boundaryVertices) {
+    radius += (vertices[vertexIdx] - center).norm();
+  }
+  radius /= static_cast<ScalarType>(boundaryVertices.size());
+
+  return {center, radius};
+}
+
+template <typename ScalarType>
+void smoothHoleFilledRegion(
+    std::vector<Eigen::Vector3<ScalarType>>& vertices,
+    gsl::span<const Eigen::Vector3i> triangles,
+    const std::unordered_set<Index>& newVertexIndices,
+    Index iterations,
+    ScalarType factor) {
+  // Build vertex-vertex adjacency for smoothing
+  std::unordered_map<Index, std::vector<Index>> adjacency;
+
+  for (const auto& triangle : triangles) {
+    for (int i = 0; i < 3; ++i) {
+      const Index v1 = triangle[i];
+      const Index v2 = triangle[(i + 1) % 3];
+
+      adjacency[v1].push_back(v2);
+      adjacency[v2].push_back(v1);
+    }
+  }
+
+  // Apply Laplacian smoothing iterations
+  for (Index iter = 0; iter < iterations; ++iter) {
+    std::vector<Eigen::Vector3<ScalarType>> newPositions = vertices;
+
+    for (const auto vertexIdx : newVertexIndices) {
+      const auto& neighbors = adjacency[vertexIdx];
+      if (neighbors.empty()) {
+        continue;
+      }
+
+      Eigen::Vector3<ScalarType> averagePos = Eigen::Vector3<ScalarType>::Zero();
+      for (const auto neighborIdx : neighbors) {
+        averagePos += vertices[neighborIdx];
+      }
+      averagePos /= static_cast<ScalarType>(neighbors.size());
+
+      // Blend between original and average position
+      newPositions[vertexIdx] =
+          (ScalarType{1} - factor) * vertices[vertexIdx] + factor * averagePos;
+    }
+
+    vertices = std::move(newPositions);
+  }
+}
+
+} // namespace
+
+template <typename ScalarType>
+HoleFillingResult fillMeshHoles(
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices,
+    gsl::span<const Eigen::Vector3i> triangles) {
+  HoleFillingResult result;
+
+  // Convert vertices to float for hole detection (detectMeshHoles expects float)
+  std::vector<Eigen::Vector3f> floatVertices;
+  floatVertices.reserve(vertices.size());
+  for (const auto& v : vertices) {
+    floatVertices.emplace_back(v.template cast<float>());
+  }
+
+  // Detect holes
+  const auto holes = detectMeshHoles(floatVertices, triangles);
+
+  if (holes.empty()) {
+    result.success = true;
+    return result;
+  }
+
+  // Fill each hole
+  size_t totalNewVertices = 0;
+
+  for (const auto& hole : holes) {
+    if (hole.vertices.size() < 3) {
+      continue; // Invalid hole
+    }
+
+    const auto holeResult = fillSingleHole(hole, vertices);
+
+    if (!holeResult.success) {
+      continue;
+    }
+
+    // Adjust indices for accumulated vertices
+    auto adjustedTriangles = holeResult.newTriangles;
+    for (auto& triangle : adjustedTriangles) {
+      // Indices >= original vertex count refer to new vertices
+      for (int i = 0; i < 3; ++i) {
+        if (triangle[i] >= static_cast<Index>(vertices.size())) {
+          // need to shift by total number of new vertices added so far
+          triangle[i] += totalNewVertices;
+        }
+      }
+    }
+
+    // Append results
+    result.newVertices.insert(
+        result.newVertices.end(), holeResult.newVertices.begin(), holeResult.newVertices.end());
+
+    result.newTriangles.insert(
+        result.newTriangles.end(), adjustedTriangles.begin(), adjustedTriangles.end());
+
+    result.filledHoles.push_back(hole);
+    result.holesFilledCount++;
+
+    totalNewVertices += holeResult.newVertices.size();
+  }
+
+  result.success = result.holesFilledCount > 0;
+  return result;
+}
+
+template <typename ScalarType>
+std::pair<std::vector<Eigen::Vector3<ScalarType>>, std::vector<Eigen::Vector3i>>
+fillMeshHolesComplete(
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices,
+    gsl::span<const Eigen::Vector3i> triangles) {
+  const auto result = fillMeshHoles(vertices, triangles);
+
+  // Combine original and new vertices
+  std::vector<Eigen::Vector3<ScalarType>> allVertices;
+  allVertices.reserve(vertices.size() + result.newVertices.size());
+
+  for (const auto& v : vertices) {
+    allVertices.push_back(v);
+  }
+
+  for (const auto& v : result.newVertices) {
+    allVertices.push_back(v.template cast<ScalarType>());
+  }
+
+  // Combine original and new triangles
+  std::vector<Eigen::Vector3i> allTriangles;
+  allTriangles.reserve(triangles.size() + result.newTriangles.size());
+
+  for (const auto& t : triangles) {
+    allTriangles.push_back(t);
+  }
+
+  for (const auto& t : result.newTriangles) {
+    allTriangles.push_back(t);
+  }
+
+  return {std::move(allVertices), std::move(allTriangles)};
+}
+
+// ================================================================================================
+// EXPLICIT INSTANTIATIONS
+// ================================================================================================
+
+template HoleFillingResult fillMeshHoles<float>(
+    gsl::span<const Eigen::Vector3<float>>,
+    gsl::span<const Eigen::Vector3i>);
+
+template HoleFillingResult fillMeshHoles<double>(
+    gsl::span<const Eigen::Vector3<double>>,
+    gsl::span<const Eigen::Vector3i>);
+
+template std::pair<std::vector<Eigen::Vector3<float>>, std::vector<Eigen::Vector3i>>
+    fillMeshHolesComplete<float>(
+        gsl::span<const Eigen::Vector3<float>>,
+        gsl::span<const Eigen::Vector3i>);
+
+template std::pair<std::vector<Eigen::Vector3<double>>, std::vector<Eigen::Vector3i>>
+    fillMeshHolesComplete<double>(
+        gsl::span<const Eigen::Vector3<double>>,
+        gsl::span<const Eigen::Vector3i>);
+
+} // namespace axel

--- a/axel/axel/math/MeshHoleFilling.h
+++ b/axel/axel/math/MeshHoleFilling.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <gsl/span>
+
+#include "axel/common/Types.h"
+
+namespace axel {
+
+/**
+ * Represents a hole boundary in the mesh.
+ */
+struct HoleBoundary {
+  /// Ordered list of vertex indices forming the hole boundary
+  std::vector<Index> vertices;
+
+  /// Edge pairs (vertex_i, vertex_i+1) forming the boundary
+  std::vector<std::pair<Index, Index>> edges;
+
+  /// Center point of the hole (computed from boundary vertices)
+  Eigen::Vector3f center;
+
+  /// Approximate radius of the hole
+  float radius{};
+};
+
+/**
+ * Result of hole filling operation.
+ */
+struct HoleFillingResult {
+  /// New vertices added during hole filling
+  std::vector<Eigen::Vector3f> newVertices;
+
+  /// New triangles added (indices refer to original + new vertices)
+  std::vector<Eigen::Vector3i> newTriangles;
+
+  /// Information about filled holes
+  std::vector<HoleBoundary> filledHoles;
+
+  /// Success flag
+  bool success = false;
+
+  /// Number of holes that were successfully filled
+  size_t holesFilledCount = 0;
+};
+
+/**
+ * Detect holes/boundaries in a triangle mesh.
+ *
+ * @param vertices Mesh vertices
+ * @param triangles Mesh triangles
+ * @return List of detected hole boundaries
+ */
+std::vector<HoleBoundary> detectMeshHoles(
+    gsl::span<const Eigen::Vector3f> vertices,
+    gsl::span<const Eigen::Vector3i> triangles);
+
+/**
+ * Fill holes in a triangle mesh using advancing front method.
+ *
+ * This function identifies holes in the mesh and fills them with new triangles
+ * to create a watertight surface suitable for SDF generation.
+ *
+ * @param vertices Original mesh vertices
+ * @param triangles Original mesh triangles
+ * @return Result containing new vertices and triangles, or failure info
+ */
+template <typename ScalarType>
+HoleFillingResult fillMeshHoles(
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices,
+    gsl::span<const Eigen::Vector3i> triangles);
+
+/**
+ * Convenience function that fills holes and returns complete mesh.
+ *
+ * @param vertices Original mesh vertices
+ * @param triangles Original mesh triangles
+ * @return Pair of (all_vertices, all_triangles) with holes filled
+ */
+template <typename ScalarType>
+std::pair<std::vector<Eigen::Vector3<ScalarType>>, std::vector<Eigen::Vector3i>>
+fillMeshHolesComplete(
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices,
+    gsl::span<const Eigen::Vector3i> triangles);
+
+} // namespace axel

--- a/axel/axel/math/test/MeshHoleFillingTest.cpp
+++ b/axel/axel/math/test/MeshHoleFillingTest.cpp
@@ -1,0 +1,599 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "axel/math/MeshHoleFilling.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <Eigen/Core>
+#include <gsl/span>
+
+using namespace axel;
+
+class MeshHoleFillingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Set up test data
+  }
+
+  /**
+   * Check if a mesh is manifold (watertight).
+   * A manifold mesh has each edge shared by exactly 2 triangles.
+   */
+  static bool isMeshManifold(
+      const std::vector<Eigen::Vector3f>& /*vertices*/,
+      const std::vector<Eigen::Vector3i>& triangles) {
+    using Edge = std::pair<Index, Index>;
+
+    // Simple hash for edge pairs - same as used in our implementation
+    struct EdgeHash {
+      std::size_t operator()(const Edge& edge) const {
+        return std::hash<Index>{}(edge.first) ^ (std::hash<Index>{}(edge.second) << 1);
+      }
+    };
+
+    // Build edge count map (reusing our optimized approach)
+    std::unordered_map<Edge, size_t, EdgeHash> edgeCountMap;
+
+    for (const auto& triangle : triangles) {
+      // Add three edges of the triangle
+      const std::array<Edge, 3> edges = {
+          {{triangle[0], triangle[1]}, {triangle[1], triangle[2]}, {triangle[2], triangle[0]}}};
+
+      for (const auto& edge : edges) {
+        // Normalize edge orientation (smaller index first)
+        const auto normalizedEdge =
+            std::make_pair(std::min(edge.first, edge.second), std::max(edge.first, edge.second));
+
+        edgeCountMap[normalizedEdge]++;
+      }
+    }
+
+    // Check manifold condition: each edge should be shared by exactly 2 triangles
+    for (const auto& [edge, count] : edgeCountMap) {
+      if (count != 2) {
+        return false; // Not manifold - edge is shared by wrong number of triangles
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Get detailed manifold statistics for debugging.
+   */
+  struct ManifoldStats {
+    size_t totalEdges = 0;
+    size_t boundaryEdges = 0; // count == 1 (holes)
+    size_t manifoldEdges = 0; // count == 2 (proper)
+    size_t nonManifoldEdges = 0; // count > 2 (intersections)
+    bool isManifold = false;
+  };
+
+  static ManifoldStats getMeshManifoldStats(
+      const std::vector<Eigen::Vector3f>& /*vertices*/,
+      const std::vector<Eigen::Vector3i>& triangles) {
+    using Edge = std::pair<Index, Index>;
+
+    // Simple hash for edge pairs - same as used in our implementation
+    struct EdgeHash {
+      std::size_t operator()(const Edge& edge) const {
+        return std::hash<Index>{}(edge.first) ^ (std::hash<Index>{}(edge.second) << 1);
+      }
+    };
+
+    ManifoldStats stats;
+    std::unordered_map<Edge, size_t, EdgeHash> edgeCountMap;
+
+    for (const auto& triangle : triangles) {
+      const std::array<Edge, 3> edges = {
+          {{triangle[0], triangle[1]}, {triangle[1], triangle[2]}, {triangle[2], triangle[0]}}};
+
+      for (const auto& edge : edges) {
+        const auto normalizedEdge =
+            std::make_pair(std::min(edge.first, edge.second), std::max(edge.first, edge.second));
+
+        edgeCountMap[normalizedEdge]++;
+      }
+    }
+
+    stats.totalEdges = edgeCountMap.size();
+
+    for (const auto& [edge, count] : edgeCountMap) {
+      if (count == 1) {
+        stats.boundaryEdges++;
+      } else if (count == 2) {
+        stats.manifoldEdges++;
+      } else {
+        stats.nonManifoldEdges++;
+      }
+    }
+
+    stats.isManifold = (stats.boundaryEdges == 0 && stats.nonManifoldEdges == 0);
+
+    return stats;
+  }
+
+  /**
+   * Helper to verify that hole filling produces manifold meshes.
+   */
+  static void verifyMeshAfterHoleFilling(
+      const std::vector<Eigen::Vector3f>& originalVertices,
+      const std::vector<Eigen::Vector3i>& originalTriangles,
+      const std::string& testName = "") {
+    // Get original mesh stats
+    const auto originalStats = getMeshManifoldStats(originalVertices, originalTriangles);
+
+    std::cout << "\n" << std::string(50, '=') << "\n";
+    std::cout << "MANIFOLD VERIFICATION: " << testName << "\n";
+    std::cout << std::string(50, '=') << "\n";
+
+    std::cout << "Original mesh:\n";
+    std::cout << "  Total edges: " << originalStats.totalEdges << "\n";
+    std::cout << "  Boundary edges (holes): " << originalStats.boundaryEdges << "\n";
+    std::cout << "  Manifold edges: " << originalStats.manifoldEdges << "\n";
+    std::cout << "  Non-manifold edges: " << originalStats.nonManifoldEdges << "\n";
+    std::cout << "  Is manifold: " << (originalStats.isManifold ? "YES" : "NO") << "\n";
+
+    // Original mesh should have holes (boundary edges > 0) for this test to be meaningful
+    if (originalStats.boundaryEdges == 0) {
+      std::cout << "  NOTE: Original mesh has no holes - test may not be meaningful\n";
+    }
+
+    // Fill holes
+    const auto [filledVertices, filledTriangles] = fillMeshHolesComplete(
+        gsl::span<const Eigen::Vector3f>(originalVertices),
+        gsl::span<const Eigen::Vector3i>(originalTriangles));
+
+    // Get filled mesh stats
+    const auto filledStats = getMeshManifoldStats(filledVertices, filledTriangles);
+
+    std::cout << "\nFilled mesh:\n";
+    std::cout << "  Total edges: " << filledStats.totalEdges << "\n";
+    std::cout << "  Boundary edges (holes): " << filledStats.boundaryEdges << "\n";
+    std::cout << "  Manifold edges: " << filledStats.manifoldEdges << "\n";
+    std::cout << "  Non-manifold edges: " << filledStats.nonManifoldEdges << "\n";
+    std::cout << "  Is manifold: " << (filledStats.isManifold ? "YES" : "NO") << "\n";
+
+    std::cout << "\nChanges:\n";
+    std::cout << "  Added vertices: " << (filledVertices.size() - originalVertices.size()) << "\n";
+    std::cout << "  Added triangles: " << (filledTriangles.size() - originalTriangles.size())
+              << "\n";
+    std::cout << "  Holes filled: " << originalStats.boundaryEdges - filledStats.boundaryEdges
+              << " boundary edges\n";
+
+    // Assertions - Note: Our basic algorithm may not create perfectly manifold meshes in all cases
+    // but should significantly improve the mesh quality
+
+    // The filled mesh should have fewer boundary edges (holes reduced)
+    if (originalStats.boundaryEdges > 0) {
+      EXPECT_LT(filledStats.boundaryEdges, originalStats.boundaryEdges)
+          << "Hole filling should reduce boundary edges";
+    }
+
+    // Should have no non-manifold edges (intersections)
+    EXPECT_EQ(filledStats.nonManifoldEdges, 0) << "Filled mesh should have no non-manifold edges";
+
+    // Should have some manifold edges
+    EXPECT_GT(filledStats.manifoldEdges, 0) << "Filled mesh should have manifold edges";
+
+    // Should preserve or increase manifold edges
+    EXPECT_GE(filledStats.manifoldEdges, originalStats.manifoldEdges)
+        << "Hole filling should preserve or increase manifold edges";
+
+    // For simple cases, expect fully manifold results
+    if (originalStats.boundaryEdges <= 6 && originalStats.nonManifoldEdges == 0) {
+      EXPECT_TRUE(filledStats.isManifold) << "Simple cases should produce fully manifold meshes";
+      EXPECT_EQ(filledStats.boundaryEdges, 0)
+          << "Simple cases should have no remaining boundary edges";
+    }
+  }
+
+  // Helper to create a simple triangle (no holes)
+  static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>> createTriangle() {
+    std::vector<Eigen::Vector3f> vertices = {
+        Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+        Eigen::Vector3f(1.0f, 0.0f, 0.0f),
+        Eigen::Vector3f(0.5f, 1.0f, 0.0f)};
+
+    std::vector<Eigen::Vector3i> triangles = {Eigen::Vector3i(0, 1, 2)};
+
+    return {vertices, triangles};
+  }
+
+  // Helper to create a square with a hole (missing one triangle)
+  static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>>
+  createSquareWithHole() {
+    std::vector<Eigen::Vector3f> vertices = {
+        Eigen::Vector3f(0.0f, 0.0f, 0.0f), // 0
+        Eigen::Vector3f(1.0f, 0.0f, 0.0f), // 1
+        Eigen::Vector3f(1.0f, 1.0f, 0.0f), // 2
+        Eigen::Vector3f(0.0f, 1.0f, 0.0f) // 3
+    };
+
+    // Only one triangle, creating a hole
+    std::vector<Eigen::Vector3i> triangles = {
+        Eigen::Vector3i(0, 1, 2)
+        // Missing: Eigen::Vector3i(0, 2, 3)
+    };
+
+    return {vertices, triangles};
+  }
+
+  // Helper to create a tetrahedron with one face missing
+  static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>>
+  createTetrahedronWithHole() {
+    std::vector<Eigen::Vector3f> vertices = {
+        Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+        Eigen::Vector3f(1.0f, 0.0f, 0.0f),
+        Eigen::Vector3f(0.5f, 1.0f, 0.0f),
+        Eigen::Vector3f(0.5f, 0.5f, 1.0f)};
+
+    // Three faces of tetrahedron, missing one
+    std::vector<Eigen::Vector3i> triangles = {
+        Eigen::Vector3i(0, 1, 2), // Base triangle
+        Eigen::Vector3i(0, 1, 3), // Side face 1
+        Eigen::Vector3i(1, 2, 3) // Side face 2
+                                 // Missing: Eigen::Vector3i(2, 0, 3) - creates hole
+    };
+
+    return {vertices, triangles};
+  }
+};
+
+// ================================================================================================
+// HOLE DETECTION TESTS
+// ================================================================================================
+
+TEST_F(MeshHoleFillingTest, DetectNoHoles) {
+  const auto [vertices, triangles] = createTriangle();
+
+  const auto holes = detectMeshHoles(vertices, triangles);
+
+  // A single triangle actually has boundary edges, so it will be detected as having holes
+  // This is correct behavior for our algorithm - it's an "open surface"
+  EXPECT_EQ(holes.size(), 1);
+
+  // But the single hole should be the perimeter of the triangle
+  ASSERT_EQ(holes.size(), 1);
+  const auto& hole = holes[0];
+  EXPECT_EQ(hole.vertices.size(), 3); // Triangle has 3 boundary vertices
+}
+
+TEST_F(MeshHoleFillingTest, DetectSingleHole) {
+  const auto [vertices, triangles] = createSquareWithHole();
+
+  const auto holes = detectMeshHoles(vertices, triangles);
+
+  ASSERT_EQ(holes.size(), 1);
+
+  const auto& hole = holes[0];
+  EXPECT_EQ(hole.vertices.size(), 3); // Three boundary vertices
+  EXPECT_GT(hole.radius, 0.0f);
+
+  // Check that boundary vertices are reasonable
+  for (const auto vertexIdx : hole.vertices) {
+    EXPECT_GE(vertexIdx, 0);
+    EXPECT_LT(vertexIdx, vertices.size());
+  }
+}
+
+TEST_F(MeshHoleFillingTest, DetectMultipleHoles) {
+  const auto [vertices, triangles] = createTetrahedronWithHole();
+
+  const auto holes = detectMeshHoles(vertices, triangles);
+
+  ASSERT_EQ(holes.size(), 1);
+
+  const auto& hole = holes[0];
+  EXPECT_EQ(hole.vertices.size(), 3); // Triangular hole
+  EXPECT_GT(hole.radius, 0.0f);
+}
+
+// ================================================================================================
+// HOLE FILLING TESTS
+// ================================================================================================
+
+TEST_F(MeshHoleFillingTest, FillNoHoles) {
+  const auto [vertices, triangles] = createTriangle();
+
+  const auto result = fillMeshHoles(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+
+  EXPECT_TRUE(result.success);
+  // A single triangle will be detected as having a hole (the perimeter), so it will be filled
+  EXPECT_EQ(result.holesFilledCount, 1);
+  EXPECT_EQ(result.newVertices.size(), 0); // Centroid vertex added
+  EXPECT_EQ(result.newTriangles.size(), 1); // Fan triangulation from centroid
+}
+
+TEST_F(MeshHoleFillingTest, FillSingleSmallHole) {
+  const auto [vertices, triangles] = createSquareWithHole();
+
+  const auto result = fillMeshHoles(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+
+  EXPECT_TRUE(result.success);
+  EXPECT_EQ(result.holesFilledCount, 1);
+
+  // For 3-vertex holes, algorithm uses direct triangulation (more efficient)
+  EXPECT_EQ(result.newVertices.size(), 0);
+  EXPECT_EQ(result.newTriangles.size(), 1); // Direct triangulation
+
+  // Validate new triangles reference valid vertices
+  for (const auto& triangle : result.newTriangles) {
+    for (int i = 0; i < 3; ++i) {
+      const auto vertexIdx = triangle[i];
+      EXPECT_TRUE(
+          vertexIdx < vertices.size() || // Original vertex
+          vertexIdx >= vertices.size() // New vertex (adjusted later)
+      );
+    }
+  }
+
+  // Verify that hole filling produces a manifold mesh
+  verifyMeshAfterHoleFilling(vertices, triangles, "Single Small Hole");
+}
+
+TEST_F(MeshHoleFillingTest, FillLargerHole) {
+  // Create a larger hole scenario
+  std::vector<Eigen::Vector3f> vertices = {
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f), // 0
+      Eigen::Vector3f(1.0f, 0.0f, 0.0f), // 1
+      Eigen::Vector3f(2.0f, 0.0f, 0.0f), // 2
+      Eigen::Vector3f(2.0f, 1.0f, 0.0f), // 3
+      Eigen::Vector3f(1.0f, 1.0f, 0.0f), // 4
+      Eigen::Vector3f(0.0f, 1.0f, 0.0f), // 5
+      Eigen::Vector3f(0.0f, 2.0f, 0.0f), // 6
+      Eigen::Vector3f(1.0f, 2.0f, 0.0f) // 7
+  };
+
+  // Create triangles around a hexagonal hole
+  std::vector<Eigen::Vector3i> triangles = {
+      Eigen::Vector3i(0, 1, 4),
+      Eigen::Vector3i(0, 4, 5),
+      Eigen::Vector3i(5, 4, 7),
+      Eigen::Vector3i(5, 7, 6)
+      // Center area forms a hole bounded by vertices 1,2,3,4,7,6,5,0 (or subset)
+  };
+
+  const auto result = fillMeshHoles(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+
+  EXPECT_TRUE(result.success);
+  EXPECT_GT(result.holesFilledCount, 0);
+  EXPECT_GT(result.newTriangles.size(), 0);
+
+  // Verify manifold properties
+  verifyMeshAfterHoleFilling(vertices, triangles, "Larger Hole");
+}
+
+// ================================================================================================
+// COMPLETE MESH TESTS
+// ================================================================================================
+
+TEST_F(MeshHoleFillingTest, FillMeshHolesComplete) {
+  const auto [vertices, triangles] = createSquareWithHole();
+
+  const auto [allVertices, allTriangles] = fillMeshHolesComplete(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+
+  // Should have original + new triangles (vertices may be same for small holes using direct
+  // triangulation)
+  EXPECT_GE(
+      allVertices.size(), vertices.size()); // Greater or equal (no new vertices for 3-vertex holes)
+  EXPECT_GT(allTriangles.size(), triangles.size()); // Should always have more triangles
+
+  // Original vertices should be preserved at the beginning
+  for (size_t i = 0; i < vertices.size(); ++i) {
+    EXPECT_EQ(allVertices[i], vertices[i]);
+  }
+
+  // Original triangles should be preserved at the beginning
+  for (size_t i = 0; i < triangles.size(); ++i) {
+    EXPECT_EQ(allTriangles[i], triangles[i]);
+  }
+}
+
+// ================================================================================================
+// EDGE CASE TESTS
+// ================================================================================================
+
+TEST_F(MeshHoleFillingTest, EmptyMesh) {
+  std::vector<Eigen::Vector3f> vertices;
+  std::vector<Eigen::Vector3i> triangles;
+
+  const auto holes = detectMeshHoles(vertices, triangles);
+  EXPECT_TRUE(holes.empty());
+
+  const auto result = fillMeshHoles(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+
+  EXPECT_TRUE(result.success); // Should succeed with no work to do
+  EXPECT_EQ(result.holesFilledCount, 0);
+}
+
+TEST_F(MeshHoleFillingTest, SingleTriangleMesh) {
+  const auto [vertices, triangles] = createTriangle();
+
+  // Single triangle has boundary edges, so it will be detected as having holes
+  const auto holes = detectMeshHoles(vertices, triangles);
+  EXPECT_EQ(holes.size(), 1);
+
+  // Hole filling will fill the perimeter
+  const auto result = fillMeshHoles(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+
+  EXPECT_TRUE(result.success);
+  EXPECT_EQ(result.holesFilledCount, 1);
+}
+
+TEST_F(MeshHoleFillingTest, DegenerateTriangles) {
+  // Create mesh with degenerate triangles (collinear points)
+  std::vector<Eigen::Vector3f> vertices = {
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+      Eigen::Vector3f(1.0f, 0.0f, 0.0f),
+      Eigen::Vector3f(2.0f, 0.0f, 0.0f) // Collinear with previous two
+  };
+
+  std::vector<Eigen::Vector3i> triangles = {Eigen::Vector3i(0, 1, 2)};
+
+  // Should handle gracefully without crashing
+  const auto holes = detectMeshHoles(vertices, triangles);
+  // May or may not detect holes depending on tolerance, but shouldn't crash
+
+  const auto result = fillMeshHoles(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+
+  // Should not crash, may or may not succeed
+  // Just check that result is valid and doesn't crash accessing it
+  EXPECT_TRUE(result.success || !result.success); // Always true, but accesses result.success
+}
+
+// ================================================================================================
+// MANIFOLD VERIFICATION TESTS
+// ================================================================================================
+
+TEST_F(MeshHoleFillingTest, TetrahedronHoleFillingManifoldCheck) {
+  const auto [vertices, triangles] = createTetrahedronWithHole();
+
+  // Verify tetrahedron with hole filling produces manifold mesh
+  verifyMeshAfterHoleFilling(vertices, triangles, "Tetrahedron with Missing Face");
+}
+
+TEST_F(MeshHoleFillingTest, ManifoldChecksOnComplexMesh) {
+  // Create a more complex mesh with multiple holes
+  std::vector<Eigen::Vector3f> vertices = {
+      // First quad (missing diagonal)
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f), // 0
+      Eigen::Vector3f(2.0f, 0.0f, 0.0f), // 1
+      Eigen::Vector3f(2.0f, 2.0f, 0.0f), // 2
+      Eigen::Vector3f(0.0f, 2.0f, 0.0f), // 3
+      // Second quad (missing triangle)
+      Eigen::Vector3f(3.0f, 0.0f, 0.0f), // 4
+      Eigen::Vector3f(5.0f, 0.0f, 0.0f), // 5
+      Eigen::Vector3f(5.0f, 2.0f, 0.0f), // 6
+      Eigen::Vector3f(3.0f, 2.0f, 0.0f), // 7
+  };
+
+  std::vector<Eigen::Vector3i> triangles = {
+      // First quad - one triangle only (creates hole)
+      Eigen::Vector3i(0, 1, 2),
+      // Missing: Eigen::Vector3i(0, 2, 3)
+
+      // Second quad - missing one triangle (another hole)
+      Eigen::Vector3i(4, 5, 6),
+      // Missing: Eigen::Vector3i(4, 6, 7)
+
+      // Connect the quads partially (create more boundary edges)
+      Eigen::Vector3i(1, 4, 5),
+      Eigen::Vector3i(2, 6, 7),
+  };
+
+  // This mesh should have multiple holes
+  const auto originalStats = getMeshManifoldStats(vertices, triangles);
+  EXPECT_GT(originalStats.boundaryEdges, 0) << "Complex mesh should have holes";
+  EXPECT_FALSE(originalStats.isManifold) << "Original complex mesh should not be manifold";
+
+  // Verify hole filling makes it manifold
+  verifyMeshAfterHoleFilling(vertices, triangles, "Complex Multi-Hole Mesh");
+}
+
+TEST_F(MeshHoleFillingTest, ManifoldStatsAccuracy) {
+  // Test our manifold checking on a known good mesh (closed cube)
+  std::vector<Eigen::Vector3f> cubeVertices = {
+      Eigen::Vector3f(-1.0f, -1.0f, -1.0f), // 0
+      Eigen::Vector3f(1.0f, -1.0f, -1.0f), // 1
+      Eigen::Vector3f(1.0f, 1.0f, -1.0f), // 2
+      Eigen::Vector3f(-1.0f, 1.0f, -1.0f), // 3
+      Eigen::Vector3f(-1.0f, -1.0f, 1.0f), // 4
+      Eigen::Vector3f(1.0f, -1.0f, 1.0f), // 5
+      Eigen::Vector3f(1.0f, 1.0f, 1.0f), // 6
+      Eigen::Vector3f(-1.0f, 1.0f, 1.0f), // 7
+  };
+
+  std::vector<Eigen::Vector3i> cubeTriangles = {
+      // Bottom face (z = -1)
+      Eigen::Vector3i(0, 2, 1),
+      Eigen::Vector3i(0, 3, 2),
+      // Top face (z = 1)
+      Eigen::Vector3i(4, 5, 6),
+      Eigen::Vector3i(4, 6, 7),
+      // Front face (y = -1)
+      Eigen::Vector3i(0, 1, 5),
+      Eigen::Vector3i(0, 5, 4),
+      // Back face (y = 1)
+      Eigen::Vector3i(2, 7, 6),
+      Eigen::Vector3i(2, 3, 7),
+      // Left face (x = -1)
+      Eigen::Vector3i(0, 4, 7),
+      Eigen::Vector3i(0, 7, 3),
+      // Right face (x = 1)
+      Eigen::Vector3i(1, 2, 6),
+      Eigen::Vector3i(1, 6, 5),
+  };
+
+  const auto cubeStats = getMeshManifoldStats(cubeVertices, cubeTriangles);
+
+  // A closed cube should be perfectly manifold
+  EXPECT_TRUE(cubeStats.isManifold) << "Closed cube should be manifold";
+  EXPECT_EQ(cubeStats.boundaryEdges, 0) << "Closed cube should have no boundary edges";
+  EXPECT_EQ(cubeStats.nonManifoldEdges, 0) << "Closed cube should have no non-manifold edges";
+  EXPECT_GT(cubeStats.manifoldEdges, 0) << "Closed cube should have manifold edges";
+  EXPECT_EQ(cubeStats.totalEdges, cubeStats.manifoldEdges) << "All edges should be manifold";
+
+  std::cout << "Closed cube manifold stats:\n";
+  std::cout << "  Total edges: " << cubeStats.totalEdges << "\n";
+  std::cout << "  Manifold edges: " << cubeStats.manifoldEdges << "\n";
+  std::cout << "  Expected edges for cube: 18 (6 faces × 3 edges/face ÷ 2 shared)\n";
+}
+
+// ================================================================================================
+// PERFORMANCE TESTS
+// =========================================================================================
+
+TEST_F(MeshHoleFillingTest, ReasonablePerformance) {
+  // Create a moderately complex mesh with holes
+  std::vector<Eigen::Vector3f> vertices;
+  std::vector<Eigen::Vector3i> triangles;
+
+  // Create a grid of vertices
+  const int gridSize = 10;
+  for (int i = 0; i < gridSize; ++i) {
+    for (int j = 0; j < gridSize; ++j) {
+      vertices.emplace_back(static_cast<float>(i), static_cast<float>(j), 0.0f);
+    }
+  }
+
+  // Create triangles with some gaps
+  for (int i = 0; i < gridSize - 1; ++i) {
+    for (int j = 0; j < gridSize - 1; ++j) {
+      if ((i + j) % 3 != 0) { // Skip some triangles to create holes
+        const int idx = i * gridSize + j;
+        triangles.emplace_back(idx, idx + 1, idx + gridSize);
+        triangles.emplace_back(idx + 1, idx + gridSize + 1, idx + gridSize);
+      }
+    }
+  }
+
+  std::cout << "Performance test: " << vertices.size() << " vertices, " << triangles.size()
+            << " triangles\n";
+
+  const auto startTime = std::chrono::high_resolution_clock::now();
+  const auto result = fillMeshHoles(
+      gsl::span<const Eigen::Vector3f>(vertices), gsl::span<const Eigen::Vector3i>(triangles));
+  const auto endTime = std::chrono::high_resolution_clock::now();
+
+  const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
+
+  std::cout << "Hole filling took: " << duration.count() << " ms\n";
+  std::cout << "Filled " << result.holesFilledCount << " holes\n";
+
+  // Should complete in reasonable time (less than 1 second for this size)
+  EXPECT_LT(duration.count(), 1000);
+}


### PR DESCRIPTION
Summary: When creating signed distance fields from meshes, we will get bad data when there are holes in the mesh: the inside-outside tests fill fail, and the distance values will be incorrect near the hole.  Therefore doing some basic hole-filling before rasterization is helpful.

Reviewed By: jeongseok-meta

Differential Revision: D84392736


