### PR TITLE
Fix PyPI publishing: Add missing auditwheel repair step for Linux wheels

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -98,6 +98,10 @@ jobs:
         if: steps.should_run.outputs.run == 'true'
         run: pixi run -e ${{ matrix.pixi-environment }} build_pypi_wheel
 
+      - name: Repair CPU wheel (Linux only)
+        if: steps.should_run.outputs.run == 'true' && matrix.os == 'ubuntu-latest'
+        run: pixi run -e ${{ matrix.pixi-environment }} build_pypi_repair
+
       - name: Upload wheel artifacts
         if: steps.should_run.outputs.run == 'true'
         uses: actions/upload-artifact@v4
@@ -199,6 +203,10 @@ jobs:
       - name: Build GPU wheel
         if: steps.should_run.outputs.run == 'true'
         run: pixi run -e ${{ matrix.pixi-environment }} build_pypi_wheel
+
+      - name: Repair GPU wheel (Linux only)
+        if: steps.should_run.outputs.run == 'true' && matrix.os == 'ubuntu-latest'
+        run: pixi run -e ${{ matrix.pixi-environment }} build_pypi_repair
 
       - name: Upload wheel artifacts
         if: steps.should_run.outputs.run == 'true'


### PR DESCRIPTION
## Summary

PyPI was rejecting Linux wheels with [error](https://github.com/facebookresearch/momentum/actions/runs/18853730732/job/53797928855):

`Binary wheel 'pymomentum_cpu-0.1.81.post0-cp312-cp312-linux_x86_64.whl'  has an unsupported platform tag 'linux_x86_64'.`

PyPI requires Linux wheels to use `manylinux` tags (e.g., `manylinux_2_17_x86_64`) instead of generic `linux_x86_64` for cross-distribution compatibility.

The `build_pypi_repair` task was already defined in `pixi.toml` since PR #725, but the CI workflow never called it. This wasn't caught because:

*   CI builds wheels successfully without publishing (no PyPI validation)
*   First actual PyPI publish attempt revealed the issue

Added `build_pypi_repair` step to CI workflow after building wheels on Linux:

*   Runs `auditwheel repair` to convert `linux_x86_64` → `manylinux_*` tags
*   Removes original wheel after repair
*   Skipped on macOS (not needed)

## Checklist:

- [ ] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [ ] Codebase formatted by running `pixi run lint`

## Test Plan

Next PyPI publish should succeed with properly tagged `manylinux` wheels.
