### PR TITLE
Drop intel mac support for pypi packages

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-14]
         python-version: ['3.12', '3.13']
         include:
           - python-version: '3.12'
@@ -52,8 +52,6 @@ jobs:
             pixi-environment: py313
           - os: ubuntu-latest
             os-short: ubuntu
-          - os: macos-13
-            os-short: mac-x64
           - os: macos-14
             os-short: mac-arm64
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -7089,6 +7089,7 @@ packages:
   depends:
   - binutils_impl_linux-64 >=2.44,<2.45.0a0
   license: GPL-3.0-only
+  license_family: GPL
   size: 34979
   timestamp: 1761335222402
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.44-h9d8b0ac_4.conda
@@ -7099,6 +7100,7 @@ packages:
   - sysroot_linux-64
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
+  license_family: GPL
   size: 3715763
   timestamp: 1761335193784
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.44-h4852527_4.conda
@@ -7107,6 +7109,7 @@ packages:
   depends:
   - binutils_impl_linux-64 2.44 h9d8b0ac_4
   license: GPL-3.0-only
+  license_family: GPL
   size: 36084
   timestamp: 1761335225100
 - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-2.137-mkl.conda
@@ -11070,6 +11073,7 @@ packages:
   constrains:
   - binutils_impl_linux-64 2.44
   license: GPL-3.0-only
+  license_family: GPL
   size: 742501
   timestamp: 1761335175964
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda

--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -64,16 +64,13 @@ dependencies = [
     "torch>={{ torch_min_py312 }},<{{ torch_max_py312 }}; platform_system == 'Linux' and python_version == '3.12'",
     "torch>={{ torch_min_py313 }},<{{ torch_max_py313 }}; platform_system == 'Linux' and python_version == '3.13'",
 {% else %}
-    # CPU package for Linux and macOS
+    # CPU package for Linux and macOS ARM64 (Apple Silicon only - Intel Macs not supported)
     # Linux uses latest PyTorch
     "torch>={{ torch_min_py312 }},<{{ torch_max_py312 }}; platform_system == 'Linux' and python_version == '3.12'",
     "torch>={{ torch_min_py313 }},<{{ torch_max_py313 }}; platform_system == 'Linux' and python_version == '3.13'",
     # macOS ARM64 (Apple Silicon) - PyTorch 2.8+ available
     "torch>={{ torch_min_py312_macos }},<{{ torch_max_py312_macos }}; platform_system == 'Darwin' and platform_machine == 'arm64' and python_version == '3.12'",
     "torch>={{ torch_min_py313_macos }},<{{ torch_max_py313_macos }}; platform_system == 'Darwin' and platform_machine == 'arm64' and python_version == '3.13'",
-    # macOS x86_64 (Intel) - Limited to PyTorch 2.2.x (latest available for Intel Mac)
-    "torch>=2.2.0,<2.3; platform_system == 'Darwin' and platform_machine == 'x86_64' and python_version == '3.12'",
-    "torch>=2.6.0,<2.7; platform_system == 'Darwin' and platform_machine == 'x86_64' and python_version == '3.13'",
 {% endif %}
 ]
 


### PR DESCRIPTION
## Summary

Intel Mac support was discontinued starting with Torch 2.2, so we no longer support it. Additionally, we need to optimize our CI costs.

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

CI
