### PR TITLE
Rename FBX to Fbx for Python types

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -80,7 +80,7 @@ PYBIND11_MODULE(geometry, m) {
 
   m.attr("PARAMETERS_PER_JOINT") = mm::kParametersPerJoint;
 
-  py::enum_<mm::FbxUpVector>(m, "FBXUpVector")
+  py::enum_<mm::FbxUpVector>(m, "FbxUpVector")
       .value("XAxis", mm::FbxUpVector::XAxis)
       .value("YAxis", mm::FbxUpVector::YAxis)
       .value("ZAxis", mm::FbxUpVector::ZAxis);
@@ -90,11 +90,11 @@ PYBIND11_MODULE(geometry, m) {
       .value("Y", mm::UpVector::Y)
       .value("Z", mm::UpVector::Z);
 
-  py::enum_<mm::FbxFrontVector>(m, "FBXFrontVector")
+  py::enum_<mm::FbxFrontVector>(m, "FbxFrontVector")
       .value("ParityEven", mm::FbxFrontVector::ParityEven)
       .value("ParityOdd", mm::FbxFrontVector::ParityOdd);
 
-  py::enum_<mm::FbxCoordSystem>(m, "FBXCoordSystem")
+  py::enum_<mm::FbxCoordSystem>(m, "FbxCoordSystem")
       .value("RightHanded", mm::FbxCoordSystem::RightHanded)
       .value("LeftHanded", mm::FbxCoordSystem::LeftHanded);
 
@@ -169,7 +169,7 @@ PYBIND11_MODULE(geometry, m) {
       "and occlusion status for each frame, along with frame rate information.");
   auto fbxCoordSystemInfoClass = py::class_<mm::FbxCoordSystemInfo>(
       m,
-      "FBXCoordSystemInfo",
+      "FbxCoordSystemInfo",
       "FBX coordinate system information containing up vector, front vector, and handedness. "
       "Used when importing/exporting FBX files to ensure proper coordinate system conversion.");
   auto parameterLimitClass = py::class_<mm::ParameterLimit>(
@@ -543,7 +543,7 @@ The resulting tensors are as follows:
         }
 
         return fmt::format(
-            "FBXCoordSystemInfo(upVector={}, frontVector={}, coordSystem={})",
+            "FbxCoordSystemInfo(upVector={}, frontVector={}, coordSystem={})",
             upVectorStr,
             frontVectorStr,
             coordSystemStr);
@@ -652,7 +652,7 @@ The resulting tensors are as follows:
         }
 
         std::string coordSystemInfoStr = fmt::format(
-            "FBXCoordSystemInfo(upVector={}, frontVector={}, coordSystem={})",
+            "FbxCoordSystemInfo(upVector={}, frontVector={}, coordSystem={})",
             upVectorStr,
             frontVectorStr,
             coordSystemStr);

--- a/pymomentum/test/test_fbx.py
+++ b/pymomentum/test/test_fbx.py
@@ -149,10 +149,10 @@ class TestFBX(unittest.TestCase):
                 motion=self.model_params.numpy(),
                 offsets=offsets,
                 fps=60,
-                coord_system_info=pym_geometry.FBXCoordSystemInfo(
-                    pym_geometry.FBXUpVector.YAxis,
-                    pym_geometry.FBXFrontVector.ParityEven,
-                    pym_geometry.FBXCoordSystem.LeftHanded,
+                coord_system_info=pym_geometry.FbxCoordSystemInfo(
+                    pym_geometry.FbxUpVector.YAxis,
+                    pym_geometry.FbxFrontVector.ParityEven,
+                    pym_geometry.FbxCoordSystem.LeftHanded,
                 ),
             )
             self._verify_fbx(temp_file.name)
@@ -178,10 +178,10 @@ class TestFBX(unittest.TestCase):
                 character=self.character,
                 joint_params=self.joint_params.numpy(),
                 fps=60,
-                coord_system_info=pym_geometry.FBXCoordSystemInfo(
-                    pym_geometry.FBXUpVector.YAxis,
-                    pym_geometry.FBXFrontVector.ParityEven,
-                    pym_geometry.FBXCoordSystem.RightHanded,
+                coord_system_info=pym_geometry.FbxCoordSystemInfo(
+                    pym_geometry.FbxUpVector.YAxis,
+                    pym_geometry.FbxFrontVector.ParityEven,
+                    pym_geometry.FbxCoordSystem.RightHanded,
                 ),
             )
             self._verify_fbx(temp_file.name)


### PR DESCRIPTION
Summary:
D86882465 updated momentum c++ code; this diff updates the names exposed in python.

Changes affected the following Python-exposed classes and enums:
- FBXUpVector → FbxUpVector
- FBXFrontVector → FbxFrontVector
- FBXCoordSystem → FbxCoordSystem
- FBXCoordSystemInfo → FbxCoordSystemInfo

The enum values themselves (XAxis, YAxis, ZAxis, ParityEven, ParityOdd, RightHanded, LeftHanded) remain unchanged.

Reviewed By: jeongseok-meta

Differential Revision: D86930433


