### PR TITLE
Migrate BlendShape.compute_shape to numpy arrays

### DIFF
--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -116,6 +116,7 @@ tensor_ik_test_sources = [
 ]
 
 geometry_public_headers = [
+    "geometry/array_blend_shape.h",
     "geometry/array_parameter_transform.h",
     "geometry/array_skeleton_state.h",
     "geometry/character_pybind.h",
@@ -131,6 +132,7 @@ geometry_public_headers = [
 ]
 
 geometry_sources = [
+    "geometry/array_blend_shape.cpp",
     "geometry/array_parameter_transform.cpp",
     "geometry/array_skeleton_state.cpp",
     "geometry/character_pybind.cpp",

--- a/pymomentum/geometry/array_blend_shape.cpp
+++ b/pymomentum/geometry/array_blend_shape.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "pymomentum/geometry/array_blend_shape.h"
+
+#include <pymomentum/array_utility/array_utility.h>
+#include <pymomentum/array_utility/batch_accessor.h>
+#include <pymomentum/array_utility/geometry_accessors.h>
+
+#include <momentum/character/blend_shape.h>
+#include <momentum/character/blend_shape_base.h>
+#include <momentum/common/exception.h>
+
+#include <dispenso/parallel_for.h>
+
+namespace pymomentum {
+
+namespace {
+
+template <typename T>
+py::array_t<T> computeBlendShapeImpl(
+    const momentum::BlendShapeBase& blendShapeBase,
+    const py::array& coefficients,
+    const LeadingDimensions& leadingDims) {
+  const auto nCoeffs = static_cast<py::ssize_t>(coefficients.shape(coefficients.ndim() - 1));
+  const auto nVertices = static_cast<py::ssize_t>(blendShapeBase.modelSize());
+  const auto nBatch = leadingDims.totalBatchElements();
+
+  MT_THROW_IF(
+      nCoeffs > blendShapeBase.shapeSize(),
+      "computeBlendShape: expected at most {} coefficients but got {}.",
+      blendShapeBase.shapeSize(),
+      nCoeffs);
+
+  // Create output array with shape [..., nVertices, 3]
+  auto result = createOutputArray<T>(leadingDims, {nVertices, static_cast<py::ssize_t>(3)});
+
+  // Create batch indexer
+  BatchIndexer indexer(leadingDims);
+
+  // Create accessors
+  BlendWeightsAccessor<T> inputAcc(coefficients, leadingDims, nCoeffs);
+  VertexPositionsAccessor<T> outputAcc(result, leadingDims, nVertices);
+
+  // Check if this is a BlendShape (has base shape) or just BlendShapeBase
+  const auto* blendShape = dynamic_cast<const momentum::BlendShape*>(&blendShapeBase);
+
+  // Release GIL for parallel computation
+  {
+    py::gil_scoped_release release;
+    dispenso::parallel_for(0, static_cast<int64_t>(nBatch), [&](int64_t iBatch) {
+      // Convert flat batch index to multi-dimensional indices
+      auto indices = indexer.decompose(iBatch);
+
+      // Get blend weights
+      auto blendWeights = inputAcc.get(indices);
+
+      // Compute the shape
+      std::vector<Eigen::Vector3<T>> positions;
+      if (blendShape != nullptr) {
+        // BlendShape: computes base_shape + weighted sum of shape vectors
+        positions = blendShape->template computeShape<T>(blendWeights);
+      } else {
+        // BlendShapeBase: computes only the weighted sum of shape vectors (deltas)
+        positions.resize(nVertices, Eigen::Vector3<T>::Zero());
+        blendShapeBase.template applyDeltas<T>(blendWeights, positions);
+      }
+
+      // Write output
+      outputAcc.set(indices, positions);
+    });
+  }
+
+  return result;
+}
+
+} // namespace
+
+py::array computeBlendShapeArray(
+    const momentum::BlendShapeBase& blendShape,
+    const py::buffer& coefficients) {
+  const auto nShapes = static_cast<int>(blendShape.shapeSize());
+
+  ArrayChecker checker("compute_shape");
+  // Use -1 for variable number of coefficients (can be less than or equal to nShapes)
+  checker.validateBuffer(coefficients, "coefficients", {-1}, {"numCoefficients"});
+
+  const auto nCoeffs = checker.getBoundValue(-1);
+  MT_THROW_IF(
+      nCoeffs > nShapes,
+      "compute_shape: expected at most {} coefficients but got {}.",
+      nShapes,
+      nCoeffs);
+
+  if (checker.isFloat64()) {
+    return computeBlendShapeImpl<double>(blendShape, coefficients, checker.getLeadingDimensions());
+  } else {
+    return computeBlendShapeImpl<float>(blendShape, coefficients, checker.getLeadingDimensions());
+  }
+}
+
+} // namespace pymomentum

--- a/pymomentum/geometry/array_blend_shape.h
+++ b/pymomentum/geometry/array_blend_shape.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/character/blend_shape.h>
+#include <momentum/character/blend_shape_base.h>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+namespace pymomentum {
+
+namespace py = pybind11;
+
+/// Computes the blend shape output by applying blend shape coefficients.
+///
+/// For BlendShape objects, this computes: base_shape + sum(coefficients[i] * shape_vectors[i])
+/// For BlendShapeBase objects, this computes: sum(coefficients[i] * shape_vectors[i])
+///
+/// Supports arbitrary leading dimensions with broadcasting and both float32/float64 dtypes.
+///
+/// @param blendShape A BlendShapeBase or BlendShape object
+/// @param coefficients Numpy array containing blend shape coefficients.
+///   Shape: [..., numCoefficients]
+/// @return Numpy array containing the computed vertex positions.
+///   Shape: [..., numVertices, 3]
+py::array computeBlendShapeArray(
+    const momentum::BlendShapeBase& blendShape,
+    const py::buffer& coefficients);
+
+} // namespace pymomentum

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "pymomentum/geometry/array_blend_shape.h"
 #include "pymomentum/geometry/array_parameter_transform.h"
 #include "pymomentum/geometry/array_skeleton_state.h"
 #include "pymomentum/geometry/character_pybind.h"
@@ -267,16 +268,16 @@ PYBIND11_MODULE(geometry, m) {
           py::arg("shape_names") = std::vector<std::string>())
       .def(
           "compute_shape",
-          [](py::object blendShape, at::Tensor coeffs) {
-            return applyBlendShapeCoefficients(std::move(blendShape), std::move(coeffs));
-          },
+          &computeBlendShapeArray,
           R"(Apply the blend shape coefficients to compute the rest shape.
 
 The resulting shape is equal to a linear combination of the shape vectors (plus the base shape, if it is a BlendShape object).
 
-:param coeffs: A torch.Tensor of size [n_batch x n_shapes] containing blend shape coefficients.
-:result: A [n_batch x n_vertices x 3] tensor containing the vertex positions.)",
-          py::arg("coeffs"));
+Supports arbitrary leading dimensions with broadcasting and both float32/float64 dtypes.
+
+:param coefficients: A numpy array of shape [..., n_shapes] containing blend shape coefficients.
+:return: A [..., n_vertices, 3] numpy array containing the vertex positions.)",
+          py::arg("coefficients"));
 
   blendShapeClass
       .def_property_readonly(

--- a/pymomentum/test/test_diff_geometry.py
+++ b/pymomentum/test/test_diff_geometry.py
@@ -852,7 +852,7 @@ class TestDiffGeometry(unittest.TestCase):
             )
 
     def test_diff_apply_blend_coeffs_base(self) -> None:
-        """Test BlendShapeBase.compute_shape with gradcheck."""
+        """Test diff_geometry.compute_blend_shape with BlendShapeBase and gradcheck."""
         np.random.seed(0)
 
         n_pts = 10
@@ -867,7 +867,7 @@ class TestDiffGeometry(unittest.TestCase):
             nBatch, n_coeffs, dtype=torch.float64, requires_grad=AUTOGRAD_ENABLED
         )
 
-        shape1 = blend_shape.compute_shape(coeffs).select(0, 0)
+        shape1 = pym_diff_geometry.compute_blend_shape(blend_shape, coeffs).select(0, 0)
         c1 = coeffs.select(0, 0).detach().numpy()
 
         # Compute the shape another way:
@@ -880,7 +880,7 @@ class TestDiffGeometry(unittest.TestCase):
 
         if AUTOGRAD_ENABLED:
             torch.autograd.gradcheck(
-                blend_shape.compute_shape,
+                lambda c: pym_diff_geometry.compute_blend_shape(blend_shape, c),
                 [coeffs],
                 eps=1e-3,
                 atol=1e-4,
@@ -888,7 +888,7 @@ class TestDiffGeometry(unittest.TestCase):
             )
 
     def test_diff_apply_blend_coeffs(self) -> None:
-        """Test BlendShape.compute_shape with gradcheck."""
+        """Test diff_geometry.compute_blend_shape with BlendShape and gradcheck."""
         np.random.seed(0)
 
         n_pts = 10
@@ -904,7 +904,7 @@ class TestDiffGeometry(unittest.TestCase):
             nBatch, n_coeffs, dtype=torch.float64, requires_grad=AUTOGRAD_ENABLED
         )
 
-        shape1 = blend_shape.compute_shape(coeffs).select(0, 0)
+        shape1 = pym_diff_geometry.compute_blend_shape(blend_shape, coeffs).select(0, 0)
         c1 = coeffs.select(0, 0).detach().numpy()
 
         # Compute the shape another way:
@@ -919,7 +919,7 @@ class TestDiffGeometry(unittest.TestCase):
 
         if AUTOGRAD_ENABLED:
             torch.autograd.gradcheck(
-                blend_shape.compute_shape,
+                lambda c: pym_diff_geometry.compute_blend_shape(blend_shape, c),
                 [coeffs],
                 eps=1e-3,
                 atol=1e-4,
@@ -945,9 +945,10 @@ class TestDiffGeometry(unittest.TestCase):
 
         # Test the module-level function
         result1 = pym_diff_geometry.compute_blend_shape(blend_shape, coeffs)
-        result2 = blend_shape.compute_shape(coeffs)
+        # geometry.compute_shape returns numpy, convert to tensor for comparison
+        result2 = torch.from_numpy(blend_shape.compute_shape(coeffs.detach().numpy()))
 
-        self.assertTrue(torch.allclose(result1, result2))
+        self.assertTrue(torch.allclose(result1, result2.float()))
 
         # Test gradients
         if AUTOGRAD_ENABLED:

--- a/pymomentum/test/test_geometry_diff_geometry_consistency.py
+++ b/pymomentum/test/test_geometry_diff_geometry_consistency.py
@@ -261,6 +261,103 @@ class TestGeometryDiffGeometryConsistency(unittest.TestCase):
             "geometry.local_skeleton_state_to_joint_parameters should match diff_geometry.local_skeleton_state_to_joint_parameters",
         )
 
+    def test_blend_shape_base_compute_shape_matches(self) -> None:
+        """Verify that BlendShapeBase.compute_shape matches diff_geometry.compute_blend_shape."""
+        np.random.seed(42)
+
+        n_pts = 10
+        n_blend = 4
+        nBatch = 2
+
+        # Create BlendShapeBase
+        shape_vectors = np.random.rand(n_blend, n_pts, 3).astype(np.float32)
+        blend_shape = pym_geometry.BlendShapeBase.from_tensors(shape_vectors)
+
+        # Create coefficients
+        n_coeffs = blend_shape.n_shapes
+        coeffs_np = np.random.rand(nBatch, n_coeffs).astype(np.float32)
+
+        # Call geometry version (numpy)
+        result_geometry = blend_shape.compute_shape(coeffs_np)
+
+        # Call diff_geometry version (torch)
+        coeffs_torch = torch.from_numpy(coeffs_np)
+        result_diff_geometry = pym_diff_geometry.compute_blend_shape(
+            blend_shape, coeffs_torch
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(result_geometry, result_diff_geometry.numpy(), atol=1e-6),
+            "BlendShapeBase.compute_shape should match diff_geometry.compute_blend_shape",
+        )
+
+    def test_blend_shape_compute_shape_matches(self) -> None:
+        """Verify that BlendShape.compute_shape matches diff_geometry.compute_blend_shape."""
+        np.random.seed(42)
+
+        n_pts = 10
+        n_blend = 4
+        nBatch = 2
+
+        # Create BlendShape with base shape
+        base_shape = np.random.rand(n_pts, 3).astype(np.float32)
+        shape_vectors = np.random.rand(n_blend, n_pts, 3).astype(np.float32)
+        blend_shape = pym_geometry.BlendShape.from_tensors(base_shape, shape_vectors)
+
+        # Create coefficients
+        n_coeffs = blend_shape.n_shapes
+        coeffs_np = np.random.rand(nBatch, n_coeffs).astype(np.float32)
+
+        # Call geometry version (numpy)
+        result_geometry = blend_shape.compute_shape(coeffs_np)
+
+        # Call diff_geometry version (torch)
+        coeffs_torch = torch.from_numpy(coeffs_np)
+        result_diff_geometry = pym_diff_geometry.compute_blend_shape(
+            blend_shape, coeffs_torch
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(result_geometry, result_diff_geometry.numpy(), atol=1e-6),
+            "BlendShape.compute_shape should match diff_geometry.compute_blend_shape",
+        )
+
+    def test_blend_shape_with_character_matches(self) -> None:
+        """Verify that BlendShape.compute_shape matches for character-based blend shapes."""
+        np.random.seed(42)
+
+        # Create a test character with blend shape
+        c = pym_geometry.create_test_character()
+        n_pts = c.mesh.n_vertices
+        n_blend = 4
+        nBatch = 2
+
+        # Create BlendShape
+        base_shape = np.random.rand(n_pts, 3).astype(np.float32)
+        shape_vectors = np.random.rand(n_blend, n_pts, 3).astype(np.float32)
+        blend_shape = pym_geometry.BlendShape.from_tensors(base_shape, shape_vectors)
+
+        # Create coefficients
+        n_coeffs = blend_shape.n_shapes
+        coeffs_np = np.random.rand(nBatch, n_coeffs).astype(np.float32)
+
+        # Call geometry version (numpy)
+        result_geometry = blend_shape.compute_shape(coeffs_np)
+
+        # Call diff_geometry version (torch)
+        coeffs_torch = torch.from_numpy(coeffs_np)
+        result_diff_geometry = pym_diff_geometry.compute_blend_shape(
+            blend_shape, coeffs_torch
+        )
+
+        # Compare results
+        self.assertTrue(
+            np.allclose(result_geometry, result_diff_geometry.numpy(), atol=1e-6),
+            "BlendShape.compute_shape with character should match diff_geometry.compute_blend_shape",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Migrates `BlendShape.compute_shape()` from torch tensors to numpy arrays as part of the ongoing effort to remove PyTorch dependencies from pymomentum.geometry.

Key changes:
- Added `VertexPositionsAccessor<T>` template class to geometry_accessors for accessing `(..., nVertices, 3)` shaped arrays
- Implemented `computeBlendShapeArray()` using momentum's native `BlendShape::computeShape<T>()` and `BlendShapeBase::applyDeltas<T>()` functions
- Updated Python binding for `compute_shape` to use the new numpy-based implementation
- Updated test_blend_shape.py to use numpy arrays instead of torch tensors
- Moved gradient tests from test_blend_shape.py to test_diff_geometry.py (gradient tests should use diff_geometry module)

Reviewed By: jeongseok-meta

Differential Revision: D89693864
