### PR TITLE
Add conversion from skinned locators to locators.

### DIFF
--- a/momentum/marker_tracking/tracker_utils.h
+++ b/momentum/marker_tracking/tracker_utils.h
@@ -42,6 +42,15 @@ momentum::Character locatorsToSkinnedLocators(
     const momentum::Character& sourceCharacter,
     float maxDistance = 3.0f);
 
+/// Convert skinned locators to regular locators by selecting the bone with the highest skin weight.
+/// This is useful when exporting to file formats that don't support skinned locators (e.g., Maya).
+/// Each skinned locator will be converted to a regular locator attached to the bone with the
+/// highest weight. The position will be transformed from the rest pose space to the local space
+/// of the selected bone.
+/// @param sourceCharacter Character with skinned locators to convert
+/// @return Character with skinned locators converted to regular locators
+momentum::Character skinnedLocatorsToLocators(const momentum::Character& sourceCharacter);
+
 std::vector<momentum::SkinnedLocatorTriangleConstraintT<float>> createSkinnedLocatorMeshConstraints(
     const momentum::Character& character,
     float targetDepth = 1.0f);

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -518,4 +518,24 @@ influenced by multiple joints through skin weights.
 :return: New character with converted skinned locators and remaining regular locators)",
       py::arg("character"),
       py::arg("max_distance") = 3.0f);
+
+  m.def(
+      "convert_skinned_locators_to_locators",
+      &momentum::skinnedLocatorsToLocators,
+      R"(Convert skinned locators to regular locators by selecting the bone with highest weight.
+
+This function is useful when exporting to file formats that don't support skinned locators
+(e.g., Maya). Each skinned locator is converted to a regular locator by:
+
+1. Finding the bone with the highest skin weight from the skinned locator's bone influences
+2. Transforming the locator's position from rest pose space to the local coordinate space
+   of the selected bone
+3. Creating a regular locator attached to that bone with the computed offset
+
+The resulting locators can be exported to formats like Maya that only support single-parent
+attachments. Any existing regular locators in the character are preserved.
+
+:param character: Character with skinned locators to convert
+:return: New character with skinned locators converted to regular locators)",
+      py::arg("character"));
 }


### PR DESCRIPTION
Summary: There are some places we can't effectively use SkinnedLocators (when exporting to FBX for example) so it would be useful to have functionality to convert them back.

Reviewed By: cstollmeta

Differential Revision: D87119723


