### PR TITLE
Add getSkinnedLocatorPosition utility and refactor SkinnedLocatorErrorFunction

### DIFF
--- a/momentum/character/linear_skinning.cpp
+++ b/momentum/character/linear_skinning.cpp
@@ -359,4 +359,57 @@ template void applySSD<double>(
     const JointStateListT<double>& jointState,
     MeshT<double>& outputMesh);
 
+template <typename T>
+Vector3<T> getSkinnedLocatorPosition(
+    const SkinnedLocator& locator,
+    const Vector3<T>& restPosition,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<T>& state) {
+  Vector3<T> worldPos = Vector3<T>::Zero();
+  T weightSum = 0;
+  for (int k = 0; k < locator.skinWeights.size(); ++k) {
+    const auto weight = static_cast<T>(locator.skinWeights[k]);
+    if (weight == 0) {
+      break;
+    }
+    const auto boneIndex = locator.parents[k];
+    const auto& jointState = state.jointState[boneIndex];
+
+    worldPos +=
+        weight * (jointState.transform * (inverseBindPose[boneIndex].cast<T>() * restPosition));
+    weightSum += weight;
+  }
+
+  return worldPos / weightSum;
+}
+
+template Vector3<float> getSkinnedLocatorPosition<float>(
+    const SkinnedLocator& locator,
+    const Vector3<float>& restPosition,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<float>& state);
+template Vector3<double> getSkinnedLocatorPosition<double>(
+    const SkinnedLocator& locator,
+    const Vector3<double>& restPosition,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<double>& state);
+
+template <typename T>
+Vector3<T> getSkinnedLocatorPosition(
+    const SkinnedLocator& locator,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<T>& state) {
+  const Vector3<T> restPosition = locator.position.template cast<T>();
+  return getSkinnedLocatorPosition(locator, restPosition, inverseBindPose, state);
+}
+
+template Vector3<float> getSkinnedLocatorPosition<float>(
+    const SkinnedLocator& locator,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<float>& state);
+template Vector3<double> getSkinnedLocatorPosition<double>(
+    const SkinnedLocator& locator,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<double>& state);
+
 } // namespace momentum

--- a/momentum/character/linear_skinning.h
+++ b/momentum/character/linear_skinning.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <momentum/character/fwd.h>
+#include <momentum/character/skinned_locator.h>
 #include <momentum/character/types.h>
 #include <momentum/math/fwd.h>
 #include <momentum/math/types.h>
@@ -135,5 +136,38 @@ void applyInverseSSD(
     std::span<const Vector3f> points,
     const SkeletonState& state,
     Mesh& mesh);
+
+/// Computes the world position of a skinned locator using linear blend skinning
+///
+/// This function applies linear blend skinning to transform a locator's rest position
+/// to its world position based on the current skeleton state. The position is computed
+/// by blending the transforms from each parent joint weighted by the corresponding
+/// skin weights.
+///
+/// @param locator The skinned locator containing parent joints and weights
+/// @param restPosition The locator's position in rest pose (bind pose)
+/// @param inverseBindPose Inverse bind pose transformations for each joint
+/// @param state Current skeleton state containing joint transformations
+/// @return The locator's world position
+template <typename T>
+Vector3<T> getSkinnedLocatorPosition(
+    const SkinnedLocator& locator,
+    const Vector3<T>& restPosition,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<T>& state);
+
+/// Computes the world position of a skinned locator using linear blend skinning
+///
+/// Convenience overload that uses the locator's stored rest position.
+///
+/// @param locator The skinned locator containing parent joints, weights, and rest position
+/// @param inverseBindPose Inverse bind pose transformations for each joint
+/// @param state Current skeleton state containing joint transformations
+/// @return The locator's world position
+template <typename T>
+Vector3<T> getSkinnedLocatorPosition(
+    const SkinnedLocator& locator,
+    const TransformationList& inverseBindPose,
+    const SkeletonStateT<T>& state);
 
 } // namespace momentum

--- a/momentum/character/skinned_locator.h
+++ b/momentum/character/skinned_locator.h
@@ -37,10 +37,10 @@ struct SkinnedLocator {
   Eigen::Matrix<float, kMaxSkinJoints, 1> skinWeights;
 
   /// Position relative to rest pose of the character
-  Vector3f position;
+  Vector3f position = Vector3f::Zero();
 
   /// Influence weight of this locator when used in constraints
-  float weight;
+  float weight = 1.0f;
 
   /// Creates a locator with the specified properties
   ///

--- a/momentum/character_solver/skinned_locator_error_function.cpp
+++ b/momentum/character_solver/skinned_locator_error_function.cpp
@@ -78,21 +78,7 @@ Eigen::Vector3<T> SkinnedLocatorErrorFunctionT<T>::calculateSkinnedLocatorPositi
   MT_CHECK(locatorIndex >= 0 && locatorIndex < static_cast<int>(character_.skinnedLocators.size()));
   const auto& locator = character_.skinnedLocators[locatorIndex];
 
-  Eigen::Vector3<T> worldPos = Eigen::Vector3<T>::Zero();
-  T weightSum = 0;
-  for (int k = 0; k < locator.skinWeights.size(); ++k) {
-    const auto& weight = locator.skinWeights[k];
-    const auto boneIndex = locator.parents[k];
-    const auto& jointState = state.jointState[boneIndex];
-
-    worldPos += weight *
-        (jointState.transform *
-         (character_.inverseBindPose[boneIndex].template cast<T>() * locatorRestPos))
-            .template cast<T>();
-    weightSum += weight;
-  }
-
-  return worldPos / weightSum;
+  return getSkinnedLocatorPosition(locator, locatorRestPos, character_.inverseBindPose, state);
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:
Adds a shared utility function getSkinnedLocatorPosition to linear_skinning.h for
computing skinned locator world positions using linear blend skinning. This allows
code reuse across the codebase.

Also refactors SkinnedLocatorErrorFunction to:
- Cache the casted inverseBindPose_ as a const member for efficiency
- Use the new shared utility in calculateSkinnedLocatorPosition
- Use .reserve() when building the cached inverseBindPose list

Additionally initializes SkinnedLocator::position to Vector3f::Zero() for safety
since Eigen variables are not default-initialized.

Reviewed By: jeongseok-meta

Differential Revision: D90043774


