### PR TITLE
Fix SequenceSolver crash with mixed frame count errors

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver.cpp
+++ b/momentum/character_sequence_solver/sequence_solver.cpp
@@ -177,8 +177,8 @@ typename SequenceSolverT<T>::JacobianResidual SequenceSolverT<T>::computeSequenc
     int rows = 0;
     errorCur += errf->getJacobian(
         std::span(fn->frameParameters_).subspan(iFrame, nFrames),
-        skelStates,
-        meshStates,
+        skelStates.subspan(0, nFrames),
+        meshStates.subspan(0, nFrames),
         jacobian.block(offset, 0, n, nFrames * nFullParameters),
         residual.middleRows(offset, n),
         rows);


### PR DESCRIPTION
Summary: The SequenceSolver would crash when combining sequence error functions that require different numbers of frames (e.g., StateSequenceErrorFunction with 2 frames and AccelerationSequenceErrorFunction with 3 frames). The bug was in computeSequenceJacobian, which passed full bandwidth-sized skelStates and meshStates spans to all error functions, but error functions have assertions expecting the span size to exactly match their numFrames(). Fixed by subspanning the state arrays to match each error function's required frame count.

Differential Revision: D90122001


