### PR TITLE
Add OpenCV fisheye camera model

### DIFF
--- a/momentum/camera/fwd.h
+++ b/momentum/camera/fwd.h
@@ -27,6 +27,12 @@ class OpenCVIntrinsicsModelT;
 template <typename T>
 struct OpenCVDistortionParametersT;
 
+template <typename T>
+struct OpenCVFisheyeDistortionParametersT;
+
+template <typename T>
+class OpenCVFisheyeIntrinsicsModelT;
+
 using Camera = CameraT<float>;
 using Camerad = CameraT<double>;
 using IntrinsicsModel = IntrinsicsModelT<float>;
@@ -37,5 +43,9 @@ using OpenCVIntrinsicsModel = OpenCVIntrinsicsModelT<float>;
 using OpenCVIntrinsicsModeld = OpenCVIntrinsicsModelT<double>;
 using OpenCVDistortionParameters = OpenCVDistortionParametersT<float>;
 using OpenCVDistortionParametersd = OpenCVDistortionParametersT<double>;
+using OpenCVFisheyeDistortionParameters = OpenCVFisheyeDistortionParametersT<float>;
+using OpenCVFisheyeDistortionParametersd = OpenCVFisheyeDistortionParametersT<double>;
+using OpenCVFisheyeIntrinsicsModel = OpenCVFisheyeIntrinsicsModelT<float>;
+using OpenCVFisheyeIntrinsicsModeld = OpenCVFisheyeIntrinsicsModelT<double>;
 
 } // namespace momentum


### PR DESCRIPTION
Summary:
Add support for the OpenCV fisheye (equidistant) camera model to the
momentum camera library. The fisheye model uses equidistant projection:

1. Normalize: a = x/z, b = y/z
2. Compute angle: r = sqrt(a² + b²), θ = atan(r)
3. Apply distortion: θ_d = θ(1 + k1·θ² + k2·θ⁴ + k3·θ⁶ + k4·θ⁸)
4. Scale: x' = (θ_d/r)·a, y' = (θ_d/r)·b (handle r→0 singularity)
5. Apply intrinsics: u = fx·x' + cx, v = fy·y' + cy

New types added:
- OpenCVFisheyeDistortionParametersT<T>: struct with k1-k4 coefficients
- OpenCVFisheyeIntrinsicsModelT<T>: camera model with full virtual method
  implementations including project(), unproject() with Newton iteration,
  projectJacobian(), projectIntrinsicsJacobian(), resize(), crop(), clone()

FOV validation:
- maxRSquared_: stores tan²(θ_max) for efficient validity checking
- maxValidAngle()/setMaxValidAngle(): get/set maximum valid angle in radians
- maxRSquared()/setMaxRSquared(): get/set maximum valid r² directly
- computeMaxValidAngleFromImageBounds(): Newton iteration to find θ_max
- Points outside the valid FOV are marked invalid during projection

This prevents distortion artifacts from points outside the calibrated
image region, which can project back inside and cause problems.

Parameter ordering for intrinsics: [fx, fy, cx, cy, k1, k2, k3, k4] (8 params)

Reviewed By: jeongseok-meta

Differential Revision: D92418286


