### PR TITLE
fix: auto-detect container engine (docker/podman) for wheel builds

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -235,8 +235,9 @@ auditwheel = ">=6.4.2,<7"
 podman = ">=5.0.0,<6"
 
 [target.linux-64.tasks]
-# Linux CPU wheel build uses cibuildwheel with podman to produce manylinux_2_28 wheels
-wheel_build = { cmd = "python scripts/generate_pyproject.py && (rm -rf build/cp* 2>/dev/null || true) && cp pyproject.toml /tmp/pyproject-backup.toml && cp pyproject-pypi-cpu-py$(python -c 'import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))').toml pyproject.toml && CIBW_CONTAINER_ENGINE=podman CIBW_BUILD=\"cp$(python -c 'import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))')-manylinux_x86_64\" cibuildwheel --platform linux --output-dir dist . ; mv /tmp/pyproject-backup.toml pyproject.toml && echo 'Wheels created:' && ls -la dist/", description = "Build CPU wheel using cibuildwheel in manylinux_2_28 container (Linux)" }
+# Linux CPU wheel build uses cibuildwheel to produce manylinux_2_28 wheels
+# Auto-detects container engine: respects CIBW_CONTAINER_ENGINE if set, otherwise detects docker/podman
+wheel_build = { cmd = "bash -c 'source scripts/detect_container_engine.sh && python scripts/generate_pyproject.py && (rm -rf build/cp* 2>/dev/null || true) && cp pyproject.toml /tmp/pyproject-backup.toml && cp pyproject-pypi-cpu-py$(python -c \"import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))\").toml pyproject.toml && CIBW_BUILD=\"cp$(python -c \"import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))\")-manylinux_x86_64\" cibuildwheel --platform linux --output-dir dist . ; cp /tmp/pyproject-backup.toml pyproject.toml && rm /tmp/pyproject-backup.toml && echo Wheels created: && ls -la dist/'", description = "Build CPU wheel using cibuildwheel (auto-detects docker/podman)" }
 
 wheel_repair = { cmd = "echo 'wheel_repair: cibuildwheel already handled repair in wheel_build'", description = "Repair handled by cibuildwheel (no-op on Linux)" }
 
@@ -559,9 +560,8 @@ dependencies = { python = "3.12.*" }
 
 [feature.gpu-wheel-build-py312.tasks]
 # GPU wheel build using cibuildwheel in manylinux_2_28 container
-# Container engine defaults to docker (cibuildwheel default)
-# For local builds with podman: CIBW_CONTAINER_ENGINE=podman pixi run -e gpu-wheel-build-py312 wheel_build
-wheel_build = { cmd = "python scripts/generate_pyproject.py && (rm -rf build/cp* 2>/dev/null || true) && cp pyproject.toml /tmp/pyproject-backup.toml && cp pyproject-pypi-gpu.toml pyproject.toml && cibuildwheel --platform linux --output-dir dist . ; mv /tmp/pyproject-backup.toml pyproject.toml && echo 'Wheels created:' && ls -la dist/", env = { CIBW_BUILD = "cp312-manylinux_x86_64" }, description = "Build GPU wheel using cibuildwheel (uses docker by default, set CIBW_CONTAINER_ENGINE=podman for local podman)" }
+# Auto-detects container engine: respects CIBW_CONTAINER_ENGINE if set, otherwise detects docker/podman
+wheel_build = { cmd = "bash -c 'source scripts/detect_container_engine.sh && python scripts/generate_pyproject.py && (rm -rf build/cp* 2>/dev/null || true) && cp pyproject.toml /tmp/pyproject-backup.toml && cp pyproject-pypi-gpu.toml pyproject.toml && cibuildwheel --platform linux --output-dir dist . ; cp /tmp/pyproject-backup.toml pyproject.toml && rm /tmp/pyproject-backup.toml && echo Wheels created: && ls -la dist/'", env = { CIBW_BUILD = "cp312-manylinux_x86_64" }, description = "Build GPU wheel using cibuildwheel (auto-detects docker/podman)" }
 
 wheel_repair = { cmd = "echo 'wheel_repair: cibuildwheel already handled repair in wheel_build'", description = "Repair handled by cibuildwheel (no-op)" }
 
@@ -579,9 +579,8 @@ dependencies = { python = "3.13.*" }
 
 [feature.gpu-wheel-build-py313.tasks]
 # GPU wheel build using cibuildwheel in manylinux_2_28 container
-# Container engine defaults to docker (cibuildwheel default)
-# For local builds with podman: CIBW_CONTAINER_ENGINE=podman pixi run -e gpu-wheel-build-py313 wheel_build
-wheel_build = { cmd = "python scripts/generate_pyproject.py && (rm -rf build/cp* 2>/dev/null || true) && cp pyproject.toml /tmp/pyproject-backup.toml && cp pyproject-pypi-gpu.toml pyproject.toml && cibuildwheel --platform linux --output-dir dist . ; mv /tmp/pyproject-backup.toml pyproject.toml && echo 'Wheels created:' && ls -la dist/", env = { CIBW_BUILD = "cp313-manylinux_x86_64" }, description = "Build GPU wheel using cibuildwheel (uses docker by default, set CIBW_CONTAINER_ENGINE=podman for local podman)" }
+# Auto-detects container engine: respects CIBW_CONTAINER_ENGINE if set, otherwise detects docker/podman
+wheel_build = { cmd = "bash -c 'source scripts/detect_container_engine.sh && python scripts/generate_pyproject.py && (rm -rf build/cp* 2>/dev/null || true) && cp pyproject.toml /tmp/pyproject-backup.toml && cp pyproject-pypi-gpu.toml pyproject.toml && cibuildwheel --platform linux --output-dir dist . ; cp /tmp/pyproject-backup.toml pyproject.toml && rm /tmp/pyproject-backup.toml && echo Wheels created: && ls -la dist/'", env = { CIBW_BUILD = "cp313-manylinux_x86_64" }, description = "Build GPU wheel using cibuildwheel (auto-detects docker/podman)" }
 
 wheel_repair = { cmd = "echo 'wheel_repair: cibuildwheel already handled repair in wheel_build'", description = "Repair handled by cibuildwheel (no-op)" }
 
@@ -610,8 +609,7 @@ gpu = ["py312-cuda129", "rerun-latest"]
 
 # GPU wheel build environments (no CUDA required on host)
 # Use these for building GPU wheels - builds happen in containers
-# CI: pixi run -e gpu-wheel-build-py312 wheel_build (uses docker, the cibuildwheel default)
-# Local with podman: CIBW_CONTAINER_ENGINE=podman pixi run -e gpu-wheel-build-py312 wheel_build
+# Auto-detects container engine: docker (CI) or podman (local)
 gpu-wheel-build-py312 = ["gpu-wheel-build", "gpu-wheel-build-py312"]
 gpu-wheel-build-py313 = ["gpu-wheel-build", "gpu-wheel-build-py313"]
 

--- a/scripts/detect_container_engine.sh
+++ b/scripts/detect_container_engine.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Detect and export the container engine for cibuildwheel
+#
+# This script detects available container engines (docker/podman) and exports
+# CIBW_CONTAINER_ENGINE if not already set.
+#
+# Priority:
+# 1. Respect CIBW_CONTAINER_ENGINE if already set
+# 2. Otherwise, detect docker first, then podman
+#
+# Usage:
+#   source scripts/detect_container_engine.sh
+#   # Then run cibuildwheel
+
+if [ -z "$CIBW_CONTAINER_ENGINE" ]; then
+    if command -v docker >/dev/null 2>&1; then
+        export CIBW_CONTAINER_ENGINE=docker
+    elif command -v podman >/dev/null 2>&1; then
+        export CIBW_CONTAINER_ENGINE=podman
+    else
+        echo "Warning: Neither docker nor podman found. cibuildwheel may fail."
+    fi
+fi
+
+echo "Container engine: ${CIBW_CONTAINER_ENGINE:-none detected}"


### PR DESCRIPTION
## Summary

PR #951 fixed CI but broke local builds where only podman is available. This PR adds auto-detection that works for both:
- **CI (docker)**: GitHub Actions has docker installed
- **Local (podman)**: Developer machines may only have podman

## Changes

1. **Add `scripts/detect_container_engine.sh`** - Reliable container engine detection script:
   - Respects `CIBW_CONTAINER_ENGINE` if externally set (CI can override)
   - Auto-detects: docker first (for CI), then podman (for local)

2. **Update GPU wheel_build tasks** - Use `bash -c` with detection script

3. **Update CPU Linux wheel_build task** - Same pattern for CPU builds

4. **Fix cross-device link error** - Use `cp + rm` instead of `mv` for `/tmp` to project directory moves

## Test Plan

Tested locally with podman:
```bash
$ pixi run -e gpu-wheel-build-py312 wheel_build
Container engine: podman ✅

$ pixi run -e gpu-wheel-build-py313 wheel_build  
Container engine: podman ✅

$ pixi run -e py312 wheel_build
Container engine: podman ✅
```

CI should auto-detect docker and use that.

## How It Works

The detection script (`scripts/detect_container_engine.sh`):
```bash
if [ -z "$CIBW_CONTAINER_ENGINE" ]; then
    if command -v docker >/dev/null 2>&1; then
        export CIBW_CONTAINER_ENGINE=docker
    elif command -v podman >/dev/null 2>&1; then
        export CIBW_CONTAINER_ENGINE=podman
    fi
fi
```