### PR TITLE
Add attachedToSkin and skinOffset fields to the locators.

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -406,6 +406,7 @@ io_skeleton_sources = [
 
 io_skeleton_test_sources = [
     "test/io/io_model_parser_test.cpp",
+    "test/io/io_locators_test.cpp",
     "test/io/io_parameter_limits_test.cpp",
 ]
 

--- a/momentum/character/locator.h
+++ b/momentum/character/locator.h
@@ -39,6 +39,13 @@ struct Locator {
   /// Higher values create stronger constraints, zero means completely free
   Vector3f limitWeight;
 
+  /// Indicates whether the locator is attached to the skin of a person (e.g. as in mocap tracking),
+  /// used to determine whether the locator can safely be converted to a skinned locator.
+  bool attachedToSkin = false;
+
+  /// Offset from the skin surface, used when trying to solve for body shape using locators.
+  float skinOffset = 0.0f;
+
   /// Creates a locator with the specified properties
   ///
   /// @param name Identifier for the locator
@@ -55,14 +62,18 @@ struct Locator {
       const Vector3i& locked = Vector3i::Zero(),
       const float weight = 1.0f,
       const Vector3f& limitOrigin = Vector3f::Zero(),
-      const Vector3f& limitWeight = Vector3f::Zero())
+      const Vector3f& limitWeight = Vector3f::Zero(),
+      bool attachedToSkin = false,
+      float skinOffset = 0.0f)
       : name(name),
         parent(parent),
         offset(offset),
         locked(locked),
         weight(weight),
         limitOrigin(limitOrigin),
-        limitWeight(limitWeight) {}
+        limitWeight(limitWeight),
+        attachedToSkin(attachedToSkin),
+        skinOffset(skinOffset) {}
 
   /// Compares two locators for equality, using approximate comparison for floating-point values
   ///
@@ -72,7 +83,8 @@ struct Locator {
     return (
         (name == locator.name) && (parent == locator.parent) && offset.isApprox(locator.offset) &&
         locked.isApprox(locator.locked) && isApprox(weight, locator.weight) &&
-        limitOrigin.isApprox(locator.limitOrigin) && limitWeight.isApprox(locator.limitWeight));
+        limitOrigin.isApprox(locator.limitOrigin) && limitWeight.isApprox(locator.limitWeight) &&
+        attachedToSkin == locator.attachedToSkin && isApprox(skinOffset, locator.skinOffset));
   }
 };
 

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -756,6 +756,12 @@ void addLocatorsToModel(
       extension["limitWeight"] = loc.limitWeight;
       extension["limitOrigin"] = loc.limitOrigin;
       extension["locked"] = loc.locked;
+      if (loc.attachedToSkin) {
+        extension["attachedToSkin"] = loc.attachedToSkin;
+      }
+      if (loc.skinOffset != 0.0f) {
+        extension["skinOffset"] = loc.skinOffset;
+      }
     }
 
     auto newMeshIdx = addMeshToModel(model, kUnitCubeGreen, true);

--- a/momentum/io/gltf/gltf_io.cpp
+++ b/momentum/io/gltf/gltf_io.cpp
@@ -91,6 +91,12 @@ Locator createLocator(const fx::gltf::Node& node, const nlohmann::json& extensio
     }
     loc.limitWeight = fromJson<Vector3f>(extension["limitWeight"]);
     loc.locked = fromJson<Vector3i>(extension["locked"]);
+    if (extension.contains("attachedToSkin")) {
+      loc.attachedToSkin = extension["attachedToSkin"];
+    }
+    if (extension.contains("skinOffset")) {
+      loc.skinOffset = extension["skinOffset"];
+    }
   } catch (const std::exception&) {
     MT_THROW(
         "Fail to parse json {} for locator {} when loading character.",

--- a/momentum/io/skeleton/locator_io.cpp
+++ b/momentum/io/skeleton/locator_io.cpp
@@ -190,6 +190,10 @@ LocatorList loadLocatorsFromBuffer(
         l.limitWeight[1] = svtof(tokens[1]);
       } else if (tokens[0] == "\"limitWeightZ\"") {
         l.limitWeight[2] = svtof(tokens[1]);
+      } else if (tokens[0] == "\"attachedToSkin\"") {
+        l.attachedToSkin = (svtoi(tokens[1]) != 0);
+      } else if (tokens[0] == "\"skinOffset\"") {
+        l.skinOffset = svtof(tokens[1]);
       }
     } while (line < lines.size() - 1 && (current != "}," || current != "}"));
 
@@ -245,6 +249,12 @@ void saveLocators(
     }
     if (locators[i].limitWeight[2] != 0.0f) {
       o << "\t\t\t\"limitWeightZ\":" << locators[i].limitWeight.z() << ",\n";
+    }
+    if (locators[i].attachedToSkin) {
+      o << "\t\t\t\"attachedToSkin\":1,\n";
+    }
+    if (locators[i].skinOffset != 0.0f) {
+      o << "\t\t\t\"skinOffset\":" << locators[i].skinOffset << ",\n";
     }
     MT_CHECK(
         0 <= locators[i].parent && locators[i].parent < skeleton.joints.size(),

--- a/momentum/test/io/io_locators_test.cpp
+++ b/momentum/test/io/io_locators_test.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <momentum/character/character.h>
+#include <momentum/io/skeleton/locator_io.h>
+#include <momentum/test/character/character_helpers.h>
+#include <momentum/test/io/io_helpers.h>
+
+#include <gtest/gtest.h>
+
+using namespace momentum;
+
+namespace {
+
+LocatorList createTestLocators() {
+  LocatorList locators;
+
+  // Locator 1: Basic locator with default values
+  {
+    Locator loc;
+    loc.name = "locator_default";
+    loc.parent = 0;
+    loc.offset = Vector3f(1.0f, 2.0f, 3.0f);
+    loc.limitOrigin = Vector3f(1.0f, 2.0f, 3.0f);
+    loc.weight = 1.0f;
+    loc.limitWeight = Vector3f(0.5f, 0.6f, 0.7f);
+    loc.locked = Vector3i(0, 0, 0);
+    loc.attachedToSkin = false;
+    loc.skinOffset = 0.0f;
+    locators.push_back(loc);
+  }
+
+  // Locator 2: Locator with attachedToSkin=true and non-zero skinOffset
+  {
+    Locator loc;
+    loc.name = "locator_skin_attached";
+    loc.parent = 1;
+    loc.offset = Vector3f(-1.5f, 0.5f, 2.5f);
+    loc.limitOrigin = Vector3f(-1.5f, 0.5f, 2.5f);
+    loc.weight = 0.8f;
+    loc.limitWeight = Vector3f(0.3f, 0.4f, 0.5f);
+    loc.locked = Vector3i(1, 0, 1);
+    loc.attachedToSkin = true;
+    loc.skinOffset = 0.05f;
+    locators.push_back(loc);
+  }
+
+  // Locator 3: Locator with various non-default values
+  {
+    Locator loc;
+    loc.name = "locator_complex";
+    loc.parent = 2;
+    loc.offset = Vector3f(0.0f, 1.0f, 0.0f);
+    loc.limitOrigin = Vector3f(0.1f, 0.9f, 0.0f);
+    loc.weight = 2.5f;
+    loc.limitWeight = Vector3f(1.0f, 0.0f, 0.8f);
+    loc.locked = Vector3i(1, 1, 0);
+    loc.attachedToSkin = false;
+    loc.skinOffset = 0.0f;
+    locators.push_back(loc);
+  }
+
+  // Locator 4: Locator with attachedToSkin=true but zero skinOffset
+  {
+    Locator loc;
+    loc.name = "locator_skin_zero_offset";
+    loc.parent = 1;
+    loc.offset = Vector3f(3.0f, 4.0f, 5.0f);
+    loc.limitOrigin = Vector3f(3.0f, 4.0f, 5.0f);
+    loc.weight = 1.5f;
+    loc.limitWeight = Vector3f(0.0f, 0.0f, 0.0f);
+    loc.locked = Vector3i(0, 1, 0);
+    loc.attachedToSkin = true;
+    loc.skinOffset = 0.0f;
+    locators.push_back(loc);
+  }
+
+  // Locator 5: Locator with all fields at various values
+  {
+    Locator loc;
+    loc.name = "locator_full_test";
+    loc.parent = 0;
+    loc.offset = Vector3f(-2.0f, -3.0f, -4.0f);
+    loc.limitOrigin = Vector3f(-2.1f, -2.9f, -4.0f);
+    loc.weight = 0.5f;
+    loc.limitWeight = Vector3f(0.2f, 0.3f, 0.0f);
+    loc.locked = Vector3i(1, 1, 1);
+    loc.attachedToSkin = true;
+    loc.skinOffset = 0.15f;
+    locators.push_back(loc);
+  }
+
+  return locators;
+}
+
+void validateLocatorsSame(const LocatorList& locators1, const LocatorList& locators2) {
+  ASSERT_EQ(locators1.size(), locators2.size())
+      << "Locator lists have different sizes: " << locators1.size() << " vs " << locators2.size();
+
+  for (size_t i = 0; i < locators1.size(); ++i) {
+    const auto& l1 = locators1[i];
+    const auto& l2 = locators2[i];
+
+    EXPECT_EQ(l1.name, l2.name) << "Locator " << i << " name mismatch";
+    EXPECT_EQ(l1.parent, l2.parent) << "Locator " << i << " (" << l1.name << ") parent mismatch";
+
+    EXPECT_NEAR(l1.offset.x(), l2.offset.x(), 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") offset.x mismatch";
+    EXPECT_NEAR(l1.offset.y(), l2.offset.y(), 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") offset.y mismatch";
+    EXPECT_NEAR(l1.offset.z(), l2.offset.z(), 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") offset.z mismatch";
+
+    // limitOrigin is not saved/loaded, it defaults to offset after loading
+    EXPECT_NEAR(l2.limitOrigin.x(), l2.offset.x(), 1e-5f)
+        << "Locator " << i << " (" << l2.name << ") limitOrigin should equal offset after loading";
+    EXPECT_NEAR(l2.limitOrigin.y(), l2.offset.y(), 1e-5f)
+        << "Locator " << i << " (" << l2.name << ") limitOrigin should equal offset after loading";
+    EXPECT_NEAR(l2.limitOrigin.z(), l2.offset.z(), 1e-5f)
+        << "Locator " << i << " (" << l2.name << ") limitOrigin should equal offset after loading";
+
+    EXPECT_NEAR(l1.weight, l2.weight, 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") weight mismatch";
+
+    EXPECT_NEAR(l1.limitWeight.x(), l2.limitWeight.x(), 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") limitWeight.x mismatch";
+    EXPECT_NEAR(l1.limitWeight.y(), l2.limitWeight.y(), 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") limitWeight.y mismatch";
+    EXPECT_NEAR(l1.limitWeight.z(), l2.limitWeight.z(), 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") limitWeight.z mismatch";
+
+    EXPECT_EQ(l1.locked.x(), l2.locked.x())
+        << "Locator " << i << " (" << l1.name << ") locked.x mismatch";
+    EXPECT_EQ(l1.locked.y(), l2.locked.y())
+        << "Locator " << i << " (" << l1.name << ") locked.y mismatch";
+    EXPECT_EQ(l1.locked.z(), l2.locked.z())
+        << "Locator " << i << " (" << l1.name << ") locked.z mismatch";
+
+    // Test the new fields
+    EXPECT_EQ(l1.attachedToSkin, l2.attachedToSkin)
+        << "Locator " << i << " (" << l1.name << ") attachedToSkin mismatch";
+    EXPECT_NEAR(l1.skinOffset, l2.skinOffset, 1e-5f)
+        << "Locator " << i << " (" << l1.name << ") skinOffset mismatch";
+  }
+}
+
+} // namespace
+
+TEST(LocatorIOTest, RoundTrip_Local) {
+  // Create test character with skeleton
+  const Character character = createTestCharacter();
+  const LocatorList originalLocators = createTestLocators();
+
+  // Save locators in local space
+  TemporaryFile tempFile = temporaryFile("", "locators");
+  const auto& path = tempFile.path();
+
+  ASSERT_NO_THROW(saveLocators(path, originalLocators, character.skeleton, LocatorSpace::Local));
+  EXPECT_TRUE(filesystem::exists(path)) << "Locator file not created at " << path;
+
+  // Load locators back
+  LocatorList loadedLocators;
+  ASSERT_NO_THROW(
+      loadedLocators = loadLocators(path, character.skeleton, character.parameterTransform));
+
+  // Validate they match
+  validateLocatorsSame(originalLocators, loadedLocators);
+}
+
+TEST(LocatorIOTest, RoundTrip_Global) {
+  // Create test character with skeleton
+  const Character character = createTestCharacter();
+  const LocatorList originalLocators = createTestLocators();
+
+  // Save locators in global space
+  TemporaryFile tempFile = temporaryFile("", "locators");
+  const auto& path = tempFile.path();
+
+  ASSERT_NO_THROW(saveLocators(path, originalLocators, character.skeleton, LocatorSpace::Global));
+  EXPECT_TRUE(filesystem::exists(path)) << "Locator file not created at " << path;
+
+  // Load locators back (should be converted back to local space)
+  LocatorList loadedLocators;
+  ASSERT_NO_THROW(
+      loadedLocators = loadLocators(path, character.skeleton, character.parameterTransform));
+
+  // Validate they match (offsets might differ due to global->local conversion,
+  // but other fields should be preserved)
+  ASSERT_EQ(originalLocators.size(), loadedLocators.size());
+  for (size_t i = 0; i < originalLocators.size(); ++i) {
+    const auto& l1 = originalLocators[i];
+    const auto& l2 = loadedLocators[i];
+
+    EXPECT_EQ(l1.name, l2.name);
+    EXPECT_EQ(l1.parent, l2.parent);
+    EXPECT_NEAR(l1.weight, l2.weight, 1e-5f);
+    EXPECT_EQ(l1.attachedToSkin, l2.attachedToSkin);
+    EXPECT_NEAR(l1.skinOffset, l2.skinOffset, 1e-5f);
+  }
+}
+
+TEST(LocatorIOTest, EmptyLocatorList) {
+  const Character character = createTestCharacter();
+  LocatorList emptyLocators;
+
+  // Save empty locator list
+  TemporaryFile tempFile = temporaryFile("", "locators");
+  const auto& path = tempFile.path();
+
+  ASSERT_NO_THROW(saveLocators(path, emptyLocators, character.skeleton, LocatorSpace::Local));
+  EXPECT_TRUE(filesystem::exists(path)) << "Locator file not created at " << path;
+
+  // Load empty locator list
+  LocatorList loadedLocators;
+  ASSERT_NO_THROW(
+      loadedLocators = loadLocators(path, character.skeleton, character.parameterTransform));
+
+  EXPECT_EQ(loadedLocators.size(), 0);
+}


### PR DESCRIPTION
Summary: The goal here is to be able to control the conversion of locators to skinned locators, some locators may be attached to e.g. a marker tree and hence it would not make sense to convert them to skinned locators, and we want some control over how far off the skin the locator sits.

Reviewed By: jeongseok-meta

Differential Revision: D85461128


