### PR TITLE
Upgrade node-forge to 1.3.2 to fix security vulnerabilities

### DIFF
--- a/momentum/website/package.json
+++ b/momentum/website/package.json
@@ -41,7 +41,8 @@
     "**/webpack-dev-server": ">=5.2.1",
     "**/on-headers": ">=1.1.0",
     "**/js-yaml": ">=4.1.1",
-    "**/gray-matter": ">=4.0.3"
+    "**/gray-matter": ">=4.0.3",
+    "**/node-forge": ">=1.3.2"
   },
   "browserslist": {
     "production": [

--- a/momentum/website/yarn.lock
+++ b/momentum/website/yarn.lock
@@ -8109,9 +8109,9 @@ node-fetch@2.6.7:
     whatwg-url "^5.0.0"
 
 node-forge@^1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.2.tgz#d0d2659a26eef778bf84d73e7f55c08144ee7750"
+  integrity sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==
 
 node-releases@^2.0.18:
   version "2.0.18"


### PR DESCRIPTION
Summary: Upgrade `node-forge` to version 1.3.2 or later in the website dependencies to address multiple security vulnerabilities, including Interpretation Conflict (CVE-2025-12816), ASN.1 Unbounded Recursion, and ASN.1 OID Integer Truncation. These vulnerabilities could allow attackers to bypass security decisions or cause Denial-of-Service via crafted ASN.1 structures. This update ensures the documentation website is protected against these known issues.

Differential Revision: D87986329


