### PR TITLE
Fix lodash-es prototype pollution vulnerability

### DIFF
--- a/momentum/website/package.json
+++ b/momentum/website/package.json
@@ -44,7 +44,8 @@
     "**/gray-matter": ">=4.0.3",
     "**/node-forge": "1.3.2",
     "@docusaurus/**/mdast-util-to-hast": "13.2.1",
-    "**/diff": ">=8.0.3"
+    "**/diff": ">=8.0.3",
+    "**/lodash-es": ">=4.17.23"
   },
   "browserslist": {
     "production": [

--- a/momentum/website/yarn.lock
+++ b/momentum/website/yarn.lock
@@ -6856,10 +6856,10 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-lodash-es@4.17.21, lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@4.17.21, lodash-es@>=4.17.23, lodash-es@^4.17.21:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
+  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
Summary:
Resolves https://github.com/facebookresearch/momentum/security/dependabot/43 by adding a yarn resolution to force `lodash-es` to version 4.17.23+, which patches CVE-2025-13465 (prototype pollution in `_.unset` and `_.omit` functions).

The vulnerability was introduced as a transitive dependency via `docusaurus-plugin-internaldocs-fb` → `chevrotain` → `lodash-es@4.17.21`.

Differential Revision: D91213309


