### PR TITLE
Add functionality to load model parameters from GLTF correctly transferring scale parameters.

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -716,7 +716,7 @@ MatrixXf mapMotionToCharacter(
   return result;
 }
 
-VectorXf mapIdentityToCharacter(
+JointParameters mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter) {
   // re-arrange offsets according to the character names
@@ -734,7 +734,7 @@ VectorXf mapIdentityToCharacter(
     const auto index = targetCharacter.skeleton.getJointIdByName(jointNames[i]);
     if (index != kInvalidIndex) {
       result.template middleRows<kParametersPerJoint>(index * kParametersPerJoint).noalias() =
-          identity.template middleRows<kParametersPerJoint>(i * kParametersPerJoint);
+          identity.v.template middleRows<kParametersPerJoint>(i * kParametersPerJoint);
     } else {
       MT_LOGW("Joint {} not found in source identity", jointNames[i]);
     }

--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -81,7 +81,7 @@ MatrixXf mapMotionToCharacter(
 /// @param[in] inputIdentity Input JointParameter vector with joint names.
 /// @param[in] targetCharacter Target character that defines its own Joints.
 /// @return A vector of joint parameters for the target character.
-VectorXf mapIdentityToCharacter(
+JointParameters mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter);
 

--- a/momentum/character/types.h
+++ b/momentum/character/types.h
@@ -194,7 +194,7 @@ using MotionParameters = std::tuple<std::vector<std::string>, Eigen::MatrixXf>;
 // each joint wrt parent joint) during FK step The identity parameters are expressed as a vector of
 // size (numSkeletonJoints * momentum::kParametersPerJoint)
 
-using IdentityParameters = std::tuple<std::vector<std::string>, Eigen::VectorXf>;
+using IdentityParameters = std::tuple<std::vector<std::string>, JointParameters>;
 
 // define static kInvalidIndex for size_t
 inline constexpr size_t kInvalidIndex = std::numeric_limits<size_t>::max();

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 
     // load motion file if it exists
     MatrixXf poses;
-    VectorXf offsets;
+    JointParameters offsets;
     float fps = 120.0;
     const bool hasMotion = !options->input_motion_file.empty();
 
@@ -182,7 +182,7 @@ int main(int argc, char** argv) {
             }
           }
           fps = framerate;
-          offsets = character.parameterTransform.zero().v;
+          offsets = character.parameterTransform.zero();
         }
       } else {
         MT_LOGW(
@@ -208,7 +208,7 @@ int main(int argc, char** argv) {
           options->output_model_file,
           character,
           poses,
-          offsets,
+          offsets.v,
           fps,
           markerSequence.frames,
           fbxOptions);

--- a/momentum/examples/export_objs/export_objs.cpp
+++ b/momentum/examples/export_objs/export_objs.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) try {
   Character character;
   MatrixXf motion; // For GLB: single motion matrix
   std::vector<MatrixXf> motions; // For FBX: vector of motion matrices
-  VectorXf id; // Identity parameters (GLB only)
+  JointParameters id; // Identity parameters (GLB only)
   float fps = 0.0f;
 
   // Load character and motion based on file type

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -591,10 +591,10 @@ void addMotionToModel(
       fullAnimation = true;
     }
 
-    if (!jointNames.empty() && identity.size() > 0) {
+    if (!jointNames.empty() && identity.v.size() > 0) {
       def["motion"]["jointNames"] = jointNames;
       def["motion"]["offsets"] = createAccessorBuffer<const float>(
-          model, std::span<const float>(identity.data(), identity.size()));
+          model, std::span<const float>(identity.v.data(), identity.v.size()));
       fullAnimation = true;
     }
   } else {

--- a/momentum/io/gltf/gltf_builder.h
+++ b/momentum/io/gltf/gltf_builder.h
@@ -24,7 +24,7 @@ struct Document;
 namespace momentum {
 
 using MotionParameters = std::tuple<std::vector<std::string>, MatrixXf>;
-using IdentityParameters = std::tuple<std::vector<std::string>, VectorXf>;
+using IdentityParameters = std::tuple<std::vector<std::string>, JointParameters>;
 
 /// Helper class to build a glb scene. It supports adding multiple characters
 /// and motions for each character.

--- a/momentum/io/gltf/gltf_io.h
+++ b/momentum/io/gltf/gltf_io.h
@@ -45,7 +45,7 @@ std::vector<int64_t> loadMotionTimestamps(const filesystem::path& gltfFilename);
 /// @param[in] filepath The path to the glTF character file.
 /// @return A tuple containing the loaded Character object, the motion represented in model
 /// parameters, the identity vector represented as joint parameters, and the fps.
-std::tuple<Character, MatrixXf, VectorXf, float> loadCharacterWithMotion(
+std::tuple<Character, MatrixXf, momentum::JointParameters, float> loadCharacterWithMotion(
     const filesystem::path& gltfFilename);
 
 /// Load a glTF character from a buffer.
@@ -53,8 +53,36 @@ std::tuple<Character, MatrixXf, VectorXf, float> loadCharacterWithMotion(
 /// @param[in] byteSpan The buffer containing the glTF character data.
 /// @return A tuple containing the loaded Character object, the motion represented in model
 /// parameters, the identity vector represented as joint parameters, and the fps.
-std::tuple<Character, MatrixXf, VectorXf, float> loadCharacterWithMotion(
+std::tuple<Character, MatrixXf, momentum::JointParameters, float> loadCharacterWithMotion(
     std::span<const std::byte> byteSpan);
+
+/// Load a glTF character with motion and apply scale parameters to the motion.
+///
+/// This function loads both the character and motion data from a glTF file, applying the
+/// character's scale parameters directly to the motion as model parameters. This approach is
+/// preferred over the deprecated method of storing scales in an offset vector in the parameter
+/// transform. The scale parameters from the identity vector are integrated into the motion data
+/// for each frame.
+///
+/// @param[in] byteSpan The buffer containing the glTF character data.
+/// @return A tuple containing the loaded Character object, the motion represented in model
+/// parameters with scales applied, the identity parameters as model parameters, and the fps.
+std::tuple<Character, MatrixXf, momentum::ModelParameters, float>
+loadCharacterWithMotionModelParameterScales(std::span<const std::byte> byteSpan);
+
+/// Load a glTF character with motion and apply scale parameters to the motion.
+///
+/// This function loads both the character and motion data from a glTF file, applying the
+/// character's scale parameters directly to the motion as model parameters. This approach is
+/// preferred over the deprecated method of storing scales in an offset vector in the parameter
+/// transform. The scale parameters from the identity vector are integrated into the motion data
+/// for each frame.
+///
+/// @param[in] gltfFilename The path to the glTF file.
+/// @return A tuple containing the loaded Character object, the motion represented in model
+/// parameters with scales applied, the identity parameters as model parameters, and the fps.
+std::tuple<Character, MatrixXf, momentum::ModelParameters, float>
+loadCharacterWithMotionModelParameterScales(const filesystem::path& gltfFilename);
 
 /// Load a GLTF Character with motion in the form of skeleton states (transform matrices)
 ///
@@ -77,7 +105,7 @@ loadCharacterWithSkeletonStates(const filesystem::path& gltfFilename);
 /// @return A tuple containing the motion represented in model parameters, the identity vector
 /// represented as joint parameters, and the fps. The model parameters and joint parameters are
 /// mapped to the input character by name matching.
-std::tuple<MatrixXf, VectorXf, float> loadMotionOnCharacter(
+std::tuple<MatrixXf, JointParameters, float> loadMotionOnCharacter(
     const filesystem::path& gltfFilename,
     const Character& character);
 
@@ -88,7 +116,7 @@ std::tuple<MatrixXf, VectorXf, float> loadMotionOnCharacter(
 /// @return A tuple containing the motion represented in model parameters, the identity vector
 /// represented as joint parameters, and the fps. The model parameters and joint parameters are
 /// mapped to the input character by name matching.
-std::tuple<MatrixXf, VectorXf, float> loadMotionOnCharacter(
+std::tuple<MatrixXf, JointParameters, float> loadMotionOnCharacter(
     std::span<const std::byte> byteSpan,
     const Character& character);
 

--- a/momentum/marker_tracking/app_utils.cpp
+++ b/momentum/marker_tracking/app_utils.cpp
@@ -168,7 +168,7 @@ std::tuple<momentum::Character, momentum::ModelParameters> loadCharacterWithIden
           .empty()) { // Assume input has precomputed proportions and marker offsets etc.
     auto [c, m, id, fps] = loadCharacterWithMotion(modelFiles.model);
     character = c;
-    if (id.size() > 0) {
+    if (id.v.size() > 0) {
       identity = jointIdentityToModelIdentity(c, c.parameterTransform.getScalingParameters(), id);
     } else {
       identity = ModelParameters::Zero(character.parameterTransform.numAllModelParameters());

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -314,7 +314,7 @@ TEST_F(CharacterUtilityTest, MapIdentityToCharacter) {
   IdentityParameters inputIdentity = std::make_tuple(jointNames, identity);
 
   // Map the identity to the character
-  VectorXf resultIdentity = mapIdentityToCharacter(inputIdentity, this->character);
+  JointParameters resultIdentity = mapIdentityToCharacter(inputIdentity, this->character);
 
   // Check that the result identity has the correct size
   EXPECT_EQ(resultIdentity.size(), this->character.skeleton.joints.size() * kParametersPerJoint);
@@ -349,10 +349,10 @@ TEST_F(CharacterUtilityTest, MapIdentityToCharacter) {
   }
 
   // Test with empty identity
-  IdentityParameters emptyIdentity = std::make_tuple(std::vector<std::string>(), VectorXf());
-  VectorXf emptyResult = mapIdentityToCharacter(emptyIdentity, this->character);
+  IdentityParameters emptyIdentity = std::make_tuple(std::vector<std::string>(), JointParameters());
+  JointParameters emptyResult = mapIdentityToCharacter(emptyIdentity, this->character);
   EXPECT_EQ(emptyResult.size(), this->character.skeleton.joints.size() * kParametersPerJoint);
-  EXPECT_TRUE(emptyResult.isZero());
+  EXPECT_TRUE(emptyResult.v.isZero());
 }
 
 // Test replaceSkeletonHierarchy error cases

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -752,10 +752,10 @@ support the proprietary momentum motion format for storing model parameters in G
           py::arg("path"),
           py::arg("character"),
           py::arg("fps") = 120.f,
-          py::arg("motion") = std::optional<momentum::MotionParameters>{},
-          py::arg("offsets") = std::optional<const momentum::IdentityParameters>{},
-          py::arg("markers") = std::optional<const std::vector<std::vector<momentum::Marker>>>{},
-          py::arg("options") = std::optional<momentum::FileSaveOptions>{})
+          py::arg("motion") = std::nullopt,
+          py::arg("offsets") = std::nullopt,
+          py::arg("markers") = std::nullopt,
+          py::arg("options") = std::nullopt)
       .def_static(
           "save_gltf_from_skel_states",
           &saveGLTFCharacterToFileFromSkelStates,

--- a/pymomentum/geometry/gltf_builder_pybind.cpp
+++ b/pymomentum/geometry/gltf_builder_pybind.cpp
@@ -136,7 +136,7 @@ node in the scene with the specified name.
              const mm::Character& character,
              float fps,
              const std::optional<mm::MotionParameters>& motion,
-             const std::optional<mm::IdentityParameters>& offsets,
+             const std::optional<std::tuple<std::vector<std::string>, Eigen::VectorXf>>& offsets,
              bool addExtensions,
              const std::string& customName) {
             // Apply same validation and transposition as
@@ -152,11 +152,17 @@ node in the scene with the specified name.
                   poses.cols());
             }
 
+            mm::IdentityParameters identityParams;
+            if (offsets.has_value()) {
+              const auto& [names, params] = offsets.value();
+              identityParams = {names, params};
+            }
+
             builder.addMotion(
                 character,
                 fps,
                 pymomentum::transpose(motion.value_or(mm::MotionParameters{})),
-                offsets.value_or(mm::IdentityParameters{}),
+                identityParams,
                 addExtensions,
                 customName);
           },

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -41,7 +41,7 @@ void saveGLTFCharacterToFile(
     const momentum::Character& character,
     float fps,
     const std::optional<const momentum::MotionParameters>& motion,
-    const std::optional<const momentum::IdentityParameters>& offsets,
+    const std::optional<const std::tuple<std::vector<std::string>, Eigen::VectorXf>>& offsets,
     const std::optional<const std::vector<std::vector<momentum::Marker>>>& markers,
     const std::optional<const momentum::FileSaveOptions>& options);
 
@@ -98,6 +98,12 @@ std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float> loadGLTFChar
 
 std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float>
 loadGLTFCharacterWithMotionFromBytes(const pybind11::bytes& gltfBytes);
+
+std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float>
+loadGLTFCharacterWithMotionModelParameterScales(const std::string& gltfFilename);
+
+std::tuple<momentum::Character, RowMatrixf, Eigen::VectorXf, float>
+loadGLTFCharacterWithMotionModelParameterScalesFromBytes(const pybind11::bytes& gltfBytes);
 
 std::tuple<momentum::Character, pybind11::array_t<float>, std::vector<float>>
 loadGLTFCharacterWithSkelStates(const std::string& gltfFilename);


### PR DESCRIPTION
Summary:
In our initial GLTF code, we always pulled the model parameters that affect identity into a separate set of _joint_ parameters, the IdentityParameters.  These joint parameters would get added in after the parameter transform was applied to the model parameters, either by stuffing them into the ParameterTransform "offset" field or by passing around CharacterParameters that combine model and identity joint parameters.  

In practice, however, nobody seems to want to work this way, people are much more comfortable  just working exclusively with model parameters, this has a few advantages such as having fewer tensors to pass around in Python and guaranteeing that the scaling parameters are within the space of the parameter transform.  

However we have a lot of old data that stores the joint parameter identity parameters.  With this diff I'm introducing a new function, loadCharacterWithMotionModelParameterScales() that automatically transfers the identity parameter back into model parameter space and only returns model parameters.  

In the long run we plan to phase out the current version of the function and replace it with this one, but that can only happen after we migrate all callers.

Reviewed By: jeongseok-meta

Differential Revision: D88656785


