### PR TITLE
Unbroke FixedAxisError function bindings

### DIFF
--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -211,7 +211,7 @@ void defFixedAxisError(py::module_& m, const char* name, const char* description
           py::arg("weight") = 1.0f)
       .def(
           "add_constraint",
-          [](mm::FixedAxisDiffErrorFunctionT<float>& self,
+          [](FixedAxisErrorFunctionT& self,
              const Eigen::Vector3f& localAxis,
              const Eigen::Vector3f& globalAxis,
              int parent,
@@ -226,7 +226,7 @@ void defFixedAxisError(py::module_& m, const char* name, const char* description
 
         :param local_axis: The axis in the parent's coordinate frame.
         :param global_axis: The target axis in the global frame.
-        :param parent_index: The index of the parent joint.
+        :param parent: The index of the parent joint.
         :param weight: The weight of the constraint.
         :param name: The name of the constraint (for debugging).)",
           py::arg("local_axis"),

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -761,10 +761,20 @@ class TestSolver(unittest.TestCase):
 
         # Create FixedAxisErrorFunction
         fixed_axis_error_function = pym_solver2.FixedAxisDiffErrorFunction(character)
+        fixed_axis_error_function2 = pym_solver2.FixedAxisCosErrorFunction(character)
+        fixed_axis_error_function3 = pym_solver2.FixedAxisAngleErrorFunction(character)
 
         # Add fixed axis constraint
         parent_idx: int = character.skeleton.size - 1
         fixed_axis_error_function.add_constraint(
+            local_axis, target_global_axis, parent=parent_idx, weight=1.0
+        )
+
+        # ensure all three variations work
+        fixed_axis_error_function2.add_constraint(
+            local_axis, target_global_axis, parent=parent_idx, weight=1.0
+        )
+        fixed_axis_error_function3.add_constraint(
             local_axis, target_global_axis, parent=parent_idx, weight=1.0
         )
 


### PR DESCRIPTION
Summary: Python bindings for add_constraint of FixedAxisErrorFunction was broken and only worked for one variation (FixedAxisDiffErrorFunction). Fixed the binding so it now works with all variants.

Differential Revision: D89265412


