### PR TITLE
Fix for missing meshState update.

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver_function.cpp
+++ b/momentum/character_sequence_solver/sequence_solver_function.cpp
@@ -192,6 +192,9 @@ double SequenceSolverFunctionT<T>::getError(const Eigen::VectorX<T>& parameters)
   // update the state according to the transformed parameters
   dispenso::parallel_for(0, nFrames, [&](size_t f) {
     states_[f].set(parameterTransform_.apply(frameParameters_[f]), character_.skeleton);
+    if (needsMesh_) {
+      meshStates_[f].update(frameParameters_[f], states_[f], character_);
+    }
   });
 
   // sum up error for all per-frame error functions


### PR DESCRIPTION
Summary: We weren't updating the meshState in the sequence_solver_function getError() function.  This turned out to be a bit hard to catch because it only shows up as an issue if you are running the sequence solver with line search turned on.

Reviewed By: cstollmeta

Differential Revision: D86116253


