### PR TITLE
Migrate geometry Python bindings from torch.Tensor to numpy arrays

### DIFF
--- a/pymomentum/test/test_fbx.py
+++ b/pymomentum/test/test_fbx.py
@@ -24,7 +24,14 @@ class TestFBX(unittest.TestCase):
         self.model_params = pym_geometry.uniform_random_to_model_parameters(
             self.character, torch.rand(nBatch, nParams)
         ).double()
-        self.joint_params = self.character.parameter_transform.apply(self.model_params)
+        self.joint_params = torch.from_numpy(
+            self.character.parameter_transform.apply(self.model_params.numpy())
+        )
+        self.skeleton_state = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                self.character, self.model_params.numpy()
+            )
+        )
 
     def test_load_animation(self) -> None:
         """
@@ -83,8 +90,8 @@ class TestFBX(unittest.TestCase):
             )
         )
 
-        skel_state = pym_geometry.joint_parameters_to_skeleton_state(
-            character, torch.from_numpy(joint_params)
+        skel_state = torch.from_numpy(
+            pym_geometry.joint_parameters_to_skeleton_state(character, joint_params)
         )
 
         skel_state_first = skel_state[0]
@@ -93,35 +100,23 @@ class TestFBX(unittest.TestCase):
         # Start and end values read out from Maya.
         # 3-joint chain basically just rotates by 90 degrees.
         self.assertTrue(
-            torch.allclose(
-                skel_state_first[joint1][0:3], torch.Tensor([0, 0, 4]), atol=1e-5
-            )
+            np.allclose(skel_state_first[joint1][0:3], np.array([0, 0, 4]), atol=1e-5)
         )
         self.assertTrue(
-            torch.allclose(
-                skel_state_first[joint2][0:3], torch.Tensor([4, 0, 4]), atol=1e-5
-            )
+            np.allclose(skel_state_first[joint2][0:3], np.array([4, 0, 4]), atol=1e-5)
         )
         self.assertTrue(
-            torch.allclose(
-                skel_state_first[joint3][0:3], torch.Tensor([4, 0, 8]), atol=1e-5
-            )
+            np.allclose(skel_state_first[joint3][0:3], np.array([4, 0, 8]), atol=1e-5)
         )
 
         self.assertTrue(
-            torch.allclose(
-                skel_state_last[joint1][0:3], torch.Tensor([0, 0, 4]), atol=1e-5
-            )
+            np.allclose(skel_state_last[joint1][0:3], np.array([0, 0, 4]), atol=1e-5)
         )
         self.assertTrue(
-            torch.allclose(
-                skel_state_last[joint2][0:3], torch.Tensor([0, 0, 0]), atol=1e-5
-            )
+            np.allclose(skel_state_last[joint2][0:3], np.array([0, 0, 0]), atol=1e-5)
         )
         self.assertTrue(
-            torch.allclose(
-                skel_state_last[joint3][0:3], torch.Tensor([4, 0, 0]), atol=1e-5
-            )
+            np.allclose(skel_state_last[joint3][0:3], np.array([4, 0, 0]), atol=1e-5)
         )
 
     def test_save_motions_with_model_params(self) -> None:

--- a/pymomentum/test/test_geometry_diff_geometry_consistency.py
+++ b/pymomentum/test/test_geometry_diff_geometry_consistency.py
@@ -1,0 +1,266 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Consistency tests between pymomentum.geometry and pymomentum.diff_geometry.
+
+This file contains tests that verify that the numpy-based implementations in
+pymomentum.geometry produce the same results as the torch-based implementations
+in pymomentum.diff_geometry.
+"""
+
+import unittest
+
+import numpy as np
+import pymomentum.diff_geometry as pym_diff_geometry
+import pymomentum.geometry as pym_geometry
+import torch
+
+
+class TestGeometryDiffGeometryConsistency(unittest.TestCase):
+    """Tests verifying consistency between geometry and diff_geometry modules."""
+
+    def test_apply_parameter_transform_matches(self) -> None:
+        """Verify that geometry.apply_parameter_transform matches diff_geometry.apply_parameter_transform."""
+        np.random.seed(42)
+
+        character = pym_geometry.create_test_character()
+        nBatch = 2
+
+        # Create model parameters with numpy
+        model_params_np = np.random.rand(
+            nBatch, character.parameter_transform.size
+        ).astype(np.float32)
+
+        # Call geometry version (numpy)
+        joint_params_geometry = pym_geometry.apply_parameter_transform(
+            character, model_params_np
+        )
+
+        # Call diff_geometry version (torch)
+        model_params_torch = torch.from_numpy(model_params_np)
+        joint_params_diff_geometry = pym_diff_geometry.apply_parameter_transform(
+            character, model_params_torch
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(
+                joint_params_geometry, joint_params_diff_geometry.numpy(), atol=1e-6
+            ),
+            "geometry.apply_parameter_transform should match diff_geometry.apply_parameter_transform",
+        )
+
+    def test_model_parameters_to_skeleton_state_matches(self) -> None:
+        """Verify that geometry.model_parameters_to_skeleton_state matches diff_geometry.model_parameters_to_skeleton_state."""
+        np.random.seed(42)
+
+        character = pym_geometry.create_test_character()
+        nBatch = 2
+
+        # Create model parameters with numpy
+        model_params_np = 0.2 * np.ones(
+            (nBatch, character.parameter_transform.size), dtype=np.float32
+        )
+
+        # Call geometry version (numpy)
+        skel_state_geometry = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_np
+        )
+
+        # Call diff_geometry version (torch)
+        model_params_torch = torch.from_numpy(model_params_np)
+        skel_state_diff_geometry = pym_diff_geometry.model_parameters_to_skeleton_state(
+            character, model_params_torch
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(
+                skel_state_geometry, skel_state_diff_geometry.numpy(), atol=1e-6
+            ),
+            "geometry.model_parameters_to_skeleton_state should match diff_geometry.model_parameters_to_skeleton_state",
+        )
+
+    def test_model_parameters_to_local_skeleton_state_matches(self) -> None:
+        """Verify that geometry.model_parameters_to_local_skeleton_state matches diff_geometry.model_parameters_to_local_skeleton_state."""
+        np.random.seed(42)
+
+        character = pym_geometry.create_test_character()
+        nBatch = 2
+
+        # Create model parameters with numpy
+        model_params_np = 0.2 * np.ones(
+            (nBatch, character.parameter_transform.size), dtype=np.float32
+        )
+
+        # Call geometry version (numpy)
+        local_skel_state_geometry = (
+            pym_geometry.model_parameters_to_local_skeleton_state(
+                character, model_params_np
+            )
+        )
+
+        # Call diff_geometry version (torch)
+        model_params_torch = torch.from_numpy(model_params_np)
+        local_skel_state_diff_geometry = (
+            pym_diff_geometry.model_parameters_to_local_skeleton_state(
+                character, model_params_torch
+            )
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(
+                local_skel_state_geometry,
+                local_skel_state_diff_geometry.numpy(),
+                atol=1e-6,
+            ),
+            "geometry.model_parameters_to_local_skeleton_state should match diff_geometry.model_parameters_to_local_skeleton_state",
+        )
+
+    def test_joint_parameters_to_skeleton_state_matches(self) -> None:
+        """Verify that geometry.joint_parameters_to_skeleton_state matches diff_geometry.joint_parameters_to_skeleton_state."""
+        np.random.seed(42)
+
+        character = pym_geometry.create_test_character()
+        nBatch = 2
+        nJoints = character.skeleton.size
+
+        # Create joint parameters with numpy (flat format)
+        joint_params_np = np.random.rand(nBatch, nJoints * 7).astype(np.float32)
+
+        # Call geometry version (numpy)
+        skel_state_geometry = pym_geometry.joint_parameters_to_skeleton_state(
+            character, joint_params_np
+        )
+
+        # Call diff_geometry version (torch)
+        joint_params_torch = torch.from_numpy(joint_params_np)
+        skel_state_diff_geometry = pym_diff_geometry.joint_parameters_to_skeleton_state(
+            character, joint_params_torch
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(
+                skel_state_geometry, skel_state_diff_geometry.numpy(), atol=1e-6
+            ),
+            "geometry.joint_parameters_to_skeleton_state should match diff_geometry.joint_parameters_to_skeleton_state",
+        )
+
+    def test_joint_parameters_to_local_skeleton_state_matches(self) -> None:
+        """Verify that geometry.joint_parameters_to_local_skeleton_state matches diff_geometry.joint_parameters_to_local_skeleton_state."""
+        np.random.seed(42)
+
+        character = pym_geometry.create_test_character()
+        nBatch = 2
+        nJoints = character.skeleton.size
+
+        # Create joint parameters with numpy (flat format)
+        joint_params_np = np.random.rand(nBatch, nJoints * 7).astype(np.float32)
+
+        # Call geometry version (numpy)
+        local_skel_state_geometry = (
+            pym_geometry.joint_parameters_to_local_skeleton_state(
+                character, joint_params_np
+            )
+        )
+
+        # Call diff_geometry version (torch)
+        joint_params_torch = torch.from_numpy(joint_params_np)
+        local_skel_state_diff_geometry = (
+            pym_diff_geometry.joint_parameters_to_local_skeleton_state(
+                character, joint_params_torch
+            )
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(
+                local_skel_state_geometry,
+                local_skel_state_diff_geometry.numpy(),
+                atol=1e-6,
+            ),
+            "geometry.joint_parameters_to_local_skeleton_state should match diff_geometry.joint_parameters_to_local_skeleton_state",
+        )
+
+    def test_skeleton_state_to_joint_parameters_matches(self) -> None:
+        """Verify that geometry.skeleton_state_to_joint_parameters matches diff_geometry.skeleton_state_to_joint_parameters."""
+        np.random.seed(42)
+
+        character = pym_geometry.create_test_character()
+        nBatch = 2
+
+        # Create model parameters and convert to skeleton state
+        model_params_np = 0.2 * np.ones(
+            (nBatch, character.parameter_transform.size), dtype=np.float32
+        )
+        skel_state_np = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_np
+        )
+
+        # Call geometry version (numpy)
+        joint_params_geometry = pym_geometry.skeleton_state_to_joint_parameters(
+            character, skel_state_np
+        )
+
+        # Call diff_geometry version (torch)
+        skel_state_torch = torch.from_numpy(skel_state_np)
+        joint_params_diff_geometry = (
+            pym_diff_geometry.skeleton_state_to_joint_parameters(
+                character, skel_state_torch
+            )
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(
+                joint_params_geometry, joint_params_diff_geometry.numpy(), atol=1e-6
+            ),
+            "geometry.skeleton_state_to_joint_parameters should match diff_geometry.skeleton_state_to_joint_parameters",
+        )
+
+    def test_local_skeleton_state_to_joint_parameters_matches(self) -> None:
+        """Verify that geometry.local_skeleton_state_to_joint_parameters matches diff_geometry.local_skeleton_state_to_joint_parameters."""
+        np.random.seed(42)
+
+        character = pym_geometry.create_test_character()
+        nBatch = 2
+
+        # Create model parameters and convert to local skeleton state
+        model_params_np = 0.2 * np.ones(
+            (nBatch, character.parameter_transform.size), dtype=np.float32
+        )
+        local_skel_state_np = pym_geometry.model_parameters_to_local_skeleton_state(
+            character, model_params_np
+        )
+
+        # Call geometry version (numpy)
+        joint_params_geometry = pym_geometry.local_skeleton_state_to_joint_parameters(
+            character, local_skel_state_np
+        )
+
+        # Call diff_geometry version (torch)
+        local_skel_state_torch = torch.from_numpy(local_skel_state_np)
+        joint_params_diff_geometry = (
+            pym_diff_geometry.local_skeleton_state_to_joint_parameters(
+                character, local_skel_state_torch
+            )
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(
+                joint_params_geometry, joint_params_diff_geometry.numpy(), atol=1e-6
+            ),
+            "geometry.local_skeleton_state_to_joint_parameters should match diff_geometry.local_skeleton_state_to_joint_parameters",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pymomentum/test/test_marker_tracking.py
+++ b/pymomentum/test/test_marker_tracking.py
@@ -27,10 +27,12 @@ class TestMarkerTracking(unittest.TestCase):
         mesh_vertex_position = character.mesh.vertices[mesh_vertex_idx]
         print("mesh_vertex_position: ", mesh_vertex_position)
 
-        rest_model_params = torch.zeros(character.parameter_transform.size)
-        rest_skeleton_state = pym_geometry.model_parameters_to_skeleton_state(
-            character, rest_model_params.unsqueeze(0)
-        )[0]  # Remove batch dimension
+        rest_model_params = np.zeros((1, character.parameter_transform.size))
+        rest_skeleton_state = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, rest_model_params
+            )[0]  # Remove batch dimension
+        )
         parent_joint_idx = character.skin_weights.index[mesh_vertex_idx][0]
 
         # Create a locator positioned at the mesh vertex
@@ -101,15 +103,15 @@ class TestMarkerTracking(unittest.TestCase):
 
         # Compute converted skinned locator's world space position
         # Skinned locator position is already in world space coordinates
-        converted_world_pos = torch.from_numpy(converted_locator.position)
+        converted_world_pos = converted_locator.position
 
         # Compare world space positions
-        position_diff = torch.norm(converted_world_pos - mesh_vertex_position).item()
+        position_diff = np.linalg.norm(converted_world_pos - mesh_vertex_position)
         self.assertLess(
             position_diff,
             0.01,  # Tight tolerance since they should match exactly
             msg=f"Converted locator world position should match original locator world position. "
-            f"Original: {mesh_vertex_position}, Converted: {converted_world_pos.numpy()}, "
+            f"Original: {mesh_vertex_position}, Converted: {converted_world_pos}, "
             f"Diff: {position_diff}",
         )
 
@@ -184,10 +186,12 @@ class TestMarkerTracking(unittest.TestCase):
 
         # Verify that the world position is preserved
         # Compute the world position of the converted locator in rest pose
-        rest_model_params = torch.zeros(character.parameter_transform.size)
-        rest_skeleton_state = pym_geometry.model_parameters_to_skeleton_state(
-            character, rest_model_params.unsqueeze(0)
-        )[0]
+        rest_model_params = np.zeros((1, character.parameter_transform.size))
+        rest_skeleton_state = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, rest_model_params
+            )[0]
+        )
 
         # Transform the offset to world space using the parent bone's transform
         converted_world_pos = pym_skel_state.transform_points(
@@ -271,8 +275,10 @@ class TestMarkerTracking(unittest.TestCase):
             model_params_batch[frame, :] = model_params_cur
 
         # Convert model parameters to skeleton states
-        skeleton_states = pym_geometry.model_parameters_to_skeleton_state(
-            character, model_params_batch
+        skeleton_states = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_batch.numpy()
+            )
         )
 
         # Compute skinned locator positions for all frames using the new function
@@ -322,8 +328,8 @@ class TestMarkerTracking(unittest.TestCase):
         tracked_motion_tensor = torch.from_numpy(tracked_motion)
 
         # Convert tracked motion to skeleton states
-        tracked_skeleton_states = pym_geometry.model_parameters_to_skeleton_state(
-            character, tracked_motion_tensor
+        tracked_skeleton_states = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(character, tracked_motion)
         )
 
         # Compute all skinned locator positions for all tracked frames using the new function
@@ -600,10 +606,14 @@ class TestMarkerTracking(unittest.TestCase):
         mesh_vertex_idx = 22  # Pick an arbitrary vertex
         mesh_vertex_position = character.mesh.vertices[mesh_vertex_idx]
 
-        rest_model_params = torch.zeros(character.parameter_transform.size)
-        rest_skeleton_state = pym_geometry.model_parameters_to_skeleton_state(
-            character, rest_model_params.unsqueeze(0)
-        )[0]
+        rest_model_params = np.zeros(
+            (1, character.parameter_transform.size), dtype=np.float32
+        )
+        rest_skeleton_state = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, rest_model_params
+            )[0]
+        )
         parent_joint_idx = character.skin_weights.index[mesh_vertex_idx][0]
 
         # Create a locator positioned at the mesh vertex

--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -26,7 +26,9 @@ class TestParameterTransform(unittest.TestCase):
         model_params = uniform_random_to_model_parameters(
             character, torch.rand(1, 10)
         ).squeeze()
-        joint_params_1 = character.parameter_transform.apply(model_params)
+        joint_params_1 = torch.from_numpy(
+            character.parameter_transform.apply(model_params.numpy()[None, :])
+        ).flatten()
         joint_params_2 = torch.matmul(transform, model_params)
         self.assertTrue(torch.allclose(joint_params_1, joint_params_2))
 
@@ -51,8 +53,10 @@ class TestParameterTransform(unittest.TestCase):
         torch.manual_seed(42)
         model_params = uniform_random_to_model_parameters(character, torch.rand(5, 10))
 
-        joint_params_original = original_pt.apply(model_params)
-        joint_params_new = new_pt.apply(model_params)
+        joint_params_original = torch.from_numpy(
+            original_pt.apply(model_params.numpy())
+        )
+        joint_params_new = torch.from_numpy(new_pt.apply(model_params.numpy()))
 
         self.assertTrue(
             torch.allclose(joint_params_original, joint_params_new, atol=1e-6)

--- a/pymomentum/test/test_pose_prior.py
+++ b/pymomentum/test/test_pose_prior.py
@@ -61,8 +61,10 @@ class TestPosePrior(unittest.TestCase):
         orient_cons_weights = torch.ones(
             batch_size, n_joints, requires_grad=AUTOGRAD_ENABLED, dtype=torch.float64
         )
-        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
-            character, model_params_init
+        skel_state_init = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_init.numpy()
+            )
         )
         orient_cons_targets = skel_state_init.index_select(1, orient_cons_parents)[
             :, :, 3:7

--- a/pymomentum/test/test_renderer.py
+++ b/pymomentum/test/test_renderer.py
@@ -310,10 +310,14 @@ class TestRendering(unittest.TestCase):
 
         # Create random joint parameters
         torch.manual_seed(42)
-        joint_parameters = torch.randn(character.skeleton.size * 7)
-        skeleton_states = pym_geometry.joint_parameters_to_skeleton_state(
-            character, joint_parameters
+        joint_parameters = torch.randn(character.skeleton.size * 7).reshape(
+            character.skeleton.size, 7
         )
+        skeleton_states = torch.from_numpy(
+            pym_geometry.joint_parameters_to_skeleton_state(
+                character, joint_parameters.unsqueeze(0).numpy()
+            )
+        ).squeeze(0)
 
         # Create cameras using old function
         cameras_old = pym_renderer.build_cameras_for_body(
@@ -338,9 +342,13 @@ class TestRendering(unittest.TestCase):
         # Create random joint parameters with batch size 3
         torch.manual_seed(42)
         n_frames = 3
-        joint_parameters = torch.randn(n_frames, character.skeleton.size * 7)
-        skeleton_states = pym_geometry.joint_parameters_to_skeleton_state(
-            character, joint_parameters
+        joint_parameters = torch.randn(n_frames, character.skeleton.size * 7).reshape(
+            n_frames, character.skeleton.size, 7
+        )
+        skeleton_states = torch.from_numpy(
+            pym_geometry.joint_parameters_to_skeleton_state(
+                character, joint_parameters.numpy()
+            )
         )
 
         # Create cameras using old function

--- a/pymomentum/test/test_sequence_ik.py
+++ b/pymomentum/test/test_sequence_ik.py
@@ -7,6 +7,7 @@
 
 import unittest
 
+import pymomentum.diff_geometry as pym_diff_geometry
 import pymomentum.geometry as pym_geometry
 import pymomentum.solver as pym_solver
 import torch
@@ -46,7 +47,7 @@ class TestSolver(unittest.TestCase):
         ).detach()
 
         orient_cons_parents = torch.arange(n_joints)
-        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
+        skel_state_init = pym_diff_geometry.model_parameters_to_skeleton_state(
             character, model_params_target
         )
         orient_cons_targets = skel_state_init.index_select(1, orient_cons_parents)[

--- a/pymomentum/test/test_solver.py
+++ b/pymomentum/test/test_solver.py
@@ -8,6 +8,7 @@
 import unittest
 from multiprocessing.dummy import Pool
 
+import pymomentum.diff_geometry as pym_diff_geometry
 import pymomentum.geometry as pym_geometry
 import pymomentum.skel_state as pym_skel_state
 import pymomentum.solver as pym_solver
@@ -121,7 +122,7 @@ class TestSolver(unittest.TestCase):
             batch_size, n_joints, requires_grad=AUTOGRAD_ENABLED, dtype=torch.float64
         )
 
-        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
+        skel_state_init = pym_diff_geometry.model_parameters_to_skeleton_state(
             character, model_params_init
         )
         orient_cons_targets = skel_state_init.index_select(1, orient_cons_parents)[
@@ -639,7 +640,7 @@ class TestSolver(unittest.TestCase):
             character, torch.rand(nBatch, nParams)
         ).double()
 
-        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
+        skel_state_init = pym_diff_geometry.model_parameters_to_skeleton_state(
             character, model_params_init
         )
 
@@ -660,7 +661,7 @@ class TestSolver(unittest.TestCase):
         model_params_final = pym_solver.transform_pose(
             character, model_params_init, transform
         )
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+        skel_state_final = pym_diff_geometry.model_parameters_to_skeleton_state(
             character, model_params_final
         )
 

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -36,8 +36,10 @@ class TestSolver(unittest.TestCase):
         model_params_init = torch.zeros(n_params, dtype=torch.float32)
 
         model_params_target = torch.rand_like(model_params_init)
-        skel_state_target = pym_geometry.model_parameters_to_skeleton_state(
-            character, model_params_target
+        skel_state_target = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_target.numpy()
+            )
         )
 
         pos_error = pym_solver2.PositionErrorFunction(character)
@@ -69,8 +71,10 @@ class TestSolver(unittest.TestCase):
         solver_options.regularization = 1e-5
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
         model_params_final = solver.solve(model_params_init.numpy())
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         self.assertTrue(
@@ -364,8 +368,10 @@ class TestSolver(unittest.TestCase):
         model_params_target = torch.rand_like(model_params_init)
 
         # Convert target model parameters to a target skeleton state
-        skel_state_target = pym_geometry.model_parameters_to_skeleton_state(
-            character, model_params_target
+        skel_state_target = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_target.numpy()
+            )
         )
 
         # Create StateErrorFunction
@@ -389,8 +395,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Assert that the solved skeleton state is close to the target
@@ -519,8 +527,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert final model parameters to skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position of the point
@@ -592,8 +602,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert final model parameters to skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position of the vertex
@@ -717,8 +729,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position and direction of the local ray
@@ -791,8 +805,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final local axis in global space
@@ -854,8 +870,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position and normal in global space
@@ -925,8 +943,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position of the point in global space
@@ -1013,8 +1033,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final orientation
@@ -1086,8 +1108,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position of the point in global space
@@ -1127,8 +1151,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_below.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position of the point in global space
@@ -1206,8 +1232,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final position of the point in global space
@@ -1298,8 +1326,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute the final mesh
@@ -1415,11 +1445,15 @@ class TestSolver(unittest.TestCase):
         )
 
         # Convert final model parameters to skeleton states
-        skel_state_frame0 = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final[0])
+        skel_state_frame0 = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final[0]
+            )
         )
-        skel_state_frame1 = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final[1])
+        skel_state_frame1 = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final[1]
+            )
         )
 
         # Compute final meshes for both frames
@@ -1462,11 +1496,15 @@ class TestSolver(unittest.TestCase):
         )
 
         # Convert to skeleton states
-        skel_state_frame0_zero = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final_zero[0])
+        skel_state_frame0_zero = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final_zero[0]
+            )
         )
-        skel_state_frame1_zero = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final_zero[1])
+        skel_state_frame1_zero = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final_zero[1]
+            )
         )
 
         # Compute meshes
@@ -1588,7 +1626,7 @@ class TestSolver(unittest.TestCase):
         # Convert to skeleton states and verify accelerations match zero target
         skel_states = [
             pym_geometry.model_parameters_to_skeleton_state(
-                character, torch.from_numpy(model_params_final[i])
+                character, model_params_final[i]
             )
             for i in range(n_frames)
         ]
@@ -1604,13 +1642,13 @@ class TestSolver(unittest.TestCase):
 
             # Assert that measured acceleration matches target
             self.assertTrue(
-                torch.allclose(
+                np.allclose(
                     acceleration,
-                    torch.from_numpy(target),
+                    target,
                     rtol=0.1,
                     atol=0.1,
                 ),
-                f"Joint {joint_idx}: acceleration {acceleration.numpy()} "
+                f"Joint {joint_idx}: acceleration {acceleration} "
                 f"does not match target {target}",
             )
 
@@ -1676,7 +1714,7 @@ class TestSolver(unittest.TestCase):
         # Convert to skeleton states and verify accelerations match target
         skel_states_ballistic = [
             pym_geometry.model_parameters_to_skeleton_state(
-                character, torch.from_numpy(model_params_final_ballistic[i])
+                character, model_params_final_ballistic[i]
             )
             for i in range(n_frames)
         ]
@@ -1688,13 +1726,13 @@ class TestSolver(unittest.TestCase):
         measured_accel = pos2 - 2 * pos1 + pos0
 
         self.assertTrue(
-            torch.allclose(
+            np.allclose(
                 measured_accel,
-                torch.from_numpy(target_accel),
+                target_accel,
                 rtol=0.1,
                 atol=0.1,
             ),
-            f"Ballistic test: measured acceleration {measured_accel.numpy()} "
+            f"Ballistic test: measured acceleration {measured_accel} "
             f"does not match target {target_accel}",
         )
 
@@ -1794,8 +1832,10 @@ class TestSolver(unittest.TestCase):
 
         # Convert to skeleton states and verify jerk matches zero target
         skel_states = [
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, torch.from_numpy(model_params_final[i])
+            torch.from_numpy(
+                pym_geometry.model_parameters_to_skeleton_state(
+                    character, model_params_final[i]
+                )
             )
             for i in range(n_frames)
         ]
@@ -1840,8 +1880,10 @@ class TestSolver(unittest.TestCase):
         weight = 1.0
 
         # Get initial positions of the vertices
-        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
-            character, model_params_init
+        skel_state_init = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_init.numpy()
+            )
         )
         initial_mesh = character.skin_points(skel_state_init)
         initial_pos1 = initial_mesh[vertex_index1, :3]
@@ -1888,8 +1930,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert final model parameters to skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute final mesh and vertex positions
@@ -1980,8 +2024,10 @@ class TestSolver(unittest.TestCase):
         weight = 1.0
 
         # Get initial positions of the points
-        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
-            character, model_params_init
+        skel_state_init = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_init.numpy()
+            )
         )
         initial_point1 = pym_skel_state.transform_points(
             skel_state_init[joint_index1],
@@ -2035,8 +2081,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert final model parameters to skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute final positions of the points
@@ -2249,8 +2297,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert final model parameters to skeleton state
-        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state_final = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
 
         # Compute final positions of the points
@@ -2377,8 +2427,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init)
 
         # Compute actual height from optimized parameters
-        skel_state = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final)
+        skel_state = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final
+            )
         )
         mesh_vertices = character.skin_points(skel_state)
 
@@ -2410,8 +2462,10 @@ class TestSolver(unittest.TestCase):
         model_params_final_2 = solver.solve(model_params_init)
 
         # Compute actual height from optimized parameters
-        skel_state_2 = pym_geometry.model_parameters_to_skeleton_state(
-            character, torch.from_numpy(model_params_final_2)
+        skel_state_2 = torch.from_numpy(
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final_2
+            )
         )
         mesh_vertices_2 = character.skin_points(skel_state_2)
 
@@ -2517,7 +2571,7 @@ class TestSolver(unittest.TestCase):
         # Convert to skeleton states and verify velocity magnitudes are close to zero
         skel_states = [
             pym_geometry.model_parameters_to_skeleton_state(
-                character, torch.from_numpy(model_params_final[i])
+                character, model_params_final[i]
             )
             for i in range(n_frames)
         ]
@@ -2529,7 +2583,7 @@ class TestSolver(unittest.TestCase):
 
             # Velocity = pos[t+1] - pos[t]
             velocity = pos1 - pos0
-            speed = torch.norm(velocity).item()
+            speed = float(np.linalg.norm(velocity))
 
             speeds.append(speed)
             # Assert that measured speed is close to zero target
@@ -2574,7 +2628,7 @@ class TestSolver(unittest.TestCase):
         # Convert to skeleton states and verify velocity magnitudes match target
         skel_states2 = [
             pym_geometry.model_parameters_to_skeleton_state(
-                character, torch.from_numpy(model_params_final2[i])
+                character, model_params_final2[i]
             )
             for i in range(n_frames)
         ]
@@ -2582,7 +2636,7 @@ class TestSolver(unittest.TestCase):
         # Check root joint velocity magnitude
         pos0 = skel_states2[0][0, :3]
         pos1 = skel_states2[1][0, :3]
-        measured_speed = torch.norm(pos1 - pos0).item()
+        measured_speed = float(np.linalg.norm(pos1 - pos0))
 
         self.assertTrue(
             np.isclose(measured_speed, target_speed, rtol=1e-3, atol=1e-3),


### PR DESCRIPTION
Summary:
Migrates Python bindings in pymomentum.geometry from torch.Tensor to numpy arrays for non-differentiable operations. This is part of the broader effort to separate differentiable (torch-based) functions in diff_geometry from non-differentiable (numpy-based) functions in geometry.

**Functions converted:**

ParameterTransform class:
- `apply()` - converts model parameters to joint parameters, returns numpy array
- `inverse().apply()` - converts joint parameters to model parameters, returns numpy array
- `parameters_for_joints()` - returns boolean numpy array of parameters affecting joints
- `find_parameters()` - returns boolean numpy array for named parameters

Geometry module functions:
- `apply_parameter_transform()` - applies parameter transform with numpy arrays
- `model_parameters_to_skeleton_state()` - converts model params to skeleton state
- `model_parameters_to_local_skeleton_state()` - converts model params to local skeleton state
- `joint_parameters_to_skeleton_state()` - converts joint params to global skeleton state
- `joint_parameters_to_local_skeleton_state()` - converts joint params to local skeleton state
- `skeleton_state_to_joint_parameters()` - converts global skeleton state to joint params
- `local_skeleton_state_to_joint_parameters()` - converts local skeleton state to joint params

Also adds a `flatten` parameter to `apply_parameter_transform()` and `ParameterTransform.apply()` to control output shape: `[..., numJoints * 7]` when True (default) or `[..., numJoints, 7]` when False.

Updated tests to use numpy arrays instead of torch tensors, added consistency tests between geometry and diff_geometry modules.

Reviewed By: jeongseok-meta

Differential Revision: D89439392


