### PR TITLE
Add proper stride support to rasterizer buffers

### DIFF
--- a/momentum/rasterizer/image.h
+++ b/momentum/rasterizer/image.h
@@ -13,6 +13,6 @@
 namespace momentum::rasterizer {
 
 template <typename T>
-void alphaMatte(Span2f zBuffer, Span3f rgbBuffer, const Span<T, 3>& tgtImage, float alpha = 1.0f);
+void alphaMatte(Span2f zBuffer, Span3f rgbBuffer, Span<T, 3> tgtImage, float alpha = 1.0f);
 
 } // namespace momentum::rasterizer

--- a/momentum/rasterizer/rasterizer.h
+++ b/momentum/rasterizer/rasterizer.h
@@ -23,8 +23,9 @@ namespace momentum::rasterizer {
 using index_t = std::ptrdiff_t;
 
 /// mdspan type aliases for cleaner signatures
+/// Using layout_stride to support strided buffers (e.g., with SIMD padding)
 template <typename T, size_t Rank>
-using Span = Kokkos::mdspan<T, Kokkos::dextents<index_t, Rank>>;
+using Span = Kokkos::mdspan<T, Kokkos::dextents<index_t, Rank>, Kokkos::layout_stride>;
 
 /// Constant variant of Span for read-only access
 template <typename T, size_t Rank>


### PR DESCRIPTION
Summary:
Update the momentum rasterizer to properly use buffer strides instead of assuming all buffers are densely packed. This allows using strided numpy arrays (e.g., with SIMD-aligned row padding) with the rasterizer.

Key changes:
- Change `Span` type to use `layout_stride` for strided buffer support
- Add `validateRasterizerBuffer()` function with descriptive error messages for invalid buffers
- Add `getPixelRowStride()` helper for computing pixel offsets in 2D/3D buffers
- Update all utility template functions to accept any layout type
- Update `checkBuffers()` to validate and verify matching row strides across buffers
- Update `Tensor::view()` to return `layout_stride` mdspan with explicit strides
- Update Python `make_mdspan()` to pass actual numpy strides (converted from bytes to elements)
- Fix 2D functions to use pixel stride instead of element stride for RGB buffers

Buffer requirements:
- Row strides must be SIMD-aligned (multiple of kSimdPacketSize)
- Pixels/channels must be packed tightly within rows
- All non-empty buffers must have matching pixel row strides

Reviewed By: jeongseok-meta

Differential Revision: D90418537


