### PR TITLE
Fix potential data race in SequenceSolverFunction::needsMesh_

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver_function.cpp
+++ b/momentum/character_sequence_solver/sequence_solver_function.cpp
@@ -451,7 +451,9 @@ template <typename T>
 void SequenceSolverFunctionT<T>::addErrorFunction(
     const size_t frame,
     std::shared_ptr<SkeletonErrorFunctionT<T>> errorFunction) {
-  needsMesh_ = needsMesh_ || errorFunction->needsMesh();
+  if (errorFunction->needsMesh()) {
+    needsMesh_.store(true, std::memory_order_relaxed);
+  }
   if (frame == kAllFrames) {
     dispenso::parallel_for(0, getNumFrames(), [this, errorFunction](size_t iFrame) {
       addErrorFunction(iFrame, errorFunction);
@@ -467,7 +469,9 @@ template <typename T>
 void SequenceSolverFunctionT<T>::addSequenceErrorFunction(
     const size_t frame,
     std::shared_ptr<SequenceErrorFunctionT<T>> errorFunction) {
-  needsMesh_ = needsMesh_ || errorFunction->needsMesh();
+  if (errorFunction->needsMesh()) {
+    needsMesh_.store(true, std::memory_order_relaxed);
+  }
   if (frame == kAllFrames) {
     if (getNumFrames() >= errorFunction->numFrames()) {
       dispenso::parallel_for(

--- a/momentum/character_sequence_solver/sequence_solver_function.h
+++ b/momentum/character_sequence_solver/sequence_solver_function.h
@@ -126,7 +126,7 @@ class SequenceSolverFunctionT : public SolverFunctionT<T> {
   std::atomic<size_t> numTotalPerFrameErrorFunctions_ = 0;
   std::atomic<size_t> numTotalSequenceErrorFunctions_ = 0;
 
-  bool needsMesh_ = false;
+  std::atomic<bool> needsMesh_{false};
 
   friend class SequenceSolverT<T>;
 };


### PR DESCRIPTION
Summary:
A data race is flagged in the addErrorFunction in a test because of the access pattern of needsMesh_. It is not a real issue in practice, but good to fix so our tests can pass. 

The fix converts needsMesh_ from a plain bool to std::atomic<bool> and updates the write operations to use atomic store with relaxed memory ordering.

Reviewed By: jeongseok-meta

Differential Revision: D85629106


