### PR TITLE
Fix potential GLTF loading crash with blendshape names without extension

### DIFF
--- a/momentum/io/gltf/gltf_io.cpp
+++ b/momentum/io/gltf/gltf_io.cpp
@@ -532,8 +532,12 @@ size_t addBlendShapes(
           kNumNewVertices);
 
       // Set the shape vector for this target
-      blendShape->setShapeVector(
-          iTarget, std::span<const Vector3f>(deltas), blendShapeNames[iTarget]);
+      if (iTarget < blendShapeNames.size()) {
+        blendShape->setShapeVector(
+            iTarget, std::span<const Vector3f>(deltas), blendShapeNames[iTarget]);
+      } else {
+        blendShape->setShapeVector(iTarget, std::span<const Vector3f>(deltas));
+      }
     }
   } else {
     // Append to existing BlendShape


### PR DESCRIPTION
Summary: There was an uncheck access to the blendshape name array, which could not be present in some cases.

Reviewed By: cdtwigg

Differential Revision: D88501289


