### PR TITLE
Enable loading of blendshapes from FBX files

### DIFF
--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -553,28 +553,36 @@ void saveFbxCommon(
 
 } // namespace
 
-Character
-loadFbxCharacter(const filesystem::path& inputPath, KeepLocators keepLocators, bool permissive) {
-  return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
+Character loadFbxCharacter(
+    const filesystem::path& inputPath,
+    KeepLocators keepLocators,
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacter(inputPath, keepLocators, permissive, loadBlendShapes);
 }
 
-Character
-loadFbxCharacter(gsl::span<const std::byte> inputSpan, KeepLocators keepLocators, bool permissive) {
-  return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
+Character loadFbxCharacter(
+    gsl::span<const std::byte> inputSpan,
+    KeepLocators keepLocators,
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacter(inputSpan, keepLocators, permissive, loadBlendShapes);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     KeepLocators keepLocators,
-    bool permissive) {
-  return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive, loadBlendShapes);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
     KeepLocators keepLocators,
-    bool permissive) {
-  return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive, loadBlendShapes);
 }
 
 void saveFbx(

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -34,6 +34,9 @@ enum class FBXCoordSystem { RightHanded, LeftHanded };
 // KeepLocators Specifies whether Nulls in the transform hierarchy should be turned into Locators.
 enum class KeepLocators { No, Yes };
 
+// LoadBlendShapes Specifies whether blendshapes should be loaded or not
+enum class LoadBlendShapes { No, Yes };
+
 // A struct containing the up, front vectors and coordinate system
 struct FBXCoordSystemInfo {
   // Default to the same orientations as FbxAxisSystem::eMayaYUp
@@ -48,7 +51,8 @@ struct FBXCoordSystemInfo {
 Character loadFbxCharacter(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    bool permissive = false,
+    LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
 
 // Using keepLocators means the Nulls in the transform hierarchy will be turned into Locators.
 // This is different from historical momentum behavior so it's off by default.
@@ -56,19 +60,22 @@ Character loadFbxCharacter(
 Character loadFbxCharacter(
     gsl::span<const std::byte> inputSpan,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    bool permissive = false,
+    LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    bool permissive = false,
+    LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
-    KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    KeepLocators keepLocatorss = KeepLocators::No,
+    bool permissive = false,
+    LoadBlendShapes loadBlendShape = LoadBlendShapes::No);
 
 // Permissive mode allows saving mesh-only characters (without skin weights).
 void saveFbx(

--- a/momentum/io/fbx/fbx_io_openfbx_only.cpp
+++ b/momentum/io/fbx/fbx_io_openfbx_only.cpp
@@ -13,28 +13,36 @@
 
 namespace momentum {
 
-Character
-loadFbxCharacter(const filesystem::path& inputPath, KeepLocators keepLocators, bool permissive) {
-  return loadOpenFbxCharacter(inputPath, keepLocators, permissive);
+Character loadFbxCharacter(
+    const filesystem::path& inputPath,
+    KeepLocators keepLocators,
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacter(inputPath, keepLocators, permissive, loadBlendShapes);
 }
 
-Character
-loadFbxCharacter(gsl::span<const std::byte> inputSpan, KeepLocators keepLocators, bool permissive) {
-  return loadOpenFbxCharacter(inputSpan, keepLocators, permissive);
+Character loadFbxCharacter(
+    gsl::span<const std::byte> inputSpan,
+    KeepLocators keepLocators,
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacter(inputSpan, keepLocators, permissive, loadBlendShapes);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     KeepLocators keepLocators,
-    bool permissive) {
-  return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive);
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacterWithMotion(inputPath, keepLocators, permissive, loadBlendShapes);
 }
 
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     gsl::span<const std::byte> inputSpan,
     KeepLocators keepLocators,
-    bool permissive) {
-  return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive);
+    bool permissive,
+    LoadBlendShapes loadBlendShapes) {
+  return loadOpenFbxCharacterWithMotion(inputSpan, keepLocators, permissive, loadBlendShapes);
 }
 
 void saveFbx(

--- a/momentum/io/fbx/openfbx_loader.h
+++ b/momentum/io/fbx/openfbx_loader.h
@@ -22,24 +22,28 @@ namespace momentum {
 Character loadOpenFbxCharacter(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    bool permissive = false,
+    LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 Character loadOpenFbxCharacter(
     gsl::span<const std::byte> inputData,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    bool permissive = false,
+    LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    bool permissive = false,
+    LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
 
 // Permissive mode allows loading mesh-only characters (without skin weights).
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     gsl::span<const std::byte> inputData,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false);
+    bool permissive = false,
+    LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
 
 } // namespace momentum


### PR DESCRIPTION
Summary: Added support to load blendshapes from FBX files. This does not automatically add them to model parameters and will require a secondary call to addBlendshape(...) after having loaded the model file.

Reviewed By: jeongseok-meta

Differential Revision: D84847993


