### PR TITLE
Expand blendshapes to have a name per shape

### DIFF
--- a/momentum/character/blend_shape_base.h
+++ b/momentum/character/blend_shape_base.h
@@ -22,14 +22,14 @@ struct BlendShapeBase {
 
   /// @param modelSize Number of vertices in the model
   /// @param numShapes Number of blend shapes
-  BlendShapeBase(size_t modelSize, size_t numShapes);
+  /// @param shapeNames Names of the blend shapes (will be automatically generated if empty or not
+  /// the right size)
+  BlendShapeBase(size_t modelSize, size_t numShapes, std::span<std::string> shapeNames = {});
 
   virtual ~BlendShapeBase() = default;
 
   /// @param shapeVectors Matrix where each column is a shape vector
-  void setShapeVectors(const MatrixXf& shapeVectors) {
-    shapeVectors_ = shapeVectors;
-  }
+  void setShapeVectors(const MatrixXf& shapeVectors, std::span<std::string> shapeNames = {});
 
   [[nodiscard]] const MatrixXf& getShapeVectors() const {
     return shapeVectors_;
@@ -54,7 +54,8 @@ struct BlendShapeBase {
 
   /// @param index Index of the shape vector to set
   /// @param shapeVector Vector of vertex offsets
-  void setShapeVector(size_t index, std::span<const Vector3f> shapeVector);
+  void
+  setShapeVector(size_t index, std::span<const Vector3f> shapeVector, std::string_view name = "");
 
   [[nodiscard]] Eigen::Index shapeSize() const {
     return shapeVectors_.cols();
@@ -65,8 +66,21 @@ struct BlendShapeBase {
     return shapeVectors_.rows() / 3;
   }
 
+  [[nodiscard]] const std::vector<std::string>& getShapeNames() const {
+    return shapeNames_;
+  }
+
+  [[nodiscard]] std::string_view getShapeName(size_t index) const {
+    return shapeNames_[index];
+  }
+
+  void setShapeName(size_t index, std::string_view name) {
+    shapeNames_[index] = name;
+  }
+
  protected:
   MatrixXf shapeVectors_;
+  std::vector<std::string> shapeNames_;
 };
 
 } // namespace momentum

--- a/momentum/test/character/blend_shape_test.cpp
+++ b/momentum/test/character/blend_shape_test.cpp
@@ -483,3 +483,26 @@ TEST(BlendShapeTest, DifferentSizes) {
   EXPECT_EQ(manyShapesBlendShape.modelSize(), modelSize);
   EXPECT_EQ(manyShapesBlendShape.shapeSize(), manyShapes);
 }
+
+TEST(BlendShapeTest, BlendShapeNames) {
+  const size_t modelSize = 10;
+  const size_t numShapes = 5;
+
+  BlendShapeBase blendShapeBase(modelSize, numShapes);
+
+  // check that we get names
+  for (size_t i = 0; i < numShapes; ++i) {
+    EXPECT_EQ(blendShapeBase.getShapeName(i), std::string("shape_") + std::to_string(i));
+  }
+
+  // do explicit names
+  std::vector<std::string> names;
+  for (size_t i = 0; i < numShapes; ++i) {
+    names.push_back(std::string("different_name_") + std::to_string(i));
+  }
+  BlendShapeBase namedBase(modelSize, numShapes, names);
+
+  for (size_t i = 0; i < numShapes; ++i) {
+    EXPECT_EQ(namedBase.getShapeName(i), names[i]);
+  }
+}


### PR DESCRIPTION
Summary: Currently blendshapes don't have names. Let's expand this so they're more easily identifiable.

Reviewed By: jeongseok-meta

Differential Revision: D87575937


