### PR TITLE
FBX blendshape loading and saving

### DIFF
--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -674,10 +674,13 @@ void parseSkinnedModel(
         const auto shape = channel->getShape(s);
         int numVertices = shape->getVertexCount();
         const auto shapeV = shape->getVertices();
+        int numIndices = shape->getIndexCount();
+        const auto indexV = shape->getIndices();
+        MT_CHECK(numIndices == numVertices);
         for (int v = 0; v < numVertices; ++v) {
-          shapes(vertexOffset * 3 + v * 3 + 0, currentShapes + shapeIndex) = shapeV[v].x;
-          shapes(vertexOffset * 3 + v * 3 + 1, currentShapes + shapeIndex) = shapeV[v].y;
-          shapes(vertexOffset * 3 + v * 3 + 2, currentShapes + shapeIndex) = shapeV[v].z;
+          shapes(vertexOffset * 3 + indexV[v] * 3 + 0, currentShapes + shapeIndex) = shapeV[v].x;
+          shapes(vertexOffset * 3 + indexV[v] * 3 + 1, currentShapes + shapeIndex) = shapeV[v].y;
+          shapes(vertexOffset * 3 + indexV[v] * 3 + 2, currentShapes + shapeIndex) = shapeV[v].z;
         }
         shapeIndex++;
       }

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -111,7 +111,7 @@ void compareBlendShapes(const BlendShape_const_p& refShapes, const BlendShape_co
     EXPECT_THAT(
         refShapes->getBaseShape(),
         testing::Pointwise(FloatNearPointwise(0.0001), shapes->getBaseShape()));
-    EXPECT_TRUE(refShapes->getShapeVectors().isApprox(shapes->getShapeVectors()));
+    EXPECT_TRUE(refShapes->getShapeVectors().isApprox(shapes->getShapeVectors(), 1e-3));
   }
 }
 
@@ -183,7 +183,11 @@ void compareCollisionGeometry(
   }
 }
 
-void compareChars(const Character& refChar, const Character& character, const bool withMesh) {
+void compareChars(
+    const Character& refChar,
+    const Character& character,
+    const bool withMesh,
+    const bool withParameterTransform) {
   ASSERT_EQ(refChar.name, character.name);
   const auto& refJoints = refChar.skeleton.joints;
   const auto& joints = character.skeleton.joints;
@@ -202,8 +206,11 @@ void compareChars(const Character& refChar, const Character& character, const bo
         << "  - preRotation: " << joints[i].preRotation.coeffs().transpose() << "\n"
         << "  - translationOffset: " << joints[i].translationOffset.transpose() << "\n";
   }
-  ASSERT_TRUE(refChar.parameterTransform.isApprox(character.parameterTransform));
-  EXPECT_THAT(refChar.parameterLimits, testing::Pointwise(ElementsEq(), character.parameterLimits));
+  if (withParameterTransform) {
+    ASSERT_TRUE(refChar.parameterTransform.isApprox(character.parameterTransform));
+    EXPECT_THAT(
+        refChar.parameterLimits, testing::Pointwise(ElementsEq(), character.parameterLimits));
+  }
   compareLocators(refChar.locators, character.locators);
   compareCollisionGeometry(refChar.collision, character.collision);
   ASSERT_EQ(refChar.inverseBindPose.size(), character.inverseBindPose.size());

--- a/momentum/test/character/character_helpers_gtest.h
+++ b/momentum/test/character/character_helpers_gtest.h
@@ -14,6 +14,10 @@ namespace momentum {
 
 // Matching methods
 void compareMeshes(const Mesh_u& refMesh, const Mesh_u& mesh);
-void compareChars(const Character& refChar, const Character& character, bool withMesh = true);
+void compareChars(
+    const Character& refChar,
+    const Character& character,
+    bool withMesh = true,
+    bool withParameterTransform = true);
 
 } // namespace momentum


### PR DESCRIPTION
Summary:
The blendshape loading ignored the blendshape vertex indices, loading blendshapes incorrectly in some cases.

Changed fbx_io to write out blendshapes if present in the character.

Reviewed By: jeongseok-meta

Differential Revision: D87094450


