### PR TITLE
docs: mark pip as experimental, recommend conda/pixi workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,28 +33,28 @@ numerical optimization solvers to apply human motion in various applications.
 Pre-built binaries are available for Windows, macOS, and Linux:
 
 ```bash
-# Python (PyPI) - uv preferred over pip
-uv add pymomentum-cpu           # CPU version
-uv add pymomentum-gpu           # GPU version with CUDA
-pip install pymomentum-cpu      # Alternative: using pip
-pip install pymomentum-gpu
-
-# Python (Conda/Pixi)
+# Python (Conda/Pixi) - Recommended
 pixi add pymomentum             # Auto-detects GPU/CPU
 conda install -c conda-forge pymomentum
 
-# C++ (Conda/Pixi only)
+# C++ (Conda/Pixi)
 pixi add momentum-cpp
 conda install -c conda-forge momentum-cpp
+
+# Python (PyPI) - Experimental ⚠️
+pip install pymomentum-cpu      # CPU version
+pip install pymomentum-gpu      # GPU version with CUDA
 ```
 
-**📦 Browse packages:** [PyPI](https://pypi.org/search/?q=pymomentum) • [conda-forge](https://anaconda.org/conda-forge/momentum) • [prefix.dev](https://prefix.dev/channels/conda-forge/packages/momentum)
+> ⚠️ **PyPI support is experimental.** For the most stable experience, we recommend using Conda or Pixi.
+
+**📦 Browse packages:** [conda-forge](https://anaconda.org/conda-forge/momentum) • [prefix.dev](https://prefix.dev/channels/conda-forge/packages/momentum) • [PyPI](https://pypi.org/search/?q=pymomentum)
 
 ### Quick Example
 
 ```bash
 # Install and run
-pip install pymomentum-cpu
+conda install -c conda-forge pymomentum
 python -c "import pymomentum.geometry as geom; print(dir(geom))"
 ```
 

--- a/momentum/website/docs_python/01_user_guide/01_getting_started.md
+++ b/momentum/website/docs_python/01_user_guide/01_getting_started.md
@@ -18,23 +18,41 @@ PyMomentum is available through multiple package managers. Pre-built binaries ar
 
 ### Quick Installation
 
-Choose your preferred installation method based on your workflow:
+Choose your preferred installation method based on your workflow. **We recommend using Conda or Pixi** for the most stable experience.
 
-#### PyPI (pip, uv)
+#### Pixi (Recommended)
 
-**Best for:** Standard Python projects, virtual environments, pip-based workflows.
+**Best for:** Development, reproducible environments, managing C++ dependencies alongside Python.
 
 ```bash
-# Using uv (preferred over pip)
-uv add pymomentum-cpu   # CPU version
-uv add pymomentum-gpu   # GPU version (requires CUDA)
+# Auto-detects GPU/CPU based on system
+pixi add pymomentum
 
-# Alternative: Using pip
-pip install pymomentum-cpu
-pip install pymomentum-gpu
+# Explicit backend selection
+pixi add pymomentum-cpu  # CPU-only
+pixi add pymomentum-gpu  # GPU (CUDA) support
 ```
 
-**Browse packages:** [pymomentum-cpu](https://pypi.org/project/pymomentum-cpu/), [pymomentum-gpu](https://pypi.org/project/pymomentum-gpu/)
+**Browse packages:** [prefix.dev/channels/conda-forge/packages/momentum](https://prefix.dev/channels/conda-forge/packages/momentum)
+
+#### Conda (Recommended)
+
+**Best for:** Existing conda workflows, scientific Python environments.
+
+```bash
+# Auto-detects GPU/CPU based on system
+conda install -c conda-forge pymomentum
+
+# Explicit backend selection
+conda install -c conda-forge pymomentum-cpu  # CPU-only
+conda install -c conda-forge pymomentum-gpu  # GPU (CUDA) support
+```
+
+**Browse packages:** [anaconda.org/conda-forge/momentum](https://anaconda.org/conda-forge/momentum)
+
+#### PyPI (Experimental ⚠️)
+
+**Best for:** Standard Python projects, virtual environments, pip-based workflows.
 
 :::caution Experimental PyPI Support
 
@@ -50,35 +68,17 @@ For the most stable and well-tested installation experience, we recommend using 
 
 :::
 
-#### Pixi
-
-**Best for:** Development, reproducible environments, managing C++ dependencies alongside Python.
-
 ```bash
-# Auto-detects GPU/CPU based on system
-pixi add pymomentum
+# Using uv (preferred over pip)
+uv add pymomentum-cpu   # CPU version
+uv add pymomentum-gpu   # GPU version (requires CUDA)
 
-# Explicit backend selection
-pixi add pymomentum-cpu  # CPU-only
-pixi add pymomentum-gpu  # GPU (CUDA) support
+# Alternative: Using pip
+pip install pymomentum-cpu
+pip install pymomentum-gpu
 ```
 
-**Browse packages:** [prefix.dev/channels/conda-forge/packages/momentum](https://prefix.dev/channels/conda-forge/packages/momentum)
-
-#### Conda
-
-**Best for:** Existing conda workflows, scientific Python environments.
-
-```bash
-# Auto-detects GPU/CPU based on system
-conda install -c conda-forge pymomentum
-
-# Explicit backend selection
-conda install -c conda-forge pymomentum-cpu  # CPU-only
-conda install -c conda-forge pymomentum-gpu  # GPU (CUDA) support
-```
-
-**Browse packages:** [anaconda.org/conda-forge/momentum](https://anaconda.org/conda-forge/momentum)
+**Browse packages:** [pymomentum-cpu](https://pypi.org/project/pymomentum-cpu/), [pymomentum-gpu](https://pypi.org/project/pymomentum-gpu/)
 
 ### Checking Available Versions
 


### PR DESCRIPTION
## Summary

Similar to [MHR #44](https://github.com/facebookresearch/MHR/issues/44), this PR updates documentation to clarify that:

- **Conda/Pixi** is the **recommended** installation workflow
- **PyPI/pip** is **experimental** and should be used at your own risk

## Changes

### README.md
- Reordered installation section: Conda/Pixi listed first as "Recommended"
- Added experimental warning for PyPI: `⚠️ PyPI support is experimental`
- Updated quick example to use `conda install` instead of `pip install`
- Reordered package links: conda-forge first, PyPI last

### Website Documentation (docs_python/01_user_guide/01_getting_started.md)
- Reordered installation sections: Pixi (Recommended) → Conda (Recommended) → PyPI (Experimental ⚠️)
- Added "(Recommended)" labels to Pixi and Conda headers
- Added "(Experimental ⚠️)" label to PyPI header
- Moved the experimental caution box directly under the PyPI section for better visibility

## Test Plan

- Documentation-only changes, no code changes
- Verified markdown renders correctly