### PR TITLE
Convert parameter transform functions to use numpy arrays

### DIFF
--- a/pymomentum/array_utility/default_parameter_set.h
+++ b/pymomentum/array_utility/default_parameter_set.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace pymomentum {
+
+// Enum for controlling default behavior when converting empty arrays/tensors to ParameterSet.
+// If the user passes an empty tensor/array for a parameter set, what kind of value to return.
+// This is different for different cases: sometimes we should include all parameters,
+// sometimes none, and sometimes no reasonable default is possible.
+// clang-format off
+enum class DefaultParameterSet { AllOnes, AllZeros, NoDefault };
+// clang-format on
+
+} // namespace pymomentum

--- a/pymomentum/backend/utils.py
+++ b/pymomentum/backend/utils.py
@@ -140,7 +140,7 @@ class LBSAdapter:
 
         # Parameter transform properties
         self.param_transform: torch.Tensor = torch.tensor(
-            character.parameter_transform.transform.numpy(),
+            character.parameter_transform.transform,
             dtype=self.dtype,
             device=self._device,
         )
@@ -150,14 +150,9 @@ class LBSAdapter:
         )
 
         # Derived parameter counts from the boolean mask for backward compatibility
-        self.nr_position_params: int = int(
-            torch.logical_not(character.parameter_transform.scaling_parameters)
-            .sum()
-            .item()
-        )
-        self.nr_scaling_params: int = int(
-            character.parameter_transform.scaling_parameters.sum().item()
-        )
+        scaling_params = character.parameter_transform.scaling_parameters
+        self.nr_position_params: int = int((~scaling_params).sum())
+        self.nr_scaling_params: int = int(scaling_params.sum())
 
         # Mesh and skinning weights
         assert character.has_mesh

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -31,6 +31,7 @@ tensor_utility_sources = [
 array_utility_public_headers = [
     "array_utility/array_utility.h",
     "array_utility/batch_accessor.h",
+    "array_utility/default_parameter_set.h",
     "array_utility/geometry_accessors.h",
 ]
 

--- a/pymomentum/geometry/array_parameter_transform.h
+++ b/pymomentum/geometry/array_parameter_transform.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <pymomentum/array_utility/default_parameter_set.h>
+
 #include <momentum/character/character.h>
 #include <momentum/character/inverse_parameter_transform.h>
 #include <momentum/character/parameter_transform.h>
@@ -50,6 +52,14 @@ std::unordered_map<std::string, py::array_t<bool>> getParameterSetsArray(
 py::array_t<bool> parameterSetToArray(
     const momentum::ParameterTransform& parameterTransform,
     const momentum::ParameterSet& paramSet);
+
+// Convert a boolean numpy array to a ParameterSet
+// If the array is empty and defaultParamSet is not NO_DEFAULT, return the default set
+// Note: DefaultParameterSet enum is defined in tensor_momentum/tensor_parameter_transform.h
+momentum::ParameterSet arrayToParameterSet(
+    const momentum::ParameterTransform& parameterTransform,
+    const py::array_t<bool>& paramSet,
+    DefaultParameterSet defaultParamSet = DefaultParameterSet::NoDefault);
 
 py::array_t<bool> getScalingParametersArray(const momentum::ParameterTransform& parameterTransform);
 

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -20,13 +20,10 @@
 #include "pymomentum/geometry/parameter_transform_pybind.h"
 #include "pymomentum/geometry/skeleton_pybind.h"
 #include "pymomentum/geometry/skin_weights_pybind.h"
-#include "pymomentum/tensor_momentum/tensor_blend_shape.h"
-#include "pymomentum/tensor_momentum/tensor_joint_parameters_to_positions.h"
+
+// Keep tensor versions for functions without array equivalents yet
 #include "pymomentum/tensor_momentum/tensor_kd_tree.h"
 #include "pymomentum/tensor_momentum/tensor_mppca.h"
-#include "pymomentum/tensor_momentum/tensor_parameter_transform.h"
-#include "pymomentum/tensor_momentum/tensor_skeleton_state.h"
-#include "pymomentum/tensor_momentum/tensor_skinning.h"
 #include "pymomentum/torch_bridge.h"
 
 #include <momentum/character/blend_shape.h>
@@ -1181,14 +1178,14 @@ blend shapes, pose shapes, and other mesh-related data.
   // reduceToSelectedModelParameters(character, activeParameters)
   m.def(
       "reduce_to_selected_model_parameters",
-      [](const momentum::Character& character, at::Tensor activeParameters) {
+      [](const momentum::Character& character, const py::array_t<bool>& activeParameters) {
         return character.simplifyParameterTransform(
-            tensorToParameterSet(character.parameterTransform, activeParameters));
+            arrayToParameterSet(character.parameterTransform, activeParameters));
       },
       R"(Strips out unused parameters from the parameter transform.
 
 :param character: Full-body character.
-:param activeParameters: A boolean tensor marking which parameters should be retained.
+:param activeParameters: A boolean numpy array marking which parameters should be retained.
 :return: A new character whose parameter transform only includes the marked parameters.)",
       py::arg("character"),
       py::arg("active_parameters"));

--- a/pymomentum/solver/momentum_ik.cpp
+++ b/pymomentum/solver/momentum_ik.cpp
@@ -420,9 +420,9 @@ variable_list IKProblemAutogradFunction<T, IKFunction>::forward(
   std::vector<at::Tensor> results = IKFunction<T>::forward(
       characters,
       tensorToParameterSet(
-          characters[0]->parameterTransform, activeParams, DefaultParameterSet::ALL_ONES),
+          characters[0]->parameterTransform, activeParams, DefaultParameterSet::AllOnes),
       tensorToParameterSet(
-          characters[0]->parameterTransform, sharedParams, DefaultParameterSet::ALL_ZEROS),
+          characters[0]->parameterTransform, sharedParams, DefaultParameterSet::AllZeros),
       solverOptions,
       modelParameters_init,
       errorFunctions,
@@ -694,9 +694,9 @@ variable_list IKProblemAutogradFunction<T, IKFunction>::backward(
   const auto [grad_modelParams, grad_errorFunctionWeights, grad_inputs] = IKFunction<T>::backward(
       characters,
       tensorToParameterSet(
-          characters[0]->parameterTransform, activeParams, DefaultParameterSet::ALL_ONES),
+          characters[0]->parameterTransform, activeParams, DefaultParameterSet::AllOnes),
       tensorToParameterSet(
-          characters[0]->parameterTransform, sharedParams, DefaultParameterSet::ALL_ZEROS),
+          characters[0]->parameterTransform, sharedParams, DefaultParameterSet::AllZeros),
       modelParameters_init,
       results,
       dLoss_dResults,

--- a/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
+++ b/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
@@ -230,16 +230,16 @@ momentum::ParameterSet tensorToParameterSet(
     DefaultParameterSet defaultParamSet) {
   if (isEmpty(paramSet)) {
     switch (defaultParamSet) {
-      case DefaultParameterSet::ALL_ZEROS: {
+      case DefaultParameterSet::AllZeros: {
         momentum::ParameterSet result;
         return result;
       }
-      case DefaultParameterSet::ALL_ONES: {
+      case DefaultParameterSet::AllOnes: {
         momentum::ParameterSet result;
         result.set();
         return result;
       }
-      case DefaultParameterSet::NO_DEFAULT:
+      case DefaultParameterSet::NoDefault:
       default:
           // fall through to the check below:
           ;

--- a/pymomentum/tensor_momentum/tensor_parameter_transform.h
+++ b/pymomentum/tensor_momentum/tensor_parameter_transform.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <pymomentum/array_utility/default_parameter_set.h>
+
 #include <momentum/character/character.h>
 #include <momentum/character/inverse_parameter_transform.h>
 #include <momentum/character/parameter_transform.h>
@@ -64,16 +66,10 @@ at::Tensor applyInverseParamTransform(
 std::unique_ptr<momentum::InverseParameterTransform> createInverseParameterTransform(
     const momentum::ParameterTransform& transform);
 
-// If the user passes an empty tensor for a parameter set, what kind of
-// value to return.  This is different for different cases: sometimes we
-// should include all parameters, sometimes none, and sometimes no reasonable
-// default is possible.
-enum class DefaultParameterSet { ALL_ONES, ALL_ZEROS, NO_DEFAULT };
-
 momentum::ParameterSet tensorToParameterSet(
     const momentum::ParameterTransform& parameterTransform,
     at::Tensor paramSet,
-    DefaultParameterSet defaultParamSet = DefaultParameterSet::NO_DEFAULT);
+    DefaultParameterSet defaultParamSet = DefaultParameterSet::NoDefault);
 
 // Change flattened joint parameter motion tensor with shape: [... x
 // (n_joint_params x 7)] to shape [... x n_joint_params x 7]. Return the same

--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -30,7 +30,10 @@ class TestParameterTransform(unittest.TestCase):
         joint_params_1 = torch.from_numpy(
             character.parameter_transform.apply(model_params[None, :])
         ).flatten()
-        joint_params_2 = torch.matmul(transform, torch.from_numpy(model_params))
+        # transform is now a numpy array, so convert to tensor for matmul
+        joint_params_2 = torch.matmul(
+            torch.from_numpy(transform), torch.from_numpy(model_params)
+        )
         self.assertTrue(torch.allclose(joint_params_1, joint_params_2))
 
     def test_parameter_transform_round_trip(self) -> None:
@@ -39,9 +42,8 @@ class TestParameterTransform(unittest.TestCase):
         character: Character = create_test_character()
         original_pt = character.parameter_transform
 
-        # Get the transform as a dense matrix
-        transform_matrix = original_pt.transform
-        transform_numpy = transform_matrix.numpy()
+        # Get the transform as a dense matrix (already a numpy array)
+        transform_numpy = original_pt.transform
 
         # Create a new parameter transform from the dense matrix
         new_pt = ParameterTransform(

--- a/pymomentum/test/test_pose_prior.py
+++ b/pymomentum/test/test_pose_prior.py
@@ -89,7 +89,7 @@ class TestPosePrior(unittest.TestCase):
         # =============== End building constraints
 
         scaling_params = character.parameter_transform.scaling_parameters
-        active_params = ~scaling_params
+        active_params = torch.from_numpy(~scaling_params)
 
         active_error_functions = [
             ErrorFunctionType.Limit,

--- a/pymomentum/test/test_sequence_ik.py
+++ b/pymomentum/test/test_sequence_ik.py
@@ -34,7 +34,9 @@ class TestSolver(unittest.TestCase):
         model_params_target = torch.rand(n_frames, n_params, dtype=torch.float64)
 
         # Make sure the scaling parameters match up between all the frames:
-        scaling_params = character.parameter_transform.scaling_parameters
+        scaling_params = torch.from_numpy(
+            character.parameter_transform.scaling_parameters
+        )
         avg_parameters = model_params_target.mean(0)
         model_params_target[:, scaling_params] = avg_parameters.unsqueeze(0).expand_as(
             model_params_target
@@ -81,7 +83,9 @@ class TestSolver(unittest.TestCase):
         # Test whether ik works without proj or dist constraints:
         model_params_final = pym_solver.solve_sequence_ik(
             character=character,
-            active_parameters=character.parameter_transform.all_parameters,
+            active_parameters=torch.from_numpy(
+                character.parameter_transform.all_parameters
+            ),
             shared_parameters=scaling_params,
             model_parameters_init=model_params_init,
             active_error_functions=active_error_functions,

--- a/pymomentum/test/test_solver.py
+++ b/pymomentum/test/test_solver.py
@@ -61,7 +61,9 @@ def solve_one_ik_problem(index: int) -> torch.Tensor:
     # Test whether ik works without proj or dist constraints:
     return pym_solver.solve_ik(
         character=character,
-        active_parameters=character.parameter_transform.all_parameters,
+        active_parameters=torch.from_numpy(
+            character.parameter_transform.all_parameters
+        ),
         model_parameters_init=model_params_init,
         active_error_functions=active_error_functions,
         error_function_weights=error_function_weights,
@@ -139,7 +141,9 @@ class TestSolver(unittest.TestCase):
 
         # =============== End building constraints
 
-        scaling_params = character.parameter_transform.scaling_parameters
+        scaling_params = torch.from_numpy(
+            character.parameter_transform.scaling_parameters
+        )
         active_params = ~scaling_params
 
         active_error_functions = [
@@ -265,7 +269,9 @@ class TestSolver(unittest.TestCase):
 
         result = pym_solver.solve_ik(
             character=character,
-            active_parameters=character.parameter_transform.all_parameters,
+            active_parameters=torch.from_numpy(
+                character.parameter_transform.all_parameters
+            ),
             model_parameters_init=model_params_init,
             active_error_functions=[ErrorFunctionType.Position],
             error_function_weights=torch.ones(batch_size, 1, dtype=torch.float64),
@@ -529,7 +535,9 @@ class TestSolver(unittest.TestCase):
         solverOptions.min_iter = 0
         solverOptions.max_iter = 0
 
-        scaling_params = character.parameter_transform.scaling_parameters
+        scaling_params = torch.from_numpy(
+            character.parameter_transform.scaling_parameters
+        )
         active_params = ~scaling_params
 
         model_params_final = pym_solver.solve_ik(
@@ -611,7 +619,9 @@ class TestSolver(unittest.TestCase):
         # prevent solver from thinking it converges
         solverOptions.threshold = 0.0
 
-        scaling_params = character.parameter_transform.scaling_parameters
+        scaling_params = torch.from_numpy(
+            character.parameter_transform.scaling_parameters
+        )
         active_params = ~scaling_params
 
         pym_solver.solve_ik(
@@ -734,7 +744,9 @@ class TestSolver(unittest.TestCase):
 
         # =============== End building constraints
 
-        scaling_params = character.parameter_transform.scaling_parameters
+        scaling_params = torch.from_numpy(
+            character.parameter_transform.scaling_parameters
+        )
         active_params = ~scaling_params
 
         active_error_functions = [

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -517,13 +517,11 @@ class TestSolver(unittest.TestCase):
             character.parameter_transform.size, dtype=torch.float32
         )
         solver = pym_solver2.GaussNewtonSolverQR(solver_function, solver_options)
-        enabled_params = torch.logical_not(
-            torch.logical_or(
-                character.parameter_transform.scaling_parameters,
-                character.parameter_transform.rigid_parameters,
-            )
+        enabled_params = ~(
+            character.parameter_transform.scaling_parameters
+            | character.parameter_transform.rigid_parameters
         )
-        solver.set_enabled_parameters(enabled_params.numpy())
+        solver.set_enabled_parameters(enabled_params)
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert final model parameters to skeleton state
@@ -596,9 +594,7 @@ class TestSolver(unittest.TestCase):
             character.parameter_transform.size, dtype=torch.float32
         )
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        solver.set_enabled_parameters(
-            character.parameter_transform.rigid_parameters.numpy()
-        )
+        solver.set_enabled_parameters(character.parameter_transform.rigid_parameters)
         model_params_final = solver.solve(model_params_init.numpy())
 
         # Convert final model parameters to skeleton state

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -577,31 +577,32 @@ class ParameterTransform(torch.nn.Module):
 
         self.register_buffer(
             "parameter_transform",
-            character.parameter_transform.transform.to(dtype=dtype)
-            .clone()
-            .detach()
-            .requires_grad_(False),
+            torch.tensor(
+                character.parameter_transform.transform,
+                dtype=dtype,
+                requires_grad=False,
+            ),
         )
 
         self.register_buffer(
             "pose_parameters",
-            character.parameter_transform.pose_parameters.clone()
-            .detach()
-            .requires_grad_(False),
+            torch.tensor(
+                character.parameter_transform.pose_parameters, requires_grad=False
+            ),
         )
 
         self.register_buffer(
             "rigid_parameters",
-            character.parameter_transform.rigid_parameters.clone()
-            .detach()
-            .requires_grad_(False),
+            torch.tensor(
+                character.parameter_transform.rigid_parameters, requires_grad=False
+            ),
         )
 
         self.register_buffer(
             "scaling_parameters",
-            character.parameter_transform.scaling_parameters.clone()
-            .detach()
-            .requires_grad_(False),
+            torch.tensor(
+                character.parameter_transform.scaling_parameters, requires_grad=False
+            ),
         )
 
         self.parameter_names: list[str] = character.parameter_transform.names


### PR DESCRIPTION
Summary:
Completed migration of parameter transform functions in the geometry module from torch.Tensor to numpy arrays. This maintains consistency with the geometry module's design principle of using numpy for fast forward operations while keeping torch tensors in diff_geometry for differentiable operations.

Key changes:
- Implemented arrayToParameterSet() to convert boolean numpy arrays to ParameterSet
- Updated all parameter property bindings (scaling_parameters, rigid_parameters, etc.) to return numpy arrays
- Converted simplify(), simplify_parameter_transform(), parameters_for_joints(), and joints_for_parameters() to use arrays
- Updated reduce_to_selected_model_parameters() to use array-based parameter sets
- Updated tests to work with numpy arrays instead of tensors
- Updated .pyi type stubs to reflect numpy array usage

Reviewed By: jeongseok-meta

Differential Revision: D89891109
