### PR TITLE
Add marker sequence support to FBX io

### DIFF
--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <momentum/character/fwd.h>
+#include <momentum/character/marker.h>
 #include <momentum/common/filesystem.h>
 #include <momentum/math/types.h>
 
@@ -99,6 +100,7 @@ void saveFbx(
     bool saveMesh = false,
     const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
     bool permissive = false,
+    const std::vector<std::vector<Marker>>& markerSequence = {},
     std::string_view fbxNamespace = "");
 
 /// Save a character with animation using joint parameters directly.
@@ -109,6 +111,7 @@ void saveFbx(
 /// @param saveMesh Whether to include mesh geometry in the output
 /// @param coordSystemInfo Coordinate system configuration for the FBX file
 /// @param permissive Permissive mode allows saving mesh-only characters (without skin weights)
+/// @param markerSequence Optional marker sequence data to save with the character
 /// @param fbxNamespace Optional namespace to prepend to all node names (e.g., "ns" will become
 /// "ns:")
 void saveFbxWithJointParams(
@@ -119,6 +122,7 @@ void saveFbxWithJointParams(
     bool saveMesh = false,
     const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
     bool permissive = false,
+    const std::vector<std::vector<Marker>>& markerSequence = {},
     std::string_view fbxNamespace = "");
 
 /// Save a character model (skeleton and mesh) without animation.
@@ -134,5 +138,19 @@ void saveFbxModel(
     const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
     bool permissive = false,
     std::string_view fbxNamespace = "");
+
+/// Loads a MarkerSequence from an FBX file.
+///
+/// This function reads motion capture marker data from an FBX file and returns
+/// it as a MarkerSequence. The markers must be stored in the FBX scene hierarchy
+/// under a "Markers" root node, and each marker node must have the custom property
+/// "Momentum_Marker" to be recognized. The Markers root node must have the custom
+/// property "Momentum_Markers_Root" to be identified.
+///
+/// @param[in] filename Path to the FBX file containing marker data.
+/// @return A MarkerSequence object containing the marker animation data, including
+///         marker positions per frame and fps. Returns an empty sequence if no
+///         markers or animations are found.
+MarkerSequence loadFbxMarkerSequence(const filesystem::path& filename);
 
 } // namespace momentum

--- a/momentum/io/fbx/fbx_io_openfbx_only.cpp
+++ b/momentum/io/fbx/fbx_io_openfbx_only.cpp
@@ -54,6 +54,7 @@ void saveFbx(
     bool /* saveMesh */,
     const FBXCoordSystemInfo& /* coordSystemInfo */,
     bool /* permissive */,
+    const std::vector<std::vector<Marker>>& /* markerSequence */,
     std::string_view /* fbxNamespace */) {
   MT_THROW(
       "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
@@ -67,6 +68,7 @@ void saveFbxWithJointParams(
     bool /* saveMesh */,
     const FBXCoordSystemInfo& /* coordSystemInfo */,
     bool /* permissive */,
+    const std::vector<std::vector<Marker>>& /* markerSequence */,
     std::string_view /* fbxNamespace */) {
   MT_THROW(
       "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
@@ -80,6 +82,10 @@ void saveFbxModel(
     std::string_view /* fbxNamespace */) {
   MT_THROW(
       "FBX saving is not supported in OpenFBX-only mode. FBX loading is available via OpenFBX, but saving requires the full Autodesk FBX SDK.");
+}
+
+MarkerSequence loadFbxMarkerSequence(const filesystem::path& filename) {
+  return loadOpenFbxMarkerSequence(filename);
 }
 
 } // namespace momentum

--- a/momentum/io/fbx/openfbx_loader.h
+++ b/momentum/io/fbx/openfbx_loader.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <momentum/character/fwd.h>
+#include <momentum/character/marker.h>
 #include <momentum/common/filesystem.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/math/types.h>
@@ -15,6 +16,10 @@
 #include <span>
 
 namespace momentum {
+
+// Custom property names for identifying Momentum-specific FBX nodes
+constexpr const char* kMomentumMarkersRootProperty = "Momentum_Markers_Root";
+constexpr const char* kMomentumMarkerProperty = "Momentum_Marker";
 
 // Using keepLocators means the Nulls in the transform hierarchy will be turned into Locators.
 // This is different from historical momentum behavior so it's off by default.
@@ -45,5 +50,7 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMoti
     KeepLocators keepLocators = KeepLocators::No,
     bool permissive = false,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No);
+
+MarkerSequence loadOpenFbxMarkerSequence(const filesystem::path& filename);
 
 } // namespace momentum

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -85,9 +85,9 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
   // - save_gltf(path, character, fps, motion, offsets, markers, options)
   // - save_gltf_from_skel_states(path, character, fps, skel_states,
   // joint_params, markers, options)
-  // - save_fbx(path, character, fps, motion, offsets, coord_system_info, fbx_namespace)
+  // - save_fbx(path, character, fps, motion, offsets, coord_system_info, markers, fbx_namespace)
   // - save_fbx_with_joint_params(path, character, fps, joint_params, coord_system_info,
-  // fbx_namespace)
+  // markers, fbx_namespace)
   // =====================================================
   characterClass
       .def(
@@ -743,6 +743,7 @@ support the proprietary momentum motion format for storing model parameters in G
 :param motion: [Optional] 2D pose matrix in [n_frames x n_parameters]
 :param offsets: [Optional] Offset array in [(n_joints x n_parameters_per_joint)]
 :param coord_system_info: [Optional] FBX coordinate system info
+:param markers: Additional marker (3d positions) data in [n_frames][n_markers]
 :param fbx_namespace: [Optional] Namespace prefix for all node names (e.g., "ns" becomes "ns:")
       )",
           py::arg("path"),
@@ -750,6 +751,7 @@ support the proprietary momentum motion format for storing model parameters in G
           py::arg("fps") = 120.f,
           py::arg("motion") = std::optional<const Eigen::MatrixXf>{},
           py::arg("offsets") = std::optional<const Eigen::VectorXf>{},
+          py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
           py::arg("coord_system_info") = std::optional<mm::FBXCoordSystemInfo>{},
           py::arg("fbx_namespace") = "")
       .def_static(
@@ -763,12 +765,14 @@ support the proprietary momentum motion format for storing model parameters in G
 :param fps: Frequency in frames per second
 :param joint_params: [Optional] 2D pose matrix in [n_frames x n_parameters]
 :param coord_system_info: [Optional] FBX coordinate system info
+:param markers: Additional marker (3d positions) data in [n_frames][n_markers]
 :param fbx_namespace: [Optional] Namespace prefix for all node names (e.g., "ns" becomes "ns:")
       )",
           py::arg("path"),
           py::arg("character"),
           py::arg("fps") = 120.f,
           py::arg("joint_params") = std::optional<const Eigen::MatrixXf>{},
+          py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
           py::arg("coord_system_info") = std::optional<mm::FBXCoordSystemInfo>{},
           py::arg("fbx_namespace") = "")
       // Legacy JSON I/O methods

--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -163,6 +163,7 @@ void saveFBXCharacterToFile(
     const float fps,
     std::optional<const Eigen::MatrixXf> motion,
     std::optional<const Eigen::VectorXf> offsets,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
     std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
     std::string_view fbxNamespace) {
   if (motion.has_value() && offsets.has_value()) {
@@ -173,14 +174,15 @@ void saveFBXCharacterToFile(
         offsets.value(),
         fps,
         true, /*saveMesh*/
-        coordSystemInfo.has_value() ? coordSystemInfo.value() : momentum::FBXCoordSystemInfo(),
+        coordSystemInfo.value_or(momentum::FBXCoordSystemInfo()),
         false, /*permissive*/
+        markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
         fbxNamespace);
   } else {
     momentum::saveFbxModel(
         path,
         character,
-        coordSystemInfo.has_value() ? coordSystemInfo.value() : momentum::FBXCoordSystemInfo(),
+        coordSystemInfo.value_or(momentum::FBXCoordSystemInfo()),
         false, /*permissive*/
         fbxNamespace);
   }
@@ -191,6 +193,7 @@ void saveFBXCharacterToFileWithJointParams(
     const momentum::Character& character,
     const float fps,
     std::optional<const Eigen::MatrixXf> jointParams,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
     std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
     std::string_view fbxNamespace) {
   if (jointParams.has_value()) {
@@ -200,14 +203,15 @@ void saveFBXCharacterToFileWithJointParams(
         jointParams.value().transpose(),
         fps,
         true, /*saveMesh*/
-        coordSystemInfo.has_value() ? coordSystemInfo.value() : momentum::FBXCoordSystemInfo(),
+        coordSystemInfo.value_or(momentum::FBXCoordSystemInfo()),
         false, /*permissive*/
+        markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
         fbxNamespace);
   } else {
     momentum::saveFbxModel(
         path,
         character,
-        coordSystemInfo.has_value() ? coordSystemInfo.value() : momentum::FBXCoordSystemInfo(),
+        coordSystemInfo.value_or(momentum::FBXCoordSystemInfo()),
         false, /*permissive*/
         fbxNamespace);
   }

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -59,6 +59,7 @@ void saveFBXCharacterToFile(
     float fps,
     std::optional<const Eigen::MatrixXf> motion,
     std::optional<const Eigen::VectorXf> offsets,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
     std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
     std::string_view fbxNamespace = "");
 
@@ -67,6 +68,7 @@ void saveFBXCharacterToFileWithJointParams(
     const momentum::Character& character,
     float fps,
     std::optional<const Eigen::MatrixXf> jointParams,
+    const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
     std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
     std::string_view fbxNamespace = "");
 


### PR DESCRIPTION
Summary:
This change adds marker sequence support to FBX format, achieving full parity with GLTF implementation.

**Key Improvements:**
- Implemented keyframe support for marker data: markers are only created at explicitly keyed frames (not interpolated), matching GLTF behavior. A missing marker will not be keyed (its visibility could be keyed for visual effect but is not implemented).
- Animation length calculation: skeleton and marker animation curves could have different numbers of keys and durations.
- Added `loadFbxMarkerSequence()` function to load marker sequences from FBX files.
- Added comprehensive cross-format tests to verify FBX/GLTF parity and mixed animation length scenarios.

**Technical Details:**
- `createMarkerNodes()`: Creates FbxMarker nodes with animation under a "Markers" hierarchy.
- `parseMarkerSequence()`: Extracts markers only at keyframed timestamps (sparse support).
- Animation curve filtering: Separates skeleton curves from marker curves when calculating durations.
- Custom properties: Uses `Momentum_MarkersRoot` and `Momentum_Marker` to identify Momentum-specific markers.

**Test Coverage:**
- `MarkerSequence_SparseData`: Tests sparse patterns and occlusion filtering across FBX/GLTF
- `MarkerSequence_DifferentAnimationLengths`: Verifies skeleton (5 frames) and markers (10 frames) coexist with independent durations

Differential Revision: D85530152


