### PR TITLE
Fix .model file parser to handle duplicate section names

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -395,6 +395,7 @@ io_skeleton_sources = [
 ]
 
 io_skeleton_test_sources = [
+    "test/io/io_model_parser_test.cpp",
     "test/io/io_parameter_limits_test.cpp",
 ]
 

--- a/momentum/io/skeleton/parameter_transform_io.cpp
+++ b/momentum/io/skeleton/parameter_transform_io.cpp
@@ -8,6 +8,7 @@
 #include "momentum/io/skeleton/parameter_transform_io.h"
 
 #include "momentum/character/skeleton.h"
+#include "momentum/common/log.h"
 #include "momentum/common/string.h"
 #include "momentum/io/common/stream_utils.h"
 #include "momentum/io/skeleton/parameter_limits_io.h"
@@ -51,7 +52,10 @@ std::unordered_map<std::string, std::string> loadMomentumModelCommon(std::istrea
     if (re2::RE2::FullMatch(line, reg, &newSectionName)) {
       // new section, store old section
       if (!sectionName.empty()) {
-        result[sectionName] = sectionContent;
+        if (result.find(sectionName) != result.end()) {
+          MT_LOGW("Repeated section [{}] found; make sure it's intentional.", sectionName);
+        }
+        result[sectionName] += sectionContent;
       }
 
       // start new section
@@ -64,7 +68,10 @@ std::unordered_map<std::string, std::string> loadMomentumModelCommon(std::istrea
 
   // store last section
   if (!sectionName.empty()) {
-    result[sectionName] = sectionContent;
+    if (result.find(sectionName) != result.end()) {
+      MT_LOGW("Repeated section [{}] found; make sure it's intentional.", sectionName);
+    }
+    result[sectionName] += sectionContent;
   }
 
   return result;
@@ -251,6 +258,7 @@ ParameterTransform parseParameterTransform(const std::string& data, const Skelet
     // ------------------------------------------------
     const auto pTokens = tokenize(line, "=");
     if (pTokens.size() != 2) {
+      MT_LOGW("Invalid line under [ParameterTransform] section; ignoring\n{}", line);
       continue;
     }
 
@@ -311,6 +319,7 @@ ParameterSets parseParameterSets(const std::string& data, const ParameterTransfo
 
     // Skip if not parameterset definitions
     if (line.find("parameterset") != 0) {
+      MT_LOGW("Invalid line under [ParameterSets] section; ignoring\n{}", line);
       continue;
     }
 
@@ -358,6 +367,7 @@ PoseConstraints parsePoseConstraints(const std::string& data, const ParameterTra
 
     // load parameterset definitions
     if (line.find("poseconstraints") != 0) {
+      MT_LOGW("Invalid line under [PoseConstraints] section; ignoring\n{}", line);
       continue;
     }
 

--- a/momentum/test/io/io_model_parser_test.cpp
+++ b/momentum/test/io/io_model_parser_test.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <momentum/io/skeleton/parameter_transform_io.h>
+
+using namespace momentum;
+
+TEST(IoModelParserTest, DuplicateSections_Concatenated) {
+  const std::string modelContent = R"(Momentum Model Definition V1.0
+
+[ParameterTransform]
+# Some parameter transforms
+root.tx = 1.0 * param1
+
+[Limits]
+# First set of limits
+limit param1 minmax [-1.0, 1.0] 1.0
+
+[PoseConstraints]
+# Some pose constraints
+poseconstraints tpose param1=0.0
+
+[Limits]
+# Second set of limits
+limit param2 minmax [-2.0, 2.0] 1.0
+)";
+
+  const auto sections = loadMomentumModelFromBuffer(
+      std::span<const std::byte>(
+          reinterpret_cast<const std::byte*>(modelContent.data()), modelContent.size()));
+
+  ASSERT_TRUE(sections.find("Limits") != sections.end());
+
+  const std::string& limitsContent = sections.at("Limits");
+
+  EXPECT_TRUE(limitsContent.find("limit param1 minmax") != std::string::npos)
+      << "First limits section should be present. Content:\n"
+      << limitsContent;
+  EXPECT_TRUE(limitsContent.find("limit param2 minmax") != std::string::npos)
+      << "Second limits section should be present. Content:\n"
+      << limitsContent;
+}
+
+TEST(IoModelParserTest, MultipleDuplicateSections_AllConcatenated) {
+  const std::string modelContent = R"(Momentum Model Definition V1.0
+
+[Limits]
+limit param1 minmax [-1.0, 1.0] 1.0
+
+[ParameterTransform]
+root.tx = 1.0 * param1
+
+[Limits]
+limit param2 minmax [-2.0, 2.0] 1.0
+
+[PoseConstraints]
+poseconstraints tpose param1=0.0
+
+[Limits]
+limit param3 minmax [-3.0, 3.0] 1.0
+)";
+
+  const auto sections = loadMomentumModelFromBuffer(
+      std::span<const std::byte>(
+          reinterpret_cast<const std::byte*>(modelContent.data()), modelContent.size()));
+
+  ASSERT_TRUE(sections.find("Limits") != sections.end());
+
+  const std::string& limitsContent = sections.at("Limits");
+
+  EXPECT_TRUE(limitsContent.find("limit param1 minmax") != std::string::npos)
+      << "First limits section should be present";
+  EXPECT_TRUE(limitsContent.find("limit param2 minmax") != std::string::npos)
+      << "Second limits section should be present";
+  EXPECT_TRUE(limitsContent.find("limit param3 minmax") != std::string::npos)
+      << "Third limits section should be present";
+}
+
+TEST(IoModelParserTest, SingleSection_WorksAsExpected) {
+  const std::string modelContent = R"(Momentum Model Definition V1.0
+
+[ParameterTransform]
+root.tx = 1.0 * param1
+
+[Limits]
+limit param1 minmax [-1.0, 1.0] 1.0
+limit param2 minmax [-2.0, 2.0] 1.0
+)";
+
+  const auto sections = loadMomentumModelFromBuffer(
+      std::span<const std::byte>(
+          reinterpret_cast<const std::byte*>(modelContent.data()), modelContent.size()));
+
+  ASSERT_TRUE(sections.find("Limits") != sections.end());
+
+  const std::string& limitsContent = sections.at("Limits");
+
+  EXPECT_TRUE(limitsContent.find("limit param1 minmax") != std::string::npos);
+  EXPECT_TRUE(limitsContent.find("limit param2 minmax") != std::string::npos);
+}


### PR DESCRIPTION
Summary:
Fixed a bug in the .model file parser where duplicate section names (e.g., multiple [Limits] sections) would cause the later sections to overwrite earlier ones, resulting in data loss.

The issue was in the `loadMomentumModelCommon` function in `parameter_transform_io.cpp`. When encountering a new section, it would store the previous section content in a map using the section name as the key. If multiple sections had the same name, only the last one would be retained.

**Changes:**
1. Modified `loadMomentumModelCommon` to check if a section name already exists in the result map
2. If it exists, concatenate the new content to the existing content instead of overwriting
3. This allows users to split limits (or any other section) across multiple locations in the file

**Example use case:**
Users can now organize their .model files like this:
```
[ParameterTransform]
...

[Limits]
# Limits for upper body
limit param1 minmax [-1.0, 1.0] 1.0

[PoseConstraints]
...

[Limits]
# Limits for lower body
limit param2 minmax [-2.0, 2.0] 1.0
```

Both sets of limits will now be processed correctly.

**Testing:**
- Added comprehensive unit tests in `io_model_parser_test.cpp` to verify:
  - Duplicate sections are concatenated correctly
  - Multiple duplicate sections (3+) all get concatenated
  - Single sections continue to work as before (backward compatibility)
- All existing tests pass
- Updated `build_variables.bzl` to include the new test file

Differential Revision: D86041361


