### PR TITLE
Allow leading comments in model files.

### DIFF
--- a/momentum/io/skeleton/parameter_transform_io.cpp
+++ b/momentum/io/skeleton/parameter_transform_io.cpp
@@ -51,12 +51,20 @@ std::unordered_map<std::string, SectionContent> loadMomentumModelCommon(std::ist
 
   std::string line;
   size_t lineNumber = 0;
-  GetLineCrossPlatform(input, line);
-  ++lineNumber;
-  if (trim(line) != "Momentum Model Definition V1.0") {
-    MT_LOGW(
+  while (GetLineCrossPlatform(input, line)) {
+    ++lineNumber;
+    line = trim(line.substr(0, line.find_first_of('#')));
+    if (line.empty()) {
+      // Skip leading comments
+      continue;
+    }
+
+    if (line == "Momentum Model Definition V1.0") {
+      break;
+    }
+
+    MT_THROW(
         "Invalid model definition file; expected 'Momentum Model Definition V1.0', got {}", line);
-    return result;
   }
 
   while (GetLineCrossPlatform(input, line)) {


### PR DESCRIPTION
Summary:
We are running into an issue where someone copied a model file and added some leading comments about the source.  Let's allow this.

Also make a file being invalid an exception rather than a warning, because we're not going to be able to do anything useful with this file anyway, and we're throwing exceptions in other cases where the file is invalid (e.g. if an expression parses incorrectly).

Also added checks that the parameter transform loaded correctly (with a reasonable number of parameters) to some of our tests which weren't actually validating anything, it's possible these could silently fail before.

Reviewed By: yutingye

Differential Revision: D86681869


