### PR TITLE
Add a simple example to export an animated sequence as objs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -864,6 +864,17 @@ if(MOMENTUM_BUILD_EXAMPLES)
       io
       marker_tracker
   )
+
+  mt_executable(
+    NAME export_objs
+    SOURCES_VARS export_objs_sources
+    LINK_LIBRARIES
+      character
+      io_fbx
+      io_gltf
+      CLI11::CLI11
+  )
+
 endif()
 
 #===============================================================================

--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -677,6 +677,10 @@ animate_shapes_sources = [
     "examples/animate_shapes/animate_shapes.cpp",
 ]
 
+export_objs_sources = [
+    "examples/export_objs/export_objs.cpp",
+]
+
 process_markers_app_sources = [
     "examples/process_markers_app/process_markers_app.cpp",
 ]

--- a/momentum/examples/export_objs/README.md
+++ b/momentum/examples/export_objs/README.md
@@ -1,0 +1,135 @@
+# Export OBJs Example
+
+This example demonstrates how to export animation data from GLB/GLTF or FBX files as per-frame OBJ mesh files.
+
+## Overview
+
+The `export_objs` utility loads a character with animation from either:
+- **GLB/GLTF files**: Using the Momentum GLTF loader
+- **FBX files**: Using the Momentum FBX loader
+
+It then exports each frame of the animation as a separate OBJ file containing the deformed mesh geometry. The output folder will be created if it doesn't exist yet.
+
+## Building with buck
+
+```bash
+buck2 build path/to/momentum/examples:export_objs
+```
+
+## Usage
+
+Using buck:
+```bash
+buck2 run path/to/momentum/examples:export_objs -- \
+  -i <input_file> \
+  -o <output_folder> \
+  [--first <frame_number>] \
+  [--last <frame_number>] \
+  [--stride <frame_stride>]
+```
+
+Using pixi:
+```
+pixi run export_objs -i <input_file> -o <output_folder> [--first <frame_number>] [--last <frame_number>] [--stride <frame_stride>]
+```
+
+### Options
+
+- `-i, --input`: Path to the input animation file (`.fbx`, `.glb`, or `.gltf`) [required]
+- `-o, --output`: Path to the output folder where OBJ files will be saved [required]
+- `--first`: First frame to export (default: 0)
+- `--last`: Last frame to export, inclusive (default: -1 for all frames)
+- `--stride`: Frame stride when exporting (default: 1)
+
+### Examples
+
+**Export all frames from a GLB file:**
+
+Using buck:
+```bash
+buck2 run path/to/momentum/examples:export_objs -- \
+  -i test.glb \
+  -o /tmp/exported_objs
+```
+
+Using pixi:
+```
+pixi run export_objs -i test.glb -o /tmp/exported_objs
+```
+
+**Export frames 10-50 from an FBX file with stride 2:**
+
+Using buck:
+```bash
+buck2 run path/to/momentum/examples:export_objs -- \
+  -i path/to/animation.fbx \
+  -o /tmp/exported_objs \
+  --first 10 \
+  --last 50 \
+  --stride 2
+```
+
+Using pixi:
+```
+pixi run export_objs -i path/to/animation.fbx -o /tmp/exported_objs --first 10 --last 50 --stride 2
+```
+
+**Export static mesh (no animation):**
+If the input file has no animation data, it will export a single OBJ file with the template mesh.
+
+## Output Format
+
+### Animation Sequences
+The exported OBJ files are named sequentially:
+- `00000.obj`, `00001.obj`, `00002.obj`, etc.
+
+### Static Mesh (No Animation)
+If the input file has no animation data, a single OBJ file is exported with the name:
+- `<input_filename>.obj` (e.g., `character.obj` for `character.glb`)
+
+### OBJ File Contents
+Each OBJ file contains:
+- Vertex positions (`v` lines)
+- Triangle faces (`f` lines, 1-indexed)
+
+Note: The simple OBJ exporter in this example does not export:
+- Texture coordinates
+- Normals
+- Materials
+
+## Implementation Notes
+
+### GLB/GLTF Files
+- Loads character with motion using `loadCharacterWithMotion()`
+- Returns motion as a single `MatrixXf` containing **model parameters**
+- Also returns a separate identity parameter (stored in `JointParameters`)
+- The identity parameter is constant for the character and not time-varying
+- Each column represents one frame's model parameters
+
+### FBX Files
+- Loads character with motion using `loadFbxCharacterWithMotion()`
+- Returns motion as a `std::vector<MatrixXf>` containing **joint parameters**
+- If multiple motions are present, only the first one is exported
+- FBX files do not store custom parameter information, so only joint parameters are available
+
+### Parameter Handling Difference
+The key difference between GLB and FBX files:
+- **GLB**: Motion matrix contains model parameters (stored in custom plugin); identity parameters are separate
+- **FBX**: Motion matrix contains joint parameters (no custom storage); model parameters are not available
+
+This affects how parameters are set in `CharacterState`:
+- For GLB: `params.offsets = id; params.pose = motion.col(iFrame)` (model parameters)
+- For FBX: `params.pose.v.setZero(0); params.offsets = motion.col(iFrame)` (joint parameters)
+
+### Per-Frame Export Process
+1. Load the character and animation
+2. For each frame:
+   - Set the character state with the appropriate parameters (model or joint)
+   - Compute the deformed mesh geometry
+   - Export the mesh to an OBJ file
+
+## See Also
+
+- `examples/glb_viewer/`: Interactive viewer for GLB files with Rerun
+- `examples/fbx_viewer/`: Interactive viewer for FBX files with Rerun
+- `examples/convert_model/`: Convert between different model formats

--- a/momentum/examples/export_objs/export_objs.cpp
+++ b/momentum/examples/export_objs/export_objs.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Export OBJs Example
+ *
+ * This example demonstrates how to export animation data from GLB/GLTF or FBX files
+ * as per-frame OBJ mesh files. It loads a character with animation and exports each
+ * frame as a separate OBJ file containing the deformed mesh geometry.
+ *
+ * Supported formats:
+ * - GLB/GLTF: Loaded using loadCharacterWithMotion()
+ * - FBX: Loaded using loadFbxCharacterWithMotion()
+ *
+ * Usage:
+ *   export_objs -i <input_file> -o <output_folder> [options]
+ *
+ * See README.md for detailed documentation.
+ */
+
+#include <momentum/character/character.h>
+#include <momentum/character/character_state.h>
+#include <momentum/common/log.h>
+#include <momentum/io/fbx/fbx_io.h>
+#include <momentum/io/gltf/gltf_io.h>
+#include <momentum/math/mesh.h>
+
+#include <CLI/CLI.hpp>
+#include <fmt/format.h>
+
+#include <filesystem>
+
+using namespace momentum;
+
+namespace {
+
+struct Options {
+  std::string inputFile;
+  std::string outputFolder;
+  size_t firstFrame = 0;
+  int lastFrame = -1;
+  size_t stride = 1;
+};
+
+std::shared_ptr<Options> setupOptions(CLI::App& app) {
+  auto opt = std::make_shared<Options>();
+  app.add_option("-i,--input", opt->inputFile, "Path to the input animation file (.fbx/.glb).")
+      ->required()
+      ->check(CLI::ExistingFile);
+  app.add_option("-o,--output", opt->outputFolder, "Path to the output folder.")->required();
+  app.add_option("--first", opt->firstFrame, "First frame in the motion to start obj export.")
+      ->default_val(opt->firstFrame)
+      ->check(CLI::NonNegativeNumber);
+  app.add_option(
+         "--last",
+         opt->lastFrame,
+         "Last frame in the motion to export (inclusive). -1 to indicate the last frame in the motion.")
+      ->default_val(opt->lastFrame);
+  app.add_option("--stride", opt->stride, "Frame stride when exporting data.")
+      ->default_val(opt->stride)
+      ->check(CLI::PositiveNumber);
+
+  return opt;
+}
+
+// A simple obj export function as an example to avoid external deps.
+int saveObj(const std::string& filename, const Mesh* mesh) {
+  std::ofstream file(filename);
+  if (!file.is_open()) {
+    MT_LOGE("Failed to open {} for writing", filename);
+    return -1;
+  }
+
+  // Simple info
+  file << "# " << mesh->vertices.size() << " vertices; " << mesh->faces.size() << " faces"
+       << std::endl;
+
+  // Vertex positions
+  for (const auto& v : mesh->vertices) {
+    file << "v " << v(0) << " " << v(1) << " " << v(2) << std::endl;
+  }
+  file << std::endl;
+
+  // Faces -- our mesh is triangle only.
+  // NOTE: obj vertex indices is 1-based not 0-based.
+  for (const auto& f : mesh->faces) {
+    file << "f " << 1 + f(0) << " " << 1 + f(1) << " " << 1 + f(2) << std::endl;
+  }
+  file.close();
+  return 0;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) try {
+  CLI::App app("Export objs app");
+  auto opts = setupOptions(app);
+  CLI11_PARSE(app, argc, argv);
+
+  // Determine file type by extension
+  const std::string extension = std::filesystem::path(opts->inputFile).extension().string();
+  const bool isGlb = (extension == ".glb" || extension == ".gltf");
+  const bool isFbx = (extension == ".fbx");
+
+  if (!isGlb && !isFbx) {
+    MT_LOGE("Unsupported file format: {}. Only .glb, .gltf, and .fbx are supported.", extension);
+    return EXIT_FAILURE;
+  }
+
+  Character character;
+  MatrixXf motion; // For GLB: single motion matrix
+  std::vector<MatrixXf> motions; // For FBX: vector of motion matrices
+  VectorXf id; // Identity parameters (GLB only)
+  float fps = 0.0f;
+
+  // Load character and motion based on file type
+  if (isGlb) {
+    MT_LOGI("Loading GLB/GLTF file: {}", opts->inputFile);
+    std::tie(character, motion, id, fps) = loadCharacterWithMotion(opts->inputFile);
+  } else {
+    MT_LOGI("Loading FBX file: {}", opts->inputFile);
+    std::tie(character, motions, fps) = loadFbxCharacterWithMotion(opts->inputFile);
+    // Convert vector of motions to single motion matrix if needed
+    if (!motions.empty() && motions[0].cols() > 0) {
+      motion = motions[0]; // Use first motion
+      if (motions.size() > 1) {
+        MT_LOGW("FBX file contains {} motions. Using only the first one.", motions.size());
+      }
+    }
+  }
+
+  if (character.mesh == nullptr) {
+    MT_LOGW("No mesh found in the input; exit without saving.");
+    return EXIT_SUCCESS;
+  }
+
+  // Check and create the output folder if needed
+  if (!std::filesystem::is_directory(opts->outputFolder)) {
+    MT_LOGI("Create output folder {}", opts->outputFolder);
+    std::filesystem::create_directories(opts->outputFolder);
+  }
+
+  const size_t numFrames = motion.cols();
+
+  if (numFrames == 0) {
+    // Export the template mesh (no animation)
+    MT_LOGI("No animation data found. Exporting template mesh.");
+    const std::string outFile = fmt::format(
+        "{}/{}.obj",
+        opts->outputFolder,
+        std::filesystem::path(opts->inputFile).filename().stem().string());
+    if (saveObj(outFile, character.mesh.get()) == 0) {
+      return EXIT_SUCCESS;
+    } else {
+      return EXIT_FAILURE;
+    }
+  }
+
+  // Export animation sequence
+  MT_LOGI("Exporting animation with {} frames at {} fps", numFrames, fps);
+
+  // Apply frame range options
+  const size_t startFrame = opts->firstFrame;
+  const size_t endFrame = (opts->lastFrame < 0)
+      ? numFrames
+      : std::min(static_cast<size_t>(opts->lastFrame + 1), numFrames);
+
+  if (startFrame >= numFrames) {
+    MT_LOGE("First frame ({}) is out of range (total frames: {})", startFrame, numFrames);
+    return EXIT_FAILURE;
+  }
+
+  CharacterState state(character);
+  CharacterParameters params;
+  if (isGlb && id.size() > 0) {
+    // id is in JointParameters. It is constant for the character and not time-varying.
+    params.offsets = id;
+  } else if (isFbx) {
+    params.pose.v.setZero(character.parameterTransform.numAllModelParameters()); // should be zero
+  }
+
+  size_t exportCount = 0;
+  for (size_t iFrame = startFrame; iFrame < endFrame; iFrame += opts->stride) {
+    // Here is the tricky part: for glb files, we store model parameters in a custom plugin and
+    // read it back in. So the motion matrix we read from glb is of ModelParameters type. For fbx
+    // files, we do not store custom information, so we can only read back joint parameters. The
+    // motion matrix we read from fbx is of JointParameters type. We will need to handle them
+    // differently.
+    if (isGlb) {
+      params.pose = motion.col(iFrame);
+    } else {
+      params.offsets = motion.col(iFrame);
+    }
+    state.set(params, character, true, false, false);
+    const std::string outFile = fmt::format("{}/{:05}.obj", opts->outputFolder, exportCount);
+    if (saveObj(outFile, state.meshState.get()) == 0) {
+      exportCount++;
+    }
+  }
+  MT_LOGI("Exported {} frames to {}", exportCount, opts->outputFolder);
+  return EXIT_SUCCESS;
+} catch (std::exception& e) {
+  MT_LOGE("Exception thrown {}", e.what());
+  return EXIT_FAILURE;
+} catch (...) {
+  MT_LOGE("Unknown exception.");
+  return EXIT_FAILURE;
+}

--- a/pixi.toml
+++ b/pixi.toml
@@ -146,6 +146,13 @@ process_markers = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/process_mark
 refine_motion = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/refine_motion", depends-on = [
     "build",
 ], description = "Run motion refinement tool" }
+export_objs = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/export_objs", depends-on = [
+    "build",
+], description = "Export animated mesh sequence as objs" }
+animate_shapes = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/animate_shapes", depends-on = [
+    "build",
+], description = "Export animation of blendshapes" }
+
 install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target install", depends-on = [
     "build",
 ], description = "Install built libraries and executables" }
@@ -424,6 +431,12 @@ process_markers = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/process_mark
     "build",
 ] }
 refine_motion = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/refine_motion.exe", depends-on = [
+    "build",
+] }
+export_objs = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/export_objs.exe", depends-on = [
+    "build",
+] }
+animate_shapes = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/animate_shapes.exe", depends-on = [
     "build",
 ] }
 install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp --target install --config Release --parallel", depends-on = [


### PR DESCRIPTION
Summary: An example to export deformed character mesh as objs. It shows how to manipulate character states from either glb or fbx files.

Differential Revision: D62511544


