### PR TITLE
Add accessors for position/rotation target weights.

### DIFF
--- a/momentum/character_solver/state_error_function.cpp
+++ b/momentum/character_solver/state_error_function.cpp
@@ -72,6 +72,18 @@ void StateErrorFunctionT<T>::setTargetWeights(
 }
 
 template <typename T>
+void StateErrorFunctionT<T>::setPositionTargetWeights(const Eigen::VectorX<T>& posWeight) {
+  MT_CHECK(posWeight.size() == static_cast<Eigen::Index>(this->skeleton_.joints.size()));
+  targetPositionWeights_ = posWeight;
+}
+
+template <typename T>
+void StateErrorFunctionT<T>::setRotationTargetWeights(const Eigen::VectorX<T>& rotWeight) {
+  MT_CHECK(rotWeight.size() == static_cast<Eigen::Index>(this->skeleton_.joints.size()));
+  targetRotationWeights_ = rotWeight;
+}
+
+template <typename T>
 double StateErrorFunctionT<T>::getError(
     const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state) {

--- a/momentum/character_solver/state_error_function.h
+++ b/momentum/character_solver/state_error_function.h
@@ -42,6 +42,15 @@ class StateErrorFunctionT : public SkeletonErrorFunctionT<T> {
   void setTargetState(TransformListT<T> target);
   void setTargetWeight(const Eigen::VectorX<T>& weights);
   void setTargetWeights(const Eigen::VectorX<T>& posWeight, const Eigen::VectorX<T>& rotWeight);
+
+  /// Set the target position weights for each joint.
+  /// @param posWeight Per-joint position weights.
+  void setPositionTargetWeights(const Eigen::VectorX<T>& posWeight);
+
+  /// Set the target rotation weights for each joint.
+  /// @param rotWeight Per-joint rotation weights.
+  void setRotationTargetWeights(const Eigen::VectorX<T>& rotWeight);
+
   void setWeights(const float posWeight, const float rotationWeight) {
     posWgt_ = posWeight;
     rotWgt_ = rotationWeight;

--- a/pymomentum/solver2/solver2_utility.cpp
+++ b/pymomentum/solver2/solver2_utility.cpp
@@ -393,4 +393,36 @@ void validateErrorFunctionMatchesCharacter(
   }
 }
 
+Eigen::VectorXf getJointWeights(
+    const std::optional<pybind11::array_t<float>>& weights,
+    const momentum::Skeleton& character,
+    const char* name) {
+  if (!weights.has_value()) {
+    return Eigen::VectorXf::Ones(character.joints.size());
+  }
+
+  return getJointWeights(weights.value(), character, name);
+}
+
+Eigen::VectorXf getJointWeights(
+    const pybind11::array_t<float>& weights,
+    const momentum::Skeleton& skeleton,
+    const char* name) {
+  MT_THROW_IF_T(weights.ndim() != 1, py::value_error, "{} weights must be a 1D array.", name);
+
+  auto wAcc = weights.unchecked<1>();
+  MT_THROW_IF_T(
+      wAcc.shape(0) != skeleton.joints.size(),
+      py::value_error,
+      "{} weights size does not match the number of joints in the skeleton, expected {} but got {}.",
+      name,
+      skeleton.joints.size(),
+      wAcc.shape(0));
+  Eigen::VectorXf result(wAcc.shape(0));
+  for (py::ssize_t i = 0; i < wAcc.shape(0); ++i) {
+    result[i] = wAcc(i);
+  }
+  return result;
+}
+
 } // namespace pymomentum

--- a/pymomentum/solver2/solver2_utility.h
+++ b/pymomentum/solver2/solver2_utility.h
@@ -95,6 +95,15 @@ void validateWeights(const Eigen::VectorXf& weights, const char* name);
 
 void validateWeights(const std::optional<Eigen::VectorXf>& weights, const char* name);
 
+Eigen::VectorXf getJointWeights(
+    const std::optional<pybind11::array_t<float>>& weights,
+    const momentum::Skeleton& character,
+    const char* name);
+Eigen::VectorXf getJointWeights(
+    const pybind11::array_t<float>& weights,
+    const momentum::Skeleton& skeleton,
+    const char* name);
+
 void validateErrorFunctionMatchesCharacter(
     const momentum::SkeletonSolverFunction& solverFunction,
     const momentum::SkeletonErrorFunction& errorFunction);


### PR DESCRIPTION
Summary:
It's useful to be able to set these after the error function has been constructions.

This required a little bit of refactoring to make setJointsWeights available in other functions.

Reviewed By: jeongseok-meta, cstollmeta

Differential Revision: D84529361


