### PR TITLE
feat(pypi): add Windows GPU wheel build for pymomentum-gpu

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -38,14 +38,30 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
-jobs:
-  # Linux CPU wheels are built with cibuildwheel (for manylinux_2_28 compatibility)
-  build_cpu_wheels_linux:
-    name: pypi-cpu-linux (cibuildwheel)
-    runs-on: ubuntu-latest
+            # Windows - py3.13 only on tags/releases
+            - os: windows-latest
+              os-short: win64
+              variant: cpu
+              python-version: '3.13'
+              pixi-environment: py313
+              artifact-pattern: wheels-cpu-windows-latest-py3.13
+              wheel-type: cpu
+            # Windows GPU - always test py3.12 (import-only, no GPU required)
+            - os: windows-latest
+              os-short: win64
+              variant: gpu
+              python-version: '3.12'
+              pixi-environment: py312
+              artifact-pattern: wheels-gpu-windows-latest-py3.12
+              wheel-type: gpu
+            # Windows GPU - py3.13 only on tags/releases
+            - os: windows-latest
+              os-short: win64
+              variant: gpu
+              python-version: '3.13'
+              pixi-environment: py313
+              artifact-pattern: wheels-gpu-windows-latest-py3.13
+              wheel-type: gpu
 
     steps:
       - uses: actions/checkout@v6
@@ -179,11 +195,110 @@ jobs:
           path: dist/*.whl
           retention-days: 7
 
+  # Windows GPU wheels are built with pixi (CPU pixi env, but linking against CUDA PyTorch)
+  # The momentum C++ code doesn't use CUDA directly; GPU only means linking against CUDA-enabled PyTorch
+  build_gpu_wheels:
+    name: pypi-gpu-py${{ matrix.python-version }}-${{ matrix.os-short }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-latest]
+        python-version: ['3.12', '3.13']
+        include:
+          - python-version: '3.12'
+            pixi-environment: py312
+          - python-version: '3.13'
+            pixi-environment: py313
+          - os: windows-latest
+            os-short: win64
+    steps:
+      # Skip Python 3.13 builds on regular commits to reduce CI cost
+      - name: Check if should run
+        id: should_run
+        run: |
+          if [[ "${{ matrix.python-version }}" == "3.13" ]]; then
+            if [[ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]] || \
+               [[ "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' }}" == "true" ]]; then
+              echo "run=true" >> $GITHUB_OUTPUT
+            else
+              echo "run=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "run=true" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - uses: actions/checkout@v6
+        if: steps.should_run.outputs.run == 'true'
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up sccache
+        if: steps.should_run.outputs.run == 'true'
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set up pixi
+        if: steps.should_run.outputs.run == 'true'
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          pixi-version: latest
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          environments: ${{ matrix.pixi-environment }}
+
+      - name: Generate pyproject configs
+        if: steps.should_run.outputs.run == 'true'
+        run: pixi run -e ${{ matrix.pixi-environment }} generate_pyproject
+
+      - name: Clean distribution artifacts
+        if: steps.should_run.outputs.run == 'true'
+        run: pixi run -e ${{ matrix.pixi-environment }} wheel_clean
+
+      - name: Install CUDA PyTorch for linking
+        if: steps.should_run.outputs.run == 'true'
+        run: |
+          pixi run -e ${{ matrix.pixi-environment }} pip install "torch>=2.8.0,<2.9" --index-url https://download.pytorch.org/whl/cu129
+
+      - name: Build GPU wheel
+        if: steps.should_run.outputs.run == 'true'
+        shell: bash
+        run: |
+          PY_VER=${{ matrix.python-version == '3.12' && '312' || '313' }}
+          # Swap in GPU pyproject
+          cp pyproject.toml .tmp-pyproject-backup.toml
+          cp pyproject-pypi-gpu-py${PY_VER}.toml pyproject.toml
+          pixi run -e ${{ matrix.pixi-environment }} pip wheel . --no-deps --no-build-isolation --wheel-dir=dist
+          mv .tmp-pyproject-backup.toml pyproject.toml
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: sccache
+          CMAKE_CXX_COMPILER_LAUNCHER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+
+      - name: Repair GPU wheel (Windows)
+        if: steps.should_run.outputs.run == 'true'
+        run: |
+          pixi run -e ${{ matrix.pixi-environment }} python -m delvewheel repair --wheel-dir dist dist/pymomentum_gpu-*.whl
+
+      - name: Print sccache stats
+        if: steps.should_run.outputs.run == 'true'
+        run: sccache --show-stats
+
+      - name: Upload wheel artifacts
+        if: steps.should_run.outputs.run == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheels-gpu-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist/*.whl
+          retention-days: 7
+
   # Regression test: Verify pip wheels work correctly (import test, parallel operations)
   # Tests all build variants with same skip logic as builds (py3.13 only on tags/releases)
   test_pip_wheels:
     name: Test pip wheel - ${{ matrix.variant }}-py${{ matrix.python-version }}-${{ matrix.os-short }}
-    needs: [build_cpu_wheels_linux, build_cpu_wheels]
+    needs: [build_cpu_wheels_linux, build_cpu_wheels, build_gpu_wheels]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -329,3 +444,41 @@ jobs:
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.event.inputs.test_pypi != 'true')
         uses: pypa/gh-action-pypi-publish@release/v1
+
+publish_gpu:
+  name: Publish pymomentum-gpu to PyPI
+  needs: [build_gpu_wheels, test_pip_wheels]
+  runs-on: ubuntu-latest
+  environment:
+    name: pypi-gpu
+    url: https://pypi.org/p/pymomentum-gpu
+  permissions:
+    id-token: write  # IMPORTANT: mandatory for trusted publishing
+  # Only publish on tag push or manual workflow dispatch with publish=true
+  if: |
+    (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+    (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
+
+  steps:
+    - name: Download GPU wheel artifacts
+      uses: actions/download-artifact@v7
+      with:
+        path: dist
+        pattern: wheels-gpu-*
+        merge-multiple: true
+
+    - name: List GPU distributions
+      run: ls -lh dist/
+
+    - name: Publish GPU to TestPyPI
+      if: |
+        github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.event.inputs.test_pypi == 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+    - name: Publish GPU to PyPI
+      if: |
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.event.inputs.test_pypi != 'true')
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -47,6 +47,20 @@
     "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF",
 {%- endmacro %}
 
+{#- Windows GPU-specific args (same as CPU; GPU only changes the PyTorch variant linked) -#}
+{%- macro cmake_windows_gpu_args() %}
+    "-DBUILD_SHARED_LIBS=OFF",
+    "-G Visual Studio 17 2022",
+    "-DMOMENTUM_BUILD_PYMOMENTUM=ON",
+    "-DMOMENTUM_BUILD_EXAMPLES=OFF",
+    "-DMOMENTUM_BUILD_TESTING=OFF",
+    "-DMOMENTUM_BUILD_RENDERER=OFF",
+    "-DMOMENTUM_ENABLE_SIMD=OFF",
+    "-DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON",
+    "-DMOMENTUM_USE_SYSTEM_PYBIND11=ON",
+    "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF",
+{%- endmacro %}
+
 
 {#- Common cibuildwheel before-all script for Linux (CPU builds) -#}
 {%- macro cibw_linux_before_all() %}
@@ -187,7 +201,11 @@ cmake.define.CMAKE_PREFIX_PATH = {env = "CMAKE_PREFIX_PATH"}
 [[tool.scikit-build.overrides]]
 if.platform-system = "^win32"
 cmake.args = [
+{% if variant == "gpu" %}
+{{ cmake_windows_gpu_args() }}
+{% else %}
 {{ cmake_windows_cpu_args() }}
+{% endif %}
 ]
 cmake.define.CMAKE_PREFIX_PATH = {env = "CMAKE_PREFIX_PATH"}
 

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -76,6 +76,18 @@ def main():
     )
     template = env.get_template("pyproject-pypi.toml.j2")
 
+    # Common template variables
+    common_vars = dict(
+        torch_min_py312=args.torch_min_py312,
+        torch_max_py312=args.torch_max_py312,
+        torch_min_py313=args.torch_min_py313,
+        torch_max_py313=args.torch_max_py313,
+        torch_min_py312_macos=args.torch_min_py312_macos,
+        torch_max_py312_macos=args.torch_max_py312_macos,
+        torch_min_py313_macos=args.torch_min_py313_macos,
+        torch_max_py313_macos=args.torch_max_py313_macos,
+    )
+
     # Generate CPU configs for each Python version
     for py_ver in ["312", "313"]:
         py_ver_min = f"3.{py_ver[1:]}"
@@ -85,18 +97,27 @@ def main():
             description_suffix="CPU-only version for Linux, macOS Intel, and macOS ARM",
             python_version_min=py_ver_min,
             python_version_max=py_ver_max,
-            torch_min_py312=args.torch_min_py312,
-            torch_max_py312=args.torch_max_py312,
-            torch_min_py313=args.torch_min_py313,
-            torch_max_py313=args.torch_max_py313,
-            torch_min_py312_macos=args.torch_min_py312_macos,
-            torch_max_py312_macos=args.torch_max_py312_macos,
-            torch_min_py313_macos=args.torch_min_py313_macos,
-            torch_max_py313_macos=args.torch_max_py313_macos,
+            **common_vars,
         )
         (output_dir / f"pyproject-pypi-cpu-py{py_ver}.toml").write_text(cpu_config)
         print(
             f"Generated pyproject-pypi-cpu-py{py_ver}.toml (requires-python: >={py_ver_min},<{py_ver_max})"
+        )
+
+    # Generate GPU configs for each Python version
+    for py_ver in ["312", "313"]:
+        py_ver_min = f"3.{py_ver[1:]}"
+        py_ver_max = f"3.{int(py_ver[1:]) + 1}"
+        gpu_config = template.render(
+            variant="gpu",
+            description_suffix="GPU (CUDA) version for Linux and Windows",
+            python_version_min=py_ver_min,
+            python_version_max=py_ver_max,
+            **common_vars,
+        )
+        (output_dir / f"pyproject-pypi-gpu-py{py_ver}.toml").write_text(gpu_config)
+        print(
+            f"Generated pyproject-pypi-gpu-py{py_ver}.toml (requires-python: >={py_ver_min},<{py_ver_max})"
         )
 
 

--- a/scripts/test_wheel.py
+++ b/scripts/test_wheel.py
@@ -22,7 +22,7 @@ from pathlib import Path
 def get_torch_index(wheel_type: str) -> str:
     """Get the appropriate PyTorch index URL for the wheel type."""
     if wheel_type == "gpu":
-        return "https://download.pytorch.org/whl/cu128"
+        return "https://download.pytorch.org/whl/cu129"
     return "https://download.pytorch.org/whl/cpu"
 
 


### PR DESCRIPTION
## Summary

Add Windows GPU wheel build, test, and publish support to the PyPI workflow. The GPU variant links against CUDA-enabled PyTorch (`cu129`) instead of CPU PyTorch, producing `pymomentum-gpu` wheels for Windows.

The momentum C++ code doesn't use CUDA directly — the GPU distinction is solely about which PyTorch variant is linked. This means the build uses the same `py312`/`py313` pixi environments as CPU builds, but overrides PyTorch with CUDA-enabled wheels from `https://download.pytorch.org/whl/cu129`.

## Changes

- **`scripts/generate_pyproject.py`**: Generate GPU variant TOML files (`pyproject-pypi-gpu-py312.toml`, etc.) alongside CPU variants
- **`pyproject-pypi.toml.j2`**: Add `cmake_windows_gpu_args()` macro and variant-aware `win32` platform override
- **`publish_to_pypi.yml`**: Add `build_gpu_wheels` job (Windows, py3.12/3.13), GPU entries in `test_pip_wheels` matrix, and `publish_gpu` job for PyPI publishing
- **`scripts/test_wheel.py`**: Fix CUDA index URL from `cu128` to `cu129`

## Testing

CI will run the full PyPI Wheels workflow:
- `pypi-gpu-py3.12-win64` build job
- GPU wheel import tests on Windows

## Notes

- GPU builds are only for Windows in this PR; Linux GPU may follow
- Python 3.13 GPU builds are skipped on non-release pushes (same as CPU)
- The GPU wheel test is import-only (no GPU hardware required on CI runner)
