### PR TITLE
Back out "Switch SolverFunction to use ResizeableMatrix for temporary storage"

### DIFF
--- a/momentum/solver/solver_function.cpp
+++ b/momentum/solver/solver_function.cpp
@@ -86,10 +86,16 @@ double SolverFunctionT<T>::getJtJR(const VectorX<T>& parameters, MatrixX<T>& jtj
 
   const size_t numParams = parameters.size();
 
-  // ResizeableMatrix only reallocates if capacity is exceeded, and zeros efficiently
-  tJacobian_.resizeAndSetZero(jacobianSize, numParams);
-  tResidual_.resizeAndSetZero(jacobianSize);
+  // Pre-allocate temporary storage once (resize only if needed)
+  if (jacobianSize > static_cast<size_t>(tJacobian_.rows()) ||
+      numParams != static_cast<size_t>(tJacobian_.cols())) {
+    tJacobian_.resize(jacobianSize, numParams);
+    tResidual_.resize(jacobianSize);
+  }
 
+  // Zero out once at the start
+  tJacobian_.topRows(jacobianSize).setZero();
+  tResidual_.head(jacobianSize).setZero();
   jtj.setZero(actualParameters_, actualParameters_);
   jtr.setZero(actualParameters_);
 
@@ -105,21 +111,21 @@ double SolverFunctionT<T>::getJtJR(const VectorX<T>& parameters, MatrixX<T>& jtj
 
     size_t blockActualRows = 0;
 
-    auto jacBlock = tJacobian_.mat().block(position, 0, blockSize, numParams);
-    auto resBlock = tResidual_.vec().segment(position, blockSize);
+    auto jacBlock = tJacobian_.block(position, 0, blockSize, numParams);
+    auto resBlock = tResidual_.segment(position, blockSize);
 
     error += computeJacobianBlock(parameters, i, jacBlock, resBlock, blockActualRows);
 
     // Update JtJ and JtR
     if (blockActualRows > 0) {
       const auto JtBlock =
-          tJacobian_.mat().block(position, 0, blockActualRows, actualParameters_).transpose();
+          tJacobian_.block(position, 0, blockActualRows, actualParameters_).transpose();
 
       // Efficiently update JtJ using selfadjointView with rankUpdate
       jtj.template selfadjointView<Eigen::Lower>().rankUpdate(JtBlock);
 
       // Update JtR
-      jtr.noalias() += JtBlock * tResidual_.vec().segment(position, blockActualRows);
+      jtr.noalias() += JtBlock * tResidual_.segment(position, blockActualRows);
     }
     position += blockSize;
   }

--- a/momentum/solver/solver_function.h
+++ b/momentum/solver/solver_function.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <momentum/math/online_householder_qr.h>
 #include <momentum/math/types.h>
 #include <momentum/solver/fwd.h>
 
@@ -173,9 +172,9 @@ class SolverFunctionT {
 
   /// Pre-allocated temporary storage for block-wise JtJ computation
   ///
-  /// Uses ResizeableMatrix to avoid reallocations when size fluctuates
-  ResizeableMatrix<T> tJacobian_;
-  ResizeableMatrix<T> tResidual_;
+  /// These are reused across calls to avoid per-block allocation overhead
+  MatrixX<T> tJacobian_;
+  VectorX<T> tResidual_;
 };
 
 } // namespace momentum


### PR DESCRIPTION
Summary:
We're seeing some non-determinism with this diff, we need to root-cause this before landing.  

Original commit changeset: f45b77fd921a

Original Phabricator Diff: D90813663

Differential Revision: D92321596


