### PR TITLE
Use nlohmann to parse locators instead of writing our own json parser.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ mt_library(
     character
   PRIVATE_LINK_LIBRARIES
     io_common
+    nlohmann_json::nlohmann_json
     re2::re2
 )
 


### PR DESCRIPTION
Summary:
I was looking at this code and it is a json parser, but hand-written with some assumptions about the white-space formatting.   I feel like it would be better in the long run to just let nlohmann do the parsing, which should be less bug-prone.

While I'm at it, let's improve the error handling to check for some failure cases: specifying both offset and global offset, specifying x but not y or z, etc.  Also fix one of my personal annoyances: we weren't getting the line number from parsing failures so it was really annoying to find problems in the locator file.

Reviewed By: cstollmeta

Differential Revision: D86922601


