### PR TITLE
Rename FBX types to follow PascalCase naming convention

### DIFF
--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -47,42 +47,42 @@ namespace momentum {
 
 namespace {
 
-[[nodiscard]] ::fbxsdk::FbxAxisSystem::EUpVector toFbx(const FBXUpVector upVector) {
+[[nodiscard]] ::fbxsdk::FbxAxisSystem::EUpVector toFbx(const FbxUpVector upVector) {
   switch (upVector) {
-    case FBXUpVector::XAxis:
+    case FbxUpVector::XAxis:
       return ::fbxsdk::FbxAxisSystem::EUpVector::eXAxis;
-    case FBXUpVector::YAxis:
+    case FbxUpVector::YAxis:
       return ::fbxsdk::FbxAxisSystem::EUpVector::eYAxis;
-    case FBXUpVector::ZAxis:
+    case FbxUpVector::ZAxis:
       return ::fbxsdk::FbxAxisSystem::EUpVector::eZAxis;
     default:
       MT_THROW("Unsupported up vector");
   }
 }
 
-[[nodiscard]] ::fbxsdk::FbxAxisSystem::EFrontVector toFbx(const FBXFrontVector frontVector) {
+[[nodiscard]] ::fbxsdk::FbxAxisSystem::EFrontVector toFbx(const FbxFrontVector frontVector) {
   switch (frontVector) {
-    case FBXFrontVector::ParityEven:
+    case FbxFrontVector::ParityEven:
       return ::fbxsdk::FbxAxisSystem::EFrontVector::eParityEven;
-    case FBXFrontVector::ParityOdd:
+    case FbxFrontVector::ParityOdd:
       return ::fbxsdk::FbxAxisSystem::EFrontVector::eParityOdd;
     default:
       MT_THROW("Unsupported front vector");
   }
 }
 
-[[nodiscard]] ::fbxsdk::FbxAxisSystem::ECoordSystem toFbx(const FBXCoordSystem coordSystem) {
+[[nodiscard]] ::fbxsdk::FbxAxisSystem::ECoordSystem toFbx(const FbxCoordSystem coordSystem) {
   switch (coordSystem) {
-    case FBXCoordSystem::RightHanded:
+    case FbxCoordSystem::RightHanded:
       return ::fbxsdk::FbxAxisSystem::ECoordSystem::eRightHanded;
-    case FBXCoordSystem::LeftHanded:
+    case FbxCoordSystem::LeftHanded:
       return ::fbxsdk::FbxAxisSystem::ECoordSystem::eLeftHanded;
     default:
       MT_THROW("Unsupported coordinate system");
   }
 }
 
-[[nodiscard]] ::fbxsdk::FbxAxisSystem toFbx(const FBXCoordSystemInfo& coordSystemInfo) {
+[[nodiscard]] ::fbxsdk::FbxAxisSystem toFbx(const FbxCoordSystemInfo& coordSystemInfo) {
   return {
       toFbx(coordSystemInfo.upVector),
       toFbx(coordSystemInfo.frontVector),
@@ -465,7 +465,7 @@ void saveFbxCommon(
     const double framerate,
     const bool saveMesh,
     const bool skipActiveJointParamCheck,
-    const FBXCoordSystemInfo& coordSystemInfo,
+    const FbxCoordSystemInfo& coordSystemInfo,
     bool permissive,
     std::span<const std::vector<Marker>> markerSequence,
     std::string_view fbxNamespace) {
@@ -799,7 +799,7 @@ void saveFbx(
     const VectorXf& identity,
     const double framerate,
     const bool saveMesh,
-    const FBXCoordSystemInfo& coordSystemInfo,
+    const FbxCoordSystemInfo& coordSystemInfo,
     const bool permissive,
     std::span<const std::vector<Marker>> markerSequence,
     std::string_view fbxNamespace) {
@@ -853,7 +853,7 @@ void saveFbxWithJointParams(
     const MatrixXf& jointParams,
     const double framerate,
     const bool saveMesh,
-    const FBXCoordSystemInfo& coordSystemInfo,
+    const FbxCoordSystemInfo& coordSystemInfo,
     const bool permissive,
     std::span<const std::vector<Marker>> markerSequence,
     std::string_view fbxNamespace) {
@@ -879,7 +879,7 @@ void saveFbxWithSkeletonStates(
     std::span<const SkeletonState> skeletonStates,
     const double framerate,
     const bool saveMesh,
-    const FBXCoordSystemInfo& coordSystemInfo,
+    const FbxCoordSystemInfo& coordSystemInfo,
     const bool permissive,
     std::span<const std::vector<Marker>> markerSequence,
     std::string_view fbxNamespace) {
@@ -909,7 +909,7 @@ void saveFbxWithSkeletonStates(
 void saveFbxModel(
     const filesystem::path& filename,
     const Character& character,
-    const FBXCoordSystemInfo& coordSystemInfo,
+    const FbxCoordSystemInfo& coordSystemInfo,
     bool permissive,
     std::string_view fbxNamespace) {
   saveFbx(
@@ -934,7 +934,7 @@ void saveFbx(
     const VectorXf& /* identity */,
     const double /* framerate */,
     const bool /* saveMesh */,
-    const FBXCoordSystemInfo& /* coordSystemInfo */,
+    const FbxCoordSystemInfo& /* coordSystemInfo */,
     const bool /* permissive */,
     std::span<const std::vector<Marker>> /* markerSequence */,
     std::string_view /* fbxNamespace */) {
@@ -948,7 +948,7 @@ void saveFbxWithJointParams(
     const MatrixXf& /* jointParams */,
     const double /* framerate */,
     const bool /* saveMesh */,
-    const FBXCoordSystemInfo& /* coordSystemInfo */,
+    const FbxCoordSystemInfo& /* coordSystemInfo */,
     const bool /* permissive */,
     std::span<const std::vector<Marker>> /* markerSequence */,
     std::string_view /* fbxNamespace */) {
@@ -962,7 +962,7 @@ void saveFbxWithSkeletonStates(
     std::span<const SkeletonState> /* skeletonStates */,
     const double /* framerate */,
     const bool /* saveMesh */,
-    const FBXCoordSystemInfo& /* coordSystemInfo */,
+    const FbxCoordSystemInfo& /* coordSystemInfo */,
     const bool /* permissive */,
     std::span<const std::vector<Marker>> /* markerSequence */,
     std::string_view /* fbxNamespace */) {
@@ -973,7 +973,7 @@ void saveFbxWithSkeletonStates(
 void saveFbxModel(
     const filesystem::path& /* filename */,
     const Character& /* character */,
-    const FBXCoordSystemInfo& /* coordSystemInfo */,
+    const FbxCoordSystemInfo& /* coordSystemInfo */,
     bool /* permissive */,
     std::string_view /* fbxNamespace */) {
   MT_THROW(

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -79,7 +79,7 @@ void saveFbx(
     const VectorXf& identity = VectorXf(),
     double framerate = 120.0,
     bool saveMesh = false,
-    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    const FbxCoordSystemInfo& coordSystemInfo = FbxCoordSystemInfo(),
     bool permissive = false,
     std::span<const std::vector<Marker>> markerSequence = {},
     std::string_view fbxNamespace = "");
@@ -101,7 +101,7 @@ void saveFbxWithJointParams(
     const MatrixXf& jointParams = MatrixXf(),
     double framerate = 120.0,
     bool saveMesh = false,
-    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    const FbxCoordSystemInfo& coordSystemInfo = FbxCoordSystemInfo(),
     bool permissive = false,
     std::span<const std::vector<Marker>> markerSequence = {},
     std::string_view fbxNamespace = "");
@@ -123,7 +123,7 @@ void saveFbxWithSkeletonStates(
     std::span<const SkeletonState> skeletonStates,
     double framerate = 120.0,
     bool saveMesh = false,
-    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    const FbxCoordSystemInfo& coordSystemInfo = FbxCoordSystemInfo(),
     bool permissive = false,
     std::span<const std::vector<Marker>> markerSequence = {},
     std::string_view fbxNamespace = "");
@@ -138,7 +138,7 @@ void saveFbxWithSkeletonStates(
 void saveFbxModel(
     const filesystem::path& filename,
     const Character& character,
-    const FBXCoordSystemInfo& coordSystemInfo = FBXCoordSystemInfo(),
+    const FbxCoordSystemInfo& coordSystemInfo = FbxCoordSystemInfo(),
     bool permissive = false,
     std::string_view fbxNamespace = "");
 

--- a/momentum/io/file_save_options.h
+++ b/momentum/io/file_save_options.h
@@ -42,25 +42,25 @@ struct GltfOptions {
 
 /// Specifies which canonical axis represents up in the system (typically Y or Z).
 /// Maps to fbxsdk::FbxAxisSystem::EUpVector
-enum class FBXUpVector { XAxis = 1, YAxis = 2, ZAxis = 3 };
+enum class FbxUpVector { XAxis = 1, YAxis = 2, ZAxis = 3 };
 
 /// Vector with origin at the screen pointing toward the camera.
 /// This is a subset of enum EUpVector because axis cannot be repeated.
 /// We use the system of "parity" to define this vector because its value (X,Y or
 /// Z axis) really depends on the up-vector.
 /// Maps to fbxsdk::FbxAxisSystem::EFrontVector
-enum class FBXFrontVector { ParityEven = 1, ParityOdd = 2 };
+enum class FbxFrontVector { ParityEven = 1, ParityOdd = 2 };
 
 /// Specifies the third vector of the system.
 /// Maps to fbxsdk::FbxAxisSystem::ECoordSystem
-enum class FBXCoordSystem { RightHanded, LeftHanded };
+enum class FbxCoordSystem { RightHanded, LeftHanded };
 
 /// A struct containing the up, front vectors and coordinate system for FBX export.
-struct FBXCoordSystemInfo {
+struct FbxCoordSystemInfo {
   /// Default to the same orientations as FbxAxisSystem::eMayaYUp
-  FBXUpVector upVector = FBXUpVector::YAxis;
-  FBXFrontVector frontVector = FBXFrontVector::ParityOdd;
-  FBXCoordSystem coordSystem = FBXCoordSystem::RightHanded;
+  FbxUpVector upVector = FbxUpVector::YAxis;
+  FbxFrontVector frontVector = FbxFrontVector::ParityOdd;
+  FbxCoordSystem coordSystem = FbxCoordSystem::RightHanded;
 };
 
 // ============================================================================
@@ -93,7 +93,7 @@ struct FileSaveOptions {
   // ---- FBX-Specific Options ----
 
   /// FBX coordinate system configuration (default: Maya Y-up)
-  FBXCoordSystemInfo coordSystemInfo = {};
+  FbxCoordSystemInfo coordSystemInfo = {};
 
   /// Optional namespace prefix for FBX node names (e.g., "ns" becomes "ns:")
   /// Only used for FBX output (default: empty = no namespace)

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -761,7 +761,7 @@ support the proprietary momentum motion format for storing model parameters in G
           py::arg("motion") = std::optional<const Eigen::MatrixXf>{},
           py::arg("offsets") = std::optional<const Eigen::VectorXf>{},
           py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
-          py::arg("coord_system_info") = std::optional<mm::FBXCoordSystemInfo>{},
+          py::arg("coord_system_info") = std::optional<mm::FbxCoordSystemInfo>{},
           py::arg("fbx_namespace") = "")
       .def_static(
           "save_fbx_with_joint_params",
@@ -782,7 +782,7 @@ support the proprietary momentum motion format for storing model parameters in G
           py::arg("fps") = 120.f,
           py::arg("joint_params") = std::optional<const Eigen::MatrixXf>{},
           py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
-          py::arg("coord_system_info") = std::optional<mm::FBXCoordSystemInfo>{},
+          py::arg("coord_system_info") = std::optional<mm::FbxCoordSystemInfo>{},
           py::arg("fbx_namespace") = "")
       .def_static(
           "save",

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -80,23 +80,23 @@ PYBIND11_MODULE(geometry, m) {
 
   m.attr("PARAMETERS_PER_JOINT") = mm::kParametersPerJoint;
 
-  py::enum_<mm::FBXUpVector>(m, "FBXUpVector")
-      .value("XAxis", mm::FBXUpVector::XAxis)
-      .value("YAxis", mm::FBXUpVector::YAxis)
-      .value("ZAxis", mm::FBXUpVector::ZAxis);
+  py::enum_<mm::FbxUpVector>(m, "FBXUpVector")
+      .value("XAxis", mm::FbxUpVector::XAxis)
+      .value("YAxis", mm::FbxUpVector::YAxis)
+      .value("ZAxis", mm::FbxUpVector::ZAxis);
 
   py::enum_<mm::UpVector>(m, "UpVector")
       .value("X", mm::UpVector::X)
       .value("Y", mm::UpVector::Y)
       .value("Z", mm::UpVector::Z);
 
-  py::enum_<mm::FBXFrontVector>(m, "FBXFrontVector")
-      .value("ParityEven", mm::FBXFrontVector::ParityEven)
-      .value("ParityOdd", mm::FBXFrontVector::ParityOdd);
+  py::enum_<mm::FbxFrontVector>(m, "FBXFrontVector")
+      .value("ParityEven", mm::FbxFrontVector::ParityEven)
+      .value("ParityOdd", mm::FbxFrontVector::ParityOdd);
 
-  py::enum_<mm::FBXCoordSystem>(m, "FBXCoordSystem")
-      .value("RightHanded", mm::FBXCoordSystem::RightHanded)
-      .value("LeftHanded", mm::FBXCoordSystem::LeftHanded);
+  py::enum_<mm::FbxCoordSystem>(m, "FBXCoordSystem")
+      .value("RightHanded", mm::FbxCoordSystem::RightHanded)
+      .value("LeftHanded", mm::FbxCoordSystem::LeftHanded);
 
   // We need to forward-declare classes so that if we refer to them they get
   // typed correctly; otherwise we end up with "momentum::Locator" in the
@@ -167,7 +167,7 @@ PYBIND11_MODULE(geometry, m) {
       "MarkerSequence",
       "A sequence of motion capture marker data over time. Contains marker positions "
       "and occlusion status for each frame, along with frame rate information.");
-  auto fbxCoordSystemInfoClass = py::class_<mm::FBXCoordSystemInfo>(
+  auto fbxCoordSystemInfoClass = py::class_<mm::FbxCoordSystemInfo>(
       m,
       "FBXCoordSystemInfo",
       "FBX coordinate system information containing up vector, front vector, and handedness. "
@@ -470,7 +470,7 @@ The resulting tensors are as follows:
       });
 
   // =====================================================
-  // momentum::FBXCoordSystemInfo
+  // momentum::FbxCoordSystemInfo
   // - upVector
   // - frontVector
   // - coordSystem
@@ -479,36 +479,36 @@ The resulting tensors are as follows:
 
   fbxCoordSystemInfoClass
       .def(
-          py::init([](const momentum::FBXUpVector upVector,
-                      const momentum::FBXFrontVector frontVector,
-                      const momentum::FBXCoordSystem coordSystem) {
-            return momentum::FBXCoordSystemInfo{upVector, frontVector, coordSystem};
+          py::init([](const momentum::FbxUpVector upVector,
+                      const momentum::FbxFrontVector frontVector,
+                      const momentum::FbxCoordSystem coordSystem) {
+            return momentum::FbxCoordSystemInfo{upVector, frontVector, coordSystem};
           }),
           py::arg("upVector"),
           py::arg("frontVector"),
           py::arg("coordSystem"))
       .def_property_readonly(
           "upVector",
-          [](const mm::FBXCoordSystemInfo& coordSystemInfo) { return coordSystemInfo.upVector; },
+          [](const mm::FbxCoordSystemInfo& coordSystemInfo) { return coordSystemInfo.upVector; },
           "Returns the up vector.")
       .def_property_readonly(
           "frontVector",
-          [](const mm::FBXCoordSystemInfo& coordSystemInfo) { return coordSystemInfo.frontVector; },
+          [](const mm::FbxCoordSystemInfo& coordSystemInfo) { return coordSystemInfo.frontVector; },
           "Returns the front vector.")
       .def_property_readonly(
           "coordSystem",
-          [](const mm::FBXCoordSystemInfo& coordSystemInfo) { return coordSystemInfo.coordSystem; },
+          [](const mm::FbxCoordSystemInfo& coordSystemInfo) { return coordSystemInfo.coordSystem; },
           "Returns the coordinate system.")
-      .def("__repr__", [](const mm::FBXCoordSystemInfo& info) {
+      .def("__repr__", [](const mm::FbxCoordSystemInfo& info) {
         std::string upVectorStr;
         switch (info.upVector) {
-          case mm::FBXUpVector::XAxis:
+          case mm::FbxUpVector::XAxis:
             upVectorStr = "XAxis";
             break;
-          case mm::FBXUpVector::YAxis:
+          case mm::FbxUpVector::YAxis:
             upVectorStr = "YAxis";
             break;
-          case mm::FBXUpVector::ZAxis:
+          case mm::FbxUpVector::ZAxis:
             upVectorStr = "ZAxis";
             break;
           default:
@@ -518,10 +518,10 @@ The resulting tensors are as follows:
 
         std::string frontVectorStr;
         switch (info.frontVector) {
-          case mm::FBXFrontVector::ParityEven:
+          case mm::FbxFrontVector::ParityEven:
             frontVectorStr = "ParityEven";
             break;
-          case mm::FBXFrontVector::ParityOdd:
+          case mm::FbxFrontVector::ParityOdd:
             frontVectorStr = "ParityOdd";
             break;
           default:
@@ -531,10 +531,10 @@ The resulting tensors are as follows:
 
         std::string coordSystemStr;
         switch (info.coordSystem) {
-          case mm::FBXCoordSystem::RightHanded:
+          case mm::FbxCoordSystem::RightHanded:
             coordSystemStr = "RightHanded";
             break;
-          case mm::FBXCoordSystem::LeftHanded:
+          case mm::FbxCoordSystem::LeftHanded:
             coordSystemStr = "LeftHanded";
             break;
           default:
@@ -611,13 +611,13 @@ The resulting tensors are as follows:
         // Format coord_system_info
         std::string upVectorStr;
         switch (opts.coordSystemInfo.upVector) {
-          case mm::FBXUpVector::XAxis:
+          case mm::FbxUpVector::XAxis:
             upVectorStr = "XAxis";
             break;
-          case mm::FBXUpVector::YAxis:
+          case mm::FbxUpVector::YAxis:
             upVectorStr = "YAxis";
             break;
-          case mm::FBXUpVector::ZAxis:
+          case mm::FbxUpVector::ZAxis:
             upVectorStr = "ZAxis";
             break;
           default:
@@ -627,10 +627,10 @@ The resulting tensors are as follows:
 
         std::string frontVectorStr;
         switch (opts.coordSystemInfo.frontVector) {
-          case mm::FBXFrontVector::ParityEven:
+          case mm::FbxFrontVector::ParityEven:
             frontVectorStr = "ParityEven";
             break;
-          case mm::FBXFrontVector::ParityOdd:
+          case mm::FbxFrontVector::ParityOdd:
             frontVectorStr = "ParityOdd";
             break;
           default:
@@ -640,10 +640,10 @@ The resulting tensors are as follows:
 
         std::string coordSystemStr;
         switch (opts.coordSystemInfo.coordSystem) {
-          case mm::FBXCoordSystem::RightHanded:
+          case mm::FbxCoordSystem::RightHanded:
             coordSystemStr = "RightHanded";
             break;
-          case mm::FBXCoordSystem::LeftHanded:
+          case mm::FbxCoordSystem::LeftHanded:
             coordSystemStr = "LeftHanded";
             break;
           default:

--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -165,7 +165,7 @@ void saveFBXCharacterToFile(
     const std::optional<const Eigen::MatrixXf>& motion,
     const std::optional<const Eigen::VectorXf>& offsets,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
+    const std::optional<const momentum::FbxCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace) {
   // Always use saveFbx to support markers even without motion
   momentum::saveFbx(
@@ -175,7 +175,7 @@ void saveFBXCharacterToFile(
       offsets.has_value() ? offsets.value() : Eigen::VectorXf(),
       fps,
       true, /*saveMesh*/
-      coordSystemInfo.value_or(momentum::FBXCoordSystemInfo()),
+      coordSystemInfo.value_or(momentum::FbxCoordSystemInfo()),
       false, /*permissive*/
       markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
       fbxNamespace);
@@ -187,7 +187,7 @@ void saveFBXCharacterToFileWithJointParams(
     const float fps,
     const std::optional<const Eigen::MatrixXf>& jointParams,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
+    const std::optional<const momentum::FbxCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace) {
   // Always use saveFbxWithJointParams to support markers even without motion
   momentum::saveFbxWithJointParams(
@@ -196,7 +196,7 @@ void saveFBXCharacterToFileWithJointParams(
       jointParams.has_value() ? jointParams.value().transpose() : Eigen::MatrixXf(),
       fps,
       true, /*saveMesh*/
-      coordSystemInfo.value_or(momentum::FBXCoordSystemInfo()),
+      coordSystemInfo.value_or(momentum::FbxCoordSystemInfo()),
       false, /*permissive*/
       markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
       fbxNamespace);
@@ -208,7 +208,7 @@ void saveFBXCharacterToFileWithSkelStates(
     float fps,
     const pybind11::array_t<float>& skelStates,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
+    const std::optional<const momentum::FbxCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace) {
   momentum::saveFbxWithSkeletonStates(
       path,
@@ -216,7 +216,7 @@ void saveFBXCharacterToFileWithSkelStates(
       arrayToSkeletonStates(skelStates, character),
       fps,
       true, /*saveMesh*/
-      coordSystemInfo.value_or(momentum::FBXCoordSystemInfo()),
+      coordSystemInfo.value_or(momentum::FbxCoordSystemInfo()),
       false, /*permissive*/
       markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
       fbxNamespace);

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -18,7 +18,7 @@
 
 // Forward declarations
 namespace momentum {
-struct FBXCoordSystemInfo;
+struct FbxCoordSystemInfo;
 } // namespace momentum
 
 namespace pymomentum {
@@ -60,7 +60,7 @@ void saveFBXCharacterToFile(
     const std::optional<const Eigen::MatrixXf>& motion,
     const std::optional<const Eigen::VectorXf>& offsets,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
+    const std::optional<const momentum::FbxCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace = "");
 
 void saveFBXCharacterToFileWithJointParams(
@@ -69,7 +69,7 @@ void saveFBXCharacterToFileWithJointParams(
     float fps,
     const std::optional<const Eigen::MatrixXf>& jointParams,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
+    const std::optional<const momentum::FbxCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace = "");
 
 void saveFBXCharacterToFileWithSkelStates(
@@ -78,7 +78,7 @@ void saveFBXCharacterToFileWithSkelStates(
     float fps,
     const pybind11::array_t<float>& skelStates,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const std::optional<const momentum::FBXCoordSystemInfo>& coordSystemInfo,
+    const std::optional<const momentum::FbxCoordSystemInfo>& coordSystemInfo,
     std::string_view fbxNamespace = "");
 
 void saveCharacterToFile(


### PR DESCRIPTION
Summary:
This diff renames FBX-related types to follow the PascalCase naming convention consistently used throughout the Momentum codebase:

- `FBXUpVector` → `FbxUpVector`
- `FBXFrontVector` → `FbxFrontVector`
- `FBXCoordSystem` → `FbxCoordSystem`
- `FBXCoordSystemInfo` → `FbxCoordSystemInfo`

The changes maintain backward compatibility in Python bindings by keeping the exposed Python class name as "FBXCoordSystemInfo" while updating the underlying C++ type names.

Files modified:
- C++ type definitions: `arvr/libraries/momentum/io/file_save_options.h`
- C++ implementations: `arvr/libraries/momentum/io/fbx/fbx_io.h`, `arvr/libraries/momentum/io/fbx/fbx_io.cpp`
- Python bindings: `arvr/libraries/pymomentum/geometry/geometry_pybind.cpp`, `arvr/libraries/pymomentum/geometry/momentum_io.h`, `arvr/libraries/pymomentum/geometry/momentum_io.cpp`

This change aligns with the C++ style guide which specifies PascalCase for class/struct names, treating abbreviations like "Fbx" as regular words rather than all-caps acronyms.

Differential Revision: D86882465


