### PR TITLE
Fix conda-metadata-app URL formatting in conda publishing docs

### DIFF
--- a/momentum/website/docs_python/03_developer_guide/04_conda_publishing.md
+++ b/momentum/website/docs_python/03_developer_guide/04_conda_publishing.md
@@ -109,11 +109,7 @@ For internal changes to the upstream momentum repository that affect conda build
 
 ### Finding Package Details
 
-Inspect installed files and metadata for any package version:
-```bash
-# Use conda-metadata-app
-https://conda-metadata-app.streamlit.app/?q=conda-forge/linux-64/pymomentum-0.1.77-cuda129_py313_h861d01a_0.conda
-```
+Inspect installed files and metadata for any package version using [conda-metadata-app](https://conda-metadata-app.streamlit.app/?q=conda-forge/linux-64/pymomentum-0.1.77-cuda129_py313_h861d01a_0.conda).
 
 Or locally:
 ```bash


### PR DESCRIPTION
Summary: The conda-metadata-app URL was incorrectly placed inside a bash code block, causing it to render as code instead of a clickable link. Converted it to a proper markdown link.

Reviewed By: cstollmeta

Differential Revision: D86120796


