### PR TITLE
Add a new constructor to the parameter transform.

### DIFF
--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -11,6 +11,7 @@ import torch
 from pymomentum.geometry import (
     Character,
     create_test_character,
+    ParameterTransform,
     uniform_random_to_model_parameters,
 )
 
@@ -28,6 +29,40 @@ class TestParameterTransform(unittest.TestCase):
         joint_params_1 = character.parameter_transform.apply(model_params)
         joint_params_2 = torch.matmul(transform, model_params)
         self.assertTrue(torch.allclose(joint_params_1, joint_params_2))
+
+    def test_parameter_transform_round_trip(self) -> None:
+        """Test that converting parameter transform to dense matrix and back is lossless."""
+        # Create a test character with parameter transform
+        character: Character = create_test_character()
+        original_pt = character.parameter_transform
+
+        # Get the transform as a dense matrix
+        transform_matrix = original_pt.transform
+        transform_numpy = transform_matrix.numpy()
+
+        # Create a new parameter transform from the dense matrix
+        new_pt = ParameterTransform(
+            names=original_pt.names,
+            skeleton=character.skeleton,
+            transform=transform_numpy,
+        )
+
+        # Verify the transform produces identical results
+        torch.manual_seed(42)
+        model_params = uniform_random_to_model_parameters(character, torch.rand(5, 10))
+
+        joint_params_original = original_pt.apply(model_params)
+        joint_params_new = new_pt.apply(model_params)
+
+        self.assertTrue(
+            torch.allclose(joint_params_original, joint_params_new, atol=1e-6)
+        )
+
+        # Verify parameter names are preserved
+        self.assertEqual(original_pt.names, new_pt.names)
+
+        # Verify size is preserved
+        self.assertEqual(original_pt.size, new_pt.size)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: We can extract a dense matrix from a parameter transform but we can't build a parameter transform from a dense matrix, which seems like an oversight.  Plus the current constructor requires a scipy.sparse.csr_matrix which I don't know how to create.

Reviewed By: jeongseok-meta

Differential Revision: D85311496
