### PR TITLE
Add safety checks for edge cases and memory handling

### DIFF
--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -360,8 +360,23 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
   if (collision != nullptr) {
     result.collision = std::make_unique<CollisionGeometry>(*collision);
     for (auto&& c : *result.collision) {
+      MT_THROW_IF(
+          c.parent >= result.jointMap.size(),
+          "Collision parent {} out of bounds for jointMap size {}",
+          c.parent,
+          result.jointMap.size());
       const auto oldParent = c.parent;
       c.parent = result.jointMap[c.parent];
+      MT_THROW_IF(
+          c.parent >= targetBindState.jointState.size(),
+          "Remapped parent {} out of bounds for targetBindState size {}",
+          c.parent,
+          targetBindState.jointState.size());
+      MT_THROW_IF(
+          oldParent >= sourceBindState.jointState.size(),
+          "Old parent {} out of bounds for sourceBindState size {}",
+          oldParent,
+          sourceBindState.jointState.size());
       c.transformation =
           (targetBindState.jointState[c.parent].transform.inverse() *
            sourceBindState.jointState[oldParent].transform * c.transformation);

--- a/pymomentum/python_utility/python_utility.cpp
+++ b/pymomentum/python_utility/python_utility.cpp
@@ -24,7 +24,9 @@ toCharacterList(PyObject* obj, int64_t nBatch, const char* context, bool forceBa
   if (PyList_Check(obj)) {
     std::vector<const momentum::Character*> result;
     for (Py_ssize_t i = 0; i < PyList_Size(obj); ++i) {
-      result.push_back(py::cast<const momentum::Character*>(PyList_GetItem(obj, i)));
+      PyObject* item = PyList_GetItem(obj, i);
+      MT_THROW_IF(item == nullptr, "Failed to get item at index {} from list in {}", i, context);
+      result.push_back(py::cast<const momentum::Character*>(item));
     }
 
     MT_THROW_IF(
@@ -110,8 +112,8 @@ pybind11::bytes to_msgpack(const nlohmann::json& j) {
   return pybytes;
 }
 
-PyBytesStreamBuffer::PyBytesStreamBuffer(const pybind11::bytes& bytes) {
-  py::buffer_info info(py::buffer(bytes).request());
+PyBytesStreamBuffer::PyBytesStreamBuffer(const pybind11::bytes& bytes) : bytes_(bytes) {
+  py::buffer_info info(py::buffer(bytes_).request());
 
   // C++ does not distinguish between const and non-const streambufs, but we
   // promise to only use this with std::istreams.

--- a/pymomentum/python_utility/python_utility.h
+++ b/pymomentum/python_utility/python_utility.h
@@ -39,6 +39,10 @@ pybind11::bytes to_msgpack(const nlohmann::json& j);
 class PyBytesStreamBuffer : public std::streambuf {
  public:
   explicit PyBytesStreamBuffer(const pybind11::bytes& bytes);
+
+ private:
+  // Store a copy of the bytes object to keep it alive for the lifetime of the streambuf
+  pybind11::bytes bytes_;
 };
 
 } // namespace pymomentum


### PR DESCRIPTION
Summary:
**WHY:**
The momentum/pymomentum libraries contain edge cases where improper inputs or unusual runtime conditions could cause crashes, undefined behavior, or memory leaks. These include division by zero in SIMD collision functions, out-of-bounds array access in character collision mapping, memory leaks in C API exception paths, and use-after-free in Python bindings.

**WHAT:**
Adds comprehensive safety checks across 8 files in momentum and pymomentum libraries to handle edge cases gracefully with proper error messages and fallback behaviors.

| Issue | Fix |
|-------|-----|
| Division by zero (collision solver) | Safe distance clamping with `kMinSafeDistance` |
| Division by zero (rasterizer) | Select fallback to infinity for invalid recipW |
| Out-of-bounds access (character) | `MT_THROW_IF` bounds validation |
| Memory leak (C API) | Pre-allocate buffer + cleanup on exception |
| Integer overflow (Python arrays) | Size validation before `pybind11::array_t` creation |
| Use-after-free (PyBytesStreamBuffer) | Store `bytes_` member to preserve lifetime |

**HOW:**
- `c_api.cpp`: Pre-allocate output buffer; add `delete[]` in catch blocks
- `character.cpp`: Add 3 `MT_THROW_IF` checks for collision parent bounds
- `simd_collision_error_function.cpp`: Add `kMinSafeDistance`/`kMaxInverseDistance` constants; use `drjit::maximum/minimum` for safe division
- `legacy_json_io.cpp`: Add empty-array checks before `size() - 1` operations
- `rasterizer.cpp`: Add `validRecipW` check; use `drjit::select` for safe fallback
- `momentum_io.cpp`: Add `MT_THROW_IF` for size overflow; use `static_cast<pybind11::ssize_t>`
- `python_utility.cpp`: Add null check for `PyList_GetItem`; store `bytes_` copy
- `python_utility.h`: Add `bytes_` member to `PyBytesStreamBuffer`

Differential Revision: D91828286


