### PR TITLE
Add axel module to API doc

### DIFF
--- a/pymomentum/doc/axel.rst
+++ b/pymomentum/doc/axel.rst
@@ -1,0 +1,7 @@
+pymomentum.axel
+===============
+
+.. automodule:: pymomentum.axel
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pymomentum/doc/index.rst
+++ b/pymomentum/doc/index.rst
@@ -5,6 +5,7 @@ Welcome to PyMomentum
    :maxdepth: 2
    :caption: Contents:
 
+   axel
    geometry
    quaternion
    skel_state


### PR DESCRIPTION
Summary: The axel module exists in pymomentum but was not included in the Sphinx documentation. This adds the missing documentation file and updates the index to include axel alongside other modules like geometry, quaternion, etc

Differential Revision: D85166581


