### PR TITLE
axel: Dual contouring implementation.

### DIFF
--- a/axel/CMakeLists.txt
+++ b/axel/CMakeLists.txt
@@ -39,6 +39,7 @@ set(headers
   axel/Bvh.h
   axel/BvhBase.h
   axel/BvhCommon.h
+  axel/DualContouring.h
   axel/MeshToSdf.h
   axel/Ray.h
   axel/SignedDistanceField.h
@@ -52,6 +53,7 @@ set(sources
   axel/math/RayTriangleIntersection.cpp
   axel/BoundingBox.cpp
   axel/Bvh.cpp
+  axel/DualContouring.cpp
   axel/MeshToSdf.cpp
   axel/SignedDistanceField.cpp
   axel/SimdKdTree.cpp

--- a/axel/axel/DualContouring.cpp
+++ b/axel/axel/DualContouring.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "axel/DualContouring.h"
+
+#include <algorithm>
+#include <cmath>
+#include <unordered_set>
+
+namespace axel {
+
+// ================================================================================================
+// DETAIL IMPLEMENTATIONS
+// ================================================================================================
+
+namespace detail {
+
+/**
+ * Hash function for 3D grid indices.
+ */
+struct GridIndexHash {
+  std::size_t operator()(const Eigen::Vector3<Index>& idx) const {
+    return std::hash<Index>{}(idx.x()) ^ (std::hash<Index>{}(idx.y()) << 1) ^
+        (std::hash<Index>{}(idx.z()) << 2);
+  }
+};
+
+using CellVertexMap = std::unordered_map<Eigen::Vector3<Index>, Index, GridIndexHash>;
+
+/**
+ * Check if a value is inside the isosurface (negative side).
+ *
+ * @param val The SDF value
+ * @param isovalue The isovalue threshold
+ * @return True if the value is on the inside (negative) side
+ */
+template <typename ScalarType>
+bool isInside(ScalarType val, ScalarType isovalue) {
+  return val <= isovalue;
+}
+
+/**
+ * Push a vertex toward the zero level set using gradient descent.
+ * Uses Newton's method to iteratively move the vertex closer to the target isovalue.
+ *
+ * @param sdf The signed distance field
+ * @param startPosition Initial vertex position (typically cell center)
+ * @param isovalue The target isovalue to move toward
+ * @return Optimized vertex position closer to the surface
+ */
+template <typename ScalarType>
+Eigen::Vector3<ScalarType> pushVertexToSurface(
+    const SignedDistanceField<ScalarType>& sdf,
+    const Eigen::Vector3<ScalarType>& startPosition,
+    ScalarType isovalue) {
+  Eigen::Vector3<ScalarType> position = startPosition;
+
+  const ScalarType targetIsovalue = isovalue;
+  const int maxIterations = 10;
+  const auto tolerance = ScalarType{1e-6};
+
+  for (int iter = 0; iter < maxIterations; ++iter) {
+    const ScalarType value = sdf.sample(position);
+    const Eigen::Vector3<ScalarType> gradient = sdf.gradient(position);
+
+    const ScalarType distance = value - targetIsovalue;
+    if (std::abs(distance) < tolerance) {
+      break;
+    }
+
+    const ScalarType gradientMagnitude = gradient.norm();
+    if (gradientMagnitude < tolerance) {
+      break;
+    }
+
+    const ScalarType stepSize = distance / gradientMagnitude;
+    position -= stepSize * gradient.normalized();
+
+    const auto voxelSize = sdf.voxelSize();
+    const ScalarType maxOffset = voxelSize.maxCoeff() * ScalarType{2.0};
+    const auto offset = position - startPosition;
+    if (offset.norm() > maxOffset) {
+      position = startPosition + offset.normalized() * maxOffset;
+      break;
+    }
+  }
+
+  return position;
+}
+
+/**
+ * Check if a cell intersects the isosurface by looking for sign changes.
+ *
+ * @param cornerValues Array of 8 corner SDF values
+ * @param isovalue The isovalue to check against
+ * @return True if the cell intersects the isosurface
+ */
+template <typename ScalarType>
+bool cellIntersectsIsosurface(const std::array<ScalarType, 8>& cornerValues, ScalarType isovalue) {
+  const ScalarType firstValue = cornerValues[0];
+  for (int c = 1; c < 8; ++c) {
+    if (isInside(firstValue, isovalue) != isInside(cornerValues[c], isovalue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Find all cells that intersect the isosurface and create vertices.
+ * Places one vertex per intersecting cell, positioned on the surface using gradient descent.
+ *
+ * @param sdf The signed distance field
+ * @param isovalue The isovalue to extract
+ * @return Pair of (vertices, cellToVertexIndex map)
+ */
+template <typename ScalarType>
+std::pair<std::vector<Eigen::Vector3<ScalarType>>, CellVertexMap>
+findIntersectingCellsAndCreateVertices(
+    const SignedDistanceField<ScalarType>& sdf,
+    ScalarType isovalue) {
+  const auto& resolution = sdf.resolution();
+  const auto& sdfData = sdf.data();
+
+  const auto linearIndex = [&](Index i, Index j, Index k) -> size_t {
+    return k * resolution.x() * resolution.y() + j * resolution.x() + i;
+  };
+
+  CellVertexMap cellToVertexIndex;
+  std::vector<Eigen::Vector3<ScalarType>> vertices;
+  Index vertexIndex = 0;
+
+  for (Index k = 0; k < resolution.z() - 1; ++k) {
+    for (Index j = 0; j < resolution.y() - 1; ++j) {
+      for (Index i = 0; i < resolution.x() - 1; ++i) {
+        // Get the 8 corner values of this cell using direct data access
+        const std::array<ScalarType, 8> cornerValues = {
+            {sdfData[linearIndex(i, j, k)], // 0: (0,0,0)
+             sdfData[linearIndex(i + 1, j, k)], // 1: (1,0,0)
+             sdfData[linearIndex(i + 1, j + 1, k)], // 2: (1,1,0)
+             sdfData[linearIndex(i, j + 1, k)], // 3: (0,1,0)
+             sdfData[linearIndex(i, j, k + 1)], // 4: (0,0,1)
+             sdfData[linearIndex(i + 1, j, k + 1)], // 5: (1,0,1)
+             sdfData[linearIndex(i + 1, j + 1, k + 1)], // 6: (1,1,1)
+             sdfData[linearIndex(i, j + 1, k + 1)]}}; // 7: (0,1,1)
+
+        if (cellIntersectsIsosurface(cornerValues, isovalue)) {
+          // This cell intersects the isosurface, create a vertex positioned on the surface
+          const Eigen::Vector3<Index> cellIdx(i, j, k);
+          const auto cellCenter = sdf.gridToWorld(
+              cellIdx.template cast<ScalarType>() + Eigen::Vector3<ScalarType>::Constant(0.5));
+
+          // Push vertex toward the zero level set using gradient descent
+          auto surfacePosition = pushVertexToSurface(sdf, cellCenter, isovalue);
+
+          cellToVertexIndex[cellIdx] = vertexIndex++;
+          vertices.push_back(surfacePosition);
+        }
+      }
+    }
+  }
+
+  return {std::move(vertices), std::move(cellToVertexIndex)};
+}
+
+/**
+ * Generate quads for edges in the X direction that cross the isosurface.
+ *
+ * @param sdf The signed distance field
+ * @param isovalue The isovalue to check against
+ * @param cellToVertexIndex Map from cell indices to vertex indices
+ * @param quads Output vector to append generated quads
+ */
+template <typename ScalarType>
+void generateQuadsForXEdges(
+    const SignedDistanceField<ScalarType>& sdf,
+    ScalarType isovalue,
+    const CellVertexMap& cellToVertexIndex,
+    std::vector<Eigen::Vector4i>& quads) {
+  const auto& resolution = sdf.resolution();
+  const auto& sdfData = sdf.data();
+
+  const auto linearIndex = [&](Index i, Index j, Index k) -> size_t {
+    return k * resolution.x() * resolution.y() + j * resolution.x() + i;
+  };
+
+  const auto hasVertex = [&](Index i, Index j, Index k) -> std::pair<bool, Index> {
+    if (i < 0 || j < 0 || k < 0 || i >= resolution.x() - 1 || j >= resolution.y() - 1 ||
+        k >= resolution.z() - 1) {
+      return {false, static_cast<Index>(-1)};
+    }
+    auto it = cellToVertexIndex.find(Eigen::Vector3<Index>(i, j, k));
+    if (it != cellToVertexIndex.end()) {
+      return {true, it->second};
+    }
+    return {false, static_cast<Index>(-1)};
+  };
+
+  // X-direction edges: from grid point (i,j,k) to (i+1,j,k)
+  for (Index k = 0; k < resolution.z(); ++k) {
+    for (Index j = 0; j < resolution.y(); ++j) {
+      for (Index i = 0; i < resolution.x() - 1; ++i) {
+        // Check if this edge crosses the isosurface
+        const ScalarType val1 = sdfData[linearIndex(i, j, k)];
+        const ScalarType val2 = sdfData[linearIndex(i + 1, j, k)];
+
+        if (isInside(val1, isovalue) != isInside(val2, isovalue)) {
+          // This X-edge crosses the isosurface
+          // Find the 4 cells that share this edge (if they exist)
+          const std::array<std::pair<bool, Index>, 4> quadVertices = {
+              {hasVertex(i, j - 1, k - 1), // Cell (i, j-1, k-1)
+               hasVertex(i, j, k - 1), // Cell (i, j, k-1)
+               hasVertex(i, j, k), // Cell (i, j, k)
+               hasVertex(i, j - 1, k)}}; // Cell (i, j-1, k)
+
+          // Check if all 4 vertices exist
+          bool allExist = true;
+          for (const auto& [exists, _] : quadVertices) {
+            if (!exists) {
+              allExist = false;
+              break;
+            }
+          }
+
+          if (allExist) {
+            // Determine winding order based on which side is inside (negative)
+            // Default winding (0,1,2,3) produces normal pointing in +X direction
+            if (val1 < val2) {
+              // val1 more negative (inside), val2 less negative (outside)
+              // Normal should point +X (toward val2/outside) - use default winding
+              quads.emplace_back(
+                  quadVertices[0].second,
+                  quadVertices[1].second,
+                  quadVertices[2].second,
+                  quadVertices[3].second);
+            } else {
+              // val2 more negative (inside), val1 less negative (outside)
+              // Normal should point -X (toward val1/outside) - flip winding
+              quads.emplace_back(
+                  quadVertices[0].second,
+                  quadVertices[3].second,
+                  quadVertices[2].second,
+                  quadVertices[1].second);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Generate quads for edges in the Y direction that cross the isosurface.
+ *
+ * @param sdf The signed distance field
+ * @param isovalue The isovalue to check against
+ * @param cellToVertexIndex Map from cell indices to vertex indices
+ * @param quads Output vector to append generated quads
+ */
+template <typename ScalarType>
+void generateQuadsForYEdges(
+    const SignedDistanceField<ScalarType>& sdf,
+    ScalarType isovalue,
+    const CellVertexMap& cellToVertexIndex,
+    std::vector<Eigen::Vector4i>& quads) {
+  const auto& resolution = sdf.resolution();
+  const auto& sdfData = sdf.data();
+
+  const auto linearIndex = [&](Index i, Index j, Index k) -> size_t {
+    return k * resolution.x() * resolution.y() + j * resolution.x() + i;
+  };
+
+  const auto hasVertex = [&](Index i, Index j, Index k) -> std::pair<bool, Index> {
+    if (i < 0 || j < 0 || k < 0 || i >= resolution.x() - 1 || j >= resolution.y() - 1 ||
+        k >= resolution.z() - 1) {
+      return {false, static_cast<Index>(-1)};
+    }
+    auto it = cellToVertexIndex.find(Eigen::Vector3<Index>(i, j, k));
+    if (it != cellToVertexIndex.end()) {
+      return {true, it->second};
+    }
+    return {false, static_cast<Index>(-1)};
+  };
+
+  // Y-direction edges: from grid point (i,j,k) to (i,j+1,k)
+  for (Index k = 0; k < resolution.z(); ++k) {
+    for (Index j = 0; j < resolution.y() - 1; ++j) {
+      for (Index i = 0; i < resolution.x(); ++i) {
+        // Check if this edge crosses the isosurface
+        const ScalarType val1 = sdfData[linearIndex(i, j, k)];
+        const ScalarType val2 = sdfData[linearIndex(i, j + 1, k)];
+
+        if (isInside(val1, isovalue) != isInside(val2, isovalue)) {
+          // This Y-edge crosses the isosurface
+          // Find the 4 cells that share this edge
+          // Reorder to maintain consistent winding: (back-left, back-right, front-right,
+          // front-left)
+          const std::array<std::pair<bool, Index>, 4> quadVertices = {
+              {hasVertex(i - 1, j, k - 1), // Cell (i-1, j, k-1)
+               hasVertex(i - 1, j, k), // Cell (i-1, j, k)
+               hasVertex(i, j, k), // Cell (i, j, k)
+               hasVertex(i, j, k - 1)}}; // Cell (i, j, k-1)
+
+          // Check if all 4 vertices exist
+          bool allExist = true;
+          for (const auto& [exists, _] : quadVertices) {
+            if (!exists) {
+              allExist = false;
+              break;
+            }
+          }
+
+          if (allExist) {
+            // Determine winding order based on which side is inside (negative)
+            // Default winding (0,1,2,3) produces normal pointing in +Y direction
+            if (val1 < val2) {
+              // val1 more negative (inside), val2 less negative (outside)
+              // Normal should point +Y (toward val2/outside) - use default winding
+              quads.emplace_back(
+                  quadVertices[0].second,
+                  quadVertices[1].second,
+                  quadVertices[2].second,
+                  quadVertices[3].second);
+            } else {
+              // val2 more negative (inside), val1 less negative (outside)
+              // Normal should point -Y (toward val1/outside) - flip winding
+              quads.emplace_back(
+                  quadVertices[0].second,
+                  quadVertices[3].second,
+                  quadVertices[2].second,
+                  quadVertices[1].second);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Generate quads for edges in the Z direction that cross the isosurface.
+ *
+ * @param sdf The signed distance field
+ * @param isovalue The isovalue to check against
+ * @param cellToVertexIndex Map from cell indices to vertex indices
+ * @param quads Output vector to append generated quads
+ */
+template <typename ScalarType>
+void generateQuadsForZEdges(
+    const SignedDistanceField<ScalarType>& sdf,
+    ScalarType isovalue,
+    const CellVertexMap& cellToVertexIndex,
+    std::vector<Eigen::Vector4i>& quads) {
+  const auto& resolution = sdf.resolution();
+  const auto& sdfData = sdf.data();
+
+  const auto linearIndex = [&](Index i, Index j, Index k) -> size_t {
+    return k * resolution.x() * resolution.y() + j * resolution.x() + i;
+  };
+
+  const auto hasVertex = [&](Index i, Index j, Index k) -> std::pair<bool, Index> {
+    if (i < 0 || j < 0 || k < 0 || i >= resolution.x() - 1 || j >= resolution.y() - 1 ||
+        k >= resolution.z() - 1) {
+      return {false, static_cast<Index>(-1)};
+    }
+    auto it = cellToVertexIndex.find(Eigen::Vector3<Index>(i, j, k));
+    if (it != cellToVertexIndex.end()) {
+      return {true, it->second};
+    }
+    return {false, static_cast<Index>(-1)};
+  };
+
+  // Z-direction edges: from grid point (i,j,k) to (i,j,k+1)
+  for (Index k = 0; k < resolution.z() - 1; ++k) {
+    for (Index j = 0; j < resolution.y(); ++j) {
+      for (Index i = 0; i < resolution.x(); ++i) {
+        // Check if this edge crosses the isosurface
+        const ScalarType val1 = sdfData[linearIndex(i, j, k)];
+        const ScalarType val2 = sdfData[linearIndex(i, j, k + 1)];
+
+        if (isInside(val1, isovalue) != isInside(val2, isovalue)) {
+          // This Z-edge crosses the isosurface
+          // Find the 4 cells that share this edge
+          const std::array<std::pair<bool, Index>, 4> quadVertices = {
+              {hasVertex(i - 1, j - 1, k), // Cell (i-1, j-1, k)
+               hasVertex(i, j - 1, k), // Cell (i, j-1, k)
+               hasVertex(i, j, k), // Cell (i, j, k)
+               hasVertex(i - 1, j, k)}}; // Cell (i-1, j, k)
+
+          // Check if all 4 vertices exist
+          bool allExist = true;
+          for (const auto& [exists, _] : quadVertices) {
+            if (!exists) {
+              allExist = false;
+              break;
+            }
+          }
+
+          if (allExist) {
+            // Determine winding order based on which side is inside (negative)
+            // Default winding (0,1,2,3) produces normal pointing in +Z direction
+            if (val1 < val2) {
+              // val1 more negative (inside), val2 less negative (outside)
+              // Normal should point +Z (toward val2/outside) - use default winding
+              quads.emplace_back(
+                  quadVertices[0].second,
+                  quadVertices[1].second,
+                  quadVertices[2].second,
+                  quadVertices[3].second);
+            } else {
+              // val2 more negative (inside), val1 less negative (outside)
+              // Normal should point -Z (toward val1/outside) - flip winding
+              quads.emplace_back(
+                  quadVertices[0].second,
+                  quadVertices[3].second,
+                  quadVertices[2].second,
+                  quadVertices[1].second);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+} // namespace detail
+
+// ================================================================================================
+// MAIN DUAL CONTOURING FUNCTIONS
+// ================================================================================================
+
+template <typename ScalarType>
+DualContouringResult<ScalarType> dualContouring(
+    const SignedDistanceField<ScalarType>& sdf,
+    ScalarType isovalue) {
+  DualContouringResult<ScalarType> result;
+
+  // Step 1: Find all cells that intersect the isosurface and create vertices
+  auto [vertices, cellToVertexIndex] =
+      detail::findIntersectingCellsAndCreateVertices(sdf, isovalue);
+
+  if (vertices.empty()) {
+    result.success = true;
+    return result;
+  }
+
+  // Step 2: Generate quads by processing edges in each direction
+  std::vector<Eigen::Vector4i> quads;
+
+  detail::generateQuadsForXEdges(sdf, isovalue, cellToVertexIndex, quads);
+  detail::generateQuadsForYEdges(sdf, isovalue, cellToVertexIndex, quads);
+  detail::generateQuadsForZEdges(sdf, isovalue, cellToVertexIndex, quads);
+
+  result.vertices = std::move(vertices);
+  result.quads = std::move(quads);
+  result.success = true;
+  result.processedCells = cellToVertexIndex.size();
+  result.generatedVertices = result.vertices.size();
+
+  return result;
+}
+
+std::vector<Eigen::Vector3i> triangulateQuads(const std::vector<Eigen::Vector4i>& quads) {
+  std::vector<Eigen::Vector3i> triangles;
+  triangles.reserve(quads.size() * 2);
+
+  for (const auto& quad : quads) {
+    // Split each quad into two triangles using diagonal (0,2)
+    // Triangle 1: vertices 0, 1, 2
+    triangles.emplace_back(quad[0], quad[1], quad[2]);
+    // Triangle 2: vertices 0, 2, 3
+    triangles.emplace_back(quad[0], quad[2], quad[3]);
+  }
+
+  return triangles;
+}
+
+// ================================================================================================
+// EXPLICIT INSTANTIATIONS
+// =========================================================================================
+
+template DualContouringResult<float> dualContouring<float>(
+    const SignedDistanceField<float>&,
+    float);
+
+template DualContouringResult<double> dualContouring<double>(
+    const SignedDistanceField<double>&,
+    double);
+
+// Helper functions are automatically instantiated when dualContouring is instantiated
+
+} // namespace axel

--- a/axel/axel/DualContouring.h
+++ b/axel/axel/DualContouring.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <gsl/span>
+
+#include "axel/BoundingBox.h"
+#include "axel/SignedDistanceField.h"
+#include "axel/common/Types.h"
+
+namespace axel {
+
+/**
+ * Result of dual contouring operation.
+ * Dual contouring naturally produces quads, so this always contains quads.
+ * Use triangulateQuads() to convert to triangles if needed.
+ */
+template <typename S>
+struct DualContouringResult {
+  using Scalar = S;
+
+  /// Generated vertices
+  std::vector<Eigen::Vector3<S>> vertices;
+
+  /// Generated quads (dual contouring naturally produces quads)
+  std::vector<Eigen::Vector4i> quads;
+
+  /// Success flag
+  bool success = false;
+
+  /// Number of cells processed
+  size_t processedCells = 0;
+
+  /// Number of vertices generated
+  size_t generatedVertices = 0;
+};
+
+/**
+ * Extract an isosurface from a signed distance field using dual contouring.
+ *
+ * Dual contouring places vertices inside grid cells (rather than on edges like marching cubes)
+ * and uses both function values and gradients to determine optimal vertex placement.
+ * This results in better preservation of sharp features and corners compared to marching cubes.
+ *
+ * The algorithm works by:
+ * 1. Finding all cells that intersect the isosurface (sign changes across cell corners)
+ * 2. Placing one vertex at each intersecting cell, positioned on the surface using gradient descent
+ * 3. Generating quads for each edge crossing that connects 4 adjacent cells
+ *
+ * @param sdf The signed distance field to extract from
+ * @param isovalue The isovalue to extract (typically 0.0 for zero level set)
+ * @return Result containing extracted mesh
+ */
+template <typename ScalarType>
+DualContouringResult<ScalarType> dualContouring(
+    const SignedDistanceField<ScalarType>& sdf,
+    ScalarType isovalue = ScalarType{0.0});
+
+/**
+ * Triangulate a quad mesh into triangles.
+ * Each quad is split into two triangles using the diagonal (0,2).
+ *
+ * @param quads Vector of quads to triangulate
+ * @return Vector of triangles
+ */
+std::vector<Eigen::Vector3i> triangulateQuads(const std::vector<Eigen::Vector4i>& quads);
+
+} // namespace axel

--- a/axel/axel/test/DualContouringTest.cpp
+++ b/axel/axel/test/DualContouringTest.cpp
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "axel/DualContouring.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "axel/BoundingBox.h"
+#include "axel/SignedDistanceField.h"
+
+namespace axel {
+
+class DualContouringTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  SignedDistanceFieldf createSphereSdf(
+      float radius,
+      const Eigen::Vector3f& center,
+      const BoundingBoxf& bounds,
+      const Eigen::Vector3<Index>& resolution) {
+    SignedDistanceFieldf sdf(bounds, resolution);
+
+    for (Index i = 0; i < resolution.x(); ++i) {
+      for (Index j = 0; j < resolution.y(); ++j) {
+        for (Index k = 0; k < resolution.z(); ++k) {
+          const Eigen::Vector3f gridPos(
+              static_cast<float>(i), static_cast<float>(j), static_cast<float>(k));
+          const Eigen::Vector3f worldPos = sdf.gridToWorld(gridPos);
+          const float distance = (worldPos - center).norm() - radius;
+          sdf.set(i, j, k, distance);
+        }
+      }
+    }
+
+    return sdf;
+  }
+
+  struct EdgeKey {
+    Index v0, v1;
+
+    EdgeKey(Index a, Index b) : v0(std::min(a, b)), v1(std::max(a, b)) {}
+
+    bool operator==(const EdgeKey& other) const {
+      return v0 == other.v0 && v1 == other.v1;
+    }
+  };
+
+  struct EdgeKeyHash {
+    std::size_t operator()(const EdgeKey& key) const {
+      return std::hash<Index>{}(key.v0) ^ (std::hash<Index>{}(key.v1) << 1);
+    }
+  };
+
+  template <typename S>
+  void validateQuadMesh(const DualContouringResult<S>& result) {
+    for (const auto& quad : result.quads) {
+      EXPECT_GE(quad[0], 0) << "Quad vertex index 0 is negative";
+      EXPECT_LT(quad[0], static_cast<int>(result.vertices.size()))
+          << "Quad vertex index 0 out of range";
+      EXPECT_GE(quad[1], 0) << "Quad vertex index 1 is negative";
+      EXPECT_LT(quad[1], static_cast<int>(result.vertices.size()))
+          << "Quad vertex index 1 out of range";
+      EXPECT_GE(quad[2], 0) << "Quad vertex index 2 is negative";
+      EXPECT_LT(quad[2], static_cast<int>(result.vertices.size()))
+          << "Quad vertex index 2 out of range";
+      EXPECT_GE(quad[3], 0) << "Quad vertex index 3 is negative";
+      EXPECT_LT(quad[3], static_cast<int>(result.vertices.size()))
+          << "Quad vertex index 3 out of range";
+    }
+  }
+
+  template <typename S>
+  void validateTriangleMesh(
+      const std::vector<Eigen::Vector3<S>>& vertices,
+      const std::vector<Eigen::Vector3i>& triangles) {
+    for (const auto& triangle : triangles) {
+      EXPECT_GE(triangle[0], 0) << "Triangle vertex index 0 is negative";
+      EXPECT_LT(triangle[0], static_cast<int>(vertices.size()))
+          << "Triangle vertex index 0 out of range";
+      EXPECT_GE(triangle[1], 0) << "Triangle vertex index 1 is negative";
+      EXPECT_LT(triangle[1], static_cast<int>(vertices.size()))
+          << "Triangle vertex index 1 out of range";
+      EXPECT_GE(triangle[2], 0) << "Triangle vertex index 2 is negative";
+      EXPECT_LT(triangle[2], static_cast<int>(vertices.size()))
+          << "Triangle vertex index 2 out of range";
+    }
+  }
+};
+
+TEST_F(DualContouringTest, SphereVerticesOnSurface) {
+  const float sphereRadius = 1.0f;
+  const Eigen::Vector3f sphereCenter(0.0f, 0.0f, 0.0f);
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-2.0f, -2.0f, -2.0f), Eigen::Vector3f(2.0f, 2.0f, 2.0f));
+  const Eigen::Vector3<Index> resolution(32, 32, 32);
+
+  auto sdf = createSphereSdf(sphereRadius, sphereCenter, bounds, resolution);
+
+  const auto result = dualContouring(sdf, 0.0f);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_GT(result.vertices.size(), 0);
+  EXPECT_GT(result.quads.size(), 0);
+
+  validateQuadMesh(result);
+
+  const float tolerance = sdf.voxelSize().maxCoeff() * 2.0f;
+
+  for (const auto& vertex : result.vertices) {
+    const float distanceToCenter = (vertex - sphereCenter).norm();
+    const float distanceToSurface = std::abs(distanceToCenter - sphereRadius);
+
+    EXPECT_LT(distanceToSurface, tolerance)
+        << "Vertex [" << vertex.transpose() << "] is too far from sphere surface. "
+        << "Distance to surface: " << distanceToSurface << ", tolerance: " << tolerance;
+  }
+}
+
+TEST_F(DualContouringTest, SphereMeshManifoldness) {
+  const float sphereRadius = 1.0f;
+  const Eigen::Vector3f sphereCenter(0.0f, 0.0f, 0.0f);
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-2.0f, -2.0f, -2.0f), Eigen::Vector3f(2.0f, 2.0f, 2.0f));
+  const Eigen::Vector3<Index> resolution(32, 32, 32);
+
+  auto sdf = createSphereSdf(sphereRadius, sphereCenter, bounds, resolution);
+
+  // If you use isovalue == 0, then you end up with vertices exactly on corners which we don't
+  // currently handle well.
+  const auto result = dualContouring(sdf, 0.0f);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_GT(result.vertices.size(), 0);
+  EXPECT_GT(result.quads.size(), 0);
+
+  validateQuadMesh(result);
+
+  struct DirectedEdge {
+    Index from, to;
+
+    bool operator==(const DirectedEdge& other) const {
+      return from == other.from && to == other.to;
+    }
+  };
+
+  struct DirectedEdgeHash {
+    std::size_t operator()(const DirectedEdge& edge) const {
+      return std::hash<Index>{}(edge.from) ^ (std::hash<Index>{}(edge.to) << 1);
+    }
+  };
+
+  std::unordered_set<DirectedEdge, DirectedEdgeHash> directedEdges;
+
+  for (const auto& quad : result.quads) {
+    directedEdges.insert({quad[0], quad[1]});
+    directedEdges.insert({quad[1], quad[2]});
+    directedEdges.insert({quad[2], quad[3]});
+    directedEdges.insert({quad[3], quad[0]});
+  }
+
+  int edgesWithOpposite = 0;
+  int edgesWithoutOpposite = 0;
+
+  for (const auto& edge : directedEdges) {
+    DirectedEdge opposite = {edge.to, edge.from};
+    if (directedEdges.find(opposite) != directedEdges.end()) {
+      edgesWithOpposite++;
+    } else {
+      edgesWithoutOpposite++;
+    }
+  }
+
+  EXPECT_EQ(edgesWithoutOpposite, 0)
+      << "All directed edges should have their opposite edge for a manifold mesh. "
+      << "Edges with opposite: " << edgesWithOpposite
+      << ", Edges without opposite: " << edgesWithoutOpposite;
+
+  EXPECT_GT(edgesWithOpposite, 0) << "Mesh should have edges";
+}
+
+TEST_F(DualContouringTest, SphereCorrectWinding) {
+  const float sphereRadius = 1.0f;
+  const Eigen::Vector3f sphereCenter(0.0f, 0.0f, 0.0f);
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-2.0f, -2.0f, -2.0f), Eigen::Vector3f(2.0f, 2.0f, 2.0f));
+  const Eigen::Vector3<Index> resolution(32, 32, 32);
+
+  auto sdf = createSphereSdf(sphereRadius, sphereCenter, bounds, resolution);
+
+  const auto result = dualContouring(sdf, 0.0f);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_GT(result.vertices.size(), 0);
+  EXPECT_GT(result.quads.size(), 0);
+
+  validateQuadMesh(result);
+
+  int correctWindingCount = 0;
+  int incorrectWindingCount = 0;
+
+  for (const auto& quad : result.quads) {
+    const Eigen::Vector3f v0 = result.vertices[quad[0]];
+    const Eigen::Vector3f v1 = result.vertices[quad[1]];
+    const Eigen::Vector3f v2 = result.vertices[quad[2]];
+    const Eigen::Vector3f v3 = result.vertices[quad[3]];
+
+    const Eigen::Vector3f edge1 = v1 - v0;
+    const Eigen::Vector3f edge2 = v2 - v0;
+    const Eigen::Vector3f normal = edge1.cross(edge2).normalized();
+
+    const Eigen::Vector3f quadCenter = (v0 + v1 + v2 + v3) / 4.0f;
+    const Eigen::Vector3f expectedNormal = (quadCenter - sphereCenter).normalized();
+
+    const float dot = normal.dot(expectedNormal);
+
+    if (dot > 0.0f) {
+      correctWindingCount++;
+    } else {
+      incorrectWindingCount++;
+    }
+  }
+
+  const float correctRatio =
+      static_cast<float>(correctWindingCount) / static_cast<float>(result.quads.size());
+
+  EXPECT_GT(correctRatio, 0.9f) << "Most quad normals should point outward from sphere center. "
+                                << "Correct: " << correctWindingCount
+                                << ", Incorrect: " << incorrectWindingCount
+                                << ", Total: " << result.quads.size()
+                                << ", Ratio: " << correctRatio;
+}
+
+TEST_F(DualContouringTest, EmptySDF) {
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-1.0f, -1.0f, -1.0f), Eigen::Vector3f(1.0f, 1.0f, 1.0f));
+  const Eigen::Vector3<Index> resolution(8, 8, 8);
+  SignedDistanceFieldf sdf(bounds, resolution);
+
+  sdf.fill(1.0f);
+
+  const auto result = dualContouring(sdf, 0.0f);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_EQ(result.vertices.size(), 0);
+  EXPECT_EQ(result.quads.size(), 0);
+}
+
+TEST_F(DualContouringTest, TriangulateQuads) {
+  const float sphereRadius = 1.0f;
+  const Eigen::Vector3f sphereCenter(0.0f, 0.0f, 0.0f);
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-2.0f, -2.0f, -2.0f), Eigen::Vector3f(2.0f, 2.0f, 2.0f));
+  const Eigen::Vector3<Index> resolution(16, 16, 16);
+
+  auto sdf = createSphereSdf(sphereRadius, sphereCenter, bounds, resolution);
+
+  const auto result = dualContouring(sdf, 0.0f);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_GT(result.quads.size(), 0);
+
+  validateQuadMesh(result);
+
+  const auto triangles = triangulateQuads(result.quads);
+
+  EXPECT_EQ(triangles.size(), result.quads.size() * 2);
+
+  for (size_t i = 0; i < result.quads.size(); ++i) {
+    const auto& quad = result.quads[i];
+    const auto& tri1 = triangles[i * 2];
+    const auto& tri2 = triangles[i * 2 + 1];
+
+    EXPECT_EQ(tri1[0], quad[0]);
+    EXPECT_EQ(tri1[1], quad[1]);
+    EXPECT_EQ(tri1[2], quad[2]);
+
+    EXPECT_EQ(tri2[0], quad[0]);
+    EXPECT_EQ(tri2[1], quad[2]);
+    EXPECT_EQ(tri2[2], quad[3]);
+  }
+}
+
+TEST_F(DualContouringTest, NonZeroIsovalue) {
+  const float sphereRadius = 1.0f;
+  const Eigen::Vector3f sphereCenter(0.0f, 0.0f, 0.0f);
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-2.0f, -2.0f, -2.0f), Eigen::Vector3f(2.0f, 2.0f, 2.0f));
+  const Eigen::Vector3<Index> resolution(16, 16, 16);
+
+  auto sdf = createSphereSdf(sphereRadius, sphereCenter, bounds, resolution);
+
+  const float isovalue = 0.2f;
+  const auto result = dualContouring(sdf, isovalue);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_GT(result.vertices.size(), 0);
+
+  validateQuadMesh(result);
+
+  const float expectedRadius = sphereRadius + isovalue;
+  const float tolerance = sdf.voxelSize().maxCoeff() * 2.0f;
+
+  for (const auto& vertex : result.vertices) {
+    const float distanceToCenter = (vertex - sphereCenter).norm();
+    const float distanceToIsosurface = std::abs(distanceToCenter - expectedRadius);
+
+    EXPECT_LT(distanceToIsosurface, tolerance)
+        << "Vertex should be near isosurface at distance " << expectedRadius;
+  }
+}
+
+TEST_F(DualContouringTest, TriangulatedQuadsCorrectWinding) {
+  const float sphereRadius = 1.0f;
+  const Eigen::Vector3f sphereCenter(0.0f, 0.0f, 0.0f);
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-2.0f, -2.0f, -2.0f), Eigen::Vector3f(2.0f, 2.0f, 2.0f));
+  const Eigen::Vector3<Index> resolution(32, 32, 32);
+
+  auto sdf = createSphereSdf(sphereRadius, sphereCenter, bounds, resolution);
+
+  const auto result = dualContouring(sdf, 0.0f);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_GT(result.vertices.size(), 0);
+  EXPECT_GT(result.quads.size(), 0);
+
+  validateQuadMesh(result);
+
+  const auto triangles = triangulateQuads(result.quads);
+
+  validateTriangleMesh(result.vertices, triangles);
+
+  int correctWindingCount = 0;
+  int incorrectWindingCount = 0;
+
+  for (const auto& triangle : triangles) {
+    const Eigen::Vector3f v0 = result.vertices[triangle[0]];
+    const Eigen::Vector3f v1 = result.vertices[triangle[1]];
+    const Eigen::Vector3f v2 = result.vertices[triangle[2]];
+
+    const Eigen::Vector3f edge1 = v1 - v0;
+    const Eigen::Vector3f edge2 = v2 - v0;
+    const Eigen::Vector3f normal = edge1.cross(edge2).normalized();
+
+    const Eigen::Vector3f triangleCenter = (v0 + v1 + v2) / 3.0f;
+    const Eigen::Vector3f expectedNormal = (triangleCenter - sphereCenter).normalized();
+
+    const float dot = normal.dot(expectedNormal);
+
+    if (dot > 0.0f) {
+      correctWindingCount++;
+    } else {
+      incorrectWindingCount++;
+    }
+  }
+
+  const float correctRatio =
+      static_cast<float>(correctWindingCount) / static_cast<float>(triangles.size());
+
+  EXPECT_GT(correctRatio, 0.9f) << "Most triangle normals should point outward from sphere center. "
+                                << "Correct: " << correctWindingCount
+                                << ", Incorrect: " << incorrectWindingCount
+                                << ", Total: " << triangles.size() << ", Ratio: " << correctRatio;
+}
+
+} // namespace axel


### PR DESCRIPTION
Summary: It's useful to be able to convert a SignedDistanceField to a mesh, dual contouring is by far the simplest way to do so (since it doesn't require dealing with all the corner cases of marching cubes).

Reviewed By: jeongseok-meta

Differential Revision: D84392740
