### PR TITLE
Rename GltfFileFormat enum values for clarity

### DIFF
--- a/momentum/io/file_save_options.h
+++ b/momentum/io/file_save_options.h
@@ -17,9 +17,9 @@ namespace momentum {
 
 /// File format in which the character is saved
 enum class GltfFileFormat {
-  Extension = 0, // The file extension is used for deduction (e.g. ".gltf" --> ASCII)
-  GltfBinary = 1, // Binary format (generally .glb)
-  GltfAscii = 2, // ASCII format (generally .gltf)
+  Auto = 0, // The file extension is used for deduction (e.g. ".gltf" --> ASCII)
+  Binary = 1, // Binary format (generally .glb)
+  Ascii = 2, // ASCII format (generally .gltf)
 };
 
 /// Options for GLTF file export
@@ -105,9 +105,9 @@ struct FileSaveOptions {
   /// Only used for GLTF output
   bool extensions = true;
 
-  /// GLTF file format selection (default: Extension)
+  /// GLTF file format selection (default: Auto)
   /// Only used for GLTF output
-  GltfFileFormat gltfFileFormat = GltfFileFormat::Extension;
+  GltfFileFormat gltfFileFormat = GltfFileFormat::Auto;
 };
 
 } // namespace momentum

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -771,9 +771,8 @@ void saveDocument(
     const GltfFileFormat fileFormat) {
   // save model
   auto deducedFileFormat = fileFormat;
-  if (fileFormat == GltfFileFormat::Extension &&
-      filename.extension() == filesystem::path(".gltf")) {
-    deducedFileFormat = GltfFileFormat::GltfAscii;
+  if (fileFormat == GltfFileFormat::Auto && filename.extension() == filesystem::path(".gltf")) {
+    deducedFileFormat = GltfFileFormat::Ascii;
   }
 
   try {
@@ -787,7 +786,7 @@ void saveDocument(
     }
 
     switch (deducedFileFormat) {
-      case GltfFileFormat::GltfAscii: {
+      case GltfFileFormat::Ascii: {
         // we can't embed binary if we writing to ascii format.
         // so we need to provide exported with a uri name relative to json root.
         filesystem::path new_filename = filename;
@@ -801,9 +800,9 @@ void saveDocument(
         fx::gltf::Save(model, filename.string(), false);
         break;
       }
-      case GltfFileFormat::Extension:
+      case GltfFileFormat::Auto:
         [[fallthrough]];
-      case GltfFileFormat::GltfBinary:
+      case GltfFileFormat::Binary:
         fx::gltf::Save(model, filename.string(), true);
         break;
     }

--- a/momentum/io/gltf/gltf_builder.h
+++ b/momentum/io/gltf/gltf_builder.h
@@ -89,18 +89,18 @@ class GltfBuilder final {
       MarkerMesh markerMesh = MarkerMesh::None,
       const std::string& animName = "default");
 
-  // Save the file with the provided filename. If the fileFormat is 'GltfFileFormat::Extension',
+  // Save the file with the provided filename. If the fileFormat is 'GltfFileFormat::Auto',
   // will deduct the file format by filename.
   // When embedResources is true, it will set all the existing buffers to embed the data.
   void save(
       const filesystem::path& filename,
-      GltfFileFormat fileFormat = GltfFileFormat::Extension,
+      GltfFileFormat fileFormat = GltfFileFormat::Auto,
       bool embedResources = false);
 
   static void save(
       fx::gltf::Document& document,
       const filesystem::path& filename,
-      GltfFileFormat fileFormat = GltfFileFormat::Extension,
+      GltfFileFormat fileFormat = GltfFileFormat::Auto,
       bool embedResources = false);
 
   /// Set all existing buffers to embed resources.

--- a/momentum/io/gltf/gltf_io.h
+++ b/momentum/io/gltf/gltf_io.h
@@ -113,7 +113,7 @@ void saveGltfCharacter(
     const MotionParameters& motion = {},
     const IdentityParameters& offsets = {},
     std::span<const std::vector<Marker>> markerSequence = {},
-    GltfFileFormat fileFormat = GltfFileFormat::Extension,
+    GltfFileFormat fileFormat = GltfFileFormat::Auto,
     const GltfOptions& options = GltfOptions());
 
 /// Saves character skeleton states to a glb file.
@@ -126,7 +126,7 @@ void saveGltfCharacter(
     float fps,
     std::span<const SkeletonState> skeletonStates,
     std::span<const std::vector<Marker>> markerSequence = {},
-    GltfFileFormat fileFormat = GltfFileFormat::Extension,
+    GltfFileFormat fileFormat = GltfFileFormat::Auto,
     const GltfOptions& options = GltfOptions());
 
 std::vector<std::byte> saveCharacterToBytes(

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -590,18 +590,18 @@ The resulting tensors are as follows:
       .def_readwrite(
           "gltf_file_format",
           &mm::FileSaveOptions::gltfFileFormat,
-          "GLTF file format selection (default: Extension), only used for GLTF output")
+          "GLTF file format selection (default: Auto), only used for GLTF output")
       .def("__repr__", [](const mm::FileSaveOptions& opts) {
         std::string gltfFormatStr;
         switch (opts.gltfFileFormat) {
-          case mm::GltfFileFormat::Extension:
-            gltfFormatStr = "Extension";
+          case mm::GltfFileFormat::Auto:
+            gltfFormatStr = "Auto";
             break;
-          case mm::GltfFileFormat::GltfBinary:
-            gltfFormatStr = "GltfBinary";
+          case mm::GltfFileFormat::Binary:
+            gltfFormatStr = "Binary";
             break;
-          case mm::GltfFileFormat::GltfAscii:
-            gltfFormatStr = "GltfAscii";
+          case mm::GltfFileFormat::Ascii:
+            gltfFormatStr = "Ascii";
             break;
           default:
             gltfFormatStr = "Unknown";

--- a/pymomentum/geometry/gltf_builder_pybind.cpp
+++ b/pymomentum/geometry/gltf_builder_pybind.cpp
@@ -39,9 +39,9 @@ void registerGltfBuilderBindings(pybind11::module& m) {
   // momentum::GltfFileFormat enum
   // =====================================================
   py::enum_<mm::GltfFileFormat>(m, "GltfFileFormat")
-      .value("Extension", mm::GltfFileFormat::Extension)
-      .value("GltfBinary", mm::GltfFileFormat::GltfBinary)
-      .value("GltfAscii", mm::GltfFileFormat::GltfAscii);
+      .value("Auto", mm::GltfFileFormat::Auto)
+      .value("Binary", mm::GltfFileFormat::Binary)
+      .value("Ascii", mm::GltfFileFormat::Ascii);
 
   // =====================================================
   // momentum::GltfBuilder
@@ -250,8 +250,7 @@ analysis or visualization. Optional marker mesh visualization can be added as un
           [](mm::GltfBuilder& builder,
              const std::string& filename,
              const std::optional<mm::GltfFileFormat>& fileFormat) {
-            mm::GltfFileFormat actualFileFormat =
-                fileFormat.value_or(mm::GltfFileFormat::Extension);
+            mm::GltfFileFormat actualFileFormat = fileFormat.value_or(mm::GltfFileFormat::Auto);
             builder.save(filename, actualFileFormat);
           },
           R"(Save the GLTF scene to a file.
@@ -277,8 +276,7 @@ can be explicitly specified or automatically deduced from the file extension.
                 doc,
                 output,
                 {},
-                fileFormat.value_or(mm::GltfFileFormat::GltfBinary) !=
-                    mm::GltfFileFormat::GltfAscii);
+                fileFormat.value_or(mm::GltfFileFormat::Binary) != mm::GltfFileFormat::Ascii);
 
             // Convert to Python bytes
             const std::string& str = output.str();
@@ -290,9 +288,9 @@ This method serializes the constructed GLTF scene to a byte array without
 writing to disk. This is useful for programmatic processing, network transmission,
 or when you need the GLTF data as bytes for other purposes.
 
-:return: The GLTF scene as bytes. For GltfBinary format, this will be GLB binary data.
-         For GltfAscii format, this will be JSON text encoded as UTF-8 bytes.)",
-          py::arg("file_format") = mm::GltfFileFormat::GltfBinary);
+:return: The GLTF scene as bytes. For Binary format, this will be GLB binary data.
+         For Ascii format, this will be JSON text encoded as UTF-8 bytes.)",
+          py::arg("file_format") = mm::GltfFileFormat::Binary);
 }
 
 } // namespace pymomentum

--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -125,7 +125,7 @@ void saveGLTFCharacterToFile(
       transpose(motion.value_or(momentum::MotionParameters{})),
       offsets.value_or(momentum::IdentityParameters{}),
       markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
-      momentum::GltfFileFormat::Extension,
+      momentum::GltfFileFormat::Auto,
       options);
 }
 
@@ -154,7 +154,7 @@ void saveGLTFCharacterToFileFromSkelStates(
       fps,
       skeletonStates,
       markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
-      momentum::GltfFileFormat::Extension,
+      momentum::GltfFileFormat::Auto,
       options);
 }
 


### PR DESCRIPTION
Summary:
Renamed GltfFileFormat enum values to be more intuitive and clear:
- Extension → Auto (automatic format detection based on file extension)
- GltfBinary → Binary (GLB binary format)
- GltfAscii → Ascii (GLTF text/JSON format)

This change improves code readability by using more descriptive names that better convey the purpose of each enum value. The name "Auto" is clearer than "Extension" for indicating automatic format detection, while "Binary" and "Ascii" are more straightforward than the prefixed versions.

Updated all references across:
- C++ core library (file_save_options.h, gltf_builder.cpp/h, gltf_io.h)
- Test files (io_test.cpp)
- Python bindings (geometry_pybind.cpp, gltf_builder_pybind.cpp, momentum_io.cpp)
- Python type stubs (geometry.pyi)

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=T243663050-2b23bf42-52e6-401a-a241-718733142fa0)

Differential Revision: D86882641


