### PR TITLE
Add namespace parameter to FBX save functions

### DIFF
--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -13,6 +13,8 @@
 
 #include <span>
 
+#include <string_view>
+
 namespace momentum {
 
 // UpVector Specifies which canonical axis represents up in the system
@@ -77,7 +79,17 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     bool permissive = false,
     LoadBlendShapes loadBlendShape = LoadBlendShapes::No);
 
-// Permissive mode allows saving mesh-only characters (without skin weights).
+/// Save a character with animation to an FBX file.
+/// @param filename Path to the output FBX file
+/// @param character The character to save
+/// @param poses Model parameters for each frame (empty for bind pose only)
+/// @param identity Identity pose parameters (empty to use bind pose)
+/// @param framerate Animation framerate in frames per second
+/// @param saveMesh Whether to include mesh geometry in the output
+/// @param coordSystemInfo Coordinate system configuration for the FBX file
+/// @param permissive Permissive mode allows saving mesh-only characters (without skin weights)
+/// @param fbxNamespace Optional namespace to prepend to all node names (e.g., "ns" will become
+/// "ns:")
 void saveFbx(
     const filesystem::path& filename,
     const Character& character,
@@ -86,9 +98,19 @@ void saveFbx(
     double framerate = 120.0,
     bool saveMesh = false,
     const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
-    bool permissive = false);
+    bool permissive = false,
+    std::string_view fbxNamespace = "");
 
-// Permissive mode allows saving mesh-only characters (without skin weights).
+/// Save a character with animation using joint parameters directly.
+/// @param filename Path to the output FBX file
+/// @param character The character to save
+/// @param jointParams Joint parameters for each frame (empty for bind pose only)
+/// @param framerate Animation framerate in frames per second
+/// @param saveMesh Whether to include mesh geometry in the output
+/// @param coordSystemInfo Coordinate system configuration for the FBX file
+/// @param permissive Permissive mode allows saving mesh-only characters (without skin weights)
+/// @param fbxNamespace Optional namespace to prepend to all node names (e.g., "ns" will become
+/// "ns:")
 void saveFbxWithJointParams(
     const filesystem::path& filename,
     const Character& character,
@@ -96,14 +118,21 @@ void saveFbxWithJointParams(
     double framerate = 120.0,
     bool saveMesh = false,
     const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
-    bool permissive = false);
+    bool permissive = false,
+    std::string_view fbxNamespace = "");
 
-// A shorthand of saveFbx() to save both the skeleton and mesh as a model but without any animation
-// Permissive mode allows saving mesh-only characters (without skin weights).
+/// Save a character model (skeleton and mesh) without animation.
+/// @param filename Path to the output FBX file
+/// @param character The character to save
+/// @param coordSystemInfo Coordinate system configuration for the FBX file
+/// @param permissive Permissive mode allows saving mesh-only characters (without skin weights)
+/// @param fbxNamespace Optional namespace to prepend to all node names (e.g., "ns" will become
+/// "ns:")
 void saveFbxModel(
     const filesystem::path& filename,
     const Character& character,
     const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
-    bool permissive = false);
+    bool permissive = false,
+    std::string_view fbxNamespace = "");
 
 } // namespace momentum

--- a/momentum/io/fbx/fbx_io_openfbx_only.cpp
+++ b/momentum/io/fbx/fbx_io_openfbx_only.cpp
@@ -53,7 +53,8 @@ void saveFbx(
     double /* framerate */,
     bool /* saveMesh */,
     const FBXCoordSystemInfo& /* coordSystemInfo */,
-    bool /* permissive */) {
+    bool /* permissive */,
+    std::string_view /* fbxNamespace */) {
   MT_THROW(
       "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
 }
@@ -65,7 +66,8 @@ void saveFbxWithJointParams(
     double /* framerate */,
     bool /* saveMesh */,
     const FBXCoordSystemInfo& /* coordSystemInfo */,
-    bool /* permissive */) {
+    bool /* permissive */,
+    std::string_view /* fbxNamespace */) {
   MT_THROW(
       "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
 }
@@ -74,7 +76,8 @@ void saveFbxModel(
     const filesystem::path& /* filename */,
     const Character& /* character */,
     const FBXCoordSystemInfo& /* coordSystemInfo */,
-    bool /* permissive */) {
+    bool /* permissive */,
+    std::string_view /* fbxNamespace */) {
   MT_THROW(
       "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
 }


### PR DESCRIPTION
Summary:
Added an optional `fbxNamespace` parameter to `saveFbx()`, `saveFbxWithJointParams()`, and `saveFbxModel()` functions to support namespace prefixing of all node names when saving FBX files.

Namespace is convenient for loading multiple fbx files in Maya to compare them.

**Implementation Details:**
- Automatically appends ":" to namespace if not present
- The namespace is applied at the end on all created nodes in the scene.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=T156594543-ff84e720-04be-478a-ba90-270021bb7422)

Differential Revision: D85516754


