### PR TITLE
Release GIL in findClosestPoints.

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -1057,6 +1057,7 @@ blend shapes, pose shapes, and other mesh-related data.
   m.def(
       "find_closest_points",
       &findClosestPoints,
+      pybind11::call_guard<py::gil_scoped_release>(),
       R"(For each point in the points_source tensor, find the closest point in the points_target tensor.  This version of find_closest points supports both 2- and 3-dimensional point sets.
 
 :param points_source: [nBatch x nPoints x dim] tensor of source points (dim must be 2 or 3).
@@ -1073,6 +1074,7 @@ blend shapes, pose shapes, and other mesh-related data.
   m.def(
       "find_closest_points",
       &findClosestPointsWithNormals,
+      pybind11::call_guard<py::gil_scoped_release>(),
       R"(For each point in the points_source tensor, find the closest point in the points_target tensor whose normal is compatible (n_source . n_target > max_normal_dot).
 Using the normal is a good way to avoid certain kinds of bad matches, such as matching the front of the body against depth values from the back of the body.
 
@@ -1096,6 +1098,7 @@ Using the normal is a good way to avoid certain kinds of bad matches, such as ma
   m.def(
       "find_closest_points_on_mesh",
       &findClosestPointsOnMesh,
+      pybind11::call_guard<py::gil_scoped_release>(),
       R"(For each point in the points_source tensor, find the closest point in the target mesh.
 
   :param points_source: [nBatch x nPoints x 3] tensor of source points.


### PR DESCRIPTION
Summary: We want to be able to call this in multithreaded contexts, this should be safe because at::Tensor ops do not require the GIL.

Reviewed By: jeongseok-meta

Differential Revision: D86220648


