### PR TITLE
Add smoothing for meshes.

### DIFF
--- a/axel/axel/math/MeshHoleFilling.h
+++ b/axel/axel/math/MeshHoleFilling.h
@@ -95,4 +95,23 @@ fillMeshHolesComplete(
     gsl::span<const Eigen::Vector3<ScalarType>> vertices,
     gsl::span<const Eigen::Vector3i> triangles);
 
+/**
+ * Apply Laplacian smoothing to mesh vertices with optional masking.
+ *
+ * @param vertices Input mesh vertices
+ * @param faces Mesh faces (triangles or quads)
+ * @param vertex_mask Optional mask to specify which vertices to smooth (if empty, all vertices are
+ * smoothed)
+ * @param iterations Number of smoothing iterations
+ * @param step Smoothing step size (0-1)
+ * @return Smoothed vertices
+ */
+template <typename ScalarType, typename FaceType>
+std::vector<Eigen::Vector3<ScalarType>> smoothMeshLaplacian(
+    gsl::span<const Eigen::Vector3<ScalarType>> vertices,
+    gsl::span<const FaceType> faces,
+    const std::vector<bool>& vertex_mask = {},
+    Index iterations = 1,
+    ScalarType step = ScalarType{0.5});
+
 } // namespace axel

--- a/pymomentum/axel/axel_utility.cpp
+++ b/pymomentum/axel/axel_utility.cpp
@@ -43,8 +43,6 @@ void validatePositionArray(const py::array_t<float>& positions, const char* para
   }
 }
 
-// validateIndexArray is now a template function in the header file
-
 void validateGridDimensions(
     const py::array_t<float>& grid,
     const axel::SignedDistanceField<float>& sdf,


### PR DESCRIPTION
Summary: I'm having some issues with the SDF fields from chopped-up meshes being a bit messy in the corners; since SDF expects the field to be smooth, it would better to have a smoothed-out mesh.  Adding some basic Laplacian smoothing that we can apply to meshes before rasterizing.

Reviewed By: jeongseok-meta

Differential Revision: D84574456
