### PR TITLE
Fix CQS signal readability-avoid-const-params-in-decls in arvr/libraries/pymomentum/solver2 (#672)

### DIFF
--- a/pymomentum/solver2/solver2_utility.h
+++ b/pymomentum/solver2/solver2_utility.h
@@ -42,10 +42,8 @@ class ArrayShapeValidator {
   std::unordered_map<int, int64_t> boundShapes_;
 };
 
-momentum::ParameterSet arrayToParameterSet(
-    const pybind11::array_t<bool>& array,
-    const size_t nParameters,
-    bool defaultValue);
+momentum::ParameterSet
+arrayToParameterSet(const pybind11::array_t<bool>& array, size_t nParameters, bool defaultValue);
 
 momentum::ParameterSet arrayToParameterSet(
     const pybind11::array_t<bool>& array,


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookresearch/momentum/pull/672

Differential Revision: D84580413


