### PR TITLE
pymomentum.axel: Python bindings for SDF

### DIFF
--- a/axel/CMakeLists.txt
+++ b/axel/CMakeLists.txt
@@ -31,6 +31,7 @@ set(headers
   axel/common/Types.h
   axel/common/VectorizationTypes.h
   axel/math/BoundingBoxUtils.h
+  axel/math/MeshHoleFilling.h
   axel/math/PointTriangleProjection.h
   axel/math/PointTriangleProjectionDefinitions.h
   axel/math/RayTriangleIntersection.h
@@ -38,16 +39,21 @@ set(headers
   axel/Bvh.h
   axel/BvhBase.h
   axel/BvhCommon.h
+  axel/MeshToSdf.h
   axel/Ray.h
+  axel/SignedDistanceField.h
   axel/SimdKdTree.h
   axel/TriBvh.h
 )
 
 set(sources
+  axel/math/MeshHoleFilling.cpp
   axel/math/PointTriangleProjection.cpp
   axel/math/RayTriangleIntersection.cpp
   axel/BoundingBox.cpp
   axel/Bvh.cpp
+  axel/MeshToSdf.cpp
+  axel/SignedDistanceField.cpp
   axel/SimdKdTree.cpp
   axel/TriBvh.cpp
 )

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -221,6 +221,25 @@ mt_python_binding(
   COMPILE_OPTIONS
 )
 
+mt_python_binding(
+  NAME pymomentum_axel
+  MODULE_NAME axel
+  PYMOMENTUM_HEADERS_VARS axel_public_headers
+  PYMOMENTUM_SOURCES_VARS axel_sources
+  INCLUDE_DIRECTORIES
+    ${ATEN_INCLUDE_DIR}
+    ${TORCH_INCLUDE_DIRS}
+  LINK_LIBRARIES
+    axel
+    python_utility
+    tensor_utility
+    ${ATEN_LIBRARIES}
+    ${TORCH_LIBRARIES}
+    ${torch_python}
+  COMPILE_OPTIONS
+    ${TORCH_CXX_FLAGS}
+)
+
 if(MOMENTUM_BUILD_RENDERER)
   mt_python_binding(
     NAME renderer

--- a/pymomentum/axel/axel_pybind.cpp
+++ b/pymomentum/axel/axel_pybind.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <axel/BoundingBox.h>
+#include <axel/MeshToSdf.h>
+#include <axel/SignedDistanceField.h>
+#include <axel/common/Types.h>
+#include <pymomentum/axel/axel_utility.h>
+
+#include <fmt/format.h>
+#include <pybind11/buffer_info.h>
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <Eigen/Core>
+
+#include <gsl/span>
+
+namespace py = pybind11;
+
+namespace pymomentum {
+
+PYBIND11_MODULE(axel, m) {
+  m.attr("__name__") = "pymomentum.axel";
+  m.doc() = "Python bindings for Axel library classes including SignedDistanceField.";
+
+  // Bind BoundingBox
+  py::class_<axel::BoundingBox<float>>(m, "BoundingBox")
+      .def(
+          py::init<const Eigen::Vector3f&, const Eigen::Vector3f&, axel::Index>(),
+          R"(Create a bounding box from minimum and maximum corners.
+
+:param min_corner: Minimum corner of the bounding box (x, y, z).
+:param max_corner: Maximum corner of the bounding box (x, y, z).
+:param id: Optional ID for the bounding box (default: 0).)",
+          py::arg("min_corner"),
+          py::arg("max_corner"),
+          py::arg("id") = 0)
+      .def(
+          py::init<const Eigen::Vector3f&, float>(),
+          R"(Create a bounding box centered at a point with given thickness.
+
+:param center: Center point of the bounding box (x, y, z).
+:param thickness: Half-width in each dimension (default: 0.0).)",
+          py::arg("center"),
+          py::arg("thickness") = 0.0f)
+      .def_property_readonly(
+          "min", &axel::BoundingBox<float>::min, "Get the minimum corner of the bounding box.")
+      .def_property_readonly(
+          "max", &axel::BoundingBox<float>::max, "Get the maximum corner of the bounding box.")
+      .def_property_readonly(
+          "center", &axel::BoundingBox<float>::center, "Get the center of the bounding box.")
+      .def(
+          "contains",
+          py::overload_cast<const Eigen::Vector3f&>(
+              &axel::BoundingBox<float>::contains, py::const_),
+          R"(Check if a point is contained within the bounding box.
+
+:param point: Point to test (x, y, z).
+:return: True if the point is inside the bounding box.)",
+          py::arg("point"))
+      .def(
+          "extend",
+          py::overload_cast<const Eigen::Vector3f&>(&axel::BoundingBox<float>::extend),
+          R"(Extend the bounding box to include a point.
+
+:param point: Point to include (x, y, z).)",
+          py::arg("point"))
+      .def("__repr__", [](const axel::BoundingBox<float>& self) {
+        const auto& minPt = self.min();
+        const auto& maxPt = self.max();
+        return fmt::format(
+            "BoundingBox(min=[{:.3f}, {:.3f}, {:.3f}], max=[{:.3f}, {:.3f}, {:.3f}])",
+            minPt.x(),
+            minPt.y(),
+            minPt.z(),
+            maxPt.x(),
+            maxPt.y(),
+            maxPt.z());
+      });
+
+  // Bind SignedDistanceField
+  py::class_<axel::SignedDistanceField<float>>(m, "SignedDistanceField", py::buffer_protocol())
+      .def(
+          py::init<const axel::BoundingBox<float>&, const Eigen::Vector3<axel::Index>&, float>(),
+          R"(Create a signed distance field with given bounds and resolution.
+
+:param bounds: 3D bounding box defining the spatial extent of the SDF.
+:param resolution: Grid resolution in each dimension (nx, ny, nz).
+:param initial_value: Initial distance value for all voxels (default: very far distance).)",
+          py::arg("bounds"),
+          py::arg("resolution"),
+          py::arg("initial_value") = axel::SignedDistanceField<float>::kVeryFarDistance)
+      .def(
+          py::init<
+              const axel::BoundingBox<float>&,
+              const Eigen::Vector3<axel::Index>&,
+              std::vector<float>>(),
+          R"(Create a signed distance field with given bounds, resolution, and initial data.
+
+:param bounds: 3D bounding box defining the spatial extent of the SDF.
+:param resolution: Grid resolution in each dimension (nx, ny, nz).
+:param data: Initial distance values. Must have size nx * ny * nz.)",
+          py::arg("bounds"),
+          py::arg("resolution"),
+          py::arg("data"))
+      .def_property_readonly(
+          "bounds", &axel::SignedDistanceField<float>::bounds, "Get the bounding box of the SDF.")
+      .def_property_readonly(
+          "resolution",
+          &axel::SignedDistanceField<float>::resolution,
+          "Get the grid resolution as (nx, ny, nz).")
+      .def_property_readonly(
+          "voxel_size",
+          &axel::SignedDistanceField<float>::voxelSize,
+          "Get the voxel size in each dimension as (dx, dy, dz).")
+      .def_property_readonly(
+          "total_voxels",
+          &axel::SignedDistanceField<float>::totalVoxels,
+          "Get the total number of voxels in the SDF.")
+      .def(
+          "sample",
+          [](const axel::SignedDistanceField<float>& self, const py::array_t<float>& positions) {
+            return applyBatchedScalarOperation(
+                self,
+                positions,
+                [](const axel::SignedDistanceField<float>& sdf, const Eigen::Vector3f& pos) {
+                  return sdf.sample(pos);
+                });
+          },
+          R"(Sample the SDF at continuous 3D positions using trilinear interpolation.
+
+Supports both single position and batch operations:
+- Single position: Pass 1D array of shape (3,) to get a scalar result
+- Batch positions: Pass 2D array of shape (N, 3) to get 1D array of N results
+
+:param positions: Position(s) to query. Either (3,) for single position or (N, 3) for batch of positions.
+:return: Interpolated signed distance value(s). Scalar for single position, 1D array for batch.)",
+          py::arg("positions"))
+      .def(
+          "gradient",
+          [](const axel::SignedDistanceField<float>& self, const py::array_t<float>& positions) {
+            return applyBatchedVectorOperation(
+                self,
+                positions,
+                [](const axel::SignedDistanceField<float>& sdf, const Eigen::Vector3f& pos) {
+                  return sdf.gradient(pos);
+                });
+          },
+          R"(Sample the SDF gradient at continuous 3D positions.
+
+Supports both single position and batch operations:
+- Single position: Pass 1D array of shape (3,) to get a 1D array of shape (3,)
+- Batch positions: Pass 2D array of shape (N, 3) to get 2D array of shape (N, 3)
+
+The gradient points in the direction of increasing distance.
+
+:param positions: Position(s) to query. Either (3,) for single position or (N, 3) for batch of positions.
+:return: Gradient vector(s) at the given position(s). Shape (3,) for single position, (N, 3) for batch.)",
+          py::arg("positions"))
+      .def(
+          "sample_with_gradient",
+          [](const axel::SignedDistanceField<float>& self, const py::array_t<float>& positions) {
+            return applyBatchedSampleGradientOperation(
+                self,
+                positions,
+                [](const axel::SignedDistanceField<float>& sdf, const Eigen::Vector3f& pos) {
+                  return sdf.sampleWithGradient(pos);
+                });
+          },
+          R"(Sample both the SDF value and gradient at continuous 3D positions.
+
+Supports both single position and batch operations:
+- Single position: Pass 1D array of shape (3,) to get tuple of (scalar, 1D array of shape (3,))
+- Batch positions: Pass 2D array of shape (N, 3) to get tuple of (1D array of N values, 2D array of shape (N, 3))
+
+More efficient than calling sample() and gradient() separately.
+
+:param positions: Position(s) to query. Either (3,) for single position or (N, 3) for batch of positions.
+:return: Tuple of (value(s), gradient(s)) at the given position(s).)",
+          py::arg("positions"))
+      .def(
+          "world_to_grid",
+          &axel::SignedDistanceField<float>::worldToGrid,
+          R"(Convert a 3D world-space position to continuous grid coordinates.
+
+:param position: 3D world-space position (x, y, z).
+:return: Continuous grid coordinates (may be fractional).)",
+          py::arg("position"))
+      .def(
+          "grid_to_world",
+          &axel::SignedDistanceField<float>::gridToWorld,
+          R"(Convert continuous grid coordinates to 3D world-space position.
+
+:param grid_pos: Continuous grid coordinates.
+:return: 3D world-space position (x, y, z).)",
+          py::arg("grid_pos"))
+      .def(
+          "is_valid_index",
+          &axel::SignedDistanceField<float>::isValidIndex,
+          R"(Check if the given grid coordinates are within bounds.
+
+:param i: Grid index in x dimension.
+:param j: Grid index in y dimension.
+:param k: Grid index in z dimension.
+:return: True if indices are within valid range.)",
+          py::arg("i"),
+          py::arg("j"),
+          py::arg("k"))
+      .def(
+          "fill",
+          &axel::SignedDistanceField<float>::fill,
+          R"(Fill the entire SDF with a constant value.
+
+:param value: The value to fill with.)",
+          py::arg("value"))
+      .def_buffer([](axel::SignedDistanceField<float>& self) -> py::buffer_info {
+        const auto& res = self.resolution();
+        auto& data = self.data();
+
+        return py::buffer_info(
+            data.data(), // Pointer to buffer
+            sizeof(float), // Size of one scalar
+            py::format_descriptor<float>::format(), // Python format
+                                                    // descriptor
+            3, // Number of dimensions
+            {static_cast<py::ssize_t>(res.x()), // Shape: nx
+             static_cast<py::ssize_t>(res.y()), //        ny
+             static_cast<py::ssize_t>(res.z())}, //        nz
+            {sizeof(float) * static_cast<py::ssize_t>(res.y()) *
+                 static_cast<py::ssize_t>(res.z()), // Strides: x dimension
+             sizeof(float) * static_cast<py::ssize_t>(res.z()), //          y dimension
+             sizeof(float)} //          z dimension
+        );
+      })
+      .def("__repr__", [](const axel::SignedDistanceField<float>& self) {
+        const auto& res = self.resolution();
+        const auto& bounds = self.bounds();
+        const auto& minPt = bounds.min();
+        const auto& maxPt = bounds.max();
+        return fmt::format(
+            "SignedDistanceField(resolution=[{}, {}, {}], bounds=([{:.3f}, {:.3f}, {:.3f}], [{:.3f}, {:.3f}, {:.3f}]))",
+            res.x(),
+            res.y(),
+            res.z(),
+            minPt.x(),
+            minPt.y(),
+            minPt.z(),
+            maxPt.x(),
+            maxPt.y(),
+            maxPt.z());
+      });
+
+  // Bind MeshToSdfConfig
+  py::class_<axel::MeshToSdfConfig<float>>(m, "MeshToSdfConfig")
+      .def(py::init<>(), "Create MeshToSdfConfig with default parameters.")
+      .def_readwrite(
+          "narrow_band_width",
+          &axel::MeshToSdfConfig<float>::narrowBandWidth,
+          R"(Narrow band width around triangles (in voxel units). Default: 1.5)")
+      .def_readwrite(
+          "max_distance",
+          &axel::MeshToSdfConfig<float>::maxDistance,
+          R"(Maximum distance to compute (distances beyond this are clamped). Set to 0 to disable clamping. Default: 0)")
+      .def_readwrite(
+          "tolerance",
+          &axel::MeshToSdfConfig<float>::tolerance,
+          R"(Numerical tolerance for computations. Default: machine epsilon * 1000)")
+      .def("__repr__", [](const axel::MeshToSdfConfig<float>& self) {
+        return fmt::format(
+            "MeshToSdfConfig(narrow_band_width={:.3f}, max_distance={:.3f}, tolerance={:.6e})",
+            self.narrowBandWidth,
+            self.maxDistance,
+            self.tolerance);
+      });
+
+  // Bind mesh_to_sdf function
+  m.def(
+      "mesh_to_sdf",
+      [](const py::array_t<float>& vertices,
+         const py::array_t<int>& triangles,
+         const axel::BoundingBox<float>& bounds,
+         const py::array_t<axel::Index>& resolution,
+         const axel::MeshToSdfConfig<float>& config) {
+        // Validate input arrays
+        validatePositionArray(vertices, "vertices");
+        validateIndexArray(triangles, "triangles");
+
+        if (resolution.ndim() != 1 || resolution.shape(0) != 3) {
+          throw std::runtime_error(fmt::format(
+              "Invalid shape for resolution: expected (3,), got {}", getArrayDimStr(resolution)));
+        }
+
+        // Convert numpy arrays to spans
+        const auto verticesData = vertices.unchecked<2>();
+        const auto trianglesData = triangles.unchecked<2>();
+        const auto resolutionData = resolution.unchecked<1>();
+
+        // Convert vertex data to std::vector<Eigen::Vector3f>
+        std::vector<Eigen::Vector3f> vertexVector;
+        vertexVector.reserve(verticesData.shape(0));
+        for (py::ssize_t i = 0; i < verticesData.shape(0); ++i) {
+          vertexVector.emplace_back(verticesData(i, 0), verticesData(i, 1), verticesData(i, 2));
+        }
+
+        // Convert triangle data to std::vector<Eigen::Vector3i>
+        std::vector<Eigen::Vector3i> triangleVector;
+        triangleVector.reserve(trianglesData.shape(0));
+        for (py::ssize_t i = 0; i < trianglesData.shape(0); ++i) {
+          triangleVector.emplace_back(
+              trianglesData(i, 0), trianglesData(i, 1), trianglesData(i, 2));
+        }
+
+        // Convert resolution to Eigen::Vector3<axel::Index>
+        const Eigen::Vector3<axel::Index> resolutionVector(
+            resolutionData(0), resolutionData(1), resolutionData(2));
+
+        // Call the mesh_to_sdf function
+        return axel::meshToSdf<float>(
+            gsl::span<const Eigen::Vector3f>(vertexVector),
+            gsl::span<const Eigen::Vector3i>(triangleVector),
+            bounds,
+            resolutionVector,
+            config);
+      },
+      R"(Convert a triangle mesh to a signed distance field using modern 3-step approach.
+
+This function creates a high-quality signed distance field from a triangle mesh using:
+1. Narrow band initialization with exact triangle distances
+2. Fast marching propagation using Eikonal equation  
+3. Sign determination using ray casting
+
+:param vertices: Vertex positions as 2D array of shape (N, 3) where N is number of vertices.
+:param triangles: Triangle indices as 2D array of shape (M, 3) where M is number of triangles. 
+                  Indices must be valid within the vertices array.
+:param bounds: Spatial bounds for the SDF as a :class:`BoundingBox`.
+:param resolution: Grid resolution as 1D array of shape (3,) containing (nx, ny, nz).
+:param config: Configuration parameters as :class:`MeshToSdfConfig` (optional).
+:return: Generated :class:`SignedDistanceField`.
+
+Example usage::
+
+    import numpy as np
+    import pymomentum.axel as axel
+    
+    # Create a simple cube mesh
+    vertices = np.array([
+        [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],  # bottom face
+        [-1, -1,  1], [1, -1,  1], [1, 1,  1], [-1, 1,  1]   # top face
+    ], dtype=np.float32)
+    
+    triangles = np.array([
+        [0, 1, 2], [0, 2, 3],  # bottom face
+        [4, 7, 6], [4, 6, 5],  # top face
+        [0, 4, 5], [0, 5, 1],  # front face
+        [2, 6, 7], [2, 7, 3],  # back face
+        [0, 3, 7], [0, 7, 4],  # left face
+        [1, 5, 6], [1, 6, 2]   # right face
+    ], dtype=np.int32)
+    
+    bounds = axel.BoundingBox(
+        min_corner=np.array([-1.5, -1.5, -1.5]), 
+        max_corner=np.array([1.5, 1.5, 1.5])
+    )
+    resolution = np.array([32, 32, 32])
+    
+    config = axel.MeshToSdfConfig()
+    config.narrow_band_width = 3.0
+    
+    sdf = axel.mesh_to_sdf(vertices, triangles, bounds, resolution, config))",
+      py::arg("vertices"),
+      py::arg("triangles"),
+      py::arg("bounds"),
+      py::arg("resolution"),
+      py::arg("config") = axel::MeshToSdfConfig<float>{});
+
+  // Bind convenience overload with automatic bounds computation
+  m.def(
+      "mesh_to_sdf",
+      [](const py::array_t<float>& vertices,
+         const py::array_t<int>& triangles,
+         const py::array_t<axel::Index>& resolution,
+         float padding,
+         const axel::MeshToSdfConfig<float>& config) {
+        // Validate input arrays
+        validatePositionArray(vertices, "vertices");
+        validateIndexArray(triangles, "triangles");
+
+        if (resolution.ndim() != 1 || resolution.shape(0) != 3) {
+          throw std::runtime_error(fmt::format(
+              "Invalid shape for resolution: expected (3,), got {}", getArrayDimStr(resolution)));
+        }
+
+        // Convert numpy arrays to spans
+        const auto verticesData = vertices.unchecked<2>();
+        const auto trianglesData = triangles.unchecked<2>();
+        const auto resolutionData = resolution.unchecked<1>();
+
+        // Convert vertex data to std::vector<Eigen::Vector3f>
+        std::vector<Eigen::Vector3f> vertexVector;
+        vertexVector.reserve(verticesData.shape(0));
+        for (py::ssize_t i = 0; i < verticesData.shape(0); ++i) {
+          vertexVector.emplace_back(verticesData(i, 0), verticesData(i, 1), verticesData(i, 2));
+        }
+
+        // Convert triangle data to std::vector<Eigen::Vector3i>
+        std::vector<Eigen::Vector3i> triangleVector;
+        triangleVector.reserve(trianglesData.shape(0));
+        for (py::ssize_t i = 0; i < trianglesData.shape(0); ++i) {
+          triangleVector.emplace_back(
+              trianglesData(i, 0), trianglesData(i, 1), trianglesData(i, 2));
+        }
+
+        // Convert resolution to Eigen::Vector3<axel::Index>
+        const Eigen::Vector3<axel::Index> resolutionVector(
+            resolutionData(0), resolutionData(1), resolutionData(2));
+
+        // Call the mesh_to_sdf function with automatic bounds
+        return axel::meshToSdf<float>(
+            gsl::span<const Eigen::Vector3f>(vertexVector),
+            gsl::span<const Eigen::Vector3i>(triangleVector),
+            resolutionVector,
+            padding,
+            config);
+      },
+      R"(Convert a triangle mesh to a signed distance field with automatic bounds computation.
+
+This convenience function automatically computes the bounding box from the mesh vertices,
+adds padding, and creates a signed distance field.
+
+:param vertices: Vertex positions as 2D array of shape (N, 3) where N is number of vertices.
+:param triangles: Triangle indices as 2D array of shape (M, 3) where M is number of triangles.
+:param resolution: Grid resolution as 1D array of shape (3,) containing (nx, ny, nz).
+:param padding: Extra space around mesh bounds as fraction of bounding box size (default: 0.1).
+:param config: Configuration parameters as :class:`MeshToSdfConfig` (optional).
+:return: Generated :class:`SignedDistanceField`.
+
+Example usage::
+
+    import numpy as np
+    import pymomentum.axel as axel
+    
+    # Create a simple tetrahedron mesh
+    vertices = np.array([
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0], 
+        [0.5, 1.0, 0.0],
+        [0.5, 0.5, 1.0]
+    ], dtype=np.float32)
+    
+    triangles = np.array([
+        [0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]
+    ], dtype=np.int32)
+    
+    resolution = np.array([32, 32, 32])
+    
+    # Automatically compute bounds with 20% padding
+    sdf = axel.mesh_to_sdf(vertices, triangles, resolution, padding=0.2))",
+      py::arg("vertices"),
+      py::arg("triangles"),
+      py::arg("resolution"),
+      py::arg("padding") = 0.1f,
+      py::arg("config") = axel::MeshToSdfConfig<float>{});
+}
+
+} // namespace pymomentum

--- a/pymomentum/axel/axel_utility.cpp
+++ b/pymomentum/axel/axel_utility.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <pymomentum/axel/axel_utility.h>
+
+#include <fmt/format.h>
+#include <pybind11/pybind11.h>
+#include <sstream>
+
+namespace py = pybind11;
+
+namespace pymomentum {
+
+std::string getArrayDimStr(const py::array& array) {
+  std::ostringstream oss;
+  oss << "(";
+  for (py::ssize_t i = 0; i < array.ndim(); ++i) {
+    if (i > 0) {
+      oss << ", ";
+    }
+    oss << array.shape(i);
+  }
+  oss << ")";
+  return oss.str();
+}
+
+void validatePositionArray(const py::array_t<float>& positions, const char* parameterName) {
+  if (positions.ndim() != 2) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected 2D array (N, 3), got {}D array {}",
+        parameterName,
+        positions.ndim(),
+        getArrayDimStr(positions)));
+  }
+
+  if (positions.shape(1) != 3) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected (N, 3), got {}", parameterName, getArrayDimStr(positions)));
+  }
+}
+
+// validateIndexArray is now a template function in the header file
+
+void validateGridDimensions(
+    const py::array_t<float>& grid,
+    const axel::SignedDistanceField<float>& sdf,
+    const char* parameterName) {
+  if (grid.ndim() != 3) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected 3D array (nx, ny, nz), got {}D array {}",
+        parameterName,
+        grid.ndim(),
+        getArrayDimStr(grid)));
+  }
+
+  const auto& resolution = sdf.resolution();
+  if (grid.shape(0) != resolution.x() || grid.shape(1) != resolution.y() ||
+      grid.shape(2) != resolution.z()) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected ({}, {}, {}) to match SDF resolution, got {}",
+        parameterName,
+        resolution.x(),
+        resolution.y(),
+        resolution.z(),
+        getArrayDimStr(grid)));
+  }
+}
+
+Eigen::Vector3f arrayToVector3f(const py::array_t<float>& array, const char* parameterName) {
+  if (array.ndim() != 1) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected 1D array (3,), got {}D array {}",
+        parameterName,
+        array.ndim(),
+        getArrayDimStr(array)));
+  }
+
+  if (array.shape(0) != 3) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected (3,), got {}", parameterName, getArrayDimStr(array)));
+  }
+
+  auto acc = array.unchecked<1>();
+  return {acc(0), acc(1), acc(2)};
+}
+
+Eigen::Vector3<axel::Index> arrayToVector3i(
+    const py::array_t<axel::Index>& array,
+    const char* parameterName) {
+  if (array.ndim() != 1) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected 1D array (3,), got {}D array {}",
+        parameterName,
+        array.ndim(),
+        getArrayDimStr(array)));
+  }
+
+  if (array.shape(0) != 3) {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected (3,), got {}", parameterName, getArrayDimStr(array)));
+  }
+
+  auto acc = array.unchecked<1>();
+  return {acc(0), acc(1), acc(2)};
+}
+
+py::array_t<float> vector3fToArray(const Eigen::Vector3f& vec) {
+  auto result = py::array_t<float>(3);
+  auto acc = result.mutable_unchecked<1>();
+  acc(0) = vec.x();
+  acc(1) = vec.y();
+  acc(2) = vec.z();
+  return result;
+}
+
+py::array_t<axel::Index> vector3iToArray(const Eigen::Vector3<axel::Index>& vec) {
+  auto result = py::array_t<axel::Index>(3);
+  auto acc = result.mutable_unchecked<1>();
+  acc(0) = vec.x();
+  acc(1) = vec.y();
+  acc(2) = vec.z();
+  return result;
+}
+
+void validateBatchPositionArray(const py::array_t<float>& positions, const char* parameterName) {
+  if (positions.ndim() == 1) {
+    // Single position: shape (3,)
+    if (positions.shape(0) != 3) {
+      throw std::runtime_error(fmt::format(
+          "Invalid shape for {}: expected (3,) for single position or (N, 3) for batch of positions, got {}",
+          parameterName,
+          getArrayDimStr(positions)));
+    }
+  } else if (positions.ndim() == 2) {
+    // Batch of positions: shape (N, 3)
+    if (positions.shape(1) != 3) {
+      throw std::runtime_error(fmt::format(
+          "Invalid shape for {}: expected (N, 3) for batch of positions, got {}",
+          parameterName,
+          getArrayDimStr(positions)));
+    }
+  } else {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected 1D array (3,) for single position or 2D array (N, 3) for batch of positions, got {}D array {}",
+        parameterName,
+        positions.ndim(),
+        getArrayDimStr(positions)));
+  }
+}
+
+// Template implementations are now in the header file
+
+} // namespace pymomentum

--- a/pymomentum/axel/axel_utility.h
+++ b/pymomentum/axel/axel_utility.h
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <axel/BoundingBox.h>
+#include <axel/SignedDistanceField.h>
+#include <axel/common/Types.h>
+
+#include <fmt/format.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <Eigen/Core>
+
+namespace py = pybind11;
+
+namespace pymomentum {
+
+/**
+ * Helper function to get a string representation of array dimensions
+ */
+std::string getArrayDimStr(const py::array& array);
+
+/**
+ * Validate array shape for 3D positions.
+ * Expected shape: (N, 3)
+ */
+void validatePositionArray(const py::array_t<float>& positions, const char* parameterName);
+
+/**
+ * Validate array shape for 3D indices (templated version).
+ * Expected shape: (N, 3) for N triplets or (3,) for single triplet
+ *
+ * @tparam T Index type (e.g., int, axel::Index)
+ */
+template <typename T>
+void validateIndexArray(const py::array_t<T>& indices, const char* parameterName) {
+  if (indices.ndim() == 1) {
+    if (indices.shape(0) != 3) {
+      throw std::runtime_error(fmt::format(
+          "Invalid shape for {}: expected (3,) for single index or (N, 3) for multiple indices, got {}",
+          parameterName,
+          getArrayDimStr(indices)));
+    }
+  } else if (indices.ndim() == 2) {
+    if (indices.shape(1) != 3) {
+      throw std::runtime_error(fmt::format(
+          "Invalid shape for {}: expected (N, 3), got {}", parameterName, getArrayDimStr(indices)));
+    }
+  } else {
+    throw std::runtime_error(fmt::format(
+        "Invalid shape for {}: expected 1D array (3,) or 2D array (N, 3), got {}D array {}",
+        parameterName,
+        indices.ndim(),
+        getArrayDimStr(indices)));
+  }
+}
+
+/**
+ * Validate array dimensions for grid coordinates.
+ * Expected shape: (nx, ny, nz) or compatible with SDF resolution
+ */
+void validateGridDimensions(
+    const py::array_t<float>& grid,
+    const axel::SignedDistanceField<float>& sdf,
+    const char* parameterName);
+
+/**
+ * Convert py::array_t<float> to Eigen::Vector3f.
+ * Input should be shape (3,) or compatible.
+ */
+Eigen::Vector3f arrayToVector3f(const py::array_t<float>& array, const char* parameterName);
+
+/**
+ * Convert py::array_t<axel::Index> to Eigen::Vector3<axel::Index>.
+ * Input should be shape (3,) or compatible.
+ */
+Eigen::Vector3<axel::Index> arrayToVector3i(
+    const py::array_t<axel::Index>& array,
+    const char* parameterName);
+
+/**
+ * Convert Eigen::Vector3f to py::array_t<float>.
+ */
+py::array_t<float> vector3fToArray(const Eigen::Vector3f& vec);
+
+/**
+ * Convert Eigen::Vector3<axel::Index> to py::array_t<axel::Index>.
+ */
+py::array_t<axel::Index> vector3iToArray(const Eigen::Vector3<axel::Index>& vec);
+
+/**
+ * Validate input positions array for batching operations.
+ * Input can be either:
+ * - 1D array of shape (3,) for single position
+ * - 2D array of shape (N, 3) for batch of N positions
+ */
+void validateBatchPositionArray(const py::array_t<float>& positions, const char* parameterName);
+
+/**
+ * Specialized version for operations that return scalar values (like sample).
+ */
+template <typename SdfType, typename Operation>
+py::array_t<float> applyBatchedScalarOperation(
+    const SdfType& sdf,
+    const py::array_t<float>& positions,
+    Operation operation) {
+  validateBatchPositionArray(positions, "positions");
+
+  if (positions.ndim() == 1) {
+    // Single position case: return scalar in 0D array
+    Eigen::Vector3f pos(positions.data()[0], positions.data()[1], positions.data()[2]);
+    float result = operation(sdf, pos);
+
+    // For single position, return a scalar wrapped in an array
+    auto resultArray = py::array_t<float>(1);
+    *resultArray.mutable_data() = result;
+    resultArray.resize({});
+    return resultArray;
+  } else {
+    // Batch case: return 1D array of results
+    const size_t numPositions = positions.shape(0);
+    auto resultArray = py::array_t<float>(numPositions);
+    auto resultData = resultArray.template mutable_unchecked<1>();
+    auto posData = positions.unchecked<2>();
+
+    for (size_t i = 0; i < numPositions; ++i) {
+      Eigen::Vector3f pos(posData(i, 0), posData(i, 1), posData(i, 2));
+      resultData(i) = operation(sdf, pos);
+    }
+
+    return resultArray;
+  }
+}
+
+/**
+ * Specialized version for operations that return Vector3f values (like
+ * gradient).
+ */
+template <typename SdfType, typename Operation>
+py::array_t<float> applyBatchedVectorOperation(
+    const SdfType& sdf,
+    const py::array_t<float>& positions,
+    Operation operation) {
+  validateBatchPositionArray(positions, "positions");
+
+  if (positions.ndim() == 1) {
+    // Single position case: return 1D array of shape (3,)
+    Eigen::Vector3f pos(positions.data()[0], positions.data()[1], positions.data()[2]);
+    Eigen::Vector3f result = operation(sdf, pos);
+    return vector3fToArray(result);
+  } else {
+    // Batch case: return 2D array of shape (N, 3)
+    const size_t numPositions = positions.shape(0);
+    std::vector<py::ssize_t> shape = {static_cast<py::ssize_t>(numPositions), 3};
+    auto resultArray = py::array_t<float>(shape);
+    auto resultData = resultArray.template mutable_unchecked<2>();
+    auto posData = positions.unchecked<2>();
+
+    for (size_t i = 0; i < numPositions; ++i) {
+      Eigen::Vector3f pos(posData(i, 0), posData(i, 1), posData(i, 2));
+      Eigen::Vector3f result = operation(sdf, pos);
+      resultData(i, 0) = result.x();
+      resultData(i, 1) = result.y();
+      resultData(i, 2) = result.z();
+    }
+
+    return resultArray;
+  }
+}
+
+/**
+ * Specialized version for operations that return pair<float, Vector3f> (like
+ * sampleWithGradient).
+ */
+template <typename SdfType, typename Operation>
+py::tuple applyBatchedSampleGradientOperation(
+    const SdfType& sdf,
+    const py::array_t<float>& positions,
+    Operation operation) {
+  validateBatchPositionArray(positions, "positions");
+
+  if (positions.ndim() == 1) {
+    // Single position case: return tuple of (scalar, vector)
+    Eigen::Vector3f pos(positions.data()[0], positions.data()[1], positions.data()[2]);
+    auto [value, gradient] = operation(sdf, pos);
+
+    return py::make_tuple(py::cast(value), vector3fToArray(gradient));
+  } else {
+    // Batch case: return tuple of (1D values array, 2D gradients array)
+    const size_t numPositions = positions.shape(0);
+    auto valuesArray = py::array_t<float>(numPositions);
+    std::vector<py::ssize_t> gradientsShape = {static_cast<py::ssize_t>(numPositions), 3};
+    auto gradientsArray = py::array_t<float>(gradientsShape);
+
+    auto valuesData = valuesArray.template mutable_unchecked<1>();
+    auto gradientsData = gradientsArray.template mutable_unchecked<2>();
+    auto posData = positions.unchecked<2>();
+
+    for (size_t i = 0; i < numPositions; ++i) {
+      Eigen::Vector3f pos(posData(i, 0), posData(i, 1), posData(i, 2));
+      auto [value, gradient] = operation(sdf, pos);
+      valuesData(i) = value;
+      gradientsData(i, 0) = gradient.x();
+      gradientsData(i, 1) = gradient.y();
+      gradientsData(i, 2) = gradient.z();
+    }
+
+    return py::make_tuple(valuesArray, gradientsArray);
+  }
+}
+
+} // namespace pymomentum

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -182,3 +182,12 @@ renderer_sources = [
     "renderer/renderer_pybind.cpp",
     "renderer/software_rasterizer.cpp",
 ]
+
+axel_public_headers = [
+    "axel/axel_utility.h",
+]
+
+axel_sources = [
+    "axel/axel_pybind.cpp",
+    "axel/axel_utility.cpp",
+]

--- a/pymomentum/test/test_axel.py
+++ b/pymomentum/test/test_axel.py
@@ -1,0 +1,430 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import pymomentum.axel as axel
+
+
+class TestAxel(unittest.TestCase):
+    def test_bounding_box_creation(self):
+        """Test basic BoundingBox creation and properties."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        np.testing.assert_array_equal(bbox.min, min_corner)
+        np.testing.assert_array_equal(bbox.max, max_corner)
+        np.testing.assert_array_almost_equal(bbox.center, [0.5, 0.5, 0.5])
+
+    def test_bounding_box_contains(self):
+        """Test BoundingBox.contains functionality."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        # Point inside
+        self.assertTrue(bbox.contains(np.array([0.5, 0.5, 0.5])))
+
+        # Point outside
+        self.assertFalse(bbox.contains(np.array([1.5, 0.5, 0.5])))
+
+        # Point on boundary
+        self.assertTrue(bbox.contains(np.array([1.0, 1.0, 1.0])))
+
+    def test_signed_distance_field_creation(self):
+        """Test basic SignedDistanceField creation and properties."""
+        min_corner = np.array([-1.0, -1.0, -1.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([10, 10, 10], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Check properties
+        np.testing.assert_array_equal(sdf.resolution, resolution)
+        self.assertEqual(sdf.total_voxels, 1000)  # 10 * 10 * 10
+
+        # Check bounds
+        np.testing.assert_array_equal(sdf.bounds.min, min_corner)
+        np.testing.assert_array_equal(sdf.bounds.max, max_corner)
+
+        # Check voxel size
+        expected_voxel_size = [
+            2.0 / 10.0,
+            2.0 / 10.0,
+            2.0 / 10.0,
+        ]  # (max - min) / resolution
+        np.testing.assert_array_almost_equal(sdf.voxel_size, expected_voxel_size)
+
+    def test_sdf_grid_access(self):
+        """Test grid access methods (at, set, is_valid_index)."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([5, 5, 5], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Test valid indices
+        self.assertTrue(sdf.is_valid_index(0, 0, 0))
+        self.assertTrue(sdf.is_valid_index(4, 4, 4))
+
+        # Test invalid indices
+        self.assertFalse(sdf.is_valid_index(5, 0, 0))
+        self.assertFalse(sdf.is_valid_index(-1, 0, 0))
+
+        # Test buffer protocol access
+        data_array = np.array(sdf)
+
+        # Test that we can set and get values through the numpy array
+        data_array[1, 2, 3] = 0.5
+        self.assertAlmostEqual(data_array[1, 2, 3], 0.5)
+
+    def test_sdf_coordinate_conversion(self):
+        """Test world-to-grid and grid-to-world coordinate conversion."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([2.0, 2.0, 2.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([3, 3, 3], dtype=np.int32)  # Simple 3x3x3 grid
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Test grid location (center of grid cell) using grid_to_world
+        # For a 3x3x3 grid with domain [0,2]x[0,2]x[0,2], grid coordinate (1,1,1) should map to world coordinate (2/3, 2/3, 2/3)
+        grid_center = sdf.grid_to_world(np.array([1.0, 1.0, 1.0]))  # Middle cell
+        expected_center = np.array(
+            [2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0]
+        )  # Actual coordinate mapping
+        np.testing.assert_array_almost_equal(grid_center, expected_center, decimal=5)
+
+        # Test world to grid conversion (inverse should be consistent)
+        world_pos = np.array([2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
+        grid_pos = sdf.world_to_grid(world_pos)
+        expected_grid_pos = np.array(
+            [1.0, 1.0, 1.0]
+        )  # Should map back to grid coordinate (1,1,1)
+        np.testing.assert_array_almost_equal(grid_pos, expected_grid_pos)
+
+        # Test grid to world conversion (round trip)
+        world_pos_back = sdf.grid_to_world(grid_pos)
+        np.testing.assert_array_almost_equal(world_pos_back, world_pos)
+
+    def test_sdf_fill_and_clear(self):
+        """Test fill and clear functionality."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([3, 3, 3], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Fill with a specific value
+        sdf.fill(2.5)
+
+        # Check a few grid points through buffer protocol
+        data_array = np.array(sdf)
+        self.assertAlmostEqual(data_array[0, 0, 0], 2.5)
+        self.assertAlmostEqual(data_array[1, 1, 1], 2.5)
+        self.assertAlmostEqual(data_array[2, 2, 2], 2.5)
+
+        # Clear using fill(0.0) (should set to zero)
+        sdf.fill(0.0)
+        # Get a new array view after clear operation
+        data_array_after_clear = np.array(sdf)
+        self.assertAlmostEqual(data_array_after_clear[1, 1, 1], 0.0)
+
+    def test_sdf_sampling(self):
+        """Test SDF sampling at continuous positions."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([2.0, 2.0, 2.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([3, 3, 3], dtype=np.int32)
+
+        # Create SDF with some initial test data instead of relying on buffer protocol to modify it
+        test_data = [1.0] * (3 * 3 * 3)  # Fill with 1.0 values
+        sdf = axel.SignedDistanceField(bbox, resolution, test_data)
+
+        # Test sampling at the bounds - should return the set value (1.0) or boundary behavior
+        sample_pos = np.array([0.0, 0.0, 0.0])  # Corner of the domain
+        sampled_value = sdf.sample(sample_pos)
+
+        # The exact sampled value depends on the SDF implementation's boundary behavior
+        # Since we filled with 1.0, we expect to get 1.0 or close to it
+        self.assertAlmostEqual(sampled_value, 1.0, places=3)
+
+        # Test sampling at center of domain
+        sample_pos = np.array([1.0, 1.0, 1.0])  # Center of [0,2]x[0,2]x[0,2] domain
+        sampled_value = sdf.sample(sample_pos)
+        self.assertAlmostEqual(sampled_value, 1.0, places=3)
+
+    def test_sdf_repr(self):
+        """Test string representation of SDF."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([10, 20, 30], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        repr_str = repr(sdf)
+
+        # Check that key information is in the string representation
+        self.assertIn("10", repr_str)  # resolution
+        self.assertIn("20", repr_str)
+        self.assertIn("30", repr_str)
+        self.assertIn("0.000", repr_str)  # bounds
+        self.assertIn("1.000", repr_str)
+
+    def test_sdf_buffer_protocol(self):
+        """Test buffer protocol for direct numpy array access."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([3, 4, 5], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Convert SDF to numpy array using buffer protocol
+        data_array = np.array(sdf)
+
+        # Check shape matches resolution
+        self.assertEqual(data_array.shape, (3, 4, 5))
+        self.assertEqual(data_array.dtype, np.float32)
+
+        # Test that we can modify the data through the numpy array
+        # This should modify the underlying SDF data directly (zero-copy)
+        data_array[1, 2, 3] = 42.0
+
+        # The buffer protocol provides direct zero-copy access, so there's no separate
+        # SDF.at() or SDF.set() methods - everything goes through the numpy array
+
+    def test_sdf_buffer_protocol_fill_operations(self):
+        """Test buffer protocol with fill operations."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([2.0, 2.0, 2.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([4, 4, 4], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Get numpy array view
+        data_array = np.array(sdf)
+
+        # Fill through numpy operations
+        data_array[:] = 5.0
+
+        # Verify all voxels have the new value using numpy array view
+        self.assertTrue(np.allclose(data_array, 5.0))
+
+        # Fill a specific slice
+        data_array[1, :, :] = -3.0
+
+        # Verify the slice was modified and other slices unchanged
+        self.assertTrue(np.allclose(data_array[1, :, :], -3.0))
+        self.assertTrue(np.allclose(data_array[0, :, :], 5.0))
+        self.assertTrue(np.allclose(data_array[2, :, :], 5.0))
+        self.assertTrue(np.allclose(data_array[3, :, :], 5.0))
+
+    def test_sdf_buffer_protocol_with_clear(self):
+        """Test buffer protocol after clear operations."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        resolution = np.array([2, 2, 2], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Get numpy array view
+        data_array = np.array(sdf)
+
+        # Fill with some values
+        data_array[:] = 10.0
+
+        # Clear using SDF method (fill with 0.0)
+        sdf.fill(0.0)
+
+        # Get a new array view after clear operation to see the changes
+        data_array_after_clear = np.array(sdf)
+
+        # Verify the new array view reflects the cleared values
+        np.testing.assert_array_equal(
+            data_array_after_clear, np.zeros((2, 2, 2), dtype=np.float32)
+        )
+
+    def test_mesh_to_sdf_tetrahedron(self):
+        """Test mesh_to_sdf with a simple tetrahedron mesh."""
+        # Create a simple tetrahedron mesh
+        vertices = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.0], [0.5, 0.5, 1.0]],
+            dtype=np.float32,
+        )
+
+        triangles = np.array(
+            [[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]], dtype=np.int32
+        )
+
+        # Define bounds and resolution
+        bounds = axel.BoundingBox(
+            min_corner=np.array([-0.5, -0.5, -0.5]),
+            max_corner=np.array([1.5, 1.5, 1.5]),
+        )
+        resolution = np.array([16, 16, 16], dtype=np.int64)
+
+        # Create configuration
+        config = axel.MeshToSdfConfig()
+        config.narrow_band_width = 2.0
+
+        # Generate SDF
+        sdf = axel.mesh_to_sdf(vertices, triangles, bounds, resolution, config)
+
+        # Verify basic properties
+        self.assertIsInstance(sdf, axel.SignedDistanceField)
+        self.assertEqual(sdf.total_voxels, 16 * 16 * 16)
+
+        # Test that the center of the tetrahedron has negative distance (inside)
+        center_point = np.array([0.5, 0.25, 0.25], dtype=np.float32)
+        center_distance = sdf.sample(center_point)
+        self.assertLess(
+            center_distance,
+            0,
+            "Center of tetrahedron should be inside (negative distance)",
+        )
+
+        # Test a point clearly outside has positive distance
+        outside_point = np.array([2.0, 2.0, 2.0], dtype=np.float32)
+        outside_distance = sdf.sample(outside_point)
+        self.assertGreater(
+            outside_distance,
+            0,
+            "Point outside tetrahedron should have positive distance",
+        )
+
+    def test_mesh_to_sdf_automatic_bounds(self):
+        """Test mesh_to_sdf with automatic bounds computation."""
+        # Create a simple tetrahedron mesh
+        vertices = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.0], [0.5, 0.5, 1.0]],
+            dtype=np.float32,
+        )
+
+        triangles = np.array(
+            [[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]], dtype=np.int32
+        )
+
+        resolution = np.array([20, 20, 20], dtype=np.int64)
+
+        # Generate SDF with automatic bounds computation
+        sdf = axel.mesh_to_sdf(vertices, triangles, resolution, padding=0.2)
+
+        # Verify basic properties
+        self.assertIsInstance(sdf, axel.SignedDistanceField)
+        self.assertEqual(sdf.total_voxels, 20 * 20 * 20)
+
+        # Test that bounds were computed correctly with padding
+        bounds = sdf.bounds
+        min_corner = bounds.min
+        max_corner = bounds.max
+
+        # Check that the bounds extend beyond the mesh vertices
+        self.assertLess(min_corner[0], 0.0)  # Should be less than min vertex x (0.0)
+        self.assertLess(min_corner[1], 0.0)  # Should be less than min vertex y (0.0)
+        self.assertLess(min_corner[2], 0.0)  # Should be less than min vertex z (0.0)
+
+        self.assertGreater(
+            max_corner[0], 1.0
+        )  # Should be greater than max vertex x (1.0)
+        self.assertGreater(
+            max_corner[1], 1.0
+        )  # Should be greater than max vertex y (1.0)
+        self.assertGreater(
+            max_corner[2], 1.0
+        )  # Should be greater than max vertex z (1.0)
+
+    def test_mesh_to_sdf_cube(self):
+        """Test mesh_to_sdf with a cube mesh."""
+        # Create a cube mesh
+        vertices = np.array(
+            [
+                [-1, -1, -1],
+                [1, -1, -1],
+                [1, 1, -1],
+                [-1, 1, -1],  # bottom face
+                [-1, -1, 1],
+                [1, -1, 1],
+                [1, 1, 1],
+                [-1, 1, 1],  # top face
+            ],
+            dtype=np.float32,
+        )
+
+        triangles = np.array(
+            [
+                [0, 1, 2],
+                [0, 2, 3],  # bottom face
+                [4, 7, 6],
+                [4, 6, 5],  # top face
+                [0, 4, 5],
+                [0, 5, 1],  # front face
+                [2, 6, 7],
+                [2, 7, 3],  # back face
+                [0, 3, 7],
+                [0, 7, 4],  # left face
+                [1, 5, 6],
+                [1, 6, 2],  # right face
+            ],
+            dtype=np.int32,
+        )
+
+        resolution = np.array([24, 24, 24], dtype=np.int64)
+
+        config = axel.MeshToSdfConfig()
+
+        sdf = axel.mesh_to_sdf(
+            vertices, triangles, resolution, padding=0.25, config=config
+        )
+
+        # Test center (should be inside)
+        center_distance = sdf.sample(np.array([0.0, 0.0, 0.0], dtype=np.float32))
+        self.assertLess(center_distance, 0, "Center of cube should be inside")
+
+        # Test corners (should be approximately on surface)
+        corner_distance = sdf.sample(np.array([1.0, 1.0, 1.0], dtype=np.float32))
+        self.assertLess(abs(corner_distance), 0.2, "Corner should be near surface")
+
+        # Test point outside
+        outside_distance = sdf.sample(np.array([2.0, 2.0, 2.0], dtype=np.float32))
+        self.assertGreater(
+            outside_distance, 0, "Point outside cube should have positive distance"
+        )
+
+    def test_mesh_to_sdf_invalid_inputs(self):
+        """Test mesh_to_sdf with invalid inputs."""
+        # Valid base case
+        vertices = np.array([[0, 0, 0], [1, 0, 0], [0.5, 1, 0]], dtype=np.float32)
+        triangles = np.array([[0, 1, 2]], dtype=np.int32)
+        resolution = np.array([10, 10, 10], dtype=np.int64)
+
+        # Test invalid vertex shape
+        invalid_vertices = np.array([[0, 0], [1, 0], [0.5, 1]], dtype=np.float32)
+        with self.assertRaisesRegex(RuntimeError, "Invalid shape for vertices"):
+            axel.mesh_to_sdf(invalid_vertices, triangles, resolution)
+
+        # Test invalid triangle shape
+        invalid_triangles = np.array([[0, 1]], dtype=np.int32)
+        with self.assertRaisesRegex(RuntimeError, "Invalid shape for triangles"):
+            axel.mesh_to_sdf(vertices, invalid_triangles, resolution)
+
+        # Test invalid resolution shape
+        invalid_resolution = np.array([10, 10], dtype=np.int64)
+        with self.assertRaisesRegex(RuntimeError, "Invalid shape for resolution"):
+            axel.mesh_to_sdf(vertices, triangles, invalid_resolution)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: We can bind out the SDF using the buffer protocol, this will let us do stuff like visualize it.

Reviewed By: jeongseok-meta

Differential Revision: D84392731


