### PR TITLE
fix(pypi): broaden requires-python in cibuildwheel default pyproject

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -65,8 +65,12 @@ jobs:
       - name: Generate pyproject.toml
         run: |
           python scripts/generate_pyproject.py
-          # Set a default pyproject.toml for the initial setup
+          # Set a default pyproject.toml for the initial cibuildwheel setup.
+          # IMPORTANT: Use py312 as base but broaden requires-python to ">=3.12"
+          # so cibuildwheel doesn't skip cp313 (the per-version pyproject with
+          # strict bounds is swapped in by the before-build hook for each build).
           cp pyproject-pypi-cpu-py312.toml pyproject.toml
+          sed -i 's/requires-python = ">=3.12,<3.13"/requires-python = ">=3.12"/' pyproject.toml
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1

--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -249,8 +249,10 @@ else
 fi
 
 # Verify torch is installed correctly
+# Temporarily clear LD_LIBRARY_PATH to avoid loading pixi env's libtorch_python.so
+# (built for a different Python version) instead of the pip-installed one
 echo "Verifying PyTorch installation..."
-python -c "import torch; print(f'PyTorch {torch.__version__} installed at {torch.__file__}')"
+LD_LIBRARY_PATH="" python -c "import torch; print(f'PyTorch {torch.__version__} installed at {torch.__file__}')"
 """
 test-command = "python -c \"import pymomentum\""
 test-requires = ["numpy", "scipy"]


### PR DESCRIPTION
## Problem

PR #1010 added Windows build for PyPI wheels but introduced a bug in the Linux cibuildwheel build. The `build_cpu_wheels_linux` job copies `pyproject-pypi-cpu-py312.toml` as the default `pyproject.toml` before running cibuildwheel. This file has:

```toml
requires-python = ">=3.12,<3.13"
```

cibuildwheel reads this to determine which Python versions to build for, and `<3.13` causes it to **skip cp313 builds entirely**. The `before-build` hook swaps in the correct per-version pyproject for each build, but that's too late — cibuildwheel has already decided what to build based on the initial `pyproject.toml`.

## Fix

After copying py312 config as the default, broaden `requires-python` to `">=3.12"` using `sed` so cibuildwheel will start builds for both cp312 and cp313. The before-build hook still swaps in the correct version-specific pyproject with strict bounds for each individual build.

## Testing

- CI will run the full PyPI wheels workflow on this branch
- Expect to see both cp312 and cp313 Linux wheels built
