### PR TITLE
Fix SDF sign errors from unsorted ray hits in meshToSdf

### DIFF
--- a/axel/axel/MeshToSdf.cpp
+++ b/axel/axel/MeshToSdf.cpp
@@ -575,10 +575,15 @@ bool isPointInsideByRayCasting(
 
   for (int i = 0; i < directions.size(); ++i) {
     const Ray3<ScalarType> ray(point, directions[i]);
-    const auto hits = bvh.allHits(ray);
+    auto hits = bvh.allHits(ray);
     const ScalarType minDelta = 0.01;
     auto lastHit = minDelta;
     int nHits = 0;
+
+    // Sort hits by distance since allHits returns them in BVH traversal order
+    std::sort(hits.begin(), hits.end(), [](const auto& a, const auto& b) {
+      return a.hitDistance < b.hitDistance;
+    });
 
     // A relatively common case is to hit right on the
     // edge between two triangles, in which case we end


### PR DESCRIPTION
Summary:
TriBvh::allHits() returns ray-triangle intersections in BVH traversal order, not sorted by distance. The hit deduplication logic in isPointInsideByRayCasting assumed ascending distance order, so when a far hit arrived before a near hit, the near hit was silently dropped. This corrupted the ray parity count and caused incorrect inside/outside classification for arbitrary voxels, producing phantom surfaces in dual contouring output.

The fix sorts hits by distance before deduplication.

Reviewed By: jeongseok-meta

Differential Revision: D92902748


