### PR TITLE
Add inverse parameter transform to diff_geometry

### DIFF
--- a/pymomentum/diff_geometry/diff_transform_pybind.cpp
+++ b/pymomentum/diff_geometry/diff_transform_pybind.cpp
@@ -41,6 +41,24 @@ batching on the character.
       py::arg("character"),
       py::arg("model_parameters"));
 
+  // apply_inverse_parameter_transform(inverse_parameter_transform, joint_parameters)
+  m.def(
+      "apply_inverse_parameter_transform",
+      [](const momentum::InverseParameterTransform* invParamTransform, at::Tensor jointParameters) {
+        return applyInverseParamTransform(invParamTransform, std::move(jointParameters));
+      },
+      R"(Apply the inverse parameter transform to a [nBatch x nJointParams] tensor of joint parameters.
+This is functionally identical to :meth:`InverseParameterTransform.apply` except that it supports
+automatic differentiation.
+
+:param inverse_parameter_transform: An inverse parameter transform (from ParameterTransform.inverse()).
+:type inverse_parameter_transform: InverseParameterTransform
+:param joint_parameters: A [nBatch x nJointParams] tensor of joint parameters.
+
+:return: a tensor of model parameters.)",
+      py::arg("inverse_parameter_transform"),
+      py::arg("joint_parameters"));
+
   // model_parameters_to_blend_shape_coefficients(character, model_parameters)
   m.def(
       "model_parameters_to_blend_shape_coefficients",

--- a/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
+++ b/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
@@ -387,7 +387,7 @@ variable_list ApplyInverseParameterTransformFunction::forward(
     at::Tensor jointParams) {
   const auto nJointParam = (int)inverseParamTransform->numJointParameters();
 
-  TensorChecker checker("ParameterTransform.apply");
+  TensorChecker checker("InverseParameterTransform.apply");
   const auto input_device = jointParams.device();
 
   bool squeeze;
@@ -424,13 +424,13 @@ variable_list ApplyInverseParameterTransformFunction::backward(
     variable_list grad_outputs) {
   MT_THROW_IF(
       grad_outputs.size() != 1,
-      "Invalid grad_outputs in ApplyParameterTransformFunction::backward");
+      "Invalid grad_outputs in ApplyInverseParameterTransformFunction::backward");
 
   // Restore variables:
   const auto inverseParamTransform = py::cast<const momentum::InverseParameterTransform*>(
       ctx->saved_data["inverseParameterTransform"].toPyObject());
 
-  const auto input_device = grad_outputs[0].device(); // grad_outputs size is guarded already
+  const auto input_device = grad_outputs[0].device();
 
   bool squeeze = false;
   auto dLoss_dModelParameters =

--- a/pymomentum/test/test_diff_geometry.py
+++ b/pymomentum/test/test_diff_geometry.py
@@ -93,14 +93,20 @@ class TestDiffGeometry(unittest.TestCase):
         jointParams = character.parameter_transform.apply(modelParams)
 
         # Validate that inversion works correctly:
-        modelParams2 = invTransform.apply(jointParams)
+        modelParams2 = pym_diff_geometry.apply_inverse_parameter_transform(
+            invTransform, jointParams
+        )
         diff = torch.norm(modelParams2 - modelParams)
         self.assertTrue(diff < 0.001)
 
         # Validate the gradients.
-        inputs = [jointParams]
+        inputs = [invTransform, jointParams]
         torch.autograd.gradcheck(
-            invTransform.apply, inputs, eps=1e-2, atol=1e-3, raise_exception=True
+            pym_diff_geometry.apply_inverse_parameter_transform,
+            inputs,
+            eps=1e-2,
+            atol=1e-3,
+            raise_exception=True,
         )
 
     def test_diffmodel_parameters_to_positions(self) -> None:


### PR DESCRIPTION
Summary:
This adds `apply_inverse_parameter_transform()` to pymomentum.diff_geometry,
which enables automatic differentiation for inverse parameter transforms. This
is a prerequisite for transitioning the inverse transform in pymomentum.geometry
to operate on numpy arrays instead of torch.Tensors, as diff_geometry provides
the differentiable path while the regular geometry module can focus on numpy
operations.

The function is functionally identical to InverseParameterTransform.apply() but
supports autograd, paralleling the existing apply_parameter_transform() for the
forward direction.

Reviewed By: jeongseok-meta

Differential Revision: D89891112


