### PR TITLE
Add targetRowsPerChunk option to GaussNewtonSolver for memory/speed trade-off

### DIFF
--- a/momentum/solver/gauss_newton_solver.cpp
+++ b/momentum/solver/gauss_newton_solver.cpp
@@ -10,7 +10,7 @@
 #include "momentum/common/profile.h"
 #include "momentum/solver/solver_function.h"
 
-#include <gsl/util>
+#include <gsl/narrow>
 
 namespace momentum {
 
@@ -21,6 +21,7 @@ GaussNewtonSolverT<T>::GaussNewtonSolverT(const SolverOptions& options, SolverFu
   doLineSearch_ = GaussNewtonSolverOptions().doLineSearch;
   regularization_ = GaussNewtonSolverOptions().regularization;
   useBlockJtJ_ = GaussNewtonSolverOptions().useBlockJtJ;
+  targetRowsPerChunk_ = GaussNewtonSolverOptions().targetRowsPerChunk;
 
   // Update values based on provided options
   setOptions(options);
@@ -39,56 +40,212 @@ void GaussNewtonSolverT<T>::setOptions(const SolverOptions& options) {
     regularization_ = derivedOptions->regularization;
     doLineSearch_ = derivedOptions->doLineSearch;
     useBlockJtJ_ = derivedOptions->useBlockJtJ;
+    targetRowsPerChunk_ = derivedOptions->targetRowsPerChunk;
   }
 }
 
 template <typename T>
 void GaussNewtonSolverT<T>::initializeSolver() {
   // This is called from the solver base class .solve()
+
+  // Build enabled parameters mapping from activeParameters_ bitset
+  updateEnabledParameters();
+}
+
+template <typename T>
+void GaussNewtonSolverT<T>::updateEnabledParameters() {
+  enabledParameters_.clear();
+  enabledParameters_.reserve(this->numParameters_);
+
+  for (int i = 0; i < gsl::narrow_cast<int>(this->numParameters_); ++i) {
+    if (this->activeParameters_.test(i)) {
+      enabledParameters_.push_back(i);
+    }
+  }
+}
+
+template <typename T>
+void GaussNewtonSolverT<T>::computeJtJFromBlockJtJ() {
+  MT_PROFILE_EVENT("Get JtJ and JtR");
+
+  // getJtJR() returns JtJ sized up to the highest enabled parameter index (actualParameters_).
+  // It doesn't compact the parameters - gaps between enabled parameters still have entries.
+  // We do in-place row/column shifting to avoid allocating a temporary matrix.
+  this->error_ = this->solverFunction_->getJtJR(this->parameters_, hessianApprox_, JtR_);
+
+  // Compact JtR in-place: shift enabled parameter entries to the front
+  const int nSubsetParams = gsl::narrow_cast<int>(enabledParameters_.size());
+  for (int iSubset = 0; iSubset < nSubsetParams; ++iSubset) {
+    const int iFull = enabledParameters_[iSubset];
+    if (iFull > iSubset) {
+      JtR_(iSubset) = JtR_(iFull);
+    }
+  }
+
+  // Compact JtJ in-place: shift rows and columns for enabled parameters to the top-left
+  // Process in order so we don't overwrite data we still need (since iFull >= iSubset always)
+  for (int iSubset = 0; iSubset < nSubsetParams; ++iSubset) {
+    const int iFull = enabledParameters_[iSubset];
+
+    // First, copy the column from iFull to iSubset (for rows 0 to iSubset that are already shifted)
+    if (iFull > iSubset) {
+      for (int jSubset = 0; jSubset <= iSubset; ++jSubset) {
+        const int jFull = enabledParameters_[jSubset];
+        // Copy from (jFull, iFull) to (jSubset, iSubset) - but jFull row is already at jSubset
+        hessianApprox_(jSubset, iSubset) = hessianApprox_(jFull, iFull);
+      }
+
+      // Copy the row from iFull to iSubset (for columns 0 to iSubset-1 that are already shifted)
+      for (int jSubset = 0; jSubset < iSubset; ++jSubset) {
+        const int jFull = enabledParameters_[jSubset];
+        // Copy from (iFull, jFull) to (iSubset, jSubset) - but jFull col is already at jSubset
+        hessianApprox_(iSubset, jSubset) = hessianApprox_(iFull, jFull);
+      }
+    }
+  }
+}
+
+template <typename T>
+void GaussNewtonSolverT<T>::computeJtJFromJacobianBlocks() {
+  const int nSubsetParams = gsl::narrow_cast<int>(enabledParameters_.size());
+
+  // Allocate and zero JtJ and JtR for subset parameters
+  hessianApprox_.setZero(nSubsetParams, nSubsetParams);
+  JtR_.setZero(nSubsetParams);
+
+  this->solverFunction_->initializeJacobianComputation(this->parameters_);
+
+  const size_t numBlocks = this->solverFunction_->getJacobianBlockCount();
+
+  // Calculate block sizes and find the maximum block size
+  std::vector<size_t> blockSizes(numBlocks);
+  size_t maxBlockSize = 0;
+  size_t totalRows = 0;
+  for (size_t i = 0; i < numBlocks; ++i) {
+    blockSizes[i] = this->solverFunction_->getJacobianBlockSize(i);
+    maxBlockSize = std::max(maxBlockSize, blockSizes[i]);
+    totalRows += blockSizes[i];
+  }
+
+  // Effective target: at least the largest block, or all rows if targetRowsPerChunk_ is SIZE_MAX
+  const size_t effectiveTarget =
+      (targetRowsPerChunk_ == SIZE_MAX) ? totalRows : std::max(targetRowsPerChunk_, maxBlockSize);
+
+  double error = 0.0;
+
+  // Process blocks in chunks using greedy bin-packing
+  size_t blockIdx = 0;
+  while (blockIdx < numBlocks) {
+    // Determine which blocks go into this chunk
+    size_t chunkRows = 0;
+    size_t chunkStartBlock = blockIdx;
+
+    // Greedily add blocks until we exceed the target
+    while (blockIdx < numBlocks) {
+      const size_t blockSize = blockSizes[blockIdx];
+      if (blockSize == 0) {
+        ++blockIdx;
+        continue;
+      }
+
+      // Add this block if: chunk is empty OR adding it doesn't exceed target
+      if (chunkRows == 0 || chunkRows + blockSize <= effectiveTarget) {
+        chunkRows += blockSize;
+        ++blockIdx;
+      } else {
+        break;
+      }
+    }
+
+    if (chunkRows == 0) {
+      continue;
+    }
+
+    // Resize Jacobian storage for this chunk (ResizeableMatrix avoids reallocations)
+    jacobian_.resizeAndSetZero(chunkRows, this->numParameters_);
+    residual_.resizeAndSetZero(chunkRows);
+
+    // Fill the chunk with block data
+    size_t rowPos = 0;
+    for (size_t i = chunkStartBlock; i < blockIdx; ++i) {
+      const size_t blockSize = blockSizes[i];
+      if (blockSize == 0) {
+        continue;
+      }
+
+      auto jacBlock = jacobian_.mat().block(rowPos, 0, blockSize, this->numParameters_);
+      auto resBlock = residual_.vec().segment(rowPos, blockSize);
+
+      size_t actualRows = 0;
+      error += this->solverFunction_->computeJacobianBlock(
+          this->parameters_, i, jacBlock, resBlock, actualRows);
+
+      rowPos += blockSize;
+    }
+
+    // Remap columns to subset parameter space (in-place, similar to SubsetGaussNewtonSolver)
+    // Move the enabled columns of the Jacobian into place.
+    // Doing this in-place minimizes total work.
+    // For the common case where all "dropped" parameters are at the end,
+    // this will effectively be a no-op since enabledParameters_[iSubsetParam] == iSubsetParam.
+    for (int iSubsetParam = 0; iSubsetParam < nSubsetParams; ++iSubsetParam) {
+      if (enabledParameters_[iSubsetParam] > iSubsetParam) {
+        jacobian_.mat().col(iSubsetParam) = jacobian_.mat().col(enabledParameters_[iSubsetParam]);
+      }
+    }
+
+    // Accumulate JtJ and JtR for this chunk
+    const auto J_chunk = jacobian_.mat().leftCols(nSubsetParams);
+    const auto r_chunk = residual_.vec();
+
+    hessianApprox_.template triangularView<Eigen::Lower>() += J_chunk.transpose() * J_chunk;
+    JtR_.noalias() += J_chunk.transpose() * r_chunk;
+  }
+
+  this->solverFunction_->finalizeJacobianComputation();
+  this->error_ = error;
 }
 
 template <typename T>
 void GaussNewtonSolverT<T>::doIteration() {
   MT_PROFILE_FUNCTION();
 
+  const int nSubsetParams = gsl::narrow_cast<int>(enabledParameters_.size());
+
+  // Compute JtJ and JtR using either pre-computed JtJ or Jacobian blocks
+  // Each code path handles its own matrix sizing
   if (useBlockJtJ_) {
-    // get JtJ and JtR pre-computed
-    MT_PROFILE_EVENT("Get JtJ and JtR");
-    this->error_ = this->solverFunction_->getJtJR(this->parameters_, hessianApprox_, JtR_);
+    computeJtJFromBlockJtJ();
   } else {
-    MT_PROFILE_EVENT("Get Jacobian and compute JtJ and JtR");
-    // Get the jacobian and compute JtJ and JtR here
-    size_t actualRows = 0;
-    this->error_ =
-        this->solverFunction_->getJacobian(this->parameters_, jacobian_, residual_, actualRows);
-
-    if (hessianApprox_.rows() != this->actualParameters_) {
-      hessianApprox_.resize(this->actualParameters_, this->actualParameters_);
-    }
-
-    const auto JBlock = jacobian_.topLeftCorner(actualRows, this->actualParameters_);
-
-    hessianApprox_.template triangularView<Eigen::Lower>() = JBlock.transpose() * JBlock;
-
-    JtR_.noalias() = JBlock.transpose() * residual_.head(actualRows);
+    computeJtJFromJacobianBlocks();
   }
 
-  // calculate the step direction according to the gauss newton update
-  Eigen::VectorX<T> delta = Eigen::VectorX<T>::Zero(this->numParameters_);
+  // Solve for delta in subset parameter space
+  // For BlockJtJ, hessianApprox_ may be larger than nSubsetParams but the compacted
+  // data is in the top-left corner. For Jacobian blocks, it's exactly nSubsetParams.
   {
     MT_PROFILE_EVENT("Dense gauss newton step");
 
-    // delta = (Jt*J)^-1*Jt*r ...
-    // - add some regularization to make sure the system is never unstable and explodes in weird
-    // ways.
-    hessianApprox_.diagonal().array() += regularization_;
+    // Get the relevant portion of the matrices
+    auto jtjBlock = hessianApprox_.topLeftCorner(nSubsetParams, nSubsetParams);
+    auto jtrBlock = JtR_.head(nSubsetParams);
 
-    // - llt solve
-    delta.head(this->actualParameters_) = llt_.compute(hessianApprox_).solve(JtR_);
+    // Add regularization
+    jtjBlock.diagonal().array() += regularization_;
+
+    // Solve
+    Eigen::VectorX<T> subsetDelta = llt_.compute(jtjBlock).solve(jtrBlock);
+
+    // Map subset delta back to full parameter space
+    Eigen::VectorX<T> delta = Eigen::VectorX<T>::Zero(this->numParameters_);
+    for (int iSubsetParam = 0; iSubsetParam < nSubsetParams; ++iSubsetParam) {
+      delta(enabledParameters_[iSubsetParam]) = subsetDelta(iSubsetParam);
+    }
+
+    updateParameters(delta);
   }
 
-  updateParameters(delta);
-
+  // Store history (if enabled)
   {
     MT_PROFILE_EVENT("Store history");
     if (this->storeHistory) {
@@ -102,7 +259,8 @@ void GaussNewtonSolverT<T>::doIteration() {
           this->iteration_ * this->actualParameters_,
           0,
           this->actualParameters_,
-          this->actualParameters_) = hessianApprox_;
+          this->actualParameters_) =
+          hessianApprox_.topLeftCorner(this->actualParameters_, this->actualParameters_);
     }
   }
 }


### PR DESCRIPTION
Summary:
Optimizes GaussNewtonSolver to match SubsetGaussNewtonSolver performance by:
- Using chunked Jacobian accumulation with a single large JᵀJ matrix multiplication per chunk instead of many small rankUpdate() calls
- Adding targetRowsPerChunk option to control memory vs speed trade-off:
  - SIZE_MAX (default): Process all rows in one chunk (fastest, most memory)
  - 0: Process each error function block separately (slowest, minimum memory)
  - Intermediate values: Group blocks via bin-packing up to target row count
- Using ResizeableMatrix for Jacobian/residual storage to avoid reallocations when processing variable-sized blocks

Performance results (ManyBlocks benchmark with 26 error functions, 10 iterations):
| Solver              | float (μs) | double (μs) |
|---------------------|------------|-------------|
| GaussNewton         | 244        | 257         |
| SubsetGaussNewton   | 243        | 256         |

GaussNewton now matches SubsetGaussNewton performance (within 1%).

ChunkSize sweep (float):
- targetRowsPerChunk=0: 410μs (per-block, minimum memory)
- targetRowsPerChunk=SIZE_MAX: 244μs (all rows, maximum speed)

Reviewed By: jeongseok-meta

Differential Revision: D89145781
