### PR TITLE
feat(pypi): add Windows GPU wheel build for pymomentum-gpu

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -183,11 +183,116 @@ jobs:
           path: dist/*.whl
           retention-days: 7
 
+  # GPU wheels for Windows (linked against CUDA-enabled PyTorch)
+  # GPU only means linking against CUDA PyTorch; the C++ code itself doesn't use CUDA directly
+  build_gpu_wheels:
+    name: pypi-gpu-py${{ matrix.python-version }}-${{ matrix.os-short }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-latest]
+        python-version: ['3.12', '3.13']
+        include:
+          - python-version: '3.12'
+            pixi-environment: py312
+            py-ver: '312'
+          - python-version: '3.13'
+            pixi-environment: py313
+            py-ver: '313'
+          - os: windows-latest
+            os-short: win64
+    steps:
+      # Skip Python 3.13 builds on regular commits to reduce CI cost
+      - name: Check if should run
+        id: should_run
+        run: |
+          if [[ "${{ matrix.python-version }}" == "3.13" ]]; then
+            if [[ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]] || \
+               [[ "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' }}" == "true" ]]; then
+              echo "run=true" >> $GITHUB_OUTPUT
+            else
+              echo "run=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "run=true" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - uses: actions/checkout@v6
+        if: steps.should_run.outputs.run == 'true'
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up sccache (Windows)
+        if: steps.should_run.outputs.run == 'true' && runner.os == 'Windows'
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set up pixi
+        if: steps.should_run.outputs.run == 'true'
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          pixi-version: latest
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          environments: ${{ matrix.pixi-environment }}
+
+      - name: Generate pyproject configs
+        if: steps.should_run.outputs.run == 'true'
+        run: pixi run -e ${{ matrix.pixi-environment }} generate_pyproject
+
+      # Override CPU PyTorch with CUDA-enabled PyTorch for GPU builds
+      - name: Install CUDA PyTorch
+        if: steps.should_run.outputs.run == 'true'
+        run: pixi run -e ${{ matrix.pixi-environment }} python -m pip install "torch>=2.8.0,<2.9" --index-url https://download.pytorch.org/whl/cu129 --force-reinstall
+        shell: bash
+
+      # Swap in GPU pyproject for the build
+      - name: Set GPU pyproject.toml
+        if: steps.should_run.outputs.run == 'true'
+        run: |
+          PY_VER="${{ matrix.py-ver }}"
+          cp pyproject-pypi-gpu-py${PY_VER}.toml pyproject.toml
+          echo "Using GPU pyproject for Python ${PY_VER}"
+          head -20 pyproject.toml
+        shell: bash
+
+      - name: Clean distribution artifacts
+        if: steps.should_run.outputs.run == 'true'
+        run: pixi run -e ${{ matrix.pixi-environment }} wheel_clean
+
+      - name: Build GPU wheel
+        if: steps.should_run.outputs.run == 'true'
+        run: pixi run -e ${{ matrix.pixi-environment }} wheel_build
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: sccache
+          CMAKE_CXX_COMPILER_LAUNCHER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+
+      # Repair wheel on Windows using delvewheel (bundles DLLs)
+      - name: Repair wheel (Windows)
+        if: steps.should_run.outputs.run == 'true' && runner.os == 'Windows'
+        run: pixi run -e ${{ matrix.pixi-environment }} wheel_repair
+
+      - name: Print sccache stats (Windows)
+        if: steps.should_run.outputs.run == 'true' && runner.os == 'Windows'
+        run: sccache --show-stats
+
+      - name: Upload wheel artifacts
+        if: steps.should_run.outputs.run == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheels-gpu-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist/*.whl
+          retention-days: 7
+
   # Regression test: Verify pip wheels work correctly (import test, parallel operations)
   # Tests all build variants with same skip logic as builds (py3.13 only on tags/releases)
   test_pip_wheels:
     name: Test pip wheel - ${{ matrix.variant }}-py${{ matrix.python-version }}-${{ matrix.os-short }}
-    needs: [build_cpu_wheels_linux, build_cpu_wheels]
+    needs: [build_cpu_wheels_linux, build_cpu_wheels, build_gpu_wheels]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -225,7 +330,7 @@ jobs:
             pixi-environment: py313
             artifact-pattern: wheels-cpu-macos-14-py3.13
             wheel-type: cpu
-          # Windows - always test py3.12
+          # Windows CPU - always test py3.12
           - os: windows-latest
             os-short: win64
             variant: cpu
@@ -233,7 +338,7 @@ jobs:
             pixi-environment: py312
             artifact-pattern: wheels-cpu-windows-latest-py3.12
             wheel-type: cpu
-          # Windows - py3.13 only on tags/releases
+          # Windows CPU - py3.13 only on tags/releases
           - os: windows-latest
             os-short: win64
             variant: cpu
@@ -241,6 +346,22 @@ jobs:
             pixi-environment: py313
             artifact-pattern: wheels-cpu-windows-latest-py3.13
             wheel-type: cpu
+          # Windows GPU - always test py3.12
+          - os: windows-latest
+            os-short: win64
+            variant: gpu
+            python-version: '3.12'
+            pixi-environment: py312
+            artifact-pattern: wheels-gpu-windows-latest-py3.12
+            wheel-type: gpu
+          # Windows GPU - py3.13 only on tags/releases
+          - os: windows-latest
+            os-short: win64
+            variant: gpu
+            python-version: '3.13'
+            pixi-environment: py313
+            artifact-pattern: wheels-gpu-windows-latest-py3.13
+            wheel-type: gpu
 
     steps:
       # Skip py3.13 tests on regular commits (same logic as builds)
@@ -329,6 +450,44 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish CPU to PyPI
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.event.inputs.test_pypi != 'true')
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish_gpu:
+    name: Publish pymomentum-gpu to PyPI
+    needs: [build_gpu_wheels, test_pip_wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-gpu
+      url: https://pypi.org/p/pymomentum-gpu
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    # Only publish on tag push or manual workflow dispatch with publish=true
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
+
+    steps:
+      - name: Download GPU wheel artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: dist
+          pattern: wheels-gpu-*
+          merge-multiple: true
+
+      - name: List GPU distributions
+        run: ls -lh dist/
+
+      - name: Publish GPU to TestPyPI
+        if: |
+          github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.event.inputs.test_pypi == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish GPU to PyPI
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.event.inputs.test_pypi != 'true')

--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -47,6 +47,20 @@
     "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF",
 {%- endmacro %}
 
+{#- Windows GPU-specific args (same as CPU; GPU only changes the PyTorch variant linked) -#}
+{%- macro cmake_windows_gpu_args() %}
+    "-DBUILD_SHARED_LIBS=OFF",
+    "-G Visual Studio 17 2022",
+    "-DMOMENTUM_BUILD_PYMOMENTUM=ON",
+    "-DMOMENTUM_BUILD_EXAMPLES=OFF",
+    "-DMOMENTUM_BUILD_TESTING=OFF",
+    "-DMOMENTUM_BUILD_RENDERER=OFF",
+    "-DMOMENTUM_ENABLE_SIMD=OFF",
+    "-DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON",
+    "-DMOMENTUM_USE_SYSTEM_PYBIND11=ON",
+    "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF",
+{%- endmacro %}
+
 
 {#- Common cibuildwheel before-all script for Linux (CPU builds) -#}
 {%- macro cibw_linux_before_all() %}
@@ -187,7 +201,11 @@ cmake.define.CMAKE_PREFIX_PATH = {env = "CMAKE_PREFIX_PATH"}
 [[tool.scikit-build.overrides]]
 if.platform-system = "^win32"
 cmake.args = [
+{% if variant == "gpu" %}
+{{ cmake_windows_gpu_args() }}
+{% else %}
 {{ cmake_windows_cpu_args() }}
+{% endif %}
 ]
 cmake.define.CMAKE_PREFIX_PATH = {env = "CMAKE_PREFIX_PATH"}
 

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -76,6 +76,18 @@ def main():
     )
     template = env.get_template("pyproject-pypi.toml.j2")
 
+    # Common template variables
+    common_vars = dict(
+        torch_min_py312=args.torch_min_py312,
+        torch_max_py312=args.torch_max_py312,
+        torch_min_py313=args.torch_min_py313,
+        torch_max_py313=args.torch_max_py313,
+        torch_min_py312_macos=args.torch_min_py312_macos,
+        torch_max_py312_macos=args.torch_max_py312_macos,
+        torch_min_py313_macos=args.torch_min_py313_macos,
+        torch_max_py313_macos=args.torch_max_py313_macos,
+    )
+
     # Generate CPU configs for each Python version
     for py_ver in ["312", "313"]:
         py_ver_min = f"3.{py_ver[1:]}"
@@ -85,18 +97,27 @@ def main():
             description_suffix="CPU-only version for Linux, macOS Intel, and macOS ARM",
             python_version_min=py_ver_min,
             python_version_max=py_ver_max,
-            torch_min_py312=args.torch_min_py312,
-            torch_max_py312=args.torch_max_py312,
-            torch_min_py313=args.torch_min_py313,
-            torch_max_py313=args.torch_max_py313,
-            torch_min_py312_macos=args.torch_min_py312_macos,
-            torch_max_py312_macos=args.torch_max_py312_macos,
-            torch_min_py313_macos=args.torch_min_py313_macos,
-            torch_max_py313_macos=args.torch_max_py313_macos,
+            **common_vars,
         )
         (output_dir / f"pyproject-pypi-cpu-py{py_ver}.toml").write_text(cpu_config)
         print(
             f"Generated pyproject-pypi-cpu-py{py_ver}.toml (requires-python: >={py_ver_min},<{py_ver_max})"
+        )
+
+    # Generate GPU configs for each Python version
+    for py_ver in ["312", "313"]:
+        py_ver_min = f"3.{py_ver[1:]}"
+        py_ver_max = f"3.{int(py_ver[1:]) + 1}"
+        gpu_config = template.render(
+            variant="gpu",
+            description_suffix="GPU (CUDA) version for Linux and Windows",
+            python_version_min=py_ver_min,
+            python_version_max=py_ver_max,
+            **common_vars,
+        )
+        (output_dir / f"pyproject-pypi-gpu-py{py_ver}.toml").write_text(gpu_config)
+        print(
+            f"Generated pyproject-pypi-gpu-py{py_ver}.toml (requires-python: >={py_ver_min},<{py_ver_max})"
         )
 
 

--- a/scripts/test_wheel.py
+++ b/scripts/test_wheel.py
@@ -22,7 +22,7 @@ from pathlib import Path
 def get_torch_index(wheel_type: str) -> str:
     """Get the appropriate PyTorch index URL for the wheel type."""
     if wheel_type == "gpu":
-        return "https://download.pytorch.org/whl/cu128"
+        return "https://download.pytorch.org/whl/cu129"
     return "https://download.pytorch.org/whl/cpu"
 
 


### PR DESCRIPTION
## Summary

This adds Windows GPU wheel builds for the `pymomentum-gpu` package, linked against CUDA-enabled PyTorch (cu129).

### What Changed

**New `build_gpu_wheels` CI job:**
- Builds GPU wheels on `windows-latest` for Python 3.12 and 3.13
- Uses regular pixi environments (py312/py313) — no CUDA host requirement
- Overrides CPU PyTorch with CUDA-enabled PyTorch via `pip install torch --index-url https://download.pytorch.org/whl/cu129`
- Uses GPU-specific pyproject config (`pyproject-pypi-gpu-py{ver}.toml`)
- Repairs wheels with delvewheel

**GPU pyproject generation (`generate_pyproject.py`):**
- Now generates both CPU and GPU TOML configs from the Jinja2 template
- GPU configs use `pymomentum-gpu` as the package name

**Template updates (`pyproject-pypi.toml.j2`):**
- Added `cmake_windows_gpu_args()` macro (same as CPU for now; GPU = different PyTorch variant linked)
- Windows override now conditionally uses GPU or CPU args based on the `variant` template variable

**Test infrastructure (`test_wheel.py`):**
- Fixed CUDA index URL from `cu128` → `cu129`
- Already supported GPU wheel testing via `WHEEL_TEST_TYPE=gpu` environment variable

**New test matrix entries:**
- Windows GPU py3.12 and py3.13 tests added to `test_pip_wheels`

**New `publish_gpu` job:**
- Publishes `pymomentum-gpu` to PyPI on tag push or manual dispatch
- Uses trusted publishing with `pypi-gpu` environment

### Design Decision
GPU in this context means linking against CUDA-enabled PyTorch — the C++ code itself does not use CUDA directly. This approach avoids needing CUDA on the CI runner.