### PR TITLE
Fix type mismatch in TransformT::inverse()

### DIFF
--- a/momentum/math/transform.cpp
+++ b/momentum/math/transform.cpp
@@ -88,7 +88,7 @@ TransformT<T> TransformT<T>::inverse() const {
   //   = scale(1/s) * rotation(invR) * translate(-t)
   //   = translate(-invR*s*t) * rotation(invR) * scale(1/s)
   const Quaternion<T> invRot = rotation.inverse();
-  const double invScale = T(1) / scale;
+  const T invScale = T(1) / scale;
   return TransformT<T>(-invScale * (invRot * translation), invRot, invScale);
 }
 

--- a/momentum/test/math/transform_test.cpp
+++ b/momentum/test/math/transform_test.cpp
@@ -329,6 +329,19 @@ TYPED_TEST(TransformTest, Inverse) {
   }
 }
 
+TYPED_TEST(TransformTest, InverseScalePrecision) {
+  using T = typename TestFixture::Type;
+
+  for (const T scale : {T(0.1), T(1.0), T(10.0)}) {
+    const TransformT<T> trans(Vector3<T>::Random(), Quaternion<T>::UnitRandom(), scale);
+    const TransformT<T> identity = trans * trans.inverse();
+
+    EXPECT_TRUE(identity.translation.isZero(Eps<T>(1e-4f, 1e-12)));
+    EXPECT_TRUE(identity.rotation.isApprox(Quaternion<T>::Identity(), Eps<T>(1e-4f, 1e-12)));
+    EXPECT_NEAR(identity.scale, T(1), Eps<T>(1e-4f, 1e-12));
+  }
+}
+
 TYPED_TEST(TransformTest, TransformPoint) {
   using T = typename TestFixture::Type;
 


### PR DESCRIPTION
Summary: Fixed a type safety bug in TransformT::inverse() where invScale was incorrectly declared as double instead of using the template type T, causing potential precision issues when using float precision transforms.

Differential Revision: D85177786


