### PR TITLE
Fix Dependabot alert #42: jsdiff DoS vulnerability

### DIFF
--- a/momentum/website/package.json
+++ b/momentum/website/package.json
@@ -43,7 +43,8 @@
     "**/js-yaml": ">=4.1.1",
     "**/gray-matter": ">=4.0.3",
     "**/node-forge": "1.3.2",
-    "@docusaurus/**/mdast-util-to-hast": "13.2.1"
+    "@docusaurus/**/mdast-util-to-hast": "13.2.1",
+    "**/diff": ">=8.0.3"
   },
   "browserslist": {
     "production": [

--- a/momentum/website/yarn.lock
+++ b/momentum/website/yarn.lock
@@ -4842,10 +4842,10 @@ devlop@^1.0.0, devlop@^1.1.0:
   dependencies:
     dequal "^2.0.0"
 
-diff@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
-  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
+diff@>=8.0.3, diff@^5.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
+  integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Summary:
Adds yarn resolution to force `diff` package to version >=8.0.3, fixing the jsdiff Denial of Service vulnerability (GHSA-73rr-hh4g-fpgx) in the website dependencies.

The `docusaurus-plugin-internaldocs-fb` package has a transitive dependency on `diff@^5.0.0` via `uvu`, which resolves to the vulnerable version 5.2.0. This resolution forces all instances of `diff` to use the patched version.

GitHub Dependabot Alert: https://github.com/facebookresearch/momentum/security/dependabot/42

Differential Revision: D90717540


