### PR TITLE
templatize SDF operations.

### DIFF
--- a/axel/axel/DualContouring.cpp
+++ b/axel/axel/DualContouring.cpp
@@ -151,7 +151,7 @@ findIntersectingCellsAndCreateVertices(
         if (cellIntersectsIsosurface(cornerValues, isovalue)) {
           // This cell intersects the isosurface, create a vertex positioned on the surface
           const Eigen::Vector3<Index> cellIdx(i, j, k);
-          const auto cellCenter = sdf.gridToWorld(
+          const auto cellCenter = sdf.template gridToWorld<ScalarType>(
               cellIdx.template cast<ScalarType>() + Eigen::Vector3<ScalarType>::Constant(0.5));
 
           // Push vertex toward the zero level set using gradient descent

--- a/axel/axel/MeshToSdf.cpp
+++ b/axel/axel/MeshToSdf.cpp
@@ -203,8 +203,7 @@ void rasterizeTriangleToNarrowBand(
   for (Index i = startIdx.x(); i <= endIdx.x(); ++i) {
     for (Index j = startIdx.y(); j <= endIdx.y(); ++j) {
       for (Index k = startIdx.z(); k <= endIdx.z(); ++k) {
-        const Vector3i voxelIdx(i, j, k);
-        const Vector3 worldPos = sdf.gridToWorld(voxelIdx.template cast<ScalarType>());
+        const Vector3 worldPos = sdf.gridLocation(i, j, k);
 
         // Calculate distance from voxel center to triangle
         Vector3 closestPoint;

--- a/axel/axel/SignedDistanceField.h
+++ b/axel/axel/SignedDistanceField.h
@@ -89,7 +89,8 @@ class SignedDistanceField {
    * @param position 3D world-space position to query
    * @return Interpolated signed distance value
    */
-  [[nodiscard]] Scalar sample(const Vector3& position) const;
+  template <typename InputScalar = Scalar>
+  [[nodiscard]] InputScalar sample(const Eigen::Vector3<InputScalar>& position) const;
 
   /**
    * Sample the SDF gradient at a continuous 3D position using analytical gradients
@@ -98,7 +99,9 @@ class SignedDistanceField {
    * @param position 3D world-space position to query
    * @return Gradient vector at the given position
    */
-  [[nodiscard]] Vector3 gradient(const Vector3& position) const;
+  template <typename InputScalar = Scalar>
+  [[nodiscard]] Eigen::Vector3<InputScalar> gradient(
+      const Eigen::Vector3<InputScalar>& position) const;
 
   /**
    * Sample both the SDF value and gradient at a continuous 3D position using
@@ -108,7 +111,9 @@ class SignedDistanceField {
    * @param position 3D world-space position to query
    * @return Pair of (value, gradient) at the given position
    */
-  [[nodiscard]] std::pair<Scalar, Vector3> sampleWithGradient(const Vector3& position) const;
+  template <typename InputScalar = Scalar>
+  [[nodiscard]] std::pair<InputScalar, Eigen::Vector3<InputScalar>> sampleWithGradient(
+      const Eigen::Vector3<InputScalar>& position) const;
 
   /**
    * Convert a 3D world-space position to continuous grid coordinates.
@@ -116,7 +121,9 @@ class SignedDistanceField {
    * @param position 3D world-space position
    * @return Continuous grid coordinates (may be fractional)
    */
-  [[nodiscard]] Vector3 worldToGrid(const Vector3& position) const;
+  template <typename InputScalar = Scalar>
+  [[nodiscard]] Eigen::Vector3<InputScalar> worldToGrid(
+      const Eigen::Vector3<InputScalar>& position) const;
 
   /**
    * Convert continuous grid coordinates to 3D world-space position.
@@ -124,7 +131,9 @@ class SignedDistanceField {
    * @param gridPos Continuous grid coordinates
    * @return 3D world-space position
    */
-  [[nodiscard]] Vector3 gridToWorld(const Vector3& gridPos) const;
+  template <typename InputScalar = Scalar>
+  [[nodiscard]] Eigen::Vector3<InputScalar> gridToWorld(
+      const Eigen::Vector3<InputScalar>& gridPos) const;
 
   /**
    * Get the world-space position of a grid cell center given discrete indices.
@@ -220,7 +229,9 @@ class SignedDistanceField {
    * @param gridPos Input grid coordinates
    * @return Clamped grid coordinates
    */
-  [[nodiscard]] Vector3 clampToGrid(const Vector3& gridPos) const;
+  template <typename InputScalar = Scalar>
+  [[nodiscard]] Eigen::Vector3<InputScalar> clampToGrid(
+      const Eigen::Vector3<InputScalar>& gridPos) const;
 
   BoundingBoxType bounds_;
   Eigen::Vector3<Index> resolution_;

--- a/axel/axel/test/SignedDistanceFieldTest.cpp
+++ b/axel/axel/test/SignedDistanceFieldTest.cpp
@@ -471,14 +471,14 @@ TEST_F(SignedDistanceFieldTest, AnalyticalGradientVsFiniteDifference) {
   // Helper function for finite difference gradients
   auto computeFiniteDifferenceGradient = [&](const Eigen::Vector3f& position,
                                              float h) -> Eigen::Vector3f {
-    const float gradX = (testSdf.sample(position + Eigen::Vector3f(h, 0, 0)) -
-                         testSdf.sample(position - Eigen::Vector3f(h, 0, 0))) /
+    const float gradX = (testSdf.sample<float>(position + Eigen::Vector3f(h, 0, 0)) -
+                         testSdf.sample<float>(position - Eigen::Vector3f(h, 0, 0))) /
         (2.0f * h);
-    const float gradY = (testSdf.sample(position + Eigen::Vector3f(0, h, 0)) -
-                         testSdf.sample(position - Eigen::Vector3f(0, h, 0))) /
+    const float gradY = (testSdf.sample<float>(position + Eigen::Vector3f(0, h, 0)) -
+                         testSdf.sample<float>(position - Eigen::Vector3f(0, h, 0))) /
         (2.0f * h);
-    const float gradZ = (testSdf.sample(position + Eigen::Vector3f(0, 0, h)) -
-                         testSdf.sample(position - Eigen::Vector3f(0, 0, h))) /
+    const float gradZ = (testSdf.sample<float>(position + Eigen::Vector3f(0, 0, h)) -
+                         testSdf.sample<float>(position - Eigen::Vector3f(0, 0, h))) /
         (2.0f * h);
     return {gradX, gradY, gradZ};
   };

--- a/pymomentum/axel/axel_pybind.cpp
+++ b/pymomentum/axel/axel_pybind.cpp
@@ -189,7 +189,7 @@ More efficient than calling sample() and gradient() separately.
           py::arg("positions"))
       .def(
           "world_to_grid",
-          &axel::SignedDistanceField<float>::worldToGrid,
+          &axel::SignedDistanceField<float>::worldToGrid<float>,
           R"(Convert a 3D world-space position to continuous grid coordinates.
 
 :param position: 3D world-space position (x, y, z).
@@ -197,7 +197,7 @@ More efficient than calling sample() and gradient() separately.
           py::arg("position"))
       .def(
           "grid_to_world",
-          &axel::SignedDistanceField<float>::gridToWorld,
+          &axel::SignedDistanceField<float>::gridToWorld<float>,
           R"(Convert continuous grid coordinates to 3D world-space position.
 
 :param grid_pos: Continuous grid coordinates.


### PR DESCRIPTION
Summary: When incorporating into error functions, we need to be able to support double precision.  I was running into issues where the accuracy isn't very good, because the interpolation all happens in single precision.  While we could address this by switching the whole field to double precision, this isn't ideal because we want to be able to use the same Field with both single and double precision error functions.  Therefore we should support SDF operations in double precision even on single-precision fields.

Reviewed By: jeongseok-meta

Differential Revision: D84392734
