### PR TITLE
Add block-wise Jacobian interface to SolverFunction

### DIFF
--- a/momentum/character_sequence_solver/multipose_solver_function.h
+++ b/momentum/character_sequence_solver/multipose_solver_function.h
@@ -30,11 +30,17 @@ class MultiposeSolverFunctionT : public SolverFunctionT<T> {
 
   double getGradient(const Eigen::VectorX<T>& parameters, Eigen::VectorX<T>& gradient) final;
 
-  double getJacobian(
+  // Block-wise Jacobian interface
+  void initializeJacobianComputation(const Eigen::VectorX<T>& parameters) override;
+  [[nodiscard]] size_t getJacobianBlockCount() const override;
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override;
+  double computeJacobianBlock(
       const Eigen::VectorX<T>& parameters,
-      Eigen::MatrixX<T>& jacobian,
-      Eigen::VectorX<T>& residual,
-      size_t& actualRows) final;
+      size_t blockIndex,
+      Eigen::Ref<Eigen::MatrixX<T>> jacobianBlock,
+      Eigen::Ref<Eigen::VectorX<T>> residualBlock,
+      size_t& actualRows) override;
+  void finalizeJacobianComputation() override;
 
   void updateParameters(Eigen::VectorX<T>& parameters, const Eigen::VectorX<T>& gradient) final;
   void setEnabledParameters(const ParameterSet& parameterSet) final;
@@ -75,6 +81,9 @@ class MultiposeSolverFunctionT : public SolverFunctionT<T> {
   std::vector<size_t> universalParameters_;
 
   std::vector<std::vector<SkeletonErrorFunctionT<T>*>> errorFunctions_;
+
+  /// Pre-allocated temporary storage for block-wise Jacobian computation
+  Eigen::MatrixX<T> tempJac_;
 
   friend class MultiposeSolverT<T>;
 };

--- a/momentum/test/solver/gauss_newton_solver_test.cpp
+++ b/momentum/test/solver/gauss_newton_solver_test.cpp
@@ -34,45 +34,36 @@ class MockSolverFunction : public SolverFunctionT<float> {
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJacobian(
+  // Block-wise Jacobian interface implementation
+  void initializeJacobianComputation(const VectorX<float>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
       const VectorX<float>& parameters,
-      MatrixX<float>& jacobian,
-      VectorX<float>& residual,
+      size_t blockIndex,
+      Eigen::Ref<MatrixX<float>> jacobianBlock,
+      Eigen::Ref<VectorX<float>> residualBlock,
       size_t& actualRows) override {
+    if (blockIndex >= 1) {
+      actualRows = 0;
+      return 0.0;
+    }
     // For a quadratic function, the Jacobian is the identity matrix
     // and the residual is the parameters
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
-    }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = parameters;
-
+    jacobianBlock.setIdentity();
+    residualBlock = parameters;
     actualRows = numParameters_;
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJtJR(
-      const VectorX<float>& parameters,
-      MatrixX<float>& hessianApprox,
-      VectorX<float>& JtR) override {
-    // For a quadratic function, the Hessian approximation is the identity matrix
-    // and JtR is the parameters
-    if (hessianApprox.rows() != numParameters_ || hessianApprox.cols() != numParameters_) {
-      hessianApprox.resize(numParameters_, numParameters_);
-    }
-    hessianApprox.setIdentity();
-
-    if (JtR.size() != numParameters_) {
-      JtR.resize(numParameters_);
-    }
-    JtR = parameters;
-
-    return 0.5 * parameters.squaredNorm();
-  }
+  void finalizeJacobianComputation() override {}
 
   double getJtJR_Sparse(
       const VectorX<float>& parameters,
@@ -347,41 +338,34 @@ class FailingSparseFunction : public SolverFunctionT<float> {
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJacobian(
+  // Block-wise Jacobian interface implementation
+  void initializeJacobianComputation(const VectorX<float>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
       const VectorX<float>& parameters,
-      MatrixX<float>& jacobian,
-      VectorX<float>& residual,
+      size_t blockIndex,
+      Eigen::Ref<MatrixX<float>> jacobianBlock,
+      Eigen::Ref<VectorX<float>> residualBlock,
       size_t& actualRows) override {
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
+    if (blockIndex >= 1) {
+      actualRows = 0;
+      return 0.0;
     }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = parameters;
-
+    jacobianBlock.setIdentity();
+    residualBlock = parameters;
     actualRows = numParameters_;
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJtJR(
-      const VectorX<float>& parameters,
-      MatrixX<float>& hessianApprox,
-      VectorX<float>& JtR) override {
-    if (hessianApprox.rows() != numParameters_ || hessianApprox.cols() != numParameters_) {
-      hessianApprox.resize(numParameters_, numParameters_);
-    }
-    hessianApprox.setIdentity();
-
-    if (JtR.size() != numParameters_) {
-      JtR.resize(numParameters_);
-    }
-    JtR = parameters;
-
-    return 0.5 * parameters.squaredNorm();
-  }
+  void finalizeJacobianComputation() override {}
 
   double getJtJR_Sparse(
       const VectorX<float>& parameters,
@@ -444,41 +428,34 @@ class FailingLineSearchFunction : public SolverFunctionT<float> {
     return 1.0;
   }
 
-  double getJacobian(
+  // Block-wise Jacobian interface implementation
+  void initializeJacobianComputation(const VectorX<float>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
       const VectorX<float>& parameters,
-      MatrixX<float>& jacobian,
-      VectorX<float>& residual,
+      size_t blockIndex,
+      Eigen::Ref<MatrixX<float>> jacobianBlock,
+      Eigen::Ref<VectorX<float>> residualBlock,
       size_t& actualRows) override {
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
+    if (blockIndex >= 1) {
+      actualRows = 0;
+      return 0.0;
     }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = VectorX<float>::Ones(parameters.size());
-
+    jacobianBlock.setIdentity();
+    residualBlock = VectorX<float>::Ones(parameters.size());
     actualRows = numParameters_;
     return 1.0;
   }
 
-  double getJtJR(
-      const VectorX<float>& parameters,
-      MatrixX<float>& hessianApprox,
-      VectorX<float>& JtR) override {
-    if (hessianApprox.rows() != numParameters_ || hessianApprox.cols() != numParameters_) {
-      hessianApprox.resize(numParameters_, numParameters_);
-    }
-    hessianApprox.setIdentity();
-
-    if (JtR.size() != numParameters_) {
-      JtR.resize(numParameters_);
-    }
-    JtR = VectorX<float>::Ones(parameters.size());
-
-    return 1.0;
-  }
+  void finalizeJacobianComputation() override {}
 
   double getJtJR_Sparse(
       const VectorX<float>& parameters,

--- a/momentum/test/solver/gradient_descent_solver_test.cpp
+++ b/momentum/test/solver/gradient_descent_solver_test.cpp
@@ -34,26 +34,31 @@ class MockSolverFunction : public SolverFunctionT<float> {
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJacobian(
+  void initializeJacobianComputation(const VectorX<float>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
       const VectorX<float>& parameters,
-      MatrixX<float>& jacobian,
-      VectorX<float>& residual,
+      size_t /* blockIndex */,
+      Eigen::Ref<MatrixX<float>> jacobianBlock,
+      Eigen::Ref<VectorX<float>> residualBlock,
       size_t& actualRows) override {
     // For a quadratic function, the Jacobian is the identity matrix
     // and the residual is the parameters
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
-    }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = parameters;
-
+    jacobianBlock.setIdentity();
+    residualBlock = parameters;
     actualRows = numParameters_;
     return 0.5 * parameters.squaredNorm();
   }
+
+  void finalizeJacobianComputation() override {}
 
   void updateParameters(VectorX<float>& parameters, const VectorX<float>& delta) override {
     // Update parameters by subtracting delta
@@ -91,26 +96,31 @@ class MockSolverFunctionDouble : public SolverFunctionT<double> {
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJacobian(
+  void initializeJacobianComputation(const VectorX<double>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
       const VectorX<double>& parameters,
-      MatrixX<double>& jacobian,
-      VectorX<double>& residual,
+      size_t /* blockIndex */,
+      Eigen::Ref<MatrixX<double>> jacobianBlock,
+      Eigen::Ref<VectorX<double>> residualBlock,
       size_t& actualRows) override {
     // For a quadratic function, the Jacobian is the identity matrix
     // and the residual is the parameters
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
-    }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = parameters;
-
+    jacobianBlock.setIdentity();
+    residualBlock = parameters;
     actualRows = numParameters_;
     return 0.5 * parameters.squaredNorm();
   }
+
+  void finalizeJacobianComputation() override {}
 
   void updateParameters(VectorX<double>& parameters, const VectorX<double>& delta) override {
     // Update parameters by subtracting delta

--- a/momentum/test/solver/subset_gauss_newton_solver_test.cpp
+++ b/momentum/test/solver/subset_gauss_newton_solver_test.cpp
@@ -34,26 +34,31 @@ class MockSolverFunction : public SolverFunctionT<float> {
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJacobian(
+  void initializeJacobianComputation(const VectorX<float>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
       const VectorX<float>& parameters,
-      MatrixX<float>& jacobian,
-      VectorX<float>& residual,
+      size_t /* blockIndex */,
+      Eigen::Ref<MatrixX<float>> jacobianBlock,
+      Eigen::Ref<VectorX<float>> residualBlock,
       size_t& actualRows) override {
     // For a quadratic function, the Jacobian is the identity matrix
     // and the residual is the parameters
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
-    }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = parameters;
-
+    jacobianBlock.setIdentity();
+    residualBlock = parameters;
     actualRows = numParameters_;
     return 0.5 * parameters.squaredNorm();
   }
+
+  void finalizeJacobianComputation() override {}
 
   void updateParameters(VectorX<float>& parameters, const VectorX<float>& delta) override {
     // Update parameters by subtracting delta
@@ -90,24 +95,29 @@ class FailingLineSearchFunction : public SolverFunctionT<float> {
     return 1.0;
   }
 
-  double getJacobian(
-      const VectorX<float>& parameters,
-      MatrixX<float>& jacobian,
-      VectorX<float>& residual,
+  void initializeJacobianComputation(const VectorX<float>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
+      const VectorX<float>& /* parameters */,
+      size_t /* blockIndex */,
+      Eigen::Ref<MatrixX<float>> jacobianBlock,
+      Eigen::Ref<VectorX<float>> residualBlock,
       size_t& actualRows) override {
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
-    }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = VectorX<float>::Ones(parameters.size());
-
+    jacobianBlock.setIdentity();
+    residualBlock.setOnes();
     actualRows = numParameters_;
     return 1.0;
   }
+
+  void finalizeJacobianComputation() override {}
 
   void updateParameters(VectorX<float>& parameters, const VectorX<float>& delta) override {
     // Don't actually update the parameters, which will cause line search to fail
@@ -381,26 +391,31 @@ class MockSolverFunctionDouble : public SolverFunctionT<double> {
     return 0.5 * parameters.squaredNorm();
   }
 
-  double getJacobian(
+  void initializeJacobianComputation(const VectorX<double>& /* parameters */) override {}
+
+  [[nodiscard]] size_t getJacobianBlockCount() const override {
+    return 1;
+  }
+
+  [[nodiscard]] size_t getJacobianBlockSize(size_t blockIndex) const override {
+    return blockIndex == 0 ? numParameters_ : 0;
+  }
+
+  double computeJacobianBlock(
       const VectorX<double>& parameters,
-      MatrixX<double>& jacobian,
-      VectorX<double>& residual,
+      size_t /* blockIndex */,
+      Eigen::Ref<MatrixX<double>> jacobianBlock,
+      Eigen::Ref<VectorX<double>> residualBlock,
       size_t& actualRows) override {
     // For a quadratic function, the Jacobian is the identity matrix
     // and the residual is the parameters
-    if (jacobian.rows() != numParameters_ || jacobian.cols() != numParameters_) {
-      jacobian.resize(numParameters_, numParameters_);
-    }
-    jacobian.setIdentity();
-
-    if (residual.size() != numParameters_) {
-      residual.resize(numParameters_);
-    }
-    residual = parameters;
-
+    jacobianBlock.setIdentity();
+    residualBlock = parameters;
     actualRows = numParameters_;
     return 0.5 * parameters.squaredNorm();
   }
+
+  void finalizeJacobianComputation() override {}
 
   void updateParameters(VectorX<double>& parameters, const VectorX<double>& delta) override {
     // Update parameters by subtracting delta


### PR DESCRIPTION
Summary:
Introduced a new block-wise interface for computing Jacobians that allows
solvers to access individual Jacobian blocks without requiring the full Jacobian
matrix to be materialized in memory. Previously, getJtJR() computed JtJ block-by-block
internally, which limited optimization opportunities in the solver. The new interface
exposes initializeJacobianComputation(), getJacobianBlockCount(), getJacobianBlockSize(),
and computeJacobianBlock() methods that enable the solver to control how blocks are
processed and combined.

Both getJacobian() and getJtJR() are now implemented in the parent SolverFunctionT
class using the block interface, removing code duplication from SkeletonSolverFunctionT.
The block interface becomes the primitive, with the full-matrix methods being derived
implementations. This provides flexibility for solvers to implement custom optimization
strategies while maintaining backward compatibility.

Reviewed By: jeongseok-meta

Differential Revision: D89145782


