### PR TITLE
Add eigen quaternion caster

### DIFF
--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -11,6 +11,7 @@ backend_sources = [
 ]
 
 python_utility_public_headers = [
+    "python_utility/eigen_quaternion.h",
     "python_utility/python_utility.h",
 ]
 

--- a/pymomentum/python_utility/eigen_quaternion.h
+++ b/pymomentum/python_utility/eigen_quaternion.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+#include <Eigen/Geometry>
+
+/// Custom type caster for Eigen::Quaternion that leverages pybind11's existing
+/// Eigen::Vector4 conversion machinery. This enables automatic conversion between
+/// Eigen::Quaternion and numpy arrays without manual .coeffs() calls.
+///
+/// Usage: Include this header after <pybind11/eigen.h> in your binding files.
+///
+/// Example:
+///   #include "pymomentum/python_utility/eigen_quaternion.h"
+///
+///   Eigen::Quaternionf getRotation() { return Eigen::Quaternionf::Identity(); }
+///   void setRotation(const Eigen::Quaternionf& q) { /* use q */ }
+///
+/// Python usage:
+///   q = module.get_rotation()  # Returns np.array([x, y, z, w])
+///   module.set_rotation(np.array([0, 0, 0, 1], dtype=np.float32))
+
+namespace pybind11::detail {
+
+/// Type caster for Eigen::Quaternion that uses the existing Vector4 conversion
+template <typename Scalar>
+struct type_caster<Eigen::Quaternion<Scalar>> {
+ public:
+  using Type = Eigen::Quaternion<Scalar>;
+  using Vector4 = Eigen::Vector<Scalar, 4>;
+
+  /// Standard pybind11 type caster interface
+  PYBIND11_TYPE_CASTER(Type, const_name("numpy.ndarray[4]"));
+
+  /// Python -> C++ conversion: delegate to Vector4 caster
+  bool load(handle src, bool convert) {
+    // Use the existing pybind11 Vector4 type caster
+    type_caster<Vector4> vec_caster;
+    if (!vec_caster.load(src, convert)) {
+      return false;
+    }
+
+    // Extract the Vector4 and construct quaternion
+    // Vector4 is [x, y, z, w], Quaternion constructor is (w, x, y, z)
+    const Vector4& coeffs = vec_caster;
+    value = Type(coeffs(3), coeffs(0), coeffs(1), coeffs(2));
+
+    return true;
+  }
+
+  /// C++ -> Python conversion: delegate to Vector4 caster
+  static handle cast(const Type& src, return_value_policy policy, handle parent) {
+    // Get coefficients as Vector4 [x, y, z, w]
+    Vector4 coeffs = src.coeffs();
+
+    // Use the existing pybind11 Vector4 type caster
+    return type_caster<Vector4>::cast(coeffs, policy, parent);
+  }
+
+  /// Support for const pointer return
+  static handle cast(const Type* src, return_value_policy policy, handle parent) {
+    return cast(*src, policy, parent);
+  }
+};
+
+} // namespace pybind11::detail

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -26,6 +26,7 @@
 #include <momentum/character_solver/state_error_function.h>
 #include <momentum/character_solver/vertex_projection_error_function.h>
 #include <momentum/character_solver/vertex_vertex_distance_error_function.h>
+#include <pymomentum/python_utility/eigen_quaternion.h>
 #include <pymomentum/solver2/solver2_utility.h>
 
 #include <fmt/format.h>
@@ -2207,14 +2208,8 @@ avoid divide-by-zero. )");
           })
       .def_readonly("parent", &mm::OrientationData::parent, "The parent joint index")
       .def_readonly("weight", &mm::OrientationData::weight, "The weight of the constraint")
-      .def_property_readonly(
-          "offset",
-          [](const mm::OrientationData& self) { return self.offset.coeffs(); },
-          "The offset in parent space (as [x, y, z, w] coefficients)")
-      .def_property_readonly(
-          "target",
-          [](const mm::OrientationData& self) { return self.target.coeffs(); },
-          "The target orientation (as [x, y, z, w] coefficients)");
+      .def_readonly("offset", &mm::OrientationData::offset, "The offset in parent space")
+      .def_readonly("target", &mm::OrientationData::target, "The target orientation");
 
   py::class_<
       mm::OrientationErrorFunctionT<float>,


### PR DESCRIPTION
Summary: Add a type caster to avoid needing to manually convert Eigen::Quaternion to Eigen::Vector4 (by calling .coeffs())

Differential Revision: D86793695


