### PR TITLE
Initialize facial expression basis from pymomentum.character.

### DIFF
--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -778,6 +778,11 @@ class Character(torch.nn.Module):
 
         if has_rest_mesh and character.blend_shape is not None:
             self.blend_shape: BlendShape = BlendShape(character, dtype=dtype)
+        if has_rest_mesh and character.face_expression_blend_shape is not None:
+            self.face_expression_blend_shape: BlendShapeBase = BlendShapeBase(
+                torch.tensor(character.face_expression_blend_shape.shape_vectors),
+                dtype=dtype,
+            )
 
     def joint_parameters_to_local_skeleton_state(
         self, joint_parameters: torch.Tensor


### PR DESCRIPTION
Summary: Modify torch character constructor so that it reads facial expression's shape vectors from the pymomentum.character passed as parameter, if available.

Reviewed By: cstollmeta

Differential Revision: D86628287


