### PR TITLE
Add Python bindings for CameraProjectionErrorFunction

### DIFF
--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -267,6 +267,7 @@ mt_python_binding(
     ${ATEN_INCLUDE_DIR}
     ${TORCH_INCLUDE_DIRS}
   LINK_LIBRARIES
+    camera
     character
     character_solver
     character_sequence_solver
@@ -312,17 +313,17 @@ mt_python_binding(
     ${TORCH_CXX_FLAGS}
 )
 
-if(MOMENTUM_BUILD_RENDERER)
-  mt_python_binding(
-    NAME pymomentum_camera
-    MODULE_NAME camera
-    PYMOMENTUM_HEADERS_VARS camera_public_headers
-    PYMOMENTUM_SOURCES_VARS camera_sources
-    LINK_LIBRARIES
-      camera
-      rasterizer
-  )
+mt_python_binding(
+  NAME pymomentum_camera
+  MODULE_NAME camera
+  PYMOMENTUM_HEADERS_VARS camera_public_headers
+  PYMOMENTUM_SOURCES_VARS camera_sources
+  LINK_LIBRARIES
+    camera
+    fmt::fmt-header-only
+)
 
+if(MOMENTUM_BUILD_RENDERER)
   mt_python_binding(
     NAME renderer
     PYMOMENTUM_HEADERS_VARS renderer_public_headers

--- a/pymomentum/doc/conf.py
+++ b/pymomentum/doc/conf.py
@@ -23,3 +23,20 @@ exclude_patterns = [
 ]
 
 html_theme = "sphinx_rtd_theme"
+
+
+def skip_pycapsule(app, what, name, obj, skip, options):
+    """Skip PyCapsule members to avoid RST warnings from their docstrings.
+
+    PyCapsule is an internal CPython/pybind11 type used for cross-module type
+    sharing. Its __init__ docstring contains '*' characters that trigger RST
+    parsing warnings. exclude-members only hides it from output but doesn't
+    prevent docstring parsing; this event fires earlier and skips it entirely.
+    """
+    if name == "PyCapsule":
+        return True
+    return skip
+
+
+def setup(app):
+    app.connect("autodoc-skip-member", skip_pycapsule)

--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -117,6 +117,7 @@ PYBIND11_MODULE(solver2, m) {
 
   pybind11::module_::import(
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry
+  pybind11::module_::import("pymomentum.camera"); // @dep=fbsource//arvr/libraries/pymomentum:camera
 
   // Error functions:
   py::class_<mm::SkeletonErrorFunction, std::shared_ptr<mm::SkeletonErrorFunction>>(


### PR DESCRIPTION
Summary: Expose CameraProjectionErrorFunctionT<float> to the pymomentum.solver2 module. This error function projects 3D skeleton points through a bone-parented camera using an IntrinsicsModel and penalizes reprojection error in pixel space. The camera can be attached to a skeleton joint or be static in world space (camera_parent=-1). Bindings include CameraProjectionConstraint data class, single/batch constraint addition, and constraint management methods. The solver2 module now imports pymomentum.camera so pybind11 can resolve IntrinsicsModel types across modules.

Reviewed By: jeongseok-meta

Differential Revision: D93160003


