### PR TITLE
Add AUTOGRAD_ENABLED flag to pybind modules

### DIFF
--- a/pymomentum/axel/axel_pybind.cpp
+++ b/pymomentum/axel/axel_pybind.cpp
@@ -120,6 +120,12 @@ PYBIND11_MODULE(axel, m) {
   m.attr("__name__") = "pymomentum.axel";
   m.doc() = "Python bindings for Axel library classes including SignedDistanceField.";
 
+#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  m.attr("AUTOGRAD_ENABLED") = false;
+#else
+  m.attr("AUTOGRAD_ENABLED") = true;
+#endif
+
   // Bind BoundingBox
   py::class_<axel::BoundingBox<float>>(m, "BoundingBox")
       .def(

--- a/pymomentum/diff_geometry/diff_geometry_pybind.cpp
+++ b/pymomentum/diff_geometry/diff_geometry_pybind.cpp
@@ -247,6 +247,12 @@ PYBIND11_MODULE(diff_geometry, m) {
       "Differentiable geometry and forward kinematics for momentum models using PyTorch tensors.";
   m.attr("__name__") = "pymomentum.diff_geometry";
 
+#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  m.attr("AUTOGRAD_ENABLED") = false;
+#else
+  m.attr("AUTOGRAD_ENABLED") = true;
+#endif
+
   pybind11::module_::import("torch"); // @dep=//caffe2:torch
   pybind11::module_::import("pymomentum.geometry"); // @dep=//pymomentum:geometry
 

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -76,6 +76,12 @@ PYBIND11_MODULE(geometry, m) {
   m.doc() = "Geometry and forward kinematics for momentum models.  ";
   m.attr("__name__") = "pymomentum.geometry";
 
+#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  m.attr("AUTOGRAD_ENABLED") = false;
+#else
+  m.attr("AUTOGRAD_ENABLED") = true;
+#endif
+
   pybind11::module_::import("torch"); // @dep=//caffe2:torch
 
   m.attr("PARAMETERS_PER_JOINT") = mm::kParametersPerJoint;

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -60,6 +60,12 @@ PYBIND11_MODULE(marker_tracking, m) {
   m.doc() = "Module for exposing the C++ APIs of the marker tracking pipeline ";
   m.attr("__name__") = "pymomentum.marker_tracking";
 
+#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  m.attr("AUTOGRAD_ENABLED") = false;
+#else
+  m.attr("AUTOGRAD_ENABLED") = true;
+#endif
+
   pybind11::module_::import(
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry
 

--- a/pymomentum/renderer/renderer_pybind.cpp
+++ b/pymomentum/renderer/renderer_pybind.cpp
@@ -35,6 +35,12 @@ PYBIND11_MODULE(renderer, m) {
   m.attr("__name__") = "pymomentum.renderer";
   m.doc() = "Functions for rendering momentum models.";
 
+#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  m.attr("AUTOGRAD_ENABLED") = false;
+#else
+  m.attr("AUTOGRAD_ENABLED") = true;
+#endif
+
   pybind11::module_::import("torch"); // @dep=//caffe2:torch
   pybind11::module_::import(
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry

--- a/pymomentum/solver/solver_pybind.cpp
+++ b/pymomentum/solver/solver_pybind.cpp
@@ -27,6 +27,12 @@ PYBIND11_MODULE(solver, m) {
   m.attr("__name__") = "pymomentum.solver";
   m.doc() = "Inverse kinematics and other optimizations for momentum models.";
 
+#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  m.attr("AUTOGRAD_ENABLED") = false;
+#else
+  m.attr("AUTOGRAD_ENABLED") = true;
+#endif
+
   pybind11::module_::import("torch"); // @dep=//caffe2:torch
   pybind11::module_::import(
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry

--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -88,6 +88,12 @@ PYBIND11_MODULE(solver2, m) {
   m.attr("__name__") = "pymomentum.solver2";
   m.doc() = "Inverse kinematics and other optimizations for momentum models.";
 
+#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  m.attr("AUTOGRAD_ENABLED") = false;
+#else
+  m.attr("AUTOGRAD_ENABLED") = true;
+#endif
+
   pybind11::module_::import(
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry
 


### PR DESCRIPTION
Summary:
It is useful to know when autograd is available in limited API moeds.

For consistency I added the flag to every module even those that don't do autograd. Adding a global flag was more annoying because there's no top level module in the current API design so I had to add a new pybind module + an `__init__.py` and generally this was a lot more complicated

Differential Revision: D90632804


