### PR TITLE
Update FBX IO function arguments to use const reference

### DIFF
--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -161,10 +161,10 @@ void saveFBXCharacterToFile(
     const std::string& path,
     const momentum::Character& character,
     const float fps,
-    std::optional<const Eigen::MatrixXf> motion,
-    std::optional<const Eigen::VectorXf> offsets,
+    const std::optional<const Eigen::MatrixXf>& motion,
+    const std::optional<const Eigen::VectorXf>& offsets,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
+    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace) {
   if (motion.has_value() && offsets.has_value()) {
     momentum::saveFbx(
@@ -192,9 +192,9 @@ void saveFBXCharacterToFileWithJointParams(
     const std::string& path,
     const momentum::Character& character,
     const float fps,
-    std::optional<const Eigen::MatrixXf> jointParams,
+    const std::optional<const Eigen::MatrixXf>& jointParams,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
+    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace) {
   if (jointParams.has_value()) {
     momentum::saveFbxWithJointParams(

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -57,19 +57,19 @@ void saveFBXCharacterToFile(
     const std::string& path,
     const momentum::Character& character,
     float fps,
-    std::optional<const Eigen::MatrixXf> motion,
-    std::optional<const Eigen::VectorXf> offsets,
+    const std::optional<const Eigen::MatrixXf>& motion,
+    const std::optional<const Eigen::VectorXf>& offsets,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
+    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace = "");
 
 void saveFBXCharacterToFileWithJointParams(
     const std::string& path,
     const momentum::Character& character,
     float fps,
-    std::optional<const Eigen::MatrixXf> jointParams,
+    const std::optional<const Eigen::MatrixXf>& jointParams,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    std::optional<const momentum::FBXCoordSystemInfo> coordSystemInfo,
+    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace = "");
 
 std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float> loadGLTFCharacterWithMotion(


### PR DESCRIPTION
Summary:
Updated function signatures in pymomentum/geometry/momentum_io to use const references for optional parameters, achieving consistency with GLTF functions and avoiding unnecessary copies.

Changed parameters in saveFBXCharacterToFile and saveFBXCharacterToFileWithJointParams:
- std::optional<const Eigen::MatrixXf> → const std::optional<const Eigen::MatrixXf>&
- std::optional<const Eigen::VectorXf> → const std::optional<const Eigen::VectorXf>&
- std::optional<const momentum::FBXCoordSystemInfo> → const std::optional<const momentum::FBXCoordSystemInfo>&

This change:
1. Makes FBX functions consistent with GLTF function signatures
2. Avoids unnecessary copies of large Eigen matrix types
3. Follows C++ best practices for passing optional parameters

Differential Revision: D86041831


