### PR TITLE
momentum: Support downsampling a character's mesh.

### DIFF
--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -85,4 +85,44 @@ VectorXf mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter);
 
+/// Reduces the mesh to only include the specified vertices and associated faces
+///
+/// @param[in] character Character to be reduced
+/// @param[in] activeVertices Boolean vector indicating which vertices to keep
+/// @return A new character with mesh reduced to the specified vertices
+template <typename T>
+[[nodiscard]] CharacterT<T> reduceMeshByVertices(
+    const CharacterT<T>& character,
+    const std::vector<bool>& activeVertices);
+
+/// Reduces the mesh to only include the specified faces and associated vertices
+///
+/// @param[in] character Character to be reduced
+/// @param[in] activeFaces Boolean vector indicating which faces to keep
+/// @return A new character with mesh reduced to the specified faces
+template <typename T>
+[[nodiscard]] CharacterT<T> reduceMeshByFaces(
+    const CharacterT<T>& character,
+    const std::vector<bool>& activeFaces);
+
+/// Converts vertex selection to face selection
+///
+/// @param[in] character Character containing the mesh
+/// @param[in] activeVertices Boolean vector indicating which vertices are active
+/// @return Boolean vector indicating which faces only contain active vertices
+template <typename T>
+[[nodiscard]] std::vector<bool> verticesToFaces(
+    const MeshT<T>& mesh,
+    const std::vector<bool>& activeVertices);
+
+/// Converts face selection to vertex selection
+///
+/// @param[in] character Character containing the mesh
+/// @param[in] activeFaces Boolean vector indicating which faces are active
+/// @return Boolean vector indicating which vertices are used by active faces
+template <typename T>
+[[nodiscard]] std::vector<bool> facesToVertices(
+    const MeshT<T>& mesh,
+    const std::vector<bool>& activeFaces);
+
 } // namespace momentum

--- a/momentum/test/character/character_test.cpp
+++ b/momentum/test/character/character_test.cpp
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <gtest/gtest.h>
+#include "momentum/character/character.h"
 
 #include "momentum/character/blend_shape.h"
 #include "momentum/character/blend_shape_skinning.h"
-#include "momentum/character/character.h"
 #include "momentum/character/character_state.h"
+#include "momentum/character/character_utility.h"
 #include "momentum/character/collision_geometry.h"
 #include "momentum/character/linear_skinning.h"
 #include "momentum/character/locator.h"
@@ -20,6 +20,8 @@
 #include "momentum/math/constants.h"
 #include "momentum/math/mesh.h"
 #include "momentum/test/character/character_helpers.h"
+
+#include <gtest/gtest.h>
 
 using namespace momentum;
 
@@ -1431,5 +1433,120 @@ TYPED_TEST(CharacterTest, AddSkinnedLocatorParameters) {
   // Verify that the parameter names are the same
   for (size_t i = 0; i < updatedTransform.name.size(); ++i) {
     EXPECT_EQ(idempotentTransform.name[i], updatedTransform.name[i]);
+  }
+}
+
+// Test mesh reduction triangle correctness
+TYPED_TEST(CharacterTest, MeshReductionTriangleCorrectness) {
+  using CharacterType = typename TestFixture::CharacterType;
+
+  const auto& originalMesh = *this->character.mesh;
+  const size_t originalVertexCount = originalMesh.vertices.size();
+
+  // Create active vertices (keep every other vertex)
+  std::vector<bool> activeVertices(originalVertexCount, false);
+  for (size_t i = 0; i < originalVertexCount / 2; i++) {
+    activeVertices[i] = true;
+  }
+  const size_t expectedNewVertexCount = (originalVertexCount + 1) / 2;
+
+  // Reduce mesh by vertices
+  CharacterType reducedCharacter = reduceMeshByVertices(this->character, activeVertices);
+
+  // Verify basic properties
+  EXPECT_TRUE(reducedCharacter.mesh);
+  EXPECT_EQ(reducedCharacter.mesh->vertices.size(), expectedNewVertexCount);
+
+  // Verify that only triangles where all vertices are active are included
+  std::vector<bool> expectedActiveFaces = verticesToFaces(*this->character.mesh, activeVertices);
+  size_t expectedFaceCount = 0;
+  for (bool active : expectedActiveFaces) {
+    if (active) {
+      expectedFaceCount++;
+    }
+  }
+
+  EXPECT_GT(expectedFaceCount, 0);
+
+  EXPECT_EQ(reducedCharacter.mesh->faces.size(), expectedFaceCount);
+
+  // Verify all face indices are valid for the reduced mesh
+  for (const auto& face : reducedCharacter.mesh->faces) {
+    EXPECT_LT(face[0], static_cast<int>(expectedNewVertexCount));
+    EXPECT_LT(face[1], static_cast<int>(expectedNewVertexCount));
+    EXPECT_LT(face[2], static_cast<int>(expectedNewVertexCount));
+    EXPECT_GE(face[0], 0);
+    EXPECT_GE(face[1], 0);
+    EXPECT_GE(face[2], 0);
+  }
+}
+
+// Test skinning consistency after mesh reduction
+TYPED_TEST(CharacterTest, MeshReductionSkinningConsistency) {
+  using CharacterType = typename TestFixture::CharacterType;
+
+  const auto& originalMesh = *this->character.mesh;
+  const size_t originalVertexCount = originalMesh.vertices.size();
+
+  // Create active vertices (keep every other vertex)
+  std::vector<bool> activeVertices(originalVertexCount, false);
+  std::vector<size_t> activeVertexIndices;
+  for (size_t i = 0; i < originalVertexCount; i += 2) {
+    activeVertices[i] = true;
+    activeVertexIndices.push_back(i);
+  }
+
+  // Reduce mesh by vertices
+  CharacterType reducedCharacter = reduceMeshByVertices(this->character, activeVertices);
+
+  // Create a test pose with some joint transformations
+  ModelParameters modelParams =
+      ModelParameters::Zero(this->character.parameterTransform.numAllModelParameters());
+  if (modelParams.size() > 0) {
+    modelParams[0] = 0.1f; // root_tx
+  }
+  if (modelParams.size() > 3) {
+    modelParams[3] = 0.2f; // root_rx
+  }
+
+  // Apply skinning to original character
+  SkeletonState originalState(
+      this->character.parameterTransform.apply(modelParams), this->character.skeleton, false);
+
+  Mesh originalSkinnedMesh = *this->character.mesh;
+  applySSD(
+      this->character.inverseBindPose,
+      *this->character.skinWeights,
+      originalSkinnedMesh,
+      originalState,
+      originalSkinnedMesh);
+
+  // Apply skinning to reduced character
+  SkeletonState reducedState(
+      reducedCharacter.parameterTransform.apply(modelParams), reducedCharacter.skeleton, false);
+
+  Mesh reducedSkinnedMesh = *reducedCharacter.mesh;
+  applySSD(
+      reducedCharacter.inverseBindPose,
+      *reducedCharacter.skinWeights,
+      reducedSkinnedMesh,
+      reducedState,
+      reducedSkinnedMesh);
+
+  // Compare skinned vertex positions
+  // The reduced character's skinned vertices should match the corresponding
+  // vertices from the original character's skinned mesh
+  EXPECT_EQ(reducedSkinnedMesh.vertices.size(), activeVertexIndices.size());
+
+  for (size_t i = 0; i < activeVertexIndices.size(); ++i) {
+    const size_t originalIdx = activeVertexIndices[i];
+    const Vector3f& originalVertex = originalSkinnedMesh.vertices[originalIdx];
+    const Vector3f& reducedVertex = reducedSkinnedMesh.vertices[i];
+
+    // Allow small floating point differences
+    EXPECT_TRUE(originalVertex.isApprox(reducedVertex, 1e-5f))
+        << "Mismatch at vertex " << i << " (original idx " << originalIdx
+        << "): " << "original=" << originalVertex.transpose()
+        << ", reduced=" << reducedVertex.transpose();
   }
 }


### PR DESCRIPTION
Summary: We occasionally want to trim a character mesh down, either by removing vertices or by removing triangles.

Reviewed By: jeongseok-meta

Differential Revision: D84392743
