### PR TITLE
Also check for spine0

### DIFF
--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -550,7 +550,11 @@ std::vector<bool> listToBitset(const std::vector<size_t>& list, const size_t sz)
 
 std::vector<size_t> getUpperBodyJoints(const momentum::Skeleton& skeleton) {
   auto upperBodyRoot_idx = skeleton.getJointIdByName("b_spine0");
-  MT_THROW_IF(upperBodyRoot_idx == momentum::kInvalidIndex, "Missing 'b_spine0' joint.");
+  if (upperBodyRoot_idx == momentum::kInvalidIndex) { // Check for different skeleton definition
+    upperBodyRoot_idx = skeleton.getJointIdByName("c_spine0");
+  }
+  MT_THROW_IF(
+      upperBodyRoot_idx == momentum::kInvalidIndex, "Missing 'b_spine0' & 'c_spine0' joint.");
 
   std::vector<size_t> result;
 


### PR DESCRIPTION
Summary: Update `getUpperBodyJoints` to handle more skeleton definitions.

Reviewed By: cdtwigg

Differential Revision: D85957988


