### PR TITLE
Unit tests for the new joint-to-joint position constraint

### DIFF
--- a/momentum/test/character_solver/error_functions_test.cpp
+++ b/momentum/test/character_solver/error_functions_test.cpp
@@ -26,6 +26,7 @@
 #include "momentum/character_solver/fwd.h"
 #include "momentum/character_solver/height_error_function.h"
 #include "momentum/character_solver/joint_to_joint_distance_error_function.h"
+#include "momentum/character_solver/joint_to_joint_position_error_function.h"
 #include "momentum/character_solver/limit_error_function.h"
 #include "momentum/character_solver/model_parameters_error_function.h"
 #include "momentum/character_solver/normal_error_function.h"
@@ -2065,6 +2066,119 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, JointToJointDistanceError_GradientsAndJa
     const double error = errorFunctionZero.getError(
         modelParams, skelState, MeshStateT<T>(modelParams, skelState, character));
     EXPECT_NEAR(error, 0.0, Eps<T>(1e-10f, 1e-15));
+  }
+}
+
+TYPED_TEST(Momentum_ErrorFunctionsTest, JointToJointPositionError_GradientsAndJacobians) {
+  using T = typename TestFixture::Type;
+
+  const Character character = createTestCharacter();
+  const Skeleton& skeleton = character.skeleton;
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+
+  JointToJointPositionErrorFunctionT<T> errorFunction(skeleton, character.parameterTransform);
+  const T kTestWeightValue = 2.5;
+
+  {
+    SCOPED_TRACE("JointToJoint Position Constraint Test");
+
+    ASSERT_GE(skeleton.joints.size(), 3);
+
+    // Add constraints with random offsets and targets
+    errorFunction.addConstraint(
+        1, // sourceJoint
+        uniform<Vector3<T>>(-1, 1), // sourceOffset
+        2, // referenceJoint
+        uniform<Vector3<T>>(-1, 1), // referenceOffset
+        uniform<Vector3<T>>(-1, 1), // target (in reference frame)
+        kTestWeightValue);
+
+    errorFunction.addConstraint(
+        0,
+        Vector3<T>::Zero(),
+        2,
+        Vector3<T>::UnitX(),
+        uniform<Vector3<T>>(-0.5, 0.5),
+        kTestWeightValue);
+
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunction,
+        ModelParametersT<T>::Zero(transform.numAllModelParameters()),
+        character,
+        Eps<T>(5e-2f, 5e-6));
+    for (size_t i = 0; i < 10; i++) {
+      ModelParametersT<T> parameters =
+          uniform<VectorX<T>>(transform.numAllModelParameters(), -1.0f, 1.0f);
+      TEST_GRADIENT_AND_JACOBIAN(
+          T, &errorFunction, parameters, character, Eps<T>(5e-2f, 5e-6), Eps<T>(1e-6f, 1e-7));
+    }
+  }
+
+  {
+    SCOPED_TRACE("JointToJoint Position Zero Error Test");
+
+    // Test that error is zero when the relative position matches the target
+    const ModelParametersT<T> modelParams =
+        ModelParametersT<T>::Zero(transform.numAllModelParameters());
+    const SkeletonStateT<T> skelState(transform.apply(modelParams), skeleton);
+
+    JointToJointPositionErrorFunctionT<T> errorFunctionZero(skeleton, character.parameterTransform);
+
+    const auto& srcJointState = skelState.jointState[1];
+    const auto& refJointState = skelState.jointState[2];
+
+    const auto sourceOffset = uniform<Vector3<T>>(-1, 1);
+    const auto referenceOffset = uniform<Vector3<T>>(-1, 1);
+
+    // Compute world positions
+    const Vector3<T> srcWorldPos = srcJointState.transform * sourceOffset;
+    const Vector3<T> refWorldPos = refJointState.transform * referenceOffset;
+
+    // Compute the relative position in reference frame (this is what the error function computes)
+    const Vector3<T> diff = srcWorldPos - refWorldPos;
+    const Vector3<T> relativePos = refJointState.transform.toRotationMatrix().transpose() * diff;
+
+    // Set the target to exactly match the current relative position
+    errorFunctionZero.addConstraint(1, sourceOffset, 2, referenceOffset, relativePos, T(1.0));
+
+    const double error = errorFunctionZero.getError(
+        modelParams, skelState, MeshStateT<T>(modelParams, skelState, character));
+    EXPECT_NEAR(error, 0.0, Eps<T>(1e-10f, 1e-15));
+  }
+
+  {
+    SCOPED_TRACE("JointToJoint Position Relative Frame Test");
+
+    // Test that the constraint correctly transforms to the reference frame
+    // by verifying that rotating the reference joint doesn't change the error
+    // when the target is set to the current relative position
+
+    const ModelParametersT<T> modelParams =
+        0.5 * uniform<VectorX<T>>(transform.numAllModelParameters(), -1.0f, 1.0f);
+    const SkeletonStateT<T> skelState(transform.apply(modelParams), skeleton);
+
+    JointToJointPositionErrorFunctionT<T> errorFunctionRelative(
+        skeleton, character.parameterTransform);
+
+    const auto& srcJointState = skelState.jointState[1];
+    const auto& refJointState = skelState.jointState[2];
+
+    const Vector3<T> sourceOffset = Vector3<T>::Zero();
+    const Vector3<T> referenceOffset = Vector3<T>::Zero();
+
+    // Compute relative position in reference frame
+    const Vector3<T> srcWorldPos = srcJointState.transform * sourceOffset;
+    const Vector3<T> refWorldPos = refJointState.transform * referenceOffset;
+    const Vector3<T> diff = srcWorldPos - refWorldPos;
+    const Vector3<T> relativePos = refJointState.transform.toRotationMatrix().transpose() * diff;
+
+    // Add constraint with target matching current relative position
+    errorFunctionRelative.addConstraint(1, sourceOffset, 2, referenceOffset, relativePos, T(1.0));
+
+    const double error = errorFunctionRelative.getError(
+        modelParams, skelState, MeshStateT<T>(modelParams, skelState, character));
+    EXPECT_NEAR(error, 0.0, Eps<T>(1e-6f, 1e-12));
   }
 }
 

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -1537,9 +1537,9 @@ source joints respectively.)")
       .def(
           "add_constraint",
           [](mm::JointToJointPositionErrorFunctionT<float>& self,
-             size_t sourceJoint,
+             int sourceJoint,
              const Eigen::Vector3f& sourceOffset,
-             size_t referenceJoint,
+             int referenceJoint,
              const Eigen::Vector3f& referenceOffset,
              const Eigen::Vector3f& target,
              float weight,


### PR DESCRIPTION
Summary:
Adds comprehensive unit tests for the `JointToJointPositionErrorFunction` to verify the gradient and Jacobian computations are correct.

**Test Cases:**

1. **JointToJoint Position Constraint Test** - Validates gradients and Jacobians against numerical finite differences with random constraints and model parameters for both float and double precision.

2. **JointToJoint Position Zero Error Test** - Verifies the error is exactly zero when the target position matches the current relative position between joints, confirming the error function formulation is correct.

3. **JointToJoint Position Relative Frame Test** - Confirms the constraint correctly transforms positions to the reference joint's coordinate frame by verifying zero error when targets match computed relative positions with non-zero model parameters.

Reviewed By: cdtwigg

Differential Revision: D89755968


