### PR TITLE
re-fit the skinned locator closest points after every iteration.

### DIFF
--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -276,7 +276,8 @@ Eigen::MatrixXf trackSequence(
 
   std::vector<momentum::SkinnedLocatorTriangleConstraintT<float>> skinnedLocatorMeshContraints;
   if ((globalParams & pt.getBlendShapeParameters()).any() && !character.skinnedLocators.empty()) {
-    skinnedLocatorMeshContraints = createSkinnedLocatorMeshConstraints(character, 1.0f);
+    skinnedLocatorMeshContraints =
+        createSkinnedLocatorMeshConstraints(character, initialMotion.col(0), 1.0f);
   }
 
   // set up the solver function

--- a/momentum/marker_tracking/tracker_utils.cpp
+++ b/momentum/marker_tracking/tracker_utils.cpp
@@ -365,6 +365,7 @@ momentum::Character skinnedLocatorsToLocators(const momentum::Character& sourceC
 
 std::vector<momentum::SkinnedLocatorTriangleConstraintT<float>> createSkinnedLocatorMeshConstraints(
     const momentum::Character& character,
+    const ModelParameters& modelParams,
     float targetDepth) {
   if (!character.mesh || !character.skinWeights) {
     return {};
@@ -375,7 +376,10 @@ std::vector<momentum::SkinnedLocatorTriangleConstraintT<float>> createSkinnedLoc
     return {};
   }
 
-  const auto& mesh = *character.mesh;
+  auto mesh = *character.mesh;
+  if (modelParams.size() > 0) {
+    mesh = extractBlendShapeFromParams(modelParams, character);
+  }
 
   std::vector<momentum::SkinnedLocatorTriangleConstraintT<float>> result;
   result.reserve(character.skinnedLocators.size());
@@ -606,6 +610,7 @@ std::tuple<Eigen::VectorXf, LocatorList, SkinnedLocatorList> extractIdAndLocator
 Mesh extractBlendShapeFromParams(
     const momentum::ModelParameters& param,
     const momentum::Character& sourceCharacter) {
+  MT_CHECK(param.size() == sourceCharacter.parameterTransform.numAllModelParameters());
   Mesh result = *sourceCharacter.mesh;
   auto blendWeights = extractBlendWeights(sourceCharacter.parameterTransform, param);
   result.vertices = sourceCharacter.blendShape->computeShape<float>(blendWeights);

--- a/momentum/marker_tracking/tracker_utils.h
+++ b/momentum/marker_tracking/tracker_utils.h
@@ -58,6 +58,7 @@ momentum::Character skinnedLocatorsToLocators(const momentum::Character& sourceC
 
 std::vector<momentum::SkinnedLocatorTriangleConstraintT<float>> createSkinnedLocatorMeshConstraints(
     const momentum::Character& character,
+    const ModelParameters& modelParams,
     float targetDepth = 1.0f);
 
 // Extract locator offsets from a LocatorCharacter for a normal Character given input calibrated


### PR DESCRIPTION
Summary: We want to allow the locators to slide along the surface to mimic the fact that markers are not always fixed on the exact same mesh location between people.  We allow a certain amount of sliding due to point-to-plane distance but we can allow more slliding by recomputing the closest mesh points after every iteration using the solved blend shape.

Reviewed By: jeongseok-meta

Differential Revision: D87104970


