### PR TITLE
Use header-only libraries for spdlog and fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,9 +168,9 @@ mt_library(
   HEADERS_VARS common_public_headers
   SOURCES_VARS common_sources
   PUBLIC_LINK_LIBRARIES
-    fmt::fmt
+    fmt::fmt-header-only
     indicators::indicators
-    spdlog::spdlog
+    spdlog::spdlog_header_only
   PUBLIC_COMPILE_DEFINITIONS
     MOMENTUM_WITH_SPDLOG=1
 )
@@ -187,7 +187,7 @@ mt_library(
   NAME fmt_eigen
   HEADERS_VARS fmt_eigen_public_headers
   PUBLIC_LINK_LIBRARIES
-    fmt::fmt
+    fmt::fmt-header-only
     Eigen3::Eigen
 )
 


### PR DESCRIPTION
Summary:
Switch from compiled spdlog and fmt libraries to their header-only versions (spdlog::spdlog_header_only and fmt::fmt-header-only) for simpler build configuration and fewer version conflicts. This change affects the common and fmt_eigen libraries in momentum's CMake configuration.

This resolves [build errors](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1368235&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=d818e662-7181-5ce9-b265-50d03742b7af) for https://github.com/conda-forge/momentum-feedstock/pull/207.

Differential Revision: D84713782


