### PR TITLE
Add addParameterSet function.

### DIFF
--- a/pymomentum/geometry/parameter_transform_pybind.cpp
+++ b/pymomentum/geometry/parameter_transform_pybind.cpp
@@ -192,6 +192,15 @@ Rotations are in Euler angles.)",
 This is convenient for turning off certain body features; for example the 'fingers' parameters
 can be used to enable/disable finger motion in the character model.  )")
       .def(
+          "add_parameter_set",
+          &addParameterSet,
+          R"(Adds a parameter set.
+
+:param parameter_set_name: The name of the parameter set.
+:param parameter_set: The tensor of parameter set values.)",
+          py::arg("parameter_set_name"),
+          py::arg("parameter_set"))
+      .def(
           "parameters_for_joints",
           &getParametersForJoints,
           R"(Gets a boolean torch.Tensor indicating which parameters affect the passed-in joints.

--- a/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
+++ b/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
@@ -297,6 +297,14 @@ std::unordered_map<std::string, at::Tensor> getParameterSets(
   return result;
 }
 
+void addParameterSet(
+    momentum::ParameterTransform& parameterTransform,
+    const std::string& paramSetName,
+    const at::Tensor& paramSet) {
+  const auto set = tensorToParameterSet(parameterTransform, paramSet);
+  parameterTransform.parameterSets.insert({paramSetName, set});
+}
+
 at::Tensor getParametersForJoints(
     const momentum::ParameterTransform& parameterTransform,
     const std::vector<size_t>& jointIndices) {

--- a/pymomentum/tensor_momentum/tensor_parameter_transform.h
+++ b/pymomentum/tensor_momentum/tensor_parameter_transform.h
@@ -37,6 +37,11 @@ at::Tensor getBlendShapeParameters(const momentum::ParameterTransform& parameter
 
 at::Tensor getPoseParameters(const momentum::ParameterTransform& parameterTransform);
 
+void addParameterSet(
+    momentum::ParameterTransform& parameterTransform,
+    const std::string& paramSetName,
+    const at::Tensor& paramSet);
+
 at::Tensor getParametersForJoints(
     const momentum::ParameterTransform& parameterTransform,
     const std::vector<size_t>& jointIndices);


### PR DESCRIPTION
Summary: Adding an `addParameterSet` function since `parameter_sets` are exposed as read-only property.

Reviewed By: jeongseok-meta

Differential Revision: D87006053


