### PR TITLE
Add USD file format support to Python bindings

### DIFF
--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -173,6 +173,7 @@ mt_python_binding(
     io_shape
     io_skeleton
     io_urdf
+    $<$<BOOL:${MOMENTUM_BUILD_IO_USD}>:io_usd>
     python_utility
     tensor_momentum
     tensor_utility
@@ -181,6 +182,7 @@ mt_python_binding(
     ${torch_python}
   COMPILE_OPTIONS
     ${TORCH_CXX_FLAGS}
+    $<$<BOOL:${MOMENTUM_BUILD_IO_USD}>:-DMOMENTUM_WITH_USD>
 )
 
 mt_python_binding(

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -813,6 +813,44 @@ Load timestamps stored in the momentum extension (usually in microseconds).
 :param urdf_bytes: Bytes array containing the urdf definition.
       )",
           py::arg("urdf_bytes"))
+#ifdef MOMENTUM_WITH_USD
+      // loadUSDCharacterFromFile(usdPath)
+      .def_static(
+          "load_usd",
+          &loadUSDCharacterFromFile,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Load a character from a USD file.
+
+Supports .usd, .usda, .usdc, and .usdz file formats.
+
+:param usd_filename: Path to the USD file.
+:return: A :class:`Character` object containing the loaded skeleton, mesh, and skin weights.
+      )",
+          py::arg("usd_filename"))
+      // loadUSDCharacterFromBytes(usdBytes)
+      .def_static(
+          "load_usd_from_bytes",
+          &loadUSDCharacterFromBytes,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Load a character from USD bytes.
+
+:param usd_bytes: Bytes array containing the USD data.
+:return: A :class:`Character` object containing the loaded skeleton, mesh, and skin weights.
+      )",
+          py::arg("usd_bytes"))
+      // saveUSDCharacterToFile(path, character)
+      .def_static(
+          "save_usd",
+          &saveUSDCharacterToFile,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Save a character to a USD file.
+
+:param path: Path to save the USD file.
+:param character: The :class:`Character` object to save.
+      )",
+          py::arg("path"),
+          py::arg("character"))
+#endif // MOMENTUM_WITH_USD
       // saveGLTFCharacterToFile(filename, character)
       .def_static(
           "save_gltf",

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -1257,6 +1257,14 @@ The character has only one parameter limit: min-max type [-0.1, 0.1] for root.
       &isFbxsdkAvailable,
       R"(When FBXSDK is available, you can save fbx files as output.)");
 
+  // isUsdAvailable()
+  m.def(
+      "is_usd_available",
+      &isUsdAvailable,
+      R"(Check if USD file format support is available.
+
+When USD is available, you can load and save USD files (.usd, .usda, .usdc, .usdz).)");
+
   registerMeshBindings(meshClass);
   registerJointBindings(jointClass);
   registerSkeletonBindings(skeletonClass);

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -27,6 +27,9 @@
 #include <momentum/io/skeleton/mppca_io.h>
 #include <momentum/io/skeleton/parameter_transform_io.h>
 #include <momentum/io/urdf/urdf_io.h>
+#ifdef MOMENTUM_WITH_USD
+#include <momentum/io/usd/usd_io.h>
+#endif
 #include <momentum/math/constants.h>
 #include <momentum/math/mesh.h>
 
@@ -213,6 +216,20 @@ momentum::Character loadURDFCharacterFromFile(const std::string& urdfPath) {
 momentum::Character loadURDFCharacterFromBytes(const pybind11::bytes& urdfBytes) {
   return momentum::loadUrdfCharacter<float>(toSpan<std::byte>(urdfBytes));
 }
+
+#ifdef MOMENTUM_WITH_USD
+momentum::Character loadUSDCharacterFromFile(const std::string& usdPath) {
+  return momentum::loadUsdCharacter(usdPath);
+}
+
+momentum::Character loadUSDCharacterFromBytes(const pybind11::bytes& usdBytes) {
+  return momentum::loadUsdCharacter(toSpan<std::byte>(usdBytes));
+}
+
+void saveUSDCharacterToFile(const std::string& path, const momentum::Character& character) {
+  momentum::saveUsd(path, character);
+}
+#endif // MOMENTUM_WITH_USD
 
 std::shared_ptr<const momentum::Mppca> loadPosePriorFromFile(const std::string& path) {
   return momentum::loadMppca(path);

--- a/pymomentum/geometry/momentum_geometry.h
+++ b/pymomentum/geometry/momentum_geometry.h
@@ -66,6 +66,12 @@ momentum::Character loadConfigFromBytes(
 momentum::Character loadURDFCharacterFromFile(const std::string& urdfPath);
 momentum::Character loadURDFCharacterFromBytes(const pybind11::bytes& urdfBytes);
 
+#ifdef MOMENTUM_WITH_USD
+momentum::Character loadUSDCharacterFromFile(const std::string& usdPath);
+momentum::Character loadUSDCharacterFromBytes(const pybind11::bytes& usdBytes);
+void saveUSDCharacterToFile(const std::string& path, const momentum::Character& character);
+#endif // MOMENTUM_WITH_USD
+
 std::shared_ptr<const momentum::Mppca> loadPosePriorFromFile(const std::string& path);
 void savePosePriorToFile(const momentum::Mppca& mppca, const std::string& path);
 std::shared_ptr<const momentum::Mppca> loadPosePriorFromBytes(const pybind11::bytes& bytes);

--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -389,4 +389,12 @@ bool isFbxsdkAvailable() {
   return false;
 #endif
 }
+
+bool isUsdAvailable() {
+#ifdef MOMENTUM_WITH_USD
+  return true;
+#else
+  return false;
+#endif
+}
 } // namespace pymomentum

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -137,4 +137,6 @@ std::vector<momentum::SkeletonState> arrayToSkeletonStates(
 
 bool isFbxsdkAvailable();
 
+bool isUsdAvailable();
+
 } // namespace pymomentum

--- a/pymomentum/test/test_usd.py
+++ b/pymomentum/test/test_usd.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import os
+import tempfile
+import unittest
+
+import pymomentum.geometry as pym_geometry
+
+# Check USD availability once at module load for skipIf decorator
+_USD_AVAILABLE = pym_geometry.is_usd_available()
+
+
+class TestUsd(unittest.TestCase):
+    @unittest.skipIf(not _USD_AVAILABLE, "USD support not available")
+    def test_is_usd_available(self) -> None:
+        """Test that USD support is available.
+
+        In BUCK builds, USD is always available (preprocessor_flags includes
+        -DMOMENTUM_WITH_USD). In OSS/CMake builds, availability depends on
+        MOMENTUM_BUILD_IO_USD option.
+        """
+        result = pym_geometry.is_usd_available()
+        self.assertIsInstance(result, bool)
+        # When this test runs, USD should be available
+        self.assertTrue(result)
+
+    @unittest.skipIf(not _USD_AVAILABLE, "USD support not available")
+    def test_save_and_load_usd_character(self) -> None:
+        """Test saving and reloading a USD character."""
+
+        # Create a test character
+        char = pym_geometry.create_test_character()
+
+        # Save to temporary file
+        with tempfile.NamedTemporaryFile(suffix=".usda", delete=False) as f:
+            temp_path = f.name
+
+        try:
+            pym_geometry.Character.save_usd(temp_path, char)  # type: ignore[attr-defined]
+
+            # Verify file was created
+            self.assertTrue(os.path.exists(temp_path))
+            self.assertGreater(os.path.getsize(temp_path), 0)
+
+            # Reload and verify
+            loaded_char = pym_geometry.Character.load_usd(temp_path)  # type: ignore[attr-defined]
+
+            # Verify skeleton joints match
+            self.assertEqual(
+                len(loaded_char.skeleton.joints),
+                len(char.skeleton.joints),
+            )
+
+            # Verify joint names match
+            for i, (loaded_joint, orig_joint) in enumerate(
+                zip(loaded_char.skeleton.joints, char.skeleton.joints)
+            ):
+                self.assertEqual(
+                    loaded_joint.name,
+                    orig_joint.name,
+                    f"Joint name mismatch at index {i}",
+                )
+
+            # Verify mesh vertices match
+            if char.mesh is not None:
+                self.assertIsNotNone(loaded_char.mesh)
+                self.assertEqual(
+                    len(loaded_char.mesh.vertices),
+                    len(char.mesh.vertices),
+                )
+        finally:
+            # Clean up
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    @unittest.skipIf(not _USD_AVAILABLE, "USD support not available")
+    def test_load_usd_from_bytes(self) -> None:
+        """Test loading a USD character from bytes after saving."""
+        # Create a test character and save it
+        char = pym_geometry.create_test_character()
+
+        with tempfile.NamedTemporaryFile(suffix=".usda", delete=False) as f:
+            temp_path = f.name
+
+        try:
+            pym_geometry.Character.save_usd(temp_path, char)  # type: ignore[attr-defined]
+
+            # Read file contents
+            with open(temp_path, "rb") as f:
+                usd_bytes = f.read()
+
+            # Load from bytes
+            loaded_char = pym_geometry.Character.load_usd_from_bytes(usd_bytes)  # type: ignore[attr-defined]
+
+            # Verify skeleton was loaded
+            self.assertGreater(len(loaded_char.skeleton.joints), 0)
+
+            # Verify skeleton joints match
+            self.assertEqual(
+                len(loaded_char.skeleton.joints),
+                len(char.skeleton.joints),
+            )
+        finally:
+            # Clean up
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Adds Python bindings for USD file format support in pymomentum, enabling loading and saving character data in USD formats (.usd, .usda, .usdc, .usdz).

This follows the same pattern as existing FBX, GLTF, and URDF bindings through the Character class interface. USD support is conditional based on the MOMENTUM_BUILD_IO_USD CMake option since OpenUSD dependencies may not be installed on all systems.

New APIs:
- Character.load_usd(path) - Load character from USD file
- Character.load_usd_from_bytes(bytes) - Load character from bytes
- Character.save_usd(path, character) - Save character to USD file
- is_usd_available() - Check if USD support is available

Reviewed By: cstollmeta

Differential Revision: D90608105


