### PR TITLE
Optimize CI costs

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   momentum:
-    if: false # Temporarily disabled to reduce CI cost
+    # Enabled for minimal macOS platform coverage
     name: cpp-${{ matrix.mode == '' && 'opt' || 'dev' }}-${{ matrix.os == 'macos-latest-large' && 'mac-x86_64' || 'mac-arm64' }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -53,6 +53,7 @@ jobs:
           pixi run cmake --build momentum/examples/hello_world/build
 
   pymomentum:
+    if: false # Disabled: Redundant with Windows, macOS is most expensive
     name: py-${{ matrix.os == 'macos-latest-large' && 'mac-x86_64' || 'mac-arm64' }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        simd: ["ON", "OFF"]
+        simd: ["ON"]  # Only test SIMD=ON (production config) to reduce CI cost
         mode: [""]
     env:
       MOMENTUM_ENABLE_SIMD: ${{ matrix.simd }}

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -47,7 +47,7 @@ jobs:
             --parallel
 
   pymomentum:
-    if: false # Temporarily disabled to reduce CI cost
+    # Enabled: CPU-only for cost optimization (GPU disabled)
     name: py-${{ matrix.pixi_env }}-win
     runs-on: windows-latest
     strategy:
@@ -55,8 +55,9 @@ jobs:
       matrix:
         include:
           - pixi_env: "cpu"
-          - pixi_env: "gpu"
-            cuda_version: "12.9.0"
+          # GPU disabled to reduce CI cost
+          # - pixi_env: "gpu"
+          #   cuda_version: "12.9.0"
     env:
       FULL_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:


### PR DESCRIPTION
Summary:
Reduce CI jobs from 5-6 to 3 while maintaining minimal coverage across all platforms for both C++ and Python.

**Before:**
```
Platform  │ C++ (momentum)         │ Python (pymomentum)
──────────┼────────────────────────┼────────────────────
Ubuntu    │ ✅ SIMD ON + SIMD OFF  │ ❌
Windows   │ ❌                     │ ❌
macOS     │ ❌                     │ ✅
          │ Total: 3 jobs          │
```

**After:**
```
Platform  │ C++ (momentum)         │ Python (pymomentum)
──────────┼────────────────────────┼────────────────────
Ubuntu    │ ✅ SIMD ON only        │ ❌
Windows   │ ❌                     │ ✅ CPU-only
macOS     │ ✅                     │ ❌
          │ Total: 3 jobs          │
```

**Changes:**
1. **Ubuntu**: Reduced from 2 C++ jobs to 1 (removed SIMD OFF variant)
2. **Windows**: Enabled Python CPU-only job (GPU variant disabled)
3. **macOS**: Switched from Python to C++ job

**Result:**
- All 3 platforms covered (Ubuntu, Windows, macOS)
- Both C++ and Python tested
- Eliminated most expensive runner (macOS Python)
- Similar total job count but better platform distribution

Reviewed By: nickyhe-gemini

Differential Revision: D84551394
