### PR TITLE
fix(ci): Fix GPU wheel build by using minimal-build environment

### DIFF
--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -49,7 +49,7 @@
 {% endif %}
 {%- endmacro %}
 
-{#- Common cibuildwheel before-all script for Linux -#}
+{#- Common cibuildwheel before-all script for Linux (CPU builds) -#}
 {%- macro cibw_linux_before_all() %}
 # Use local pixi binary if available to avoid network issues
 if [ -f /project/pixi_bin ]; then
@@ -68,6 +68,29 @@ mkdir -p /tmp/build_env
 cp {project}/pixi.toml {project}/pixi.lock {project}/README.md {project}/LICENSE /tmp/build_env/
 cd /tmp/build_env
 pixi install -e default
+{%- endmacro %}
+
+{#- GPU-specific cibuildwheel before-all script for Linux -#}
+{#- Uses minimal-build environment to save ~2.5GB disk space in Docker container -#}
+{%- macro cibw_linux_before_all_gpu() %}
+# Use local pixi binary if available to avoid network issues
+if [ -f /project/pixi_bin ]; then
+  echo "Using local pixi binary"
+  mkdir -p $HOME/.pixi/bin
+  cp /project/pixi_bin $HOME/.pixi/bin/pixi
+  chmod +x $HOME/.pixi/bin/pixi
+else
+  echo "Downloading pixi"
+  curl -fsSL https://pixi.sh/install.sh | bash
+fi
+export PATH=$HOME/.pixi/bin:$PATH
+
+# Install minimal-build environment (smaller footprint for GPU Docker builds)
+# This environment contains only essential build dependencies from CMakeLists.txt
+mkdir -p /tmp/build_env
+cp {project}/pixi.toml {project}/pixi.lock {project}/README.md {project}/LICENSE /tmp/build_env/
+cd /tmp/build_env
+pixi install -e minimal-build
 {%- endmacro %}
 
 {#- ============================================================================ -#}
@@ -450,7 +473,7 @@ export CUDA_HOME=/usr/local/cuda-12.8
 export PATH=$CUDA_HOME/bin:$PATH
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 
-{{ cibw_linux_before_all() }}
+{{ cibw_linux_before_all_gpu() }}
 """
 # Use manylinux container's gcc-toolset-12 compiler for manylinux_2_28 compatibility
 # Pixi provides dependencies (headers/libs) but we use the container's compiler


### PR DESCRIPTION
## Summary

The GPU wheel build was failing with 'Could not find Ceres' error.

**Root cause**: Environment path mismatch in cibuildwheel configuration:
- The shared `cibw_linux_before_all()` macro installed the `default` pixi environment
- But `CMAKE_PREFIX_PATH` was pointing to `/tmp/build_env/.pixi/envs/minimal-build`
- This caused CMake to not find any dependencies (Ceres, etc.) since that path didn't exist

## Fix

1. Created a new GPU-specific macro `cibw_linux_before_all_gpu()` that installs the `minimal-build` environment instead of `default`
2. Updated GPU build configuration to use this new macro
3. The `minimal-build` environment contains all necessary CMake dependencies (including ceres-solver) while being ~2.5GB smaller than `default`

## Why PR CI didn't catch this

1. Regular PR CI (`ci_ubuntu.yml`, etc.) uses the full `default` environment
2. The PyPI publish workflow (`publish_to_pypi.yml`) only runs on push to main, not on PRs
3. GPU builds specifically use `minimal-build` feature which wasn't tested in PRs

## Test Plan

- Wait for CI to pass on this PR
- Verify GPU wheel builds complete successfully

Fixes: https://github.com/facebookresearch/momentum/actions/runs/21003964802