### PR TITLE
Permissive flag strongly typed

### DIFF
--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
         MT_LOGI("Loading motion from fbx...");
         int motionIndex = -1;
         auto [c, motions, framerate] =
-            loadFbxCharacterWithMotion(motionPath, KeepLocators::Yes, false);
+            loadFbxCharacterWithMotion(motionPath, KeepLocators::Yes, Permissive::No);
         // Validate the motion
         if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
           MT_LOGW("No motion loaded from file");

--- a/momentum/examples/fbx_viewer/fbx_viewer.cpp
+++ b/momentum/examples/fbx_viewer/fbx_viewer.cpp
@@ -70,8 +70,10 @@ int main(int argc, char* argv[]) {
 
     rec.log_static("world", ViewCoordinates(::components::ViewCoordinates::RUB)); // Set an up-axis
 
-    const auto [character, motions, fps] =
-        loadFbxCharacterWithMotion(options->fbxFile, KeepLocators::Yes, options->permissive);
+    const auto [character, motions, fps] = loadFbxCharacterWithMotion(
+        options->fbxFile,
+        KeepLocators::Yes,
+        options->permissive ? Permissive::Yes : Permissive::No);
     // Validate the loaded motion
     if (motions.empty() || (motions.size() == 1 && motions.at(0).cols() == 0)) {
       MT_LOGW("No motion loaded from file");

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -550,7 +550,7 @@ void saveFbxCommon(
     const bool saveMesh,
     const bool skipActiveJointParamCheck,
     const FbxCoordSystemInfo& coordSystemInfo,
-    bool permissive,
+    Permissive permissive,
     std::span<const std::vector<Marker>> markerSequence,
     std::string_view fbxNamespace) {
   // ---------------------------------------------
@@ -728,7 +728,7 @@ void saveFbxCommon(
     // weight the vertex for that joint.
 
     MT_THROW_IF(
-        !permissive && !character.skinWeights,
+        permissive == Permissive::No && !character.skinWeights,
         " Failed to save the character '{}' to {}. The character has no skinning weights and permissive mode is not enabled. Only mesh-only characters are allowed in permissive mode.",
         character.name,
         filename.string());
@@ -803,7 +803,7 @@ void saveFbxCommon(
 Character loadFbxCharacter(
     const filesystem::path& inputPath,
     KeepLocators keepLocators,
-    bool permissive,
+    Permissive permissive,
     LoadBlendShapes loadBlendShapes,
     bool stripNamespaces) {
   return loadOpenFbxCharacter(
@@ -813,7 +813,7 @@ Character loadFbxCharacter(
 Character loadFbxCharacter(
     std::span<const std::byte> inputSpan,
     KeepLocators keepLocators,
-    bool permissive,
+    Permissive permissive,
     LoadBlendShapes loadBlendShapes,
     bool stripNamespaces) {
   return loadOpenFbxCharacter(
@@ -823,7 +823,7 @@ Character loadFbxCharacter(
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     KeepLocators keepLocators,
-    bool permissive,
+    Permissive permissive,
     LoadBlendShapes loadBlendShapes,
     bool stripNamespaces) {
   return loadOpenFbxCharacterWithMotion(
@@ -833,7 +833,7 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     std::span<const std::byte> inputSpan,
     KeepLocators keepLocators,
-    bool permissive,
+    Permissive permissive,
     LoadBlendShapes loadBlendShapes,
     bool stripNamespaces) {
   return loadOpenFbxCharacterWithMotion(

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -31,7 +31,7 @@ enum class LoadBlendShapes { No, Yes };
 Character loadFbxCharacter(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No,
     bool stripNamespaces = true);
 
@@ -41,7 +41,7 @@ Character loadFbxCharacter(
 Character loadFbxCharacter(
     std::span<const std::byte> inputSpan,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No,
     bool stripNamespaces = true);
 
@@ -49,7 +49,7 @@ Character loadFbxCharacter(
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No,
     bool stripNamespaces = true);
 
@@ -57,7 +57,7 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
 std::tuple<Character, std::vector<MatrixXf>, float> loadFbxCharacterWithMotion(
     std::span<const std::byte> inputSpan,
     KeepLocators keepLocatorss = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShape = LoadBlendShapes::No,
     bool stripNamespaces = true);
 

--- a/momentum/io/fbx/openfbx_loader.h
+++ b/momentum/io/fbx/openfbx_loader.h
@@ -27,7 +27,7 @@ constexpr const char* kMomentumMarkerProperty = "Momentum_Marker";
 Character loadOpenFbxCharacter(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No,
     bool stripNamespaces = true);
 
@@ -35,7 +35,7 @@ Character loadOpenFbxCharacter(
 Character loadOpenFbxCharacter(
     std::span<const std::byte> inputData,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No,
     bool stripNamespaces = true);
 
@@ -43,7 +43,7 @@ Character loadOpenFbxCharacter(
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     const filesystem::path& inputPath,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No,
     bool stripNamespaces = true);
 
@@ -51,7 +51,7 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMoti
 std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMotion(
     std::span<const std::byte> inputData,
     KeepLocators keepLocators = KeepLocators::No,
-    bool permissive = false,
+    Permissive permissive = Permissive::No,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No,
     bool stripNamespaces = true);
 

--- a/momentum/io/file_save_options.h
+++ b/momentum/io/file_save_options.h
@@ -12,6 +12,14 @@
 namespace momentum {
 
 // ============================================================================
+// Permissive Mode
+// ============================================================================
+
+// Permissive specifies whether we want to be able to load mesh-only characters (without skin
+// weights), and whether we want to bake the unhandled pose information into base skeleton.
+enum class Permissive { No, Yes };
+
+// ============================================================================
 // GLTF File Format
 // ============================================================================
 
@@ -74,7 +82,7 @@ struct FileSaveOptions {
   bool blendShapes = true;
 
   /// Permissive mode: allow saving mesh-only characters without skin weights (default: false)
-  bool permissive = false;
+  Permissive permissive = Permissive::No;
 
   // ---- FBX-Specific Options ----
 

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -592,7 +592,7 @@ The resulting tensors are as follows:
             options.locators = locators;
             options.collisions = collisions;
             options.blendShapes = blendShapes;
-            options.permissive = permissive;
+            options.permissive = permissive ? mm::Permissive::Yes : mm::Permissive::No;
             options.coordSystemInfo = coordSystemInfo;
             options.fbxNamespace = fbxNamespace;
             options.extensions = extensions;
@@ -634,9 +634,12 @@ The resulting tensors are as follows:
           "blend_shapes",
           &mm::FileSaveOptions::blendShapes,
           "Include blend shapes in the output (default: true)")
-      .def_readwrite(
+      .def_property(
           "permissive",
-          &mm::FileSaveOptions::permissive,
+          [](const mm::FileSaveOptions& opts) { return opts.permissive == mm::Permissive::Yes; },
+          [](mm::FileSaveOptions& opts, bool permissive) {
+            opts.permissive = permissive ? mm::Permissive::Yes : mm::Permissive::No;
+          },
           "Permissive mode: allow saving mesh-only characters without skin weights (default: false)")
       .def_readwrite(
           "coord_system_info",
@@ -727,7 +730,7 @@ The resulting tensors are as follows:
             opts.locators,
             opts.collisions,
             opts.blendShapes,
-            opts.permissive,
+            (opts.permissive == mm::Permissive::Yes),
             coordSystemInfoStr,
             opts.fbxNamespace,
             opts.extensions,

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -180,7 +180,7 @@ momentum::Character loadFBXCharacterFromFile(
   momentum::Character result = momentum::loadFbxCharacter(
       filesystem::path(fbxPath),
       keepLocators,
-      permissive,
+      permissive ? momentum::Permissive::Yes : momentum::Permissive::No,
       loadBlendShapes ? momentum::LoadBlendShapes::Yes : momentum::LoadBlendShapes::No,
       stripNamespaces);
   if (configPath && !configPath->empty()) {
@@ -213,7 +213,7 @@ loadFBXCharacterWithMotionFromFile(
   auto [character, motion, fps] = momentum::loadFbxCharacterWithMotion(
       filesystem::path(fbxPath),
       keepLocators,
-      permissive,
+      permissive ? momentum::Permissive::Yes : momentum::Permissive::No,
       loadBlendShapes ? momentum::LoadBlendShapes::Yes : momentum::LoadBlendShapes::No,
       stripNamespaces);
   transposeMotionInPlace(motion);
@@ -229,7 +229,7 @@ loadFBXCharacterWithMotionFromBytes(
   auto [character, motion, fps] = momentum::loadFbxCharacterWithMotion(
       toSpan<std::byte>(fbxBytes),
       keepLocators,
-      permissive,
+      permissive ? momentum::Permissive::Yes : momentum::Permissive::No,
       loadBlendShapes ? momentum::LoadBlendShapes::Yes : momentum::LoadBlendShapes::No,
       stripNamespaces);
   transposeMotionInPlace(motion);
@@ -279,7 +279,7 @@ momentum::Character loadFBXCharacterFromBytes(
   return momentum::loadFbxCharacter(
       toSpan<std::byte>(bytes),
       keepLocators,
-      permissive,
+      permissive ? momentum::Permissive::Yes : momentum::Permissive::No,
       loadBlendShapes ? momentum::LoadBlendShapes::Yes : momentum::LoadBlendShapes::No,
       stripNamespaces);
 }


### PR DESCRIPTION
Summary:
To be able to load some of the fbx files coming from the Maya-specific pipelines, we need a "partially permissive" mode - the `permissive` flag does a lot of hard work in Momentum, and to load these files correctly, only *some* of those are necessary.

Let's start with making the bool a strong type, following other similar flags in the codebase.

Reviewed By: jeongseok-meta

Differential Revision: D87076283
