### PR TITLE
Fix Sphinx documentation warnings and enable warnings-as-errors in CI

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -163,9 +163,9 @@ test_py = { cmd = "pytest pymomentum/test/*.py", env = { MOMENTUM_MODELS_PATH = 
 test_py_verbose = { cmd = "pytest pymomentum/test/*.py -v", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ], description = "Run Python tests with verbose output" }
-doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
+doc_py = { cmd = "sphinx-build -a -E -W -b html pymomentum/doc build/python_api_doc", depends-on = [
     "build_py",
-], description = "Build Python API documentation" }
+], description = "Build Python API documentation with warnings as errors" }
 open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = [
     "doc_py",
 ], description = "Open Python documentation in browser" }
@@ -308,7 +308,7 @@ build_py = { cmd = "pip install . -v --no-build-isolation", env = { FBXSDK_PATH 
 test_py = { cmd = "pytest pymomentum/test/*.py", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ] }
-doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
+doc_py = { cmd = "sphinx-build -a -E -W -b html pymomentum/doc build/python_api_doc", depends-on = [
     "build_py",
 ] }
 open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = [
@@ -334,7 +334,7 @@ build_py = { cmd = "pip install . -v", env = { CMAKE_ARGS = """
 test_py = { cmd = "pytest pymomentum/test/*.py -k 'not (TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params))'", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py", "install",
 ] }
-doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
+doc_py = { cmd = "sphinx-build -a -E -W -b html pymomentum/doc build/python_api_doc", depends-on = [
     "build_py",
 ] }
 open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = [
@@ -360,7 +360,7 @@ build_py = { cmd = "pip install . -v", env = { CMAKE_ARGS = """
 test_py = { cmd = "pytest pymomentum/test/*.py -k 'not (TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params))'", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py", "install",
 ] }
-doc_py = { cmd = "sphinx-build -a -E -b html pymomentum/doc build/python_api_doc", depends-on = [
+doc_py = { cmd = "sphinx-build -a -E -W -b html pymomentum/doc build/python_api_doc", depends-on = [
     "build_py",
 ] }
 open_doc_py = { cmd = "open build/python_api_doc/index.html", depends-on = [

--- a/pymomentum/backend/skel_state_backend.py
+++ b/pymomentum/backend/skel_state_backend.py
@@ -310,6 +310,16 @@ class GlobalSkelStateFromLocalSkelStateJIT(th.autograd.Function):
         local_skel_state: th.Tensor,
         prefix_mul_indices: List[th.Tensor],
     ) -> Tuple[th.Tensor, List[th.Tensor]]:
+        """
+        Compute forward pass for differentiable forward kinematics.
+
+        Args:
+            local_skel_state: Local joint transformations, shape (batch_size, num_joints, 8)
+            prefix_mul_indices: List of [child_index, parent_index] tensor pairs
+
+        Returns:
+            Tuple of (global_skel_state, intermediate_results)
+        """
         return global_skel_state_from_local_skel_state_no_grad(
             local_skel_state,
             prefix_mul_indices,
@@ -319,6 +329,14 @@ class GlobalSkelStateFromLocalSkelStateJIT(th.autograd.Function):
     # pyre-ignore[14]
     # pyre-ignore[2]
     def setup_context(ctx, inputs, outputs) -> None:
+        """
+        Save context for backward pass.
+
+        Args:
+            ctx: Context object for saving tensors and data
+            inputs: Tuple of (local_skel_state, prefix_mul_indices)
+            outputs: Tuple of (global_skel_state, intermediate_results)
+        """
         (
             _,
             prefix_mul_indices,
@@ -594,8 +612,7 @@ def unpose_from_momentum_global_joint_state(
         skin_indices_flattened: (N, ) LBS skinning nbr joint indices
         skin_weights_flattened: (N, ) LBS skinning nbr joint weights
         vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
-        with_high_precision: if True, use high precision solver (LDLT),
-            but requires a cuda device sync
+        with_high_precision: if True, use high precision solver (LDLT), but requires a cuda device sync
     """
     t, r, s = trs.from_skeleton_state(global_joint_state)
     t0, r0, _ = trs.from_skeleton_state(binded_joint_state_inv)

--- a/pymomentum/backend/trs_backend.py
+++ b/pymomentum/backend/trs_backend.py
@@ -384,6 +384,18 @@ class ForwardKinematicsFromLocalTransformationJIT(th.autograd.Function):
     ) -> Tuple[
         th.Tensor, th.Tensor, th.Tensor, List[Tuple[th.Tensor, th.Tensor, th.Tensor]]
     ]:
+        """
+        Compute forward pass for differentiable forward kinematics using TRS representation.
+
+        Args:
+            local_state_t: Local joint translations, shape (batch_size, num_joints, 3)
+            local_state_r: Local joint rotations, shape (batch_size, num_joints, 3, 3)
+            local_state_s: Local joint scales, shape (batch_size, num_joints, 1)
+            prefix_mul_indices: List of [child_index, parent_index] tensor pairs
+
+        Returns:
+            Tuple of (global_state_t, global_state_r, global_state_s, intermediate_results)
+        """
         return global_trs_state_from_local_trs_state_no_grad(
             local_state_t,
             local_state_r,
@@ -395,6 +407,14 @@ class ForwardKinematicsFromLocalTransformationJIT(th.autograd.Function):
     # pyre-ignore[14]
     # pyre-ignore[2]
     def setup_context(ctx, inputs, outputs) -> None:
+        """
+        Save context for backward pass.
+
+        Args:
+            ctx: Context object for saving tensors and data
+            inputs: Tuple of (local_state_t, local_state_r, local_state_s, prefix_mul_indices)
+            outputs: Tuple of (joint_state_t, joint_state_r, joint_state_s, intermediate_results)
+        """
         (
             _,
             _,
@@ -468,8 +488,7 @@ def global_trs_state_from_local_trs_state(
         local_state_t: Local joint translations, shape (batch_size, num_joints, 3).
         local_state_r: Local joint rotations, shape (batch_size, num_joints, 3, 3).
         local_state_s: Local joint scales, shape (batch_size, num_joints, 1).
-        prefix_mul_indices: List of [child_index, parent_index] tensor pairs defining
-                           the kinematic hierarchy traversal order.
+        prefix_mul_indices: List of [child_index, parent_index] tensor pairs defining the kinematic hierarchy traversal order.
 
     Returns:
         global_state_t: Global joint translations, shape (batch_size, num_joints, 3).
@@ -731,8 +750,7 @@ def unpose_from_global_joint_state(
         skin_indices_flattened: (N, ) LBS skinning nbr joint indices
         skin_weights_flattened: (N, ) LBS skinning nbr joint weights
         vert_indices_flattened: (N, ) LBS skinning nbr corresponding vertex indices
-        with_high_precision: if True, use high precision solver (LDLT),
-            but requires a cuda device sync
+        with_high_precision: if True, use high precision solver (LDLT), but requires a cuda device sync
     """
     dtype = verts.dtype
     device = verts.device

--- a/pymomentum/renderer/renderer_pybind.cpp
+++ b/pymomentum/renderer/renderer_pybind.cpp
@@ -813,7 +813,7 @@ PYBIND11_MODULE(renderer, m) {
 :param normals: n x 3 numpy.ndarray of vertex normals.
 :param triangles: n x 3 numpy.ndarray of triangles.
 :param texture_coordinates: n x numpy.ndarray or texture coordinates.
-:param texture_triangles: n x numpy.ndarray or texture triangles (see :mesh:`rasterize_mesh` for more details).).
+:param texture_triangles: n x numpy.ndarray or texture triangles (see :func:`rasterize_mesh` for more details).).
 :param levels: Maximum levels to subdivide (default = 1)
 :param max_edge_length: Stop subdividing when the longest edge is shorter than this length.
 :return: A tuple [vertices, normals, triangles, texture_coordinates, texture_triangles].

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -426,8 +426,7 @@ class LinearBlendSkinning(torch.nn.Module):
             global_state_t: Global joint translations, shape (batch_size, num_joints, 3)
             global_state_r: Global joint rotations as 3x3 matrices, shape (batch_size, num_joints, 3, 3)
             global_state_s: Global joint scales, shape (batch_size, num_joints, 1)
-            rest_vertex_positions: Rest vertex positions, shape (batch_size, num_vertices, 3)
-                or (num_vertices, 3) which will be expanded to batch size
+            rest_vertex_positions: Rest vertex positions, shape (batch_size, num_vertices, 3) or (num_vertices, 3) which will be expanded to batch size
 
         Returns:
             skinned_vertices: Skinned vertex positions, shape (batch_size, num_vertices, 3)


### PR DESCRIPTION
## Summary

This change resolves all Sphinx documentation warnings in the PyMomentum API documentation and configures the build system to treat warnings as errors to prevent similar issues in the future.

**Fixed Documentation Issues:**

1. **Indentation errors in docstrings (4 fixes):**
   - Fixed continuation lines in docstrings that were causing "Unexpected indentation" errors
   - Files affected: skel_state_backend.py, trs_backend.py, character.py
   - Solution: Put continuation lines on the same line to avoid RST parsing issues

2. **Undefined label warnings (6 fixes):**
   - Added explicit docstrings to forward() and setup_context() methods in PyTorch autograd function classes
   - Files affected: GlobalSkelStateFromLocalSkelStateJIT in skel_state_backend.py and ForwardKinematicsFromLocalTransformationJIT in trs_backend.py
   - These methods were inheriting PyTorch's docstrings that contained references to PyTorch documentation labels not available in our build

**CI Improvements:**

- Added -W flag to all doc_py tasks in pixi.toml across all platforms (Linux, macOS, Windows)
- This flag treats Sphinx warnings as errors, ensuring documentation quality is maintained
- Prevents merging code with documentation issues

The documentation build now completes with 0 warnings and 0 errors.

Test Plan:
1. Verified all Sphinx warnings are resolved by running `pixi run doc_py`
2. Documentation build completes successfully with no warnings or errors
3. Tested that the -W flag causes the build to fail if warnings are introduced
4. Validated changes with `validate_changes` tool - no errors found

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

GitHub CI
