### PR TITLE
Refactor shared Gauss-Newton solver options into base class

### DIFF
--- a/momentum/character_solver/gauss_newton_solver_qr.h
+++ b/momentum/character_solver/gauss_newton_solver_qr.h
@@ -11,27 +11,18 @@
 #include <momentum/character_solver/fwd.h>
 #include <momentum/character_solver/skeleton_solver_function.h>
 #include <momentum/math/online_householder_qr.h>
-#include <momentum/solver/solver.h>
+#include <momentum/solver/gauss_newton_solver.h>
 
 #include <Eigen/Core>
 
 namespace momentum {
 
 /// Gauss-Newton solver with QR decomposition specific options
-struct GaussNewtonSolverQROptions : SolverOptions {
-  /// Damping parameter added to Hessian diagonal for numerical stability; see
-  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
-  float regularization = 0.05f;
-
-  /// Flag to enable line search during optimization.
-  bool doLineSearch = false;
-
+struct GaussNewtonSolverQROptions : GaussNewtonSolverBaseOptions {
   GaussNewtonSolverQROptions() = default;
 
   /* implicit */ GaussNewtonSolverQROptions(const SolverOptions& baseOptions)
-      : SolverOptions(baseOptions) {
-    // Empty
-  }
+      : GaussNewtonSolverBaseOptions(baseOptions) {}
 };
 
 template <typename T>

--- a/momentum/solver/gauss_newton_solver.h
+++ b/momentum/solver/gauss_newton_solver.h
@@ -12,8 +12,8 @@
 
 namespace momentum {
 
-/// Extended options specific to the Gauss-Newton optimization algorithm
-struct GaussNewtonSolverOptions : SolverOptions {
+/// Base options shared by all Gauss-Newton solver variants
+struct GaussNewtonSolverBaseOptions : SolverOptions {
   /// Damping parameter added to Hessian diagonal for numerical stability; see
   /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
   ///
@@ -23,6 +23,16 @@ struct GaussNewtonSolverOptions : SolverOptions {
   /// Enables backtracking line search to ensure error reduction at each step
   bool doLineSearch = false;
 
+  /// Default constructor
+  GaussNewtonSolverBaseOptions() = default;
+
+  /// Construct from base solver options while preserving Gauss-Newton defaults
+  /* implicit */ GaussNewtonSolverBaseOptions(const SolverOptions& baseOptions)
+      : SolverOptions(baseOptions) {}
+};
+
+/// Extended options specific to the Gauss-Newton optimization algorithm
+struct GaussNewtonSolverOptions : GaussNewtonSolverBaseOptions {
   /// Uses pre-computed JᵀJ and JᵀR from the solver function
   ///
   /// Can improve performance for problems with specialized structure
@@ -43,7 +53,7 @@ struct GaussNewtonSolverOptions : SolverOptions {
 
   /// Construct from base solver options while preserving Gauss-Newton defaults
   /* implicit */ GaussNewtonSolverOptions(const SolverOptions& baseOptions)
-      : SolverOptions(baseOptions) {}
+      : GaussNewtonSolverBaseOptions(baseOptions) {}
 };
 
 /// Implementation of the Gauss-Newton optimization algorithm

--- a/momentum/solver/subset_gauss_newton_solver.h
+++ b/momentum/solver/subset_gauss_newton_solver.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <momentum/solver/fwd.h>
-#include <momentum/solver/solver.h>
+#include <momentum/solver/gauss_newton_solver.h>
 
 namespace momentum {
 
@@ -16,22 +16,13 @@ namespace momentum {
 ///
 /// Provides configuration specific to the subset-based Gauss-Newton solver
 /// that optimizes only a selected subset of parameters
-struct SubsetGaussNewtonSolverOptions : SolverOptions {
-  /// Damping parameter added to Hessian diagonal for numerical stability; see
-  /// https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
-  ///
-  /// Higher values improve stability but may slow convergence
-  float regularization = 0.05f;
-
-  /// Enables backtracking line search to ensure error reduction at each step
-  bool doLineSearch = false;
-
+struct SubsetGaussNewtonSolverOptions : GaussNewtonSolverBaseOptions {
   /// Default constructor
   SubsetGaussNewtonSolverOptions() = default;
 
   /// Construct from base solver options while preserving Subset Gauss-Newton defaults
   /* implicit */ SubsetGaussNewtonSolverOptions(const SolverOptions& baseOptions)
-      : SolverOptions(baseOptions) {}
+      : GaussNewtonSolverBaseOptions(baseOptions) {}
 };
 
 /// Gauss-Newton solver that optimizes only a selected subset of parameters

--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -404,8 +404,35 @@ Note that if you're trying to actually solve a problem using SGD, you should con
           "verbose", &mm::SolverOptions::verbose, "Enable detailed logging during optimization");
 
   py::class_<
-      mm::GaussNewtonSolverOptions,
+      mm::GaussNewtonSolverBaseOptions,
       mm::SolverOptions,
+      std::shared_ptr<mm::GaussNewtonSolverBaseOptions>>(
+      m, "GaussNewtonSolverBaseOptions", "Base options shared by all Gauss-Newton solver variants")
+      .def(py::init<>())
+      .def(
+          "__repr__",
+          [](const mm::GaussNewtonSolverBaseOptions& self) {
+            return fmt::format(
+                "GaussNewtonSolverBaseOptions(min_iterations={}, max_iterations={}, threshold={}, verbose={}, regularization={}, do_line_search={})",
+                self.minIterations,
+                self.maxIterations,
+                self.threshold,
+                boolToString(self.verbose),
+                self.regularization,
+                boolToString(self.doLineSearch));
+          })
+      .def_readwrite(
+          "regularization",
+          &mm::GaussNewtonSolverBaseOptions::regularization,
+          "Damping parameter added to Hessian diagonal for numerical stability")
+      .def_readwrite(
+          "do_line_search",
+          &mm::GaussNewtonSolverBaseOptions::doLineSearch,
+          "Enables backtracking line search to ensure error reduction at each step");
+
+  py::class_<
+      mm::GaussNewtonSolverOptions,
+      mm::GaussNewtonSolverBaseOptions,
       std::shared_ptr<mm::GaussNewtonSolverOptions>>(m, "GaussNewtonSolverOptions")
       .def(py::init<>())
       .def(
@@ -446,57 +473,37 @@ Note that if you're trying to actually solve a problem using SGD, you should con
 
   py::class_<
       mm::GaussNewtonSolverQROptions,
-      mm::SolverOptions,
+      mm::GaussNewtonSolverBaseOptions,
       std::shared_ptr<mm::GaussNewtonSolverQROptions>>(
       m, "GaussNewtonSolverQROptions", "Options specific to the Gauss-Newton QR solver")
       .def(py::init<>())
-      .def(
-          "__repr__",
-          [](const mm::GaussNewtonSolverQROptions& self) {
-            return fmt::format(
-                "GaussNewtonSolverQROptions(min_iterations={}, max_iterations={}, threshold={}, verbose={}, regularization={}, do_line_search={})",
-                self.minIterations,
-                self.maxIterations,
-                self.threshold,
-                boolToString(self.verbose),
-                self.regularization,
-                boolToString(self.doLineSearch));
-          })
-      .def_readwrite(
-          "regularization",
-          &mm::GaussNewtonSolverQROptions::regularization,
-          "Regularization parameter for QR decomposition.")
-      .def_readwrite(
-          "do_line_search",
-          &mm::GaussNewtonSolverQROptions::doLineSearch,
-          "Flag to enable line search during optimization.");
+      .def("__repr__", [](const mm::GaussNewtonSolverQROptions& self) {
+        return fmt::format(
+            "GaussNewtonSolverQROptions(min_iterations={}, max_iterations={}, threshold={}, verbose={}, regularization={}, do_line_search={})",
+            self.minIterations,
+            self.maxIterations,
+            self.threshold,
+            boolToString(self.verbose),
+            self.regularization,
+            boolToString(self.doLineSearch));
+      });
 
   py::class_<
       mm::SubsetGaussNewtonSolverOptions,
-      mm::SolverOptions,
+      mm::GaussNewtonSolverBaseOptions,
       std::shared_ptr<mm::SubsetGaussNewtonSolverOptions>>(
       m, "SubsetGaussNewtonSolverOptions", "Options specific to the Subset Gauss-Newton solver")
       .def(py::init<>())
-      .def(
-          "__repr__",
-          [](const mm::SubsetGaussNewtonSolverOptions& self) {
-            return fmt::format(
-                "SubsetGaussNewtonSolverOptions(min_iterations={}, max_iterations={}, threshold={}, verbose={}, regularization={}, do_line_search={})",
-                self.minIterations,
-                self.maxIterations,
-                self.threshold,
-                boolToString(self.verbose),
-                self.regularization,
-                boolToString(self.doLineSearch));
-          })
-      .def_readwrite(
-          "regularization",
-          &mm::SubsetGaussNewtonSolverOptions::regularization,
-          "Damping parameter added to Hessian diagonal for numerical stability")
-      .def_readwrite(
-          "do_line_search",
-          &mm::SubsetGaussNewtonSolverOptions::doLineSearch,
-          "Enables backtracking line search to ensure error reduction at each step");
+      .def("__repr__", [](const mm::SubsetGaussNewtonSolverOptions& self) {
+        return fmt::format(
+            "SubsetGaussNewtonSolverOptions(min_iterations={}, max_iterations={}, threshold={}, verbose={}, regularization={}, do_line_search={})",
+            self.minIterations,
+            self.maxIterations,
+            self.threshold,
+            boolToString(self.verbose),
+            self.regularization,
+            boolToString(self.doLineSearch));
+      });
 
   py::class_<
       mm::SequenceSolverOptions,


### PR DESCRIPTION
Summary:
Extract common options (regularization, doLineSearch) shared between
GaussNewtonSolver, GaussNewtonSolverQR, and SubsetGaussNewtonSolver
into a new GaussNewtonSolverBaseOptions parent struct.

This reduces code duplication and ensures consistency across all
Gauss-Newton solver variants. The inheritance hierarchy is now:

```
SolverOptions
└── GaussNewtonSolverBaseOptions
      ├── GaussNewtonSolverOptions
      ├── GaussNewtonSolverQROptions
      └── SubsetGaussNewtonSolverOptions
```

Also updates Python bindings in pymomentum.solver2 to expose the new
GaussNewtonSolverBaseOptions class and correctly reflect the updated
inheritance hierarchy for all solver option types.

Reviewed By: jeongseok-meta

Differential Revision: D90280542


