### PR TITLE
Add unified saveCharacter function for FBX/GLTF parity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,7 @@ mt_library(
   PRIVATE_LINK_LIBRARIES
     io_common
     io_gltf
+    io_fbx
     ezc3d
 )
 
@@ -920,7 +921,7 @@ install(
 
 # Install CMake modules
 install(
-  FILES cmake/Findre2.cmake
+  FILES cmake/Findre2.cmake cmake/FindFbxSdk.cmake
   DESTINATION ${MOMENTUM_CONFIG_INSTALL_DIR}
 )
 

--- a/cmake/FindFbxSdk.cmake
+++ b/cmake/FindFbxSdk.cmake
@@ -86,9 +86,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   list(APPEND required_vars LibXml2_FOUND Iconv_FOUND ZLIB_LIBRARIES)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   find_package(LibXml2 MODULE QUIET)
-  list(APPEND FBXSDK_LIBRARIES LibXml2::LibXml2)
-  list(APPEND FBXSDK_LIBRARIES_DEBUG LibXml2::LibXml2)
-  list(APPEND required_vars LibXml2_FOUND)
+  find_package(ZLIB MODULE QUIET)
+  list(APPEND FBXSDK_LIBRARIES LibXml2::LibXml2 ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
+  list(APPEND FBXSDK_LIBRARIES_DEBUG LibXml2::LibXml2 ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
+  list(APPEND required_vars LibXml2_FOUND ZLIB_LIBRARIES)
 endif()
 
 # Set (NAME)_FOUND if all the variables and the version are satisfied.

--- a/momentum/io/character_io.cpp
+++ b/momentum/io/character_io.cpp
@@ -8,6 +8,7 @@
 #include "momentum/io/character_io.h"
 
 #include "momentum/character/character.h"
+#include "momentum/character/skeleton_state.h"
 #include "momentum/io/fbx/fbx_io.h"
 #include "momentum/io/gltf/gltf_io.h"
 #include "momentum/io/shape/pose_shape_io.h"
@@ -137,6 +138,72 @@ Character loadFullCharacterFromBuffer(
   }
 
   return character.value();
+}
+
+void saveCharacter(
+    const filesystem::path& filename,
+    const Character& character,
+    const float fps,
+    const MatrixXf& motion,
+    const std::vector<std::vector<Marker>>& markerSequence) {
+  // Parse format from file extension
+  const auto format = parseCharacterFormat(filename);
+  MT_THROW_IF(
+      format == CharacterFormat::Unknown,
+      "Unknown character format for path: {}. Supported formats: .fbx, .glb, .gltf",
+      filename.string());
+
+  if (format == CharacterFormat::Gltf) {
+    saveGltfCharacter(
+        filename, character, fps, {character.parameterTransform.name, motion}, {}, markerSequence);
+  } else if (format == CharacterFormat::Fbx) {
+    // Save as FBX
+    saveFbx(
+        filename,
+        character,
+        motion,
+        VectorXf(),
+        static_cast<double>(fps),
+        true, // saveMesh
+        FBXCoordSystemInfo(),
+        false, // permissive
+        markerSequence);
+  } else {
+    MT_THROW(
+        "{} is not a supported format. Supported formats: .fbx, .glb, .gltf", filename.string());
+  }
+}
+
+void saveCharacter(
+    const filesystem::path& filename,
+    const Character& character,
+    std::span<const SkeletonState> skeletonStates,
+    const std::vector<std::vector<Marker>>& markerSequence,
+    const float fps) {
+  // Parse format from file extension
+  const auto format = parseCharacterFormat(filename);
+  MT_THROW_IF(
+      format == CharacterFormat::Unknown,
+      "Unknown character format for path: {}. Supported formats: .fbx, .glb, .gltf",
+      filename.string());
+
+  if (format == CharacterFormat::Gltf) {
+    saveGltfCharacter(filename, character, fps, skeletonStates, markerSequence);
+  } else if (format == CharacterFormat::Fbx) {
+    // Save as FBX
+    saveFbxWithSkeletonStates(
+        filename,
+        character,
+        skeletonStates,
+        static_cast<double>(fps),
+        true, // saveMesh
+        FBXCoordSystemInfo(),
+        false, // permissive
+        markerSequence);
+  } else {
+    MT_THROW(
+        "{} is not a supported format. Supported formats: .fbx, .glb, .gltf", filename.string());
+  }
 }
 
 } // namespace momentum

--- a/momentum/io/character_io.h
+++ b/momentum/io/character_io.h
@@ -8,10 +8,13 @@
 #pragma once
 
 #include <momentum/character/fwd.h>
+#include <momentum/character/marker.h>
+#include <momentum/common/filesystem.h>
 #include <momentum/math/fwd.h>
 #include <momentum/math/types.h>
 
 #include <string>
+#include <vector>
 
 namespace momentum {
 
@@ -53,4 +56,36 @@ enum class CharacterFormat : uint8_t {
     std::span<const std::byte> paramBuffer = std::span<const std::byte>(),
     std::span<const std::byte> locBuffer = std::span<const std::byte>());
 
+/// High level function to save a character with motion and markers to any supported format.
+///
+/// The format is determined by the file extension (.fbx, .glb, .gltf).
+/// This is a unified interface that automatically selects between FBX and GLTF based on extension.
+/// @param[in] filename The path where the character file will be saved.
+/// @param[in] character The Character object to save.
+/// @param[in] fps Frame rate for the animation (default: 120.0f).
+/// @param[in] motion The motion represented in model parameters (numModelParams, numFrames).
+/// @param[in] markerSequence Optional marker sequence data to save with the character.
+void saveCharacter(
+    const filesystem::path& filename,
+    const Character& character,
+    float fps /* = 120.f*/,
+    const MatrixXf& motion /* = MatrixXf()*/,
+    const std::vector<std::vector<Marker>>& markerSequence /* = {}*/);
+
+/// High level function to save a character with motion in skeleton states and markers to any
+/// supported format.
+///
+/// The format is determined by the file extension (.fbx, .glb, .gltf).
+/// This is a unified interface that automatically selects between FBX and GLTF based on extension.
+/// @param[in] filename The path where the character file will be saved.
+/// @param[in] character The Character object to save.
+/// @param[in] fps Frame rate for the animation.
+/// @param[in] skeletonStates The motion represented in skeleton states (ie. JointStates).
+/// @param[in] markerSequence Optional marker sequence data to save with the character.
+void saveCharacter(
+    const filesystem::path& filename,
+    const Character& character,
+    std::span<const SkeletonState> skeletonStates,
+    const std::vector<std::vector<Marker>>& markerSequence = {},
+    float fps = 120.f);
 } // namespace momentum

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -857,6 +857,39 @@ void saveFbxWithJointParams(
       fbxNamespace);
 }
 
+void saveFbxWithSkeletonStates(
+    const filesystem::path& filename,
+    const Character& character,
+    std::span<const SkeletonState> skeletonStates,
+    const double framerate,
+    const bool saveMesh,
+    const FBXCoordSystemInfo& coordSystemInfo,
+    bool permissive,
+    const std::vector<std::vector<Marker>>& markerSequence,
+    std::string_view fbxNamespace) {
+  const size_t nFrames = skeletonStates.size();
+  MatrixXf jointParams(character.parameterTransform.zero().v.size(), nFrames);
+  for (size_t iFrame = 0; iFrame < nFrames; ++iFrame) {
+    jointParams.col(iFrame) =
+        skeletonStateToJointParameters(skeletonStates[iFrame], character.skeleton).v;
+  }
+
+  // Call the helper function to save FBX file with joint values.
+  // Set skipActiveJointParamCheck=true to skip the active joint param check as the joint params are
+  // passed in directly from user.
+  saveFbxCommon(
+      filename,
+      character,
+      jointParams,
+      framerate,
+      saveMesh,
+      true,
+      coordSystemInfo,
+      permissive,
+      markerSequence,
+      fbxNamespace);
+}
+
 void saveFbxModel(
     const filesystem::path& filename,
     const Character& character,

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -129,6 +129,28 @@ void saveFbxWithJointParams(
     const std::vector<std::vector<Marker>>& markerSequence = {},
     std::string_view fbxNamespace = "");
 
+/// Save a character with animation using skeleton states directly.
+/// @param filename Path to the output FBX file
+/// @param character The character to save
+/// @param skeletonStates SkeletonState for each frame (empty for bind pose only)
+/// @param framerate Animation framerate in frames per second
+/// @param saveMesh Whether to include mesh geometry in the output
+/// @param coordSystemInfo Coordinate system configuration for the FBX file
+/// @param permissive Permissive mode allows saving mesh-only characters (without skin weights)
+/// @param markerSequence Optional marker sequence data to save with the character
+/// @param fbxNamespace Optional namespace to prepend to all node names (e.g., "ns" will become
+/// "ns:")
+void saveFbxWithSkeletonStates(
+    const filesystem::path& filename,
+    const Character& character,
+    std::span<const SkeletonState> skeletonStates,
+    double framerate = 120.0,
+    bool saveMesh = false,
+    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    bool permissive = false,
+    const std::vector<std::vector<Marker>>& markerSequence = {},
+    std::string_view fbxNamespace = "");
+
 /// Save a character model (skeleton and mesh) without animation.
 /// @param filename Path to the output FBX file
 /// @param character The character to save

--- a/momentum/io/fbx/fbx_io_openfbx_only.cpp
+++ b/momentum/io/fbx/fbx_io_openfbx_only.cpp
@@ -82,6 +82,20 @@ void saveFbxWithJointParams(
       "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
 }
 
+void saveFbxWithSkeletonStates(
+    const filesystem::path& /* filename */,
+    const Character& /* character */,
+    std::span<const SkeletonState> /* skeletonStates */,
+    double /* framerate */,
+    bool /* saveMesh */,
+    const FBXCoordSystemInfo& /* coordSystemInfo */,
+    bool /* permissive */,
+    const std::vector<std::vector<Marker>>& /* markerSequence */,
+    std::string_view /* fbxNamespace */) {
+  MT_THROW(
+      "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
+}
+
 void saveFbxModel(
     const filesystem::path& /* filename */,
     const Character& /* character */,

--- a/momentum/io/gltf/gltf_io.cpp
+++ b/momentum/io/gltf/gltf_io.cpp
@@ -1308,7 +1308,7 @@ MarkerSequence loadMarkerSequence(const filesystem::path& filename) {
   return result;
 }
 
-void saveCharacter(
+void saveGltfCharacter(
     const filesystem::path& filename,
     const Character& character,
     const float fps,
@@ -1329,6 +1329,19 @@ void saveCharacter(
     const filesystem::path& filename,
     const Character& character,
     const float fps,
+    const MotionParameters& motion,
+    const IdentityParameters& offsets,
+    const std::vector<std::vector<Marker>>& markerSequence,
+    const GltfFileFormat fileFormat,
+    const GltfOptions& options) {
+  return saveGltfCharacter(
+      filename, character, fps, motion, offsets, markerSequence, fileFormat, options);
+}
+
+void saveGltfCharacter(
+    const filesystem::path& filename,
+    const Character& character,
+    const float fps,
     std::span<const SkeletonState> skeletonStates,
     const std::vector<std::vector<Marker>>& markerSequence,
     const GltfFileFormat fileFormat,
@@ -1339,6 +1352,18 @@ void saveCharacter(
       character, fps, skeletonStates, markerSequence, kEmbedResources, options);
 
   GltfBuilder::save(model, filename, fileFormat, kEmbedResources);
+}
+
+void saveCharacter(
+    const filesystem::path& filename,
+    const Character& character,
+    const float fps,
+    std::span<const SkeletonState> skeletonStates,
+    const std::vector<std::vector<Marker>>& markerSequence,
+    const GltfFileFormat fileFormat,
+    const GltfOptions& options) {
+  return saveGltfCharacter(
+      filename, character, fps, skeletonStates, markerSequence, fileFormat, options);
 }
 
 std::vector<std::byte> saveCharacterToBytes(

--- a/momentum/io/gltf/gltf_io.h
+++ b/momentum/io/gltf/gltf_io.h
@@ -114,9 +114,25 @@ fx::gltf::Document makeCharacterDocument(
 /// numFrames)
 /// @param[in] offsets Offset values per joint capturing the skeleton bone lengths using translation
 /// and scale offset (7*numJoints, 1)
-void saveCharacter(
+[[deprecated("Use saveGltfCharacter() instead")]] void saveCharacter(
     const filesystem::path& filename,
-    const Character& Character,
+    const Character& character,
+    float fps = 120.0f,
+    const MotionParameters& motion = {},
+    const IdentityParameters& offsets = {},
+    const std::vector<std::vector<Marker>>& markerSequence = {},
+    GltfFileFormat fileFormat = GltfFileFormat::Extension,
+    const GltfOptions& options = GltfOptions());
+
+/// Saves character motion to a glb file.
+///
+/// @param[in] motion The model parameters representing the motion of the character (numModelParams,
+/// numFrames)
+/// @param[in] offsets Offset values per joint capturing the skeleton bone lengths using translation
+/// and scale offset (7*numJoints, 1)
+void saveGltfCharacter(
+    const filesystem::path& filename,
+    const Character& character,
     float fps = 120.0f,
     const MotionParameters& motion = {},
     const IdentityParameters& offsets = {},
@@ -128,9 +144,22 @@ void saveCharacter(
 ///
 /// @param[in] skeletonStates The skeleton states for each frame of the motion sequence (numFrames,
 /// numJoints, 8)
-void saveCharacter(
+[[deprecated("Use saveGltfCharacter() instead")]] void saveCharacter(
     const filesystem::path& filename,
-    const Character& Character,
+    const Character& character,
+    float fps,
+    std::span<const SkeletonState> skeletonStates,
+    const std::vector<std::vector<Marker>>& markerSequence = {},
+    GltfFileFormat fileFormat = GltfFileFormat::Extension,
+    const GltfOptions& options = GltfOptions());
+
+/// Saves character skeleton states to a glb file.
+///
+/// @param[in] skeletonStates The skeleton states for each frame of the motion sequence (numFrames,
+/// numJoints, 8)
+void saveGltfCharacter(
+    const filesystem::path& filename,
+    const Character& character,
     float fps,
     std::span<const SkeletonState> skeletonStates,
     const std::vector<std::vector<Marker>>& markerSequence = {},

--- a/momentum/io/marker/marker_io.cpp
+++ b/momentum/io/marker/marker_io.cpp
@@ -10,6 +10,7 @@
 #include "momentum/character/marker.h"
 #include "momentum/common/filesystem.h"
 #include "momentum/common/log.h"
+#include "momentum/io/fbx/fbx_io.h"
 #include "momentum/io/gltf/gltf_io.h"
 #include "momentum/io/marker/c3d_io.h"
 #include "momentum/io/marker/trc_io.h"
@@ -40,6 +41,8 @@ std::vector<MarkerSequence> loadMarkers(
       return {loadTrc(filename, up)};
     } else if (ext == ".glb") {
       return {loadMarkerSequence(filename)};
+    } else if (ext == ".fbx") {
+      return {loadFbxMarkerSequence(filename)};
     } else {
       MT_LOGE("{} Unknown marker file type {}", __func__, filename);
       return {};

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -158,6 +158,7 @@ mt_python_binding(
   LINK_LIBRARIES
     character
     character_test_helpers
+    io
     io_fbx
     io_gltf
     io_legacy_json

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -16,6 +16,7 @@
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>
 #include <momentum/character/skeleton.h>
+#include <momentum/character/skeleton_state.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
 #include <momentum/io/legacy_json/legacy_json_io.h>
@@ -783,6 +784,45 @@ support the proprietary momentum motion format for storing model parameters in G
           py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
           py::arg("coord_system_info") = std::optional<mm::FBXCoordSystemInfo>{},
           py::arg("fbx_namespace") = "")
+      .def_static(
+          "save",
+          &saveCharacterToFile,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Save a character to a file. The format is determined by the file extension (.fbx, .glb, .gltf).
+
+    This is a unified interface that automatically selects between FBX and GLTF based on the file extension.
+
+    :param path: Export filename with extension (.fbx, .glb, or .gltf).
+    :param character: A Character to be saved to the output file.
+    :param fps: [Optional] Frequency in frames per second
+    :param motion: [Optional] 2D pose matrix in [n_frames x n_parameters]
+    :param offsets: [Optional] Offset array in [(n_joints x n_parameters_per_joint)]
+    :param markers: [Optional] Additional marker (3d positions) data in [n_frames][n_markers]
+          )",
+          py::arg("path"),
+          py::arg("character"),
+          py::arg("fps") = 120.f,
+          py::arg("motion") = std::optional<const Eigen::MatrixXf>{},
+          py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{})
+      .def_static(
+          "save_with_skel_states",
+          &saveCharacterToFileWithSkelStates,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Save a character to a file using skeleton states. The format is determined by the file extension (.fbx, .glb, .gltf).
+
+    This function allows saving a character and its animation using skeleton state matrices instead of model parameters.
+
+    :param path: Export filename with extension (.fbx, .glb, or .gltf).
+    :param character: A Character to be saved to the output file.
+    :param fps: Frequency in frames per second
+    :param skel_states: Skeleton states [n_frames x n_joints x n_parameters_per_joint]
+    :param markers: [Optional] Additional marker (3d positions) data in [n_frames][n_markers]
+    )",
+          py::arg("path"),
+          py::arg("character"),
+          py::arg("fps"),
+          py::arg("skel_states"),
+          py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{})
       // Legacy JSON I/O methods
       .def_static(
           "load_legacy_json",

--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -13,6 +13,7 @@
 #include <momentum/character/skeleton_state.h>
 #include <momentum/character/types.h>
 #include <momentum/common/checks.h>
+#include <momentum/io/character_io.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
 #include <momentum/io/marker/marker_io.h>
@@ -117,7 +118,7 @@ void saveGLTFCharacterToFile(
         poses.rows(),
         poses.cols());
   }
-  momentum::saveCharacter(
+  momentum::saveGltfCharacter(
       path,
       character,
       fps,
@@ -147,7 +148,7 @@ void saveGLTFCharacterToFileFromSkelStates(
   std::vector<momentum::SkeletonState> skeletonStates =
       arrayToSkeletonStates(skel_states, character);
 
-  momentum::saveCharacter(
+  momentum::saveGltfCharacter(
       path,
       character,
       fps,
@@ -215,6 +216,34 @@ void saveFBXCharacterToFileWithJointParams(
         false, /*permissive*/
         fbxNamespace);
   }
+}
+
+void saveCharacterToFile(
+    const std::string& path,
+    const momentum::Character& character,
+    const float fps,
+    const std::optional<const Eigen::MatrixXf>& motion,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers) {
+  momentum::saveCharacter(
+      path,
+      character,
+      fps,
+      motion.has_value() ? motion.value().transpose() : Eigen::MatrixXf{},
+      markers.value_or(std::vector<std::vector<momentum::Marker>>{}));
+}
+
+void saveCharacterToFileWithSkelStates(
+    const std::string& path,
+    const momentum::Character& character,
+    const float fps,
+    std::span<const momentum::SkeletonState> skel_states,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers) {
+  momentum::saveCharacter(
+      path,
+      character,
+      skel_states,
+      markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
+      fps);
 }
 
 std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float> loadGLTFCharacterWithMotion(

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -72,6 +72,20 @@ void saveFBXCharacterToFileWithJointParams(
     const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace = "");
 
+void saveCharacterToFile(
+    const std::string& path,
+    const momentum::Character& character,
+    float fps,
+    const std::optional<const Eigen::MatrixXf>& motion,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers);
+
+void saveCharacterToFileWithSkelStates(
+    const std::string& path,
+    const momentum::Character& character,
+    float fps,
+    std::span<const momentum::SkeletonState> skel_states,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers);
+
 std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float> loadGLTFCharacterWithMotion(
     const std::string& gltfFilename);
 


### PR DESCRIPTION
Summary:
After D85530152 added marker sequence support to fbx, we have functionality parity between fbx and gltf. This diff created a unified `saveCharacterToFile()` function in `character_io` that automatically selects between FBX and GLTF export based on file extension.

Added .fbx support loadMarkers as the unified function for loading marker data from any supported format.

Differential Revision: D85517572


