### PR TITLE
Add a parameter for regularizer weights.

### DIFF
--- a/momentum/marker_tracking/marker_tracker.h
+++ b/momentum/marker_tracking/marker_tracker.h
@@ -175,11 +175,17 @@ Eigen::MatrixXf trackPosesForFrames(
 /// updated in return.
 /// @param[in,out] identity Initial identity parameters that get updated in return. It could also
 /// hold the pose of the first frame for better initialization for tracking later.
+/// @param[in] regularizerWeights Regularizer weights used for global parameters, at each different
+/// stage (3 in total) of the calibration. Ideally these weights would increase over stages: in
+/// stage 0, 0 or low regularization weight to allow a large change; in stage 1, a small
+/// regularization weight to prevent too large of a change; in stage 2, a higher regularization
+/// weight to prevent large changes.
 void calibrateModel(
     std::span<const std::vector<momentum::Marker>> markerData,
     const CalibrationConfig& config,
     momentum::Character& character,
-    momentum::ModelParameters& identity);
+    momentum::ModelParameters& identity,
+    const std::array<float, 3>& regularizerWeights = {0.0f, 0.0f, 0.0f});
 
 /// Calibrate locator offsets of a character from input identity and marker data.
 ///


### PR DESCRIPTION
Summary: Allow the caller to set a stronger regularization towards the identity/global parameters passed as initialization.

Reviewed By: jeongseok-meta

Differential Revision: D87931014


