### PR TITLE
Fix off-by-one boundary check in glTF hierarchy loading

### DIFF
--- a/momentum/io/gltf/gltf_io.cpp
+++ b/momentum/io/gltf/gltf_io.cpp
@@ -324,7 +324,7 @@ void loadHierarchyRecursive(
   MT_CHECK(!model.nodes.empty());
   for (auto childId : model.nodes[nodeId].children) {
     MT_THROW_IF(
-        (childId < 0) || (childId > model.nodes.size()),
+        (childId < 0) || (childId >= model.nodes.size()),
         "Invalid node id found in the gltf hierarchy: {}",
         childId);
 


### PR DESCRIPTION
Summary:
The bounds validation used `>` instead of `>=` when checking child node IDs against the model's node array size. This allowed `childId == model.nodes.size()` to pass validation, causing out-of-bounds access when the code subsequently tried to read `model.nodes[childId]`.

This is a classic off-by-one error - valid indices are 0 to size()-1, so we must reject any index >= size().

Differential Revision: D91740328


