### PR TITLE
Fix PyPI publishing: exclude dependency wheels from dist/

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -195,7 +195,7 @@ publish_pypi_test = { cmd = "twine upload --repository testpypi --skip-existing 
 # CPU environments (py312, py313) use these tasks
 build_pypi_wheel = { cmd = """
     python -c "import sys, os, shutil; py_ver = str(sys.version_info.major) + str(sys.version_info.minor); os.makedirs('.tmp', exist_ok=True); shutil.copy('pyproject.toml', '.tmp/pyproject-backup.toml'); shutil.copy(f'pyproject-pypi-cpu-py{py_ver}.toml', 'pyproject.toml')" && \
-    pip wheel . --no-build-isolation --wheel-dir=dist && \
+    pip wheel . --no-deps --no-build-isolation --wheel-dir=dist && \
     python -c "import shutil; shutil.move('.tmp/pyproject-backup.toml', 'pyproject.toml')"
 """, depends-on = [
     "generate_pyproject",
@@ -463,7 +463,7 @@ dependencies = { cuda-toolkit = ">=12.9.0,<13", nvtx-c = ">=3.1.1", cuda-version
 # GPU-specific PyPI tasks - build GPU wheels
 build_pypi_wheel = { cmd = """
     python -c "import os, shutil; os.makedirs('.tmp', exist_ok=True); shutil.copy('pyproject.toml', '.tmp/pyproject-backup.toml'); shutil.copy('pyproject-pypi-gpu.toml', 'pyproject.toml')" && \
-    pip wheel . --no-build-isolation --wheel-dir=dist && \
+    pip wheel . --no-deps --no-build-isolation --wheel-dir=dist && \
     python -c "import shutil; shutil.move('.tmp/pyproject-backup.toml', 'pyproject.toml')"
 """, depends-on = [
     "generate_pyproject",
@@ -491,7 +491,7 @@ dependencies = { cuda-toolkit = ">=12.9.0,<13", nvtx-c = ">=3.1.1", cuda-version
 # GPU-specific PyPI tasks - build GPU wheels
 build_pypi_wheel = { cmd = """
     python -c "import os, shutil; os.makedirs('.tmp', exist_ok=True); shutil.copy('pyproject.toml', '.tmp/pyproject-backup.toml'); shutil.copy('pyproject-pypi-gpu.toml', 'pyproject.toml')" && \
-    pip wheel . --no-build-isolation --wheel-dir=dist && \
+    pip wheel . --no-deps --no-build-isolation --wheel-dir=dist && \
     python -c "import shutil; shutil.move('.tmp/pyproject-backup.toml', 'pyproject.toml')"
 """, depends-on = [
     "generate_pyproject",


### PR DESCRIPTION
## Summary

### Issue

`pip wheel` was downloading all dependencies (torch, numpy, nvidia packages, etc.) into `dist/` along with our wheels. Publishing attempts would fail trying to upload these third-party packages.

### Fix

Added `--no-deps` flag to `pip wheel` commands in `pixi.toml` to build only momentum wheels.

### Why wasn't this caught earlier?

The workflow only publishes on git tags. Previous PRs only tested the build step (which succeeded), but never triggered the actual PyPI publish step that would have failed.

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

Verify locally that `dist/` contains only `pymomentum_*.whl` files (no dependencies), then merge and trigger workflow with a git tag to test full publish flow.
