### PR TITLE
Fix CQS signal modernize-avoid-c-arrays in arvr/libraries/pymomentum/renderer (#673)

### DIFF
--- a/pymomentum/renderer/software_rasterizer.cpp
+++ b/pymomentum/renderer/software_rasterizer.cpp
@@ -1597,7 +1597,7 @@ void rasterizeTransforms(
   const float c2 = 0.3f;
   const bool backfaceCulling = true;
 
-  momentum::rasterizer::PhongMaterial materials[3] = {
+  std::array<momentum::rasterizer::PhongMaterial, 3> materials = {
       material.value_or(momentum::rasterizer::PhongMaterial(Eigen::Vector3f(c1, c2, c2))),
       material.value_or(momentum::rasterizer::PhongMaterial(Eigen::Vector3f(c2, c1, c2))),
       material.value_or(momentum::rasterizer::PhongMaterial(Eigen::Vector3f(c2, c2, c1)))};


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookresearch/momentum/pull/673

Reviewed By: jeongseok-meta

Differential Revision: D84596054
