### PR TITLE
Replace GltfOptions with FileSaveOptions in saveGltfCharacter APIs

### DIFF
--- a/momentum/io/character_io.cpp
+++ b/momentum/io/character_io.cpp
@@ -155,14 +155,6 @@ void saveCharacter(
       filename.string());
 
   if (format == CharacterFormat::Gltf) {
-    // Convert FileSaveOptions to GltfOptions
-    GltfOptions gltfOptions;
-    gltfOptions.extensions = options.extensions;
-    gltfOptions.collisions = options.collisions;
-    gltfOptions.locators = options.locators;
-    gltfOptions.mesh = options.mesh;
-    gltfOptions.blendShapes = options.blendShapes;
-
     saveGltfCharacter(
         filename,
         character,
@@ -170,8 +162,7 @@ void saveCharacter(
         {character.parameterTransform.name, motion},
         {},
         markerSequence,
-        options.gltfFileFormat,
-        gltfOptions);
+        options);
   } else if (format == CharacterFormat::Fbx) {
     // Save as FBX
     saveFbx(
@@ -206,22 +197,7 @@ void saveCharacter(
       filename.string());
 
   if (format == CharacterFormat::Gltf) {
-    // Convert FileSaveOptions to GltfOptions
-    GltfOptions gltfOptions;
-    gltfOptions.extensions = options.extensions;
-    gltfOptions.collisions = options.collisions;
-    gltfOptions.locators = options.locators;
-    gltfOptions.mesh = options.mesh;
-    gltfOptions.blendShapes = options.blendShapes;
-
-    saveGltfCharacter(
-        filename,
-        character,
-        fps,
-        skeletonStates,
-        markerSequence,
-        options.gltfFileFormat,
-        gltfOptions);
+    saveGltfCharacter(filename, character, fps, skeletonStates, markerSequence, options);
   } else if (format == CharacterFormat::Fbx) {
     // Save as FBX
     saveFbxWithSkeletonStates(

--- a/momentum/io/file_save_options.h
+++ b/momentum/io/file_save_options.h
@@ -22,23 +22,9 @@ enum class GltfFileFormat {
   Ascii = 2, // ASCII format (generally .gltf)
 };
 
-/// Options for GLTF file export
-struct GltfOptions {
-  /// Include GLTF extensions in the output.
-  bool extensions = true;
-  /// Include collision geometry in the output.
-  bool collisions = true;
-  /// Include locators in the output.
-  bool locators = true;
-  /// Include mesh geometry in the output.
-  bool mesh = true;
-  /// Include blend shapes in the output.
-  bool blendShapes = true;
-};
-
 // ============================================================================
 // FBX Coordinate System Options
-// =====================================================================
+// ============================================================================
 
 /// Specifies which canonical axis represents up in the system (typically Y or Z).
 /// Maps to fbxsdk::FbxAxisSystem::EUpVector

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -855,7 +855,7 @@ void GltfBuilder::addCharacter(
     const Character& character,
     const Vector3f& positionOffset /*= Vector3f::Zero()*/,
     const Quaternionf& rotationOffset /*= Quaternionf::Identity()*/,
-    const GltfOptions& options) {
+    const FileSaveOptions& options) {
   if (impl_->characterData.find(character.name) != impl_->characterData.end()) {
     // Character already exist. Doesn't allow character with the same name to be saved.
     // #TODO: proper warning

--- a/momentum/io/gltf/gltf_builder.h
+++ b/momentum/io/gltf/gltf_builder.h
@@ -50,7 +50,7 @@ class GltfBuilder final {
       const Character& character,
       const Vector3f& positionOffset = Vector3f::Zero(),
       const Quaternionf& rotationOffset = Quaternionf::Identity(),
-      const GltfOptions& options = GltfOptions());
+      const FileSaveOptions& options = FileSaveOptions());
 
   /// Add a static mesh, such as an environment or a target scan
   void addMesh(const Mesh& mesh, const std::string& name, bool addColor = false);

--- a/momentum/io/gltf/gltf_io.h
+++ b/momentum/io/gltf/gltf_io.h
@@ -98,7 +98,7 @@ fx::gltf::Document makeCharacterDocument(
     const IdentityParameters& offsets = {},
     std::span<const std::vector<Marker>> markerSequence = {},
     bool embedResource = true,
-    const GltfOptions& options = GltfOptions());
+    const FileSaveOptions& options = FileSaveOptions());
 
 /// Saves character motion to a glb file.
 ///
@@ -106,6 +106,8 @@ fx::gltf::Document makeCharacterDocument(
 /// numFrames)
 /// @param[in] offsets Offset values per joint capturing the skeleton bone lengths using translation
 /// and scale offset (7*numJoints, 1)
+/// @param[in] options Optional file save options for controlling output (default:
+/// FileSaveOptions{}).
 void saveGltfCharacter(
     const filesystem::path& filename,
     const Character& character,
@@ -113,21 +115,21 @@ void saveGltfCharacter(
     const MotionParameters& motion = {},
     const IdentityParameters& offsets = {},
     std::span<const std::vector<Marker>> markerSequence = {},
-    GltfFileFormat fileFormat = GltfFileFormat::Auto,
-    const GltfOptions& options = GltfOptions());
+    const FileSaveOptions& options = FileSaveOptions());
 
 /// Saves character skeleton states to a glb file.
 ///
 /// @param[in] skeletonStates The skeleton states for each frame of the motion sequence (numFrames,
 /// numJoints, 8)
+/// @param[in] options Optional file save options for controlling output (default:
+/// FileSaveOptions{}).
 void saveGltfCharacter(
     const filesystem::path& filename,
     const Character& character,
     float fps,
     std::span<const SkeletonState> skeletonStates,
     std::span<const std::vector<Marker>> markerSequence = {},
-    GltfFileFormat fileFormat = GltfFileFormat::Auto,
-    const GltfOptions& options = GltfOptions());
+    const FileSaveOptions& options = FileSaveOptions());
 
 std::vector<std::byte> saveCharacterToBytes(
     const Character& character,
@@ -135,6 +137,6 @@ std::vector<std::byte> saveCharacterToBytes(
     const MotionParameters& motion = {},
     const IdentityParameters& offsets = {},
     std::span<const std::vector<Marker>> markerSequence = {},
-    const GltfOptions& options = GltfOptions());
+    const FileSaveOptions& options = FileSaveOptions());
 
 } // namespace momentum

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -714,6 +714,7 @@ support the proprietary momentum motion format for storing model parameters in G
 :param motion: Pose array in [n_frames x n_parameters]
 :param offsets: Offset array in [n_joints x n_parameters_per_joint]
 :param markers: Additional marker (3d positions) data in [n_frames][n_markers]
+:param options: FileSaveOptions for controlling output (mesh, locators, collisions, etc.)
       )",
           py::arg("path"),
           py::arg("character"),
@@ -721,7 +722,7 @@ support the proprietary momentum motion format for storing model parameters in G
           py::arg("motion") = std::optional<momentum::MotionParameters>{},
           py::arg("offsets") = std::optional<const momentum::IdentityParameters>{},
           py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
-          py::arg("options") = momentum::GltfOptions{})
+          py::arg("options") = std::optional<momentum::FileSaveOptions>{})
       .def_static(
           "save_gltf_from_skel_states",
           &saveGLTFCharacterToFileFromSkelStates,
@@ -733,13 +734,14 @@ support the proprietary momentum motion format for storing model parameters in G
 :param fps: Frequency in frames per second
 :param skel_states: Skeleton states [n_frames x n_joints x n_parameters_per_joint]
 :param markers: Additional marker (3d positions) data in [n_frames][n_markers]
+:param options: FileSaveOptions for controlling output (mesh, locators, collisions, etc.)
       )",
           py::arg("path"),
           py::arg("character"),
           py::arg("fps"),
           py::arg("skel_states"),
           py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
-          py::arg("options") = momentum::GltfOptions{})
+          py::arg("options") = std::optional<momentum::FileSaveOptions>{})
       .def_static(
           "save_fbx",
           &saveFBXCharacterToFile,

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -187,8 +187,6 @@ PYBIND11_MODULE(geometry, m) {
       "A constraint on model or joint parameters used to enforce realistic poses. "
       "Supports various limit types including min/max bounds, linear relationships, "
       "ellipsoid constraints, and half-plane constraints.");
-  auto gltfOptionsClass =
-      py::class_<mm::GltfOptions>(m, "GltfOptions", "Storage options for Gltf export.");
   auto fileSaveOptionsClass = py::class_<mm::FileSaveOptions>(
       m,
       "FileSaveOptions",
@@ -196,31 +194,6 @@ PYBIND11_MODULE(geometry, m) {
       "This struct consolidates save options that were previously scattered across "
       "multiple function parameters. Format-specific options (e.g., FBX coordinate "
       "system, GLTF extensions) are included but only used by their respective formats.");
-
-  gltfOptionsClass.def(py::init<>())
-      .def(
-          py::init<bool, bool, bool, bool, bool>(),
-          py::arg("extensions") = true,
-          py::arg("collisions") = true,
-          py::arg("locators") = true,
-          py::arg("mesh") = true,
-          py::arg("blend_shapes") = true)
-      .def(
-          "__repr__",
-          [](const mm::GltfOptions& self) {
-            return fmt::format(
-                "GltfData(extensions={}, collisions={}, locators={}, mesh={}, blendShapes={})",
-                self.extensions,
-                self.collisions,
-                self.locators,
-                self.mesh,
-                self.blendShapes);
-          })
-      .def_readwrite("extensions", &mm::GltfOptions::extensions, "Save momentum extensions")
-      .def_readwrite("collisions", &mm::GltfOptions::collisions, "Save collision geometry")
-      .def_readwrite("locators", &mm::GltfOptions::locators, "Save locator data")
-      .def_readwrite("mesh", &mm::GltfOptions::mesh, "Save mesh data")
-      .def_readwrite("blend_shapes", &mm::GltfOptions::blendShapes, "Save blend shape data");
 
   blendShapeClass
       .def_property_readonly(

--- a/pymomentum/geometry/gltf_builder_pybind.cpp
+++ b/pymomentum/geometry/gltf_builder_pybind.cpp
@@ -82,12 +82,12 @@ Setting this value will affect subsequently added motions and animations.
              const mm::Character& character,
              const std::optional<Eigen::Vector3f>& positionOffset,
              const std::optional<Eigen::Vector4f>& rotationOffset,
-             const std::optional<mm::GltfOptions>& options) {
+             const std::optional<mm::FileSaveOptions>& options) {
             // Use defaults if not provided
             Eigen::Vector3f actualPositionOffset = positionOffset.value_or(Eigen::Vector3f::Zero());
             Eigen::Vector4f actualRotationOffset =
                 rotationOffset.value_or(Eigen::Vector4f(0.0f, 0.0f, 0.0f, 1.0f));
-            mm::GltfOptions actualOptions = options.value_or(mm::GltfOptions{});
+            mm::FileSaveOptions actualOptions = options.value_or(mm::FileSaveOptions{});
 
             // Convert Vector4f (x,y,z,w) to Quaternionf (w,x,y,z)
             mm::Quaternionf quaternionOffset(
@@ -273,7 +273,7 @@ can be explicitly specified or automatically deduced from the file extension.
 
             // Convert to Python bytes
             const std::string& str = output.str();
-            return py::bytes(str);
+            return {str};
           },
           R"(Convert the GLTF scene to bytes in memory.
 

--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -26,8 +26,8 @@ momentum::Character loadGLTFCharacterFromFile(const std::string& path) {
 
 momentum::Character loadGLTFCharacterFromBytes(const pybind11::bytes& bytes) {
   pybind11::buffer_info info(pybind11::buffer(bytes).request());
-  const std::byte* data = reinterpret_cast<const std::byte*>(info.ptr);
-  const size_t length = static_cast<size_t>(info.size);
+  const auto* data = reinterpret_cast<const std::byte*>(info.ptr);
+  const auto length = static_cast<size_t>(info.size);
 
   MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.");
 
@@ -108,7 +108,7 @@ void saveGLTFCharacterToFile(
     const std::optional<const momentum::MotionParameters>& motion,
     const std::optional<const momentum::IdentityParameters>& offsets,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const momentum::GltfOptions& options) {
+    const std::optional<const momentum::FileSaveOptions>& options) {
   if (motion.has_value()) {
     const auto& [parameters, poses] = motion.value();
     MT_THROW_IF(
@@ -125,8 +125,7 @@ void saveGLTFCharacterToFile(
       transpose(motion.value_or(momentum::MotionParameters{})),
       offsets.value_or(momentum::IdentityParameters{}),
       markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
-      momentum::GltfFileFormat::Auto,
-      options);
+      options.value_or(momentum::FileSaveOptions{}));
 }
 
 void saveGLTFCharacterToFileFromSkelStates(
@@ -135,7 +134,7 @@ void saveGLTFCharacterToFileFromSkelStates(
     const float fps,
     const pybind11::array_t<float>& skelStates,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const momentum::GltfOptions& options) {
+    const std::optional<const momentum::FileSaveOptions>& options) {
   const auto numFrames = skelStates.shape(0);
 
   MT_THROW_IF(
@@ -154,8 +153,7 @@ void saveGLTFCharacterToFileFromSkelStates(
       fps,
       skeletonStates,
       markers.value_or(std::vector<std::vector<momentum::Marker>>{}),
-      momentum::GltfFileFormat::Auto,
-      options);
+      options.value_or(momentum::FileSaveOptions{}));
 }
 
 void saveFBXCharacterToFile(
@@ -261,8 +259,8 @@ std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float> loadGLTFChar
 std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float>
 loadGLTFCharacterWithMotionFromBytes(const pybind11::bytes& gltfBytes) {
   pybind11::buffer_info info(pybind11::buffer(gltfBytes).request());
-  const std::byte* data = reinterpret_cast<const std::byte*>(info.ptr);
-  const size_t length = static_cast<size_t>(info.size);
+  const auto* data = reinterpret_cast<const std::byte*>(info.ptr);
+  const auto length = static_cast<size_t>(info.size);
 
   MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.");
 
@@ -302,8 +300,8 @@ pybind11::array_t<float> skelStatesToTensor(
 std::tuple<momentum::Character, pybind11::array_t<float>, std::vector<float>>
 loadGLTFCharacterWithSkelStatesFromBytes(const pybind11::bytes& gltfBytes) {
   pybind11::buffer_info info(pybind11::buffer(gltfBytes).request());
-  const std::byte* data = reinterpret_cast<const std::byte*>(info.ptr);
-  const size_t length = static_cast<size_t>(info.size);
+  const auto* data = reinterpret_cast<const std::byte*>(info.ptr);
+  const auto length = static_cast<size_t>(info.size);
 
   MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.");
 

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -43,7 +43,7 @@ void saveGLTFCharacterToFile(
     const std::optional<const momentum::MotionParameters>& motion,
     const std::optional<const momentum::IdentityParameters>& offsets,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const momentum::GltfOptions& options);
+    const std::optional<const momentum::FileSaveOptions>& options);
 
 void saveGLTFCharacterToFileFromSkelStates(
     const std::string& path,
@@ -51,7 +51,7 @@ void saveGLTFCharacterToFileFromSkelStates(
     float fps,
     const pybind11::array_t<float>& skelStates,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
-    const momentum::GltfOptions& options);
+    const std::optional<const momentum::FileSaveOptions>& options);
 
 void saveFBXCharacterToFile(
     const std::string& path,
@@ -100,13 +100,13 @@ std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float> loadGLTFChar
     const std::string& gltfFilename);
 
 std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float>
-loadGLTFCharacterWithMotionFromBytes(const pybind11::bytes& bytes);
+loadGLTFCharacterWithMotionFromBytes(const pybind11::bytes& gltfBytes);
 
 std::tuple<momentum::Character, pybind11::array_t<float>, std::vector<float>>
 loadGLTFCharacterWithSkelStates(const std::string& gltfFilename);
 
 std::tuple<momentum::Character, pybind11::array_t<float>, std::vector<float>>
-loadGLTFCharacterWithSkelStatesFromBytes(const pybind11::bytes& gltfFilename);
+loadGLTFCharacterWithSkelStatesFromBytes(const pybind11::bytes& gltfBytes);
 
 std::string toGLTF(const momentum::Character& character);
 


### PR DESCRIPTION
Summary: This diff replaces the `GltfOptions` parameter with `FileSaveOptions` in the `saveGltfCharacter` function signatures to provide a unified interface for file saving options across different formats (GLTF and FBX).

Reviewed By: cstollmeta, jeongseok-meta

Differential Revision: D86882964


