### PR TITLE
Add SDFCollider type for SDF-based collision geometry

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -185,6 +185,7 @@ character_public_headers = [
     "character/marker.h",
     "character/mesh_state.h",
     "character/pose_shape.h",
+    "character/sdf_collision_geometry.h",
     "character/skinned_locator.h",
     "character/skin_weights.h",
 ]

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -259,4 +259,23 @@ using TaperedCapsuled_const_p = ::std::shared_ptr<const TaperedCapsuled>;
 using TaperedCapsuled_const_u = ::std::unique_ptr<const TaperedCapsuled>;
 using TaperedCapsuled_const_w = ::std::weak_ptr<const TaperedCapsuled>;
 
+template <typename T>
+struct SDFColliderT;
+using SDFCollider = SDFColliderT<float>;
+using SDFColliderd = SDFColliderT<double>;
+
+using SDFCollider_p = ::std::shared_ptr<SDFCollider>;
+using SDFCollider_u = ::std::unique_ptr<SDFCollider>;
+using SDFCollider_w = ::std::weak_ptr<SDFCollider>;
+using SDFCollider_const_p = ::std::shared_ptr<const SDFCollider>;
+using SDFCollider_const_u = ::std::unique_ptr<const SDFCollider>;
+using SDFCollider_const_w = ::std::weak_ptr<const SDFCollider>;
+
+using SDFColliderd_p = ::std::shared_ptr<SDFColliderd>;
+using SDFColliderd_u = ::std::unique_ptr<SDFColliderd>;
+using SDFColliderd_w = ::std::weak_ptr<SDFColliderd>;
+using SDFColliderd_const_p = ::std::shared_ptr<const SDFColliderd>;
+using SDFColliderd_const_u = ::std::unique_ptr<const SDFColliderd>;
+using SDFColliderd_const_w = ::std::weak_ptr<const SDFColliderd>;
+
 } // namespace momentum

--- a/momentum/character/sdf_collision_geometry.h
+++ b/momentum/character/sdf_collision_geometry.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/character/fwd.h>
+#include <momentum/character/types.h>
+#include <momentum/common/memory.h>
+#include <momentum/math/constants.h>
+#include <momentum/math/transform.h>
+#include <momentum/math/utility.h>
+
+#include <axel/SignedDistanceField.h>
+
+#include <memory>
+
+namespace momentum {
+
+/// SDF collision geometry for character collision detection.
+///
+/// Defined by a transformation, parent joint, and a shared pointer to a SignedDistanceField.
+/// The SDF data is shared to avoid expensive copies of large SDF volumes.
+template <typename S>
+struct SDFColliderT {
+  using Scalar = S;
+  using SDFType = axel::SignedDistanceField<S>;
+
+  /// Transformation defining the orientation and position relative to the parent coordinate
+  /// system.
+  TransformT<S> transformation;
+
+  /// Parent joint to which the geometry is attached.  Use kInvalidIndex to indicate it is
+  /// fixed in world space.
+  size_t parent = kInvalidIndex;
+
+  /// Shared pointer to the SignedDistanceField data.
+  /// Using shared_ptr to avoid expensive copies of potentially large SDF volumes.
+  std::shared_ptr<const SDFType> sdf;
+
+  SDFColliderT() : transformation(TransformT<S>()), parent(kInvalidIndex), sdf(nullptr) {
+    // Empty
+  }
+
+  /// Constructor with SDF initialization.
+  SDFColliderT(
+      const TransformT<S>& transform,
+      size_t parentJoint,
+      std::shared_ptr<const SDFType> sdfPtr)
+      : transformation(transform), parent(parentJoint), sdf(std::move(sdfPtr)) {
+    // Empty
+  }
+
+  /// Checks if the current SDF collider is approximately equal to another.
+  [[nodiscard]] bool isApprox(const SDFColliderT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (parent != other.parent) {
+      return false;
+    }
+
+    // Compare SDF pointers - they should point to the same SDF instance
+    if (sdf != other.sdf) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Checks if the SDF collider is valid (has a valid SDF pointer).
+  [[nodiscard]] bool isValid() const {
+    return sdf != nullptr;
+  }
+};
+
+/// Collection of SDF colliders representing a character's collision geometry.
+template <typename S>
+using SDFCollisionGeometryT = std::vector<SDFColliderT<S>>;
+
+using SDFCollisionGeometry = SDFCollisionGeometryT<float>;
+using SDFCollisionGeometryd = SDFCollisionGeometryT<double>;
+
+MOMENTUM_DEFINE_POINTERS(SDFCollisionGeometry)
+MOMENTUM_DEFINE_POINTERS(SDFCollisionGeometryd)
+
+} // namespace momentum

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -37,7 +37,8 @@ template_structs = [
     "Skeleton",
     "SkeletonState",
     "MeshState",
-    "TaperedCapsule"
+    "TaperedCapsule",
+    "SDFCollider",
 ]
 
 [[fwd]]


### PR DESCRIPTION
Summary:
Adds SDFColliderT, a new collision geometry type that uses signed distance fields
(SDFs) for collision detection. Each collider consists of:

- A transformation defining position/orientation relative to the parent joint
- A parent joint index (or kInvalidIndex for world-space SDFs)
- A shared pointer to an axel::SignedDistanceField

Using shared_ptr for the SDF data allows efficient sharing of potentially large
SDF volumes across multiple collider instances. The SDFCollisionGeometryT type
alias provides a vector of colliders representing a character's full collision
geometry.

This is a prerequisite for the SDFCollisionErrorFunction which will use these
colliders for mesh-to-SDF collision detection during character solving.

Reviewed By: jeongseok-meta

Differential Revision: D91731678


