### PR TITLE
Separate Camera into its own library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,12 +584,25 @@ mt_library(
 
 if(MOMENTUM_BUILD_RENDERER)
   mt_library(
+    NAME camera
+    HEADERS_VARS
+      camera_public_headers
+    SOURCES_VARS
+      camera_sources
+    PUBLIC_LINK_LIBRARIES
+      simd
+      drjit
+      Eigen3::Eigen
+  )
+
+  mt_library(
     NAME rasterizer
     HEADERS_VARS
       rasterizer_public_headers
     SOURCES_VARS
       rasterizer_sources
     PUBLIC_LINK_LIBRARIES
+      camera
       common
       drjit
       Eigen3::Eigen
@@ -858,6 +871,13 @@ if(MOMENTUM_BUILD_TESTING)
         "TEST_RESOURCES_PATH=${CMAKE_SOURCE_DIR}/momentum/test/resources"
     )
   endif()
+
+  mt_test(
+    NAME camera_test
+    SOURCES_VARS camera_test_sources
+    LINK_LIBRARIES
+      camera
+  )
 
   mt_test(
     NAME rasterizer_test

--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -42,6 +42,19 @@ simd_test_sources = [
     "test/simd/simd_test.cpp",
 ]
 
+camera_public_headers = [
+    "camera/camera.h",
+    "camera/fwd.h",
+]
+
+camera_sources = [
+    "camera/camera.cpp",
+]
+
+camera_test_sources = [
+    "test/camera/test_camera.cpp",
+]
+
 fmt_eigen_public_headers = [
     "math/fmt_eigen.h",
 ]
@@ -713,7 +726,6 @@ refine_motion_sources = [
 ]
 
 rasterizer_public_headers = [
-    "rasterizer/camera.h",
     "rasterizer/geometry.h",
     "rasterizer/fwd.h",
     "rasterizer/image.h",
@@ -724,7 +736,6 @@ rasterizer_public_headers = [
 ]
 
 rasterizer_sources = [
-    "rasterizer/camera.cpp",
     "rasterizer/geometry.cpp",
     "rasterizer/rasterizer.cpp",
     "rasterizer/image.cpp",
@@ -732,7 +743,6 @@ rasterizer_sources = [
 ]
 
 rasterizer_test_sources = [
-    "test/rasterizer/test_camera.cpp",
     "test/rasterizer/test_geometry.cpp",
     "test/rasterizer/test_software_rasterizer.cpp",
     "test/rasterizer/test_text_rasterizer.cpp",

--- a/momentum/camera/camera.cpp
+++ b/momentum/camera/camera.cpp
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "momentum/camera/camera.h"
+
+#include "momentum/camera/fwd.h"
+
 #include <drjit/array.h>
 #include <drjit/fwd.h>
 #include <drjit/matrix.h>
 
 #include <cfloat>
 
-#include <momentum/rasterizer/camera.h>
-#include <momentum/rasterizer/fwd.h>
-
-namespace momentum::rasterizer {
+namespace momentum {
 
 // Default constructor is VGA res.
 template <typename T>
@@ -26,22 +27,14 @@ CameraT<T>::CameraT()
               (5.0 / 3.6) * 640,
               (5.0 / 3.6) * 640)) {}
 
-/// Constructor implementation for CameraT.
-/// @param intrinsicsModel Shared pointer to the camera's intrinsics model
-/// @param eyeFromWorld Transform from world space to camera/eye space
+// Constructor implementation for CameraT.
 template <typename T>
 CameraT<T>::CameraT(
     std::shared_ptr<const IntrinsicsModelT<T>> intrinsicsModel,
     const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld)
     : eyeFromWorld_(eyeFromWorld), intrinsicsModel_(intrinsicsModel) {}
 
-/// Constructor for PinholeIntrinsicsModelT with explicit principal point.
-/// @param imageWidth Width of the image in pixels
-/// @param imageHeight Height of the image in pixels
-/// @param fx Focal length in x direction (pixels)
-/// @param fy Focal length in y direction (pixels)
-/// @param cx Principal point x-coordinate (pixels)
-/// @param cy Principal point y-coordinate (pixels)
+// Constructor for PinholeIntrinsicsModelT with explicit principal point.
 template <typename T>
 PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     int32_t imageWidth,
@@ -52,11 +45,7 @@ PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     T cy)
     : IntrinsicsModelT<T>(imageWidth, imageHeight), fx_(fx), fy_(fy), cx_(cx), cy_(cy) {}
 
-/// Constructor for PinholeIntrinsicsModelT with principal point at image center.
-/// @param imageWidth Width of the image in pixels
-/// @param imageHeight Height of the image in pixels
-/// @param fx Focal length in x direction (pixels)
-/// @param fy Focal length in y direction (pixels)
+// Constructor for PinholeIntrinsicsModelT with principal point at image center.
 template <typename T>
 PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     int32_t imageWidth,
@@ -69,14 +58,7 @@ PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
       cx_(T(imageWidth) / T(2)),
       cy_(T(imageHeight) / T(2)) {}
 
-/// Constructor for OpenCVIntrinsicsModelT with optional distortion parameters.
-/// @param imageWidth Width of the image in pixels
-/// @param imageHeight Height of the image in pixels
-/// @param fx Focal length in x direction (pixels)
-/// @param fy Focal length in y direction (pixels)
-/// @param cx Principal point x-coordinate (pixels)
-/// @param cy Principal point y-coordinate (pixels)
-/// @param params OpenCV distortion parameters (defaults to no distortion)
+// Constructor for OpenCVIntrinsicsModelT with optional distortion parameters.
 template <typename T>
 OpenCVIntrinsicsModelT<T>::OpenCVIntrinsicsModelT(
     int32_t imageWidth,
@@ -705,7 +687,7 @@ CameraT<T>::unproject(const Vector3xP<T>& imagePoints, int maxIterations, T tole
   Vector3xP<T> worldPoints;
   auto validMask = drjit::full<typename PacketT::MaskType>(true);
 
-  for (int i = 0; i < PacketT::Size; ++i) {
+  for (size_t i = 0; i < PacketT::Size; ++i) {
     // Extract 3D image point for this element (u, v, z)
     Eigen::Vector3<T> imagePoint(imagePoints.x()[i], imagePoints.y()[i], imagePoints.z()[i]);
 
@@ -760,4 +742,4 @@ template class PinholeIntrinsicsModelT<double>;
 template class OpenCVIntrinsicsModelT<float>;
 template class OpenCVIntrinsicsModelT<double>;
 
-} // namespace momentum::rasterizer
+} // namespace momentum

--- a/momentum/camera/fwd.h
+++ b/momentum/camera/fwd.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/simd/simd.h>
+
+#include <drjit/fwd.h>
+#include <drjit/matrix.h>
+
+namespace momentum {
+
+// Forward declarations
+template <typename T>
+class CameraT;
+
+template <typename T>
+class IntrinsicsModelT;
+
+template <typename T>
+class PinholeIntrinsicsModelT;
+
+template <typename T>
+class OpenCVIntrinsicsModelT;
+
+template <typename T>
+struct OpenCVDistortionParametersT;
+
+using Camera = CameraT<float>;
+using Camerad = CameraT<double>;
+using IntrinsicsModel = IntrinsicsModelT<float>;
+using IntrinsicsModeld = IntrinsicsModelT<double>;
+using PinholeIntrinsicsModel = PinholeIntrinsicsModelT<float>;
+using PinholeIntrinsicsModeld = PinholeIntrinsicsModelT<double>;
+using OpenCVIntrinsicsModel = OpenCVIntrinsicsModelT<float>;
+using OpenCVIntrinsicsModeld = OpenCVIntrinsicsModelT<double>;
+using OpenCVDistortionParameters = OpenCVDistortionParametersT<float>;
+using OpenCVDistortionParametersd = OpenCVDistortionParametersT<double>;
+
+// Additional SIMD types used by camera that are not in simd/simd.h
+using ByteP = Packet<uint8_t>;
+using UintP = Packet<uint32_t>;
+
+using Vector2iP = drjit::Array<IntP, 2>;
+using Vector3bP = drjit::Array<ByteP, 3>;
+using Vector3iP = drjit::Array<IntP, 3>;
+using Vector4fP = drjit::Array<FloatP, 4>;
+using Vector4dP = drjit::Array<DoubleP, 4>;
+using Matrix3fP = drjit::Matrix<FloatP, 3>;
+using Matrix3dP = drjit::Matrix<DoubleP, 3>;
+
+/// Template metafunction to map scalar types to their packet equivalents.
+template <typename T>
+struct PacketType;
+
+template <>
+struct PacketType<float> {
+  using type = FloatP;
+};
+
+template <>
+struct PacketType<double> {
+  using type = DoubleP;
+};
+
+template <>
+struct PacketType<int32_t> {
+  using type = IntP;
+};
+
+template <>
+struct PacketType<uint32_t> {
+  using type = UintP;
+};
+
+template <>
+struct PacketType<uint8_t> {
+  using type = ByteP;
+};
+
+template <typename T>
+using PacketType_t = typename PacketType<T>::type;
+
+/// Templatized SIMD vector types.
+template <typename T>
+using Vector2xP = drjit::Array<PacketType_t<T>, 2>;
+
+template <typename T>
+using Vector3xP = drjit::Array<PacketType_t<T>, 3>;
+
+template <typename T>
+using Vector4xP = drjit::Array<PacketType_t<T>, 4>;
+
+/// Templatized SIMD matrix types.
+template <typename T>
+using Matrix3xP = drjit::Matrix<PacketType_t<T>, 3>;
+
+template <typename T>
+using Matrix4xP = drjit::Matrix<PacketType_t<T>, 4>;
+
+} // namespace momentum

--- a/momentum/rasterizer/fwd.h
+++ b/momentum/rasterizer/fwd.h
@@ -7,96 +7,71 @@
 
 #pragma once
 
-#include <drjit/fwd.h>
+#include <momentum/camera/fwd.h>
+
+#include <drjit/array.h>
+#include <drjit/matrix.h>
 
 namespace momentum::rasterizer {
 
-template <typename T>
-class CameraT;
+// Re-export camera types from momentum namespace for backward compatibility
+using momentum::Camera;
+using momentum::Camerad;
+using momentum::IntrinsicsModel;
+using momentum::IntrinsicsModeld;
+using momentum::OpenCVDistortionParameters;
+using momentum::OpenCVDistortionParametersd;
+using momentum::OpenCVIntrinsicsModel;
+using momentum::OpenCVIntrinsicsModeld;
+using momentum::PinholeIntrinsicsModel;
+using momentum::PinholeIntrinsicsModeld;
 
-template <typename T>
-class IntrinsicsModelT;
+// Re-export SIMD constants for use in rasterizer
+using momentum::kSimdAlignment;
+using momentum::kSimdPacketSize;
 
-using Camera = CameraT<float>;
-using IntrinsicsModel = IntrinsicsModelT<float>;
+using momentum::ByteP;
+using momentum::DoubleP;
+using momentum::FloatP;
+using momentum::IntP;
+using momentum::UintP;
 
-constexpr size_t kSimdPacketSize = drjit::DefaultSize;
-constexpr size_t kSimdAlignment = 4 * kSimdPacketSize;
-
-using IntP = drjit::Packet<int32_t, kSimdPacketSize>;
-using UintP = drjit::Packet<uint32_t, kSimdPacketSize>;
-using Uint8P = drjit::Packet<uint8_t, kSimdPacketSize>;
-
-using FloatP = drjit::Packet<float, kSimdPacketSize>;
-using DoubleP = drjit::Packet<double, kSimdPacketSize>;
-using ByteP = drjit::Packet<uint8_t, kSimdPacketSize>;
+// DrJit-based scalar vector/matrix types used internally by rasterizer.
+// These are distinct from the Eigen-based types in momentum namespace.
+using Vector2f = drjit::Array<float, 2>;
+using Vector2d = drjit::Array<double, 2>;
 using Vector3f = drjit::Array<float, 3>;
 using Vector3d = drjit::Array<double, 3>;
 using Vector3b = drjit::Array<uint8_t, 3>;
-using Vector2f = drjit::Array<float, 2>;
-using Vector2d = drjit::Array<double, 2>;
 using Matrix3f = drjit::Matrix<float, 3>;
 using Matrix3d = drjit::Matrix<double, 3>;
 using Matrix4f = drjit::Matrix<float, 4>;
 using Matrix4d = drjit::Matrix<double, 4>;
-using Vector2fP = drjit::Array<FloatP, 2>;
-using Vector2dP = drjit::Array<DoubleP, 2>;
-using Vector2iP = drjit::Array<IntP, 2>;
-using Vector3fP = drjit::Array<FloatP, 3>;
-using Vector3dP = drjit::Array<DoubleP, 3>;
-using Vector3bP = drjit::Array<ByteP, 3>;
-using Vector3iP = drjit::Array<IntP, 3>;
-using Vector4fP = drjit::Array<FloatP, 4>;
-using Vector4dP = drjit::Array<DoubleP, 4>;
-using Matrix3fP = drjit::Matrix<FloatP, 3>;
-using Matrix3dP = drjit::Matrix<DoubleP, 3>;
 
-// Template metafunction to map scalar types to their packet equivalents
-template <typename T>
-struct PacketType;
+// Re-export SIMD packet types from momentum namespace
+using momentum::Matrix3dP;
+using momentum::Matrix3fP;
+using momentum::Matrix3xP;
+using momentum::Matrix4xP;
 
-template <>
-struct PacketType<float> {
-  using type = FloatP;
-};
+using momentum::Vector2dP;
+using momentum::Vector2fP;
+using momentum::Vector2iP;
+using momentum::Vector2xP;
 
-template <>
-struct PacketType<double> {
-  using type = DoubleP;
-};
+using momentum::Vector3bP;
+using momentum::Vector3dP;
+using momentum::Vector3fP;
+using momentum::Vector3iP;
+using momentum::Vector3xP;
 
-template <>
-struct PacketType<int32_t> {
-  using type = IntP;
-};
+using momentum::Vector4dP;
+using momentum::Vector4fP;
+using momentum::Vector4xP;
 
-template <>
-struct PacketType<uint32_t> {
-  using type = UintP;
-};
+using momentum::PacketType_t;
 
-template <>
-struct PacketType<uint8_t> {
-  using type = ByteP;
-};
-
-template <typename T>
-using PacketType_t = typename PacketType<T>::type;
-
-// Templatized vector and matrix definitions
-template <typename T>
-using Vector2xP = drjit::Array<PacketType_t<T>, 2>;
-
-template <typename T>
-using Vector3xP = drjit::Array<PacketType_t<T>, 3>;
-
-template <typename T>
-using Vector4xP = drjit::Array<PacketType_t<T>, 4>;
-
-template <typename T>
-using Matrix3xP = drjit::Matrix<PacketType_t<T>, 3>;
-
-template <typename T>
-using Matrix4xP = drjit::Matrix<PacketType_t<T>, 4>;
+// Additional type alias for backward compatibility
+using Uint8P = momentum::Packet<uint8_t>;
 
 } // namespace momentum::rasterizer

--- a/momentum/rasterizer/geometry.h
+++ b/momentum/rasterizer/geometry.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
+#include <momentum/camera/camera.h>
 #include <momentum/math/mesh.h>
-#include <momentum/rasterizer/camera.h>
 #include <Eigen/Core>
 #include <utility>
 

--- a/momentum/rasterizer/rasterizer.h
+++ b/momentum/rasterizer/rasterizer.h
@@ -9,8 +9,8 @@
 
 #include <drjit/fwd.h>
 #include <mdspan/mdspan.hpp>
+#include <momentum/camera/camera.h>
 #include <momentum/common/aligned.h>
-#include <momentum/rasterizer/camera.h>
 #include <momentum/rasterizer/fwd.h>
 #include <momentum/rasterizer/geometry.h>
 #include <momentum/rasterizer/tensor.h>

--- a/momentum/rasterizer/text_rasterizer.h
+++ b/momentum/rasterizer/text_rasterizer.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <momentum/rasterizer/camera.h>
+#include <momentum/camera/camera.h>
 #include <momentum/rasterizer/fwd.h>
 #include <momentum/rasterizer/rasterizer.h>
 #include <Eigen/Core>

--- a/momentum/rasterizer/utility.h
+++ b/momentum/rasterizer/utility.h
@@ -246,7 +246,7 @@ class SimdCamera {
  private:
   const Eigen::Matrix4f _modelMatrix;
   const Eigen::Vector2f _imageOffset;
-  std::shared_ptr<const IntrinsicsModelT<float>> _intrinsics;
+  std::shared_ptr<const momentum::IntrinsicsModelT<float>> _intrinsics;
 
   const Matrix3f _modelToWorld_rotation;
   const Vector3f _modelToWorld_translation;

--- a/momentum/test/camera/test_camera.cpp
+++ b/momentum/test/camera/test_camera.cpp
@@ -6,8 +6,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <momentum/rasterizer/camera.h>
-#include <momentum/rasterizer/fwd.h>
+#include <momentum/camera/camera.h>
+#include <momentum/camera/fwd.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <cmath>
@@ -15,7 +15,7 @@
 #include <memory>
 #include <vector>
 
-using namespace momentum::rasterizer;
+using namespace momentum;
 
 class CameraTest : public ::testing::Test {
  protected:

--- a/momentum/test/rasterizer/test_geometry.cpp
+++ b/momentum/test/rasterizer/test_geometry.cpp
@@ -6,8 +6,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <momentum/camera/camera.h>
 #include <momentum/math/constants.h>
-#include <momentum/rasterizer/camera.h>
 #include <momentum/rasterizer/geometry.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/momentum/test/rasterizer/test_software_rasterizer.cpp
+++ b/momentum/test/rasterizer/test_software_rasterizer.cpp
@@ -7,8 +7,8 @@
 
 #include <axel/math/RayTriangleIntersection.h>
 #include <gtest/gtest.h>
+#include <momentum/camera/camera.h>
 #include <momentum/math/constants.h>
-#include <momentum/rasterizer/camera.h>
 #include <momentum/rasterizer/geometry.h>
 #include <momentum/rasterizer/image.h>
 #include <momentum/rasterizer/rasterizer.h>
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <iomanip>
 
+using namespace momentum;
 using namespace momentum::rasterizer;
 
 Eigen::Matrix4d

--- a/momentum/test/rasterizer/test_text_rasterizer.cpp
+++ b/momentum/test/rasterizer/test_text_rasterizer.cpp
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <momentum/rasterizer/camera.h>
+#include <momentum/camera/camera.h>
 #include <momentum/rasterizer/image.h>
 #include <momentum/rasterizer/text_rasterizer.h>
 
 #include <gtest/gtest.h>
 
+using namespace momentum;
 using namespace momentum::rasterizer;
 
 TEST(TextRasterizer, BasicText3D) {

--- a/pymomentum/renderer/momentum_render.h
+++ b/pymomentum/renderer/momentum_render.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
+#include <momentum/camera/camera.h>
 #include <momentum/character/character.h>
-#include <momentum/rasterizer/camera.h>
 
 #include <ATen/ATen.h>
 #include <pybind11/numpy.h>
@@ -20,7 +20,7 @@
 namespace pymomentum {
 
 // Returned camera is in cm unit.
-std::vector<momentum::rasterizer::Camera> buildCamerasForBodyJoints(
+std::vector<momentum::Camera> buildCamerasForBodyJoints(
     at::Tensor jointLocalToWorldTransforms,
     int spineJointIndexToOrientCamera,
     int imageHeight,
@@ -32,7 +32,7 @@ std::vector<momentum::rasterizer::Camera> buildCamerasForBodyJoints(
 // is in cm unit.
 // cameraAngle: control from what angle the camera looks at the body. Default:
 // 0, looking at the front. Pi/2: looking at the body left side.
-std::vector<momentum::rasterizer::Camera> buildCamerasForBody(
+std::vector<momentum::Camera> buildCamerasForBody(
     const momentum::Character& character,
     at::Tensor jointParameters,
     int imageHeight,
@@ -41,7 +41,7 @@ std::vector<momentum::rasterizer::Camera> buildCamerasForBody(
     bool horizontal,
     float cameraAngle = 0.0f);
 
-momentum::rasterizer::Camera createCameraForBody(
+momentum::Camera createCameraForBody(
     const momentum::Character& character,
     const pybind11::array_t<float>& skeletonStates,
     int imageHeight,
@@ -54,10 +54,10 @@ Eigen::Matrix<int, Eigen::Dynamic, 3, Eigen::RowMajor> triangulate(
     const Eigen::VectorXi& faceIndices,
     const Eigen::VectorXi& faceOffsets);
 
-std::vector<momentum::rasterizer::Camera>
+std::vector<momentum::Camera>
 buildCamerasForHand(at::Tensor wristTransformation, int imageHeight, int imageWidth);
 
-std::vector<momentum::rasterizer::Camera>
+std::vector<momentum::Camera>
 buildCamerasForHandSurface(at::Tensor wristTransformation, int imageHeight, int imageWidth);
 
 } // namespace pymomentum

--- a/pymomentum/renderer/renderer_pybind.cpp
+++ b/pymomentum/renderer/renderer_pybind.cpp
@@ -12,9 +12,9 @@
 #include <pymomentum/tensor_momentum/tensor_skeleton_state.h>
 #include <pymomentum/torch_bridge.h>
 
+#include <momentum/camera/camera.h>
 #include <momentum/character/character.h>
 #include <momentum/character/skeleton_state.h>
-#include <momentum/rasterizer/camera.h>
 #include <momentum/rasterizer/rasterizer.h>
 #include <momentum/rasterizer/text_rasterizer.h>
 
@@ -45,25 +45,19 @@ PYBIND11_MODULE(renderer, m) {
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry
 
   // Bind IntrinsicsModel and its derived classes
-  py::class_<
-      momentum::rasterizer::IntrinsicsModel,
-      std::shared_ptr<momentum::rasterizer::IntrinsicsModel>>(
+  py::class_<momentum::IntrinsicsModel, std::shared_ptr<momentum::IntrinsicsModel>>(
       m, "IntrinsicsModel", "Base class for camera intrinsics models")
       .def_property_readonly(
-          "image_width",
-          &momentum::rasterizer::IntrinsicsModel::imageWidth,
-          "Width of the image in pixels")
+          "image_width", &momentum::IntrinsicsModel::imageWidth, "Width of the image in pixels")
       .def_property_readonly(
-          "image_height",
-          &momentum::rasterizer::IntrinsicsModel::imageHeight,
-          "Height of the image in pixels")
+          "image_height", &momentum::IntrinsicsModel::imageHeight, "Height of the image in pixels")
       .def_property_readonly(
-          "fx", &momentum::rasterizer::IntrinsicsModel::fx, "Focal length in x direction (pixels)")
+          "fx", &momentum::IntrinsicsModel::fx, "Focal length in x direction (pixels)")
       .def_property_readonly(
-          "fy", &momentum::rasterizer::IntrinsicsModel::fy, "Focal length in y direction (pixels)")
+          "fy", &momentum::IntrinsicsModel::fy, "Focal length in y direction (pixels)")
       .def(
           "__repr__",
-          [](const momentum::rasterizer::IntrinsicsModel& self) {
+          [](const momentum::IntrinsicsModel& self) {
             return fmt::format(
                 "IntrinsicsModel(image_size=({}, {}), focal_length=({:.2f}, {:.2f}))",
                 self.imageWidth(),
@@ -73,7 +67,7 @@ PYBIND11_MODULE(renderer, m) {
           })
       .def(
           "project",
-          [](const momentum::rasterizer::IntrinsicsModel& intrinsics,
+          [](const momentum::IntrinsicsModel& intrinsics,
              const py::array_t<float>& points) -> py::array_t<float> {
             if (points.ndim() != 2 || points.shape(1) != 3) {
               throw std::runtime_error("Expected a 2D array of shape (nPoints, 3)");
@@ -110,7 +104,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("points"))
       .def(
           "upsample",
-          &momentum::rasterizer::IntrinsicsModel::upsample,
+          &momentum::IntrinsicsModel::upsample,
           R"(Create a new intrinsics model upsampled by the given factor.
 
 :param factor: Upsampling factor (e.g., 2.0 doubles the resolution).
@@ -118,7 +112,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("factor"))
       .def(
           "downsample",
-          &momentum::rasterizer::IntrinsicsModel::downsample,
+          &momentum::IntrinsicsModel::downsample,
           R"(Create a new intrinsics model downsampled by the given factor.
 
 :param factor: Downsampling factor (e.g., 2.0 halves the resolution).
@@ -126,7 +120,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("factor"))
       .def(
           "crop",
-          &momentum::rasterizer::IntrinsicsModel::crop,
+          &momentum::IntrinsicsModel::crop,
           R"(Create a new intrinsics model cropped to a sub-region of the image.
 
 :param top: Top offset in pixels.
@@ -140,7 +134,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("height"))
       .def(
           "resize",
-          &momentum::rasterizer::IntrinsicsModel::resize,
+          &momentum::IntrinsicsModel::resize,
           R"(Create a new intrinsics model resized to new image dimensions.
 
 :param image_width: New image width in pixels.
@@ -149,50 +143,30 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("image_width"),
           py::arg("image_height"));
 
-  py::class_<momentum::rasterizer::OpenCVDistortionParameters>(
+  py::class_<momentum::OpenCVDistortionParameters>(
       m, "OpenCVDistortionParameters", "OpenCV distortion parameters")
       .def(py::init<>(), "Initialize with default parameters (no distortion)")
       .def_readwrite(
-          "k1",
-          &momentum::rasterizer::OpenCVDistortionParameters::k1,
-          "Radial distortion coefficient k1")
+          "k1", &momentum::OpenCVDistortionParameters::k1, "Radial distortion coefficient k1")
       .def_readwrite(
-          "k2",
-          &momentum::rasterizer::OpenCVDistortionParameters::k2,
-          "Radial distortion coefficient k2")
+          "k2", &momentum::OpenCVDistortionParameters::k2, "Radial distortion coefficient k2")
       .def_readwrite(
-          "k3",
-          &momentum::rasterizer::OpenCVDistortionParameters::k3,
-          "Radial distortion coefficient k3")
+          "k3", &momentum::OpenCVDistortionParameters::k3, "Radial distortion coefficient k3")
       .def_readwrite(
-          "k4",
-          &momentum::rasterizer::OpenCVDistortionParameters::k4,
-          "Radial distortion coefficient k4")
+          "k4", &momentum::OpenCVDistortionParameters::k4, "Radial distortion coefficient k4")
       .def_readwrite(
-          "k5",
-          &momentum::rasterizer::OpenCVDistortionParameters::k5,
-          "Radial distortion coefficient k5")
+          "k5", &momentum::OpenCVDistortionParameters::k5, "Radial distortion coefficient k5")
       .def_readwrite(
-          "k6",
-          &momentum::rasterizer::OpenCVDistortionParameters::k6,
-          "Radial distortion coefficient k6")
+          "k6", &momentum::OpenCVDistortionParameters::k6, "Radial distortion coefficient k6")
       .def_readwrite(
-          "p1",
-          &momentum::rasterizer::OpenCVDistortionParameters::p1,
-          "Tangential distortion coefficient p1")
+          "p1", &momentum::OpenCVDistortionParameters::p1, "Tangential distortion coefficient p1")
       .def_readwrite(
-          "p2",
-          &momentum::rasterizer::OpenCVDistortionParameters::p2,
-          "Tangential distortion coefficient p2")
+          "p2", &momentum::OpenCVDistortionParameters::p2, "Tangential distortion coefficient p2")
       .def_readwrite(
-          "p3",
-          &momentum::rasterizer::OpenCVDistortionParameters::p3,
-          "Tangential distortion coefficient p3")
+          "p3", &momentum::OpenCVDistortionParameters::p3, "Tangential distortion coefficient p3")
       .def_readwrite(
-          "p4",
-          &momentum::rasterizer::OpenCVDistortionParameters::p4,
-          "Tangential distortion coefficient p4")
-      .def("__repr__", [](const momentum::rasterizer::OpenCVDistortionParameters& self) {
+          "p4", &momentum::OpenCVDistortionParameters::p4, "Tangential distortion coefficient p4")
+      .def("__repr__", [](const momentum::OpenCVDistortionParameters& self) {
         return fmt::format(
             "OpenCVDistortionParameters(k1={:.4f}, k2={:.4f}, k3={:.4f}, k4={:.4f}, k5={:.4f}, k6={:.4f}, p1={:.4f}, p2={:.4f}, p3={:.4f}, p4={:.4f})",
             self.k1,
@@ -214,7 +188,7 @@ PYBIND11_MODULE(renderer, m) {
          std::optional<float> fx,
          std::optional<float> fy,
          std::optional<float> cx,
-         std::optional<float> cy) -> std::shared_ptr<momentum::rasterizer::PinholeIntrinsicsModel> {
+         std::optional<float> cy) -> std::shared_ptr<momentum::PinholeIntrinsicsModel> {
     // Default focal length calculation: "normal" lens is a 50mm lens on
     // a 35mm camera body
     const float focal_length_cm = 5.0f;
@@ -229,7 +203,7 @@ PYBIND11_MODULE(renderer, m) {
       throw std::runtime_error("cx and cy must be both specified or both omitted");
     }
 
-    return std::make_shared<momentum::rasterizer::PinholeIntrinsicsModel>(
+    return std::make_shared<momentum::PinholeIntrinsicsModel>(
         imageWidth,
         imageHeight,
         fx.value_or(default_focal_length_pixels),
@@ -239,9 +213,9 @@ PYBIND11_MODULE(renderer, m) {
   };
 
   py::class_<
-      momentum::rasterizer::PinholeIntrinsicsModel,
-      momentum::rasterizer::IntrinsicsModel,
-      std::shared_ptr<momentum::rasterizer::PinholeIntrinsicsModel>>(
+      momentum::PinholeIntrinsicsModel,
+      momentum::IntrinsicsModel,
+      std::shared_ptr<momentum::PinholeIntrinsicsModel>>(
       m, "PinholeIntrinsicsModel", "Pinhole camera intrinsics model without distortion")
       .def(
           py::init(pinholeFactory),
@@ -261,14 +235,10 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("cx") = std::nullopt,
           py::arg("cy") = std::nullopt)
       .def_property_readonly(
-          "cx",
-          &momentum::rasterizer::PinholeIntrinsicsModel::cx,
-          "Principal point x-coordinate (pixels)")
+          "cx", &momentum::PinholeIntrinsicsModel::cx, "Principal point x-coordinate (pixels)")
       .def_property_readonly(
-          "cy",
-          &momentum::rasterizer::PinholeIntrinsicsModel::cy,
-          "Principal point y-coordinate (pixels)")
-      .def("__repr__", [](const momentum::rasterizer::PinholeIntrinsicsModel& self) {
+          "cy", &momentum::PinholeIntrinsicsModel::cy, "Principal point y-coordinate (pixels)")
+      .def("__repr__", [](const momentum::PinholeIntrinsicsModel& self) {
         return fmt::format(
             "PinholeIntrinsicsModel(image_size=({}, {}), fx={:.2f}, fy={:.2f}, cx={:.2f}, cy={:.2f})",
             self.imageWidth(),
@@ -280,34 +250,33 @@ PYBIND11_MODULE(renderer, m) {
       });
 
   // Factory function for OpenCVIntrinsicsModel to avoid template ambiguity
-  auto opencvFactory =
-      [](int32_t imageWidth,
-         int32_t imageHeight,
-         std::optional<float> fx,
-         std::optional<float> fy,
-         std::optional<float> cx,
-         std::optional<float> cy,
-         std::optional<momentum::rasterizer::OpenCVDistortionParameters> distortionParams)
-      -> std::shared_ptr<momentum::rasterizer::OpenCVIntrinsicsModel> {
+  auto opencvFactory = [](int32_t imageWidth,
+                          int32_t imageHeight,
+                          std::optional<float> fx,
+                          std::optional<float> fy,
+                          std::optional<float> cx,
+                          std::optional<float> cy,
+                          std::optional<momentum::OpenCVDistortionParameters> distortionParams)
+      -> std::shared_ptr<momentum::OpenCVIntrinsicsModel> {
     // Default focal length calculation: "normal" lens is a 50mm
     // lens on a 35mm camera body
     const float focal_length_cm = 5.0f;
     const float film_width_cm = 3.6f;
     const float default_focal_length_pixels = (focal_length_cm / film_width_cm) * (float)imageWidth;
-    return std::make_shared<momentum::rasterizer::OpenCVIntrinsicsModel>(
+    return std::make_shared<momentum::OpenCVIntrinsicsModel>(
         imageWidth,
         imageHeight,
         fx.value_or(default_focal_length_pixels),
         fy.value_or(default_focal_length_pixels),
         cx.value_or(imageWidth / 2.0f),
         cy.value_or(imageHeight / 2.0f),
-        distortionParams.value_or(momentum::rasterizer::OpenCVDistortionParameters{}));
+        distortionParams.value_or(momentum::OpenCVDistortionParameters{}));
   };
 
   py::class_<
-      momentum::rasterizer::OpenCVIntrinsicsModel,
-      momentum::rasterizer::IntrinsicsModel,
-      std::shared_ptr<momentum::rasterizer::OpenCVIntrinsicsModel>>(
+      momentum::OpenCVIntrinsicsModel,
+      momentum::IntrinsicsModel,
+      std::shared_ptr<momentum::OpenCVIntrinsicsModel>>(
       m, "OpenCVIntrinsicsModel", "OpenCV camera intrinsics model with distortion")
       .def(
           py::init(opencvFactory),
@@ -329,14 +298,10 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("cy"),
           py::arg("distortion_params") = std::nullopt)
       .def_property_readonly(
-          "cx",
-          &momentum::rasterizer::OpenCVIntrinsicsModel::cx,
-          "Principal point x-coordinate (pixels)")
+          "cx", &momentum::OpenCVIntrinsicsModel::cx, "Principal point x-coordinate (pixels)")
       .def_property_readonly(
-          "cy",
-          &momentum::rasterizer::OpenCVIntrinsicsModel::cy,
-          "Principal point y-coordinate (pixels)")
-      .def("__repr__", [](const momentum::rasterizer::OpenCVIntrinsicsModel& self) {
+          "cy", &momentum::OpenCVIntrinsicsModel::cy, "Principal point y-coordinate (pixels)")
+      .def("__repr__", [](const momentum::OpenCVIntrinsicsModel& self) {
         return fmt::format(
             "OpenCVIntrinsicsModel(image_size=({}, {}), fx={:.2f}, fy={:.2f}, cx={:.2f}, cy={:.2f})",
             self.imageWidth(),
@@ -349,14 +314,14 @@ PYBIND11_MODULE(renderer, m) {
 
   // Factory function for Camera to avoid template ambiguity
   auto cameraFactory =
-      [](std::shared_ptr<const momentum::rasterizer::IntrinsicsModel> intrinsics,
-         const std::optional<Eigen::Matrix4f>& eye_from_world) -> momentum::rasterizer::Camera {
-    return momentum::rasterizer::Camera(
+      [](std::shared_ptr<const momentum::IntrinsicsModel> intrinsics,
+         const std::optional<Eigen::Matrix4f>& eye_from_world) -> momentum::Camera {
+    return momentum::Camera(
         intrinsics, Eigen::Affine3f(eye_from_world.value_or(Eigen::Matrix4f::Identity())));
   };
 
   // Bind Camera class
-  py::class_<momentum::rasterizer::Camera>(m, "Camera", "Camera for rendering")
+  py::class_<momentum::Camera>(m, "Camera", "Camera for rendering")
       .def(
           py::init(cameraFactory),
           R"(Create a camera with specified intrinsics and pose.
@@ -368,7 +333,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("eye_from_world") = std::nullopt)
       .def(
           "__repr__",
-          [](const momentum::rasterizer::Camera& self) {
+          [](const momentum::Camera& self) {
             Eigen::Vector3f position = self.eyeFromWorld().inverse().translation();
             return fmt::format(
                 "Camera(image_size=({}, {}), focal_length=({:.2f}, {:.2f}), position=({:.2f}, {:.2f}, {:.2f}))",
@@ -381,46 +346,40 @@ PYBIND11_MODULE(renderer, m) {
                 position.z());
           })
       .def_property_readonly(
-          "image_width", &momentum::rasterizer::Camera::imageWidth, "Width of the image in pixels")
+          "image_width", &momentum::Camera::imageWidth, "Width of the image in pixels")
       .def_property_readonly(
-          "image_height",
-          &momentum::rasterizer::Camera::imageHeight,
-          "Height of the image in pixels")
+          "image_height", &momentum::Camera::imageHeight, "Height of the image in pixels")
+      .def_property_readonly("fx", &momentum::Camera::fx, "Focal length in x direction (pixels)")
+      .def_property_readonly("fy", &momentum::Camera::fy, "Focal length in y direction (pixels)")
       .def_property_readonly(
-          "fx", &momentum::rasterizer::Camera::fx, "Focal length in x direction (pixels)")
-      .def_property_readonly(
-          "fy", &momentum::rasterizer::Camera::fy, "Focal length in y direction (pixels)")
-      .def_property_readonly(
-          "intrinsics_model",
-          &momentum::rasterizer::Camera::intrinsicsModel,
-          "The camera's intrinsics model")
+          "intrinsics_model", &momentum::Camera::intrinsicsModel, "The camera's intrinsics model")
       .def_property(
           "T_eye_from_world",
-          [](const momentum::rasterizer::Camera& self) -> Eigen::Matrix4f {
+          [](const momentum::Camera& self) -> Eigen::Matrix4f {
             return self.eyeFromWorld().matrix();
           },
-          [](momentum::rasterizer::Camera& self, const Eigen::Matrix4f& value) {
+          [](momentum::Camera& self, const Eigen::Matrix4f& value) {
             self.setEyeFromWorld(Eigen::Affine3f(value));
           },
           "Transform from world space to camera/eye space")
       .def_property(
           "T_world_from_eye",
-          [](const momentum::rasterizer::Camera& self) -> Eigen::Matrix4f {
+          [](const momentum::Camera& self) -> Eigen::Matrix4f {
             return self.worldFromEye().matrix();
           },
-          [](momentum::rasterizer::Camera& self, const Eigen::Matrix4f& value) {
+          [](momentum::Camera& self, const Eigen::Matrix4f& value) {
             self.setEyeFromWorld(Eigen::Affine3f(value));
           },
           "Transform from world space to camera/eye space")
       .def_property_readonly(
           "center_of_projection",
-          [](const momentum::rasterizer::Camera& self) -> Eigen::Vector3f {
+          [](const momentum::Camera& self) -> Eigen::Vector3f {
             return (self.eyeFromWorld().inverse().translation()).eval();
           },
           "Position of the camera center in world space")
       .def(
           "look_at",
-          [](const momentum::rasterizer::Camera& self,
+          [](const momentum::Camera& self,
              const Eigen::Vector3f& position,
              const std::optional<Eigen::Vector3f>& target,
              const std::optional<Eigen::Vector3f>& up) {
@@ -440,10 +399,10 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("up") = std::nullopt)
       .def(
           "frame",
-          [](const momentum::rasterizer::Camera& self,
+          [](const momentum::Camera& self,
              const py::array_t<float>& points,
              float min_z,
-             float edge_padding) -> momentum::rasterizer::Camera {
+             float edge_padding) -> momentum::Camera {
             if (points.ndim() != 2 || points.shape(1) != 3) {
               throw std::runtime_error("Expected a 2D array of shape (nPoints, 3)");
             }
@@ -470,7 +429,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("edge_padding") = 0.05f)
       .def_property_readonly(
           "world_space_principle_axis",
-          [](const momentum::rasterizer::Camera& self) -> Eigen::Vector3f {
+          [](const momentum::Camera& self) -> Eigen::Vector3f {
             // The principle axis is the direction the camera is looking
             // In camera space, this is the positive Z axis (0, 0, 1)
             Eigen::Vector3f cameraSpacePrincipalAxis = Eigen::Vector3f::UnitZ();
@@ -479,9 +438,8 @@ PYBIND11_MODULE(renderer, m) {
           "Camera world-space principal axis (direction the camera is looking)")
       .def(
           "upsample",
-          [](const momentum::rasterizer::Camera& self, float factor) {
-            return momentum::rasterizer::Camera(
-                self.intrinsicsModel()->upsample(factor), self.eyeFromWorld());
+          [](const momentum::Camera& self, float factor) {
+            return momentum::Camera(self.intrinsicsModel()->upsample(factor), self.eyeFromWorld());
           },
           R"(Create a new camera with upsampled resolution by the given factor.
 
@@ -490,7 +448,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("factor"))
       .def(
           "crop",
-          [](const momentum::rasterizer::Camera& self,
+          [](const momentum::Camera& self,
              int32_t top,
              int32_t left,
              int32_t width,
@@ -508,7 +466,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("height"))
       .def(
           "project",
-          [](const momentum::rasterizer::Camera& self,
+          [](const momentum::Camera& self,
              const py::array_t<float>& world_points) -> py::array_t<float> {
             if (world_points.ndim() != 2 || world_points.shape(1) != 3) {
               throw std::runtime_error("Expected a 2D array of shape (nPoints, 3)");
@@ -538,7 +496,7 @@ PYBIND11_MODULE(renderer, m) {
           py::arg("world_points"))
       .def(
           "unproject",
-          [](const momentum::rasterizer::Camera& self,
+          [](const momentum::Camera& self,
              const py::array_t<float>& image_points) -> py::array_t<float> {
             if (image_points.ndim() != 2 || image_points.shape(1) != 3) {
               throw std::runtime_error(

--- a/pymomentum/renderer/software_rasterizer.h
+++ b/pymomentum/renderer/software_rasterizer.h
@@ -7,9 +7,8 @@
 
 #pragma once
 
+#include <momentum/camera/camera.h>
 #include <momentum/character/character.h>
-
-#include <momentum/rasterizer/camera.h>
 #include <momentum/rasterizer/fwd.h>
 #include <momentum/rasterizer/rasterizer.h>
 #include <momentum/rasterizer/text_rasterizer.h>
@@ -29,7 +28,7 @@ void rasterizeMesh(
     at::Tensor positions,
     std::optional<at::Tensor> normals,
     at::Tensor triangles,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -49,7 +48,7 @@ void rasterizeMesh(
 void rasterizeWireframe(
     at::Tensor positions,
     at::Tensor triangles,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     float width,
@@ -62,7 +61,7 @@ void rasterizeWireframe(
 
 void rasterizeSpheres(
     at::Tensor center,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -80,7 +79,7 @@ void rasterizeSpheres(
 void rasterizeCylinders(
     at::Tensor start_position,
     at::Tensor end_position,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -100,7 +99,7 @@ void rasterizeCapsules(
     at::Tensor transformation,
     at::Tensor radius,
     at::Tensor length,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -122,7 +121,7 @@ enum class SkeletonStyle {
 void rasterizeSkeleton(
     const momentum::Character& character,
     at::Tensor skeletonState,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -145,7 +144,7 @@ void rasterizeSkeleton(
 void rasterizeCharacter(
     const momentum::Character& character,
     at::Tensor skeletonState,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -162,7 +161,7 @@ void rasterizeCharacter(
     std::optional<Eigen::Vector3f> wireframeColor);
 
 void rasterizeCheckerboard(
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -180,7 +179,7 @@ void rasterizeCheckerboard(
 
 void rasterizeLines(
     at::Tensor positions,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     float width,
@@ -191,8 +190,8 @@ void rasterizeLines(
     const std::optional<Eigen::Vector2f>& imageOffset);
 
 void rasterizeCameraFrustum(
-    const momentum::rasterizer::Camera& frustumCamera,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& frustumCamera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     float lineWidth,
@@ -206,7 +205,7 @@ void rasterizeCameraFrustum(
 
 void rasterizeTransforms(
     at::Tensor transforms,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     std::optional<at::Tensor> surfaceNormalsBuffer,
@@ -222,7 +221,7 @@ void rasterizeTransforms(
 
 void rasterizeCircles(
     at::Tensor positions,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     float lineThickness,
@@ -248,7 +247,7 @@ void rasterizeLines2D(
 void rasterizeText(
     at::Tensor positions,
     const std::vector<std::string>& texts,
-    const momentum::rasterizer::Camera& camera,
+    const momentum::Camera& camera,
     at::Tensor zBuffer,
     std::optional<at::Tensor> rgbBuffer,
     const std::optional<Eigen::Vector3f>& color,
@@ -281,11 +280,9 @@ void rasterizeCircles2D(
     std::optional<at::Tensor> zBuffer,
     const std::optional<Eigen::Vector2f>& imageOffset);
 
-at::Tensor createZBuffer(const momentum::rasterizer::Camera& camera, float far_clip = FLT_MAX);
-at::Tensor createRGBBuffer(
-    const momentum::rasterizer::Camera& camera,
-    std::optional<Eigen::Vector3f> bgColor);
-at::Tensor createIndexBuffer(const momentum::rasterizer::Camera& camera);
+at::Tensor createZBuffer(const momentum::Camera& camera, float far_clip = FLT_MAX);
+at::Tensor createRGBBuffer(const momentum::Camera& camera, std::optional<Eigen::Vector3f> bgColor);
+at::Tensor createIndexBuffer(const momentum::Camera& camera);
 
 momentum::rasterizer::PhongMaterial createPhongMaterial(
     const std::optional<Eigen::Vector3f>& diffuseColor,


### PR DESCRIPTION
Summary:
Extract camera functionality from momentum/rasterizer into a new
momentum/camera library. This allows the camera classes to be used
independently without pulling in the full rasterizer dependency.

Key changes:
- Create new camera library with Camera, IntrinsicsModel,
  PinholeIntrinsicsModel, OpenCVIntrinsicsModel classes
- Camera classes now live in momentum namespace (previously
  momentum::rasterizer)
- Backward compatibility maintained via using declarations in
  rasterizer/fwd.h
- DrJit scalar types defined locally in momentum::rasterizer to
  avoid conflicts with Eigen types in math/types.h
- Update pymomentum to use new momentum::Camera namespace

Reviewed By: jeongseok-meta

Differential Revision: D92191661
