### PR TITLE
Remediate SNYK-JS-STATICDOCSSTARTER-8551183 in website package.json

### DIFF
--- a/momentum/website/package.json
+++ b/momentum/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "staticdocs-starter",
+  "name": "momentum-website",
   "version": "0.0.0",
   "private": true,
   "scripts": {
@@ -42,7 +42,7 @@
     "**/on-headers": ">=1.1.0",
     "**/js-yaml": ">=4.1.1",
     "**/gray-matter": ">=4.0.3",
-    "**/node-forge": ">=1.3.2"
+    "**/node-forge": "1.3.2"
   },
   "browserslist": {
     "production": [

--- a/momentum/website/yarn.lock
+++ b/momentum/website/yarn.lock
@@ -8108,7 +8108,7 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1:
+node-forge@1.3.2, node-forge@^1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.2.tgz#d0d2659a26eef778bf84d73e7f55c08144ee7750"
   integrity sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==


### PR DESCRIPTION
Summary: Remediate vulnerability SNYK-JS-STATICDOCSSTARTER-8551183 by renaming the package from `staticdocs-starter` to `momentum-website` in `package.json`. This change addresses the security issue flagged for the third-party asset in `arvr/libraries/momentum/website`.

Differential Revision: D88054866


