### PR TITLE
Extend reading glb weights to handle unsigned byte and short component types

### DIFF
--- a/momentum/io/gltf/utils/accessor_utils.h
+++ b/momentum/io/gltf/utils/accessor_utils.h
@@ -251,6 +251,12 @@ inline void setAccessorType<const Vector4s>(fx::gltf::Accessor& accessor) {
 }
 
 template <>
+inline void setAccessorType<const Vector4b>(fx::gltf::Accessor& accessor) {
+  accessor.componentType = fx::gltf::Accessor::ComponentType::UnsignedByte;
+  accessor.type = fx::gltf::Accessor::Type::Vec4;
+}
+
+template <>
 inline void setAccessorType<const Matrix4f>(fx::gltf::Accessor& accessor) {
   accessor.componentType = fx::gltf::Accessor::ComponentType::Float;
   accessor.type = fx::gltf::Accessor::Type::Mat4;


### PR DESCRIPTION
Summary:
From the spec:
> WEIGHTS_n: float, or normalized unsigned byte, or normalized unsigned short

This extends support for weight types output in common tools.

Differential Revision: D90891854


