### PR TITLE
Expose blendshape name generation from data

### DIFF
--- a/momentum/character/blend_shape.cpp
+++ b/momentum/character/blend_shape.cpp
@@ -88,13 +88,19 @@ VectorXf BlendShape::estimateCoefficients(
   }
 }
 
-BlendShape::BlendShape(std::span<const Vector3f> baseShape, const size_t numShapes)
-    : BlendShapeBase(baseShape.size(), numShapes),
+BlendShape::BlendShape(
+    std::span<const Vector3f> baseShape,
+    const size_t numShapes,
+    std::span<const std::string> shapeNames)
+    : BlendShapeBase(baseShape.size(), numShapes, shapeNames),
       baseShape_(baseShape.begin(), baseShape.end()),
       factorizationValid_(false) {}
 
-void BlendShape::setShapeVector(const size_t index, std::span<const Vector3f> shape) {
-  BlendShapeBase::setShapeVector(index, shape);
+void BlendShape::setShapeVector(
+    const size_t index,
+    std::span<const Vector3f> shape,
+    std::string_view name) {
+  BlendShapeBase::setShapeVector(index, shape, name);
 
   // mark as not up to date
   factorizationValid_ = false;

--- a/momentum/character/blend_shape.h
+++ b/momentum/character/blend_shape.h
@@ -22,7 +22,12 @@ struct BlendShape : public BlendShapeBase {
 
   /// @param baseShape Base shape vertices
   /// @param numShapes Number of blend shapes
-  BlendShape(std::span<const Vector3f> baseShape, size_t numShapes);
+  /// @param shapeNames Names of the blend shapes (will be automatically generated if empty or not
+  /// the right size)
+  BlendShape(
+      std::span<const Vector3f> baseShape,
+      size_t numShapes,
+      std::span<const std::string> shapeNames = {});
 
   void setBaseShape(std::span<const Vector3f> baseShape) {
     baseShape_.assign(baseShape.begin(), baseShape.end());
@@ -75,7 +80,8 @@ struct BlendShape : public BlendShapeBase {
   ///
   /// @param index Index of the shape vector to set
   /// @param shapeVector Vector of vertex offsets
-  void setShapeVector(size_t index, std::span<const Vector3f> shapeVector);
+  void
+  setShapeVector(size_t index, std::span<const Vector3f> shapeVector, std::string_view name = "");
 
   /// Compares all components of two blend shapes
   ///

--- a/momentum/character/blend_shape_base.cpp
+++ b/momentum/character/blend_shape_base.cpp
@@ -36,7 +36,7 @@ void BlendShapeBase::applyDeltas(
 BlendShapeBase::BlendShapeBase(
     const size_t modelSize,
     const size_t numShapes,
-    std::span<std::string> shapeNames)
+    std::span<const std::string> shapeNames)
     : shapeVectors_(MatrixXf::Zero(modelSize * 3, numShapes)) {
   shapeNames_.assign(shapeNames.begin(), shapeNames.end());
   if (shapeNames_.size() != numShapes) {
@@ -52,7 +52,7 @@ BlendShapeBase::BlendShapeBase(
 
 void BlendShapeBase::setShapeVectors(
     const MatrixXf& shapeVectors,
-    std::span<std::string> shapeNames) {
+    std::span<const std::string> shapeNames) {
   shapeVectors_ = shapeVectors;
 
   if (shapeNames.size() == static_cast<size_t>(shapeVectors_.cols())) {

--- a/momentum/character/blend_shape_base.h
+++ b/momentum/character/blend_shape_base.h
@@ -24,12 +24,12 @@ struct BlendShapeBase {
   /// @param numShapes Number of blend shapes
   /// @param shapeNames Names of the blend shapes (will be automatically generated if empty or not
   /// the right size)
-  BlendShapeBase(size_t modelSize, size_t numShapes, std::span<std::string> shapeNames = {});
+  BlendShapeBase(size_t modelSize, size_t numShapes, std::span<const std::string> shapeNames = {});
 
   virtual ~BlendShapeBase() = default;
 
   /// @param shapeVectors Matrix where each column is a shape vector
-  void setShapeVectors(const MatrixXf& shapeVectors, std::span<std::string> shapeNames = {});
+  void setShapeVectors(const MatrixXf& shapeVectors, std::span<const std::string> shapeNames = {});
 
   [[nodiscard]] const MatrixXf& getShapeVectors() const {
     return shapeVectors_;

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -220,6 +220,10 @@ PYBIND11_MODULE(geometry, m) {
           [](const mm::BlendShapeBase& blendShape) { return blendShape.shapeSize(); },
           "Number of shapes in the blend shape basis.")
       .def_property_readonly(
+          "shape_names",
+          [](const mm::BlendShapeBase& blendShape) { return blendShape.getShapeNames(); },
+          "Names of the shapes in the blend shape basis.")
+      .def_property_readonly(
           "n_vertices",
           [](const mm::BlendShapeBase& blendShape) { return blendShape.modelSize(); },
           "Number of vertices in the mesh.")
@@ -250,8 +254,10 @@ PYBIND11_MODULE(geometry, m) {
           R"(Create a blend shape basis (shape vectors) from numpy.ndarray.
 
 :param shape_vectors: A [nShapes x nPts x 3] ndarray containing the blend shape basis.
+:param shape_names: An optional list of shape names.
 :return: a :class:`BlendShapeBase`.)",
-          py::arg("shape_vectors"))
+          py::arg("shape_vectors"),
+          py::arg("shape_names") = std::vector<std::string>())
       .def(
           "compute_shape",
           [](py::object blendShape, at::Tensor coeffs) {
@@ -305,9 +311,11 @@ The resulting shape is equal to a linear combination of the shape vectors (plus 
 
 :param base_shape: A [nPts x 3] ndarray containing the base shape.
 :param shape_vectors: A [nShapes x nPts x 3] ndarray containing the blend shape basis.
+:param shape_names: An optional list of shape names.
 :return: a :class:`BlendShape`.)",
           py::arg("base_shape"),
-          py::arg("shape_vectors"))
+          py::arg("shape_vectors"),
+          py::arg("shape_names") = std::vector<std::string>())
       .def("__repr__", [](const mm::BlendShape& bs) {
         return fmt::format("BlendShape(shapes={}, vertices={})", bs.shapeSize(), bs.modelSize());
       });

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -410,7 +410,8 @@ std::string formatDimensions(const py::array& array) {
 }
 
 std::shared_ptr<momentum::BlendShapeBase> loadBlendShapeBaseFromTensors(
-    const pybind11::array_t<float>& shapeVectors) {
+    const pybind11::array_t<float>& shapeVectors,
+    const std::vector<std::string>& shapeNames) {
   MT_THROW_IF(
       shapeVectors.ndim() != 3 || shapeVectors.shape(2) != 3,
       "In BlendShapeBase.from_tensors(), expected shape_vectors shape to be [n_shapes x n_pts x 3] but got {}",
@@ -429,14 +430,15 @@ std::shared_ptr<momentum::BlendShapeBase> loadBlendShapeBaseFromTensors(
     }
   }
 
-  auto result = std::make_shared<momentum::BlendShapeBase>(nPts, nShapes);
+  auto result = std::make_shared<momentum::BlendShapeBase>(nPts, nShapes, shapeNames);
   result->setShapeVectors(shapeVectorsRes);
   return result;
 }
 
 std::shared_ptr<momentum::BlendShape> loadBlendShapeFromTensors(
     const pybind11::array_t<float>& baseShape,
-    const pybind11::array_t<float>& shapeVectors) {
+    const pybind11::array_t<float>& shapeVectors,
+    const std::vector<std::string>& shapeNames) {
   MT_THROW_IF(
       baseShape.ndim() != 2 || baseShape.shape(1) != 3,
       "In BlendShape.from_tensors(), expected base_shape to be [n_pts x 3] but got {}",
@@ -453,7 +455,8 @@ std::shared_ptr<momentum::BlendShape> loadBlendShapeFromTensors(
 
   // Create a BlendShape and get the shape vectors from the base
   auto result = std::make_shared<momentum::BlendShape>();
-  result->setShapeVectors(loadBlendShapeBaseFromTensors(shapeVectors)->getShapeVectors());
+  result->setShapeVectors(
+      loadBlendShapeBaseFromTensors(shapeVectors)->getShapeVectors(), shapeNames);
 
   // Set the base shape specific to BlendShape
   std::vector<Eigen::Vector3f> baseShapeRes(nPts, Eigen::Vector3f::Zero());

--- a/pymomentum/geometry/momentum_geometry.h
+++ b/pymomentum/geometry/momentum_geometry.h
@@ -120,11 +120,13 @@ void saveBlendShapeBaseToFile(const momentum::BlendShapeBase& blendShape, const 
 void saveBlendShapeToFile(const momentum::BlendShape& blendShape, const std::string& path);
 
 std::shared_ptr<momentum::BlendShapeBase> loadBlendShapeBaseFromTensors(
-    const pybind11::array_t<float>& shapeVectors);
+    const pybind11::array_t<float>& shapeVectors,
+    const std::vector<std::string>& shapeNames = {});
 
 std::shared_ptr<momentum::BlendShape> loadBlendShapeFromTensors(
     const pybind11::array_t<float>& baseShape,
-    const pybind11::array_t<float>& shapeVectors);
+    const pybind11::array_t<float>& shapeVectors,
+    const std::vector<std::string>& shapeNames = {});
 
 // Strips out vertices attached to the lower body.
 // Does not actually change the skeleton, this is so you can

--- a/pymomentum/test/test_blend_shape.py
+++ b/pymomentum/test/test_blend_shape.py
@@ -75,6 +75,7 @@ class TestBlendShapeBase(unittest.TestCase):
         shape1, shape2, coeffs = _apply_blend_coeffs(blend_shape, None, shape_vectors)
 
         self.assertTrue(shape1.allclose(shape2))
+        self.assertTrue(len(blend_shape.shape_names) == n_blend)
 
         torch.autograd.gradcheck(
             blend_shape.compute_shape,
@@ -106,6 +107,8 @@ class TestBlendShapeBase(unittest.TestCase):
 
         # Build a set of shape vectors and instantiate as blend shape base
         blend_shape = pym_geometry.BlendShapeBase.from_tensors(_build_shape_vectors(c))
+        self.assertTrue(len(blend_shape.shape_names) == 4)
+        self.assertTrue(blend_shape.shape_names[0] == "shape_0")
 
         c2 = c.with_face_expression_blend_shape(blend_shape)
         # Check the right parameters are retrieved


### PR DESCRIPTION
Summary: We already generate blendshape names on loading FBX files, now we also can set them with the generation functions.

Differential Revision: D87888423


