### PR TITLE
Add logging for skinned locators

### DIFF
--- a/momentum/marker_tracking/tracker_utils.h
+++ b/momentum/marker_tracking/tracker_utils.h
@@ -38,9 +38,14 @@ momentum::Character createLocatorCharacter(
 /// @param sourceCharacter Character with locators to convert
 /// @param maxDistance Maximum distance to search for the closest point on the mesh surface.  If the
 /// locator is further than this distance, it will not be converted.
+/// @param minSkinWeight Minimum skin weight threshold for considering a mesh triangle as belonging
+/// to the same bone as the locator.
+/// @param verbose If true, print diagnostic messages about locators that could not be converted.
 momentum::Character locatorsToSkinnedLocators(
     const momentum::Character& sourceCharacter,
-    float maxDistance = 3.0f);
+    float maxDistance = 3.0f,
+    float minSkinWeight = 0.03f,
+    bool verbose = false);
 
 /// Convert skinned locators to regular locators by selecting the bone with the highest skin weight.
 /// This is useful when exporting to file formats that don't support skinned locators (e.g., Maya).

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -515,9 +515,15 @@ influenced by multiple joints through skin weights.
 
 :param character: Character with mesh, skin weights, and locators to convert
 :param max_distance: Maximum distance from mesh surface to convert a locator (default: 3.0)
+:param min_skin_weight: Minimum skin weight threshold for considering a mesh triangle as
+    belonging to the same bone as the locator (default: 0.03)
+:param verbose: If True, print diagnostic messages about locators that could not be
+    converted (default: False)
 :return: New character with converted skinned locators and remaining regular locators)",
       py::arg("character"),
-      py::arg("max_distance") = 3.0f);
+      py::arg("max_distance") = 3.0f,
+      py::arg("min_skin_weight") = 0.03f,
+      py::arg("verbose") = false);
 
   m.def(
       "convert_skinned_locators_to_locators",


### PR DESCRIPTION
Summary: It's annoying to debug the conversion of locators to skinned locators, let's add some printouts for the various possibilities (converted, not converted) and control it with a verbosity flag.

Reviewed By: jeongseok-meta

Differential Revision: D87104967


