### PR TITLE
Add camera intrinsics parameter transform infrastructure

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -233,6 +233,7 @@ character_test_sources = [
 
 character_solver_public_headers = [
     "character_solver/aim_error_function.h",
+    "character_solver/camera_intrinsics_parameters.h",
     "character_solver/camera_projection_error_function.h",
     "character_solver/collision_error_function.h",
     "character_solver/collision_error_function_stateless.h",
@@ -272,6 +273,7 @@ character_solver_public_headers = [
 
 character_solver_sources = [
     "character_solver/aim_error_function.cpp",
+    "character_solver/camera_intrinsics_parameters.cpp",
     "character_solver/camera_projection_error_function.cpp",
     "character_solver/collision_error_function.cpp",
     "character_solver/collision_error_function_stateless.cpp",

--- a/momentum/camera/camera.cpp
+++ b/momentum/camera/camera.cpp
@@ -230,8 +230,15 @@ void PinholeIntrinsicsModelT<T>::setIntrinsicParameters(
 
 template <typename T>
 std::shared_ptr<IntrinsicsModelT<T>> PinholeIntrinsicsModelT<T>::clone() const {
-  return std::make_shared<PinholeIntrinsicsModelT<T>>(
+  auto result = std::make_shared<PinholeIntrinsicsModelT<T>>(
       this->imageWidth(), this->imageHeight(), fx_, fy_, cx_, cy_);
+  result->setName(this->name());
+  return result;
+}
+
+template <typename T>
+std::vector<std::string> PinholeIntrinsicsModelT<T>::getParameterNames() const {
+  return {"fx", "fy", "cx", "cy"};
 }
 
 template <typename T>
@@ -618,8 +625,15 @@ void OpenCVIntrinsicsModelT<T>::setIntrinsicParameters(
 
 template <typename T>
 std::shared_ptr<IntrinsicsModelT<T>> OpenCVIntrinsicsModelT<T>::clone() const {
-  return std::make_shared<OpenCVIntrinsicsModelT<T>>(
+  auto result = std::make_shared<OpenCVIntrinsicsModelT<T>>(
       this->imageWidth(), this->imageHeight(), fx_, fy_, cx_, cy_, distortionParams_);
+  result->setName(this->name());
+  return result;
+}
+
+template <typename T>
+std::vector<std::string> OpenCVIntrinsicsModelT<T>::getParameterNames() const {
+  return {"fx", "fy", "cx", "cy", "k1", "k2", "k3", "k4", "k5", "k6", "p1", "p2", "p3", "p4"};
 }
 
 template <typename T>
@@ -1131,8 +1145,15 @@ void OpenCVFisheyeIntrinsicsModelT<T>::setIntrinsicParameters(
 
 template <typename T>
 std::shared_ptr<IntrinsicsModelT<T>> OpenCVFisheyeIntrinsicsModelT<T>::clone() const {
-  return std::make_shared<OpenCVFisheyeIntrinsicsModelT<T>>(
+  auto result = std::make_shared<OpenCVFisheyeIntrinsicsModelT<T>>(
       this->imageWidth(), this->imageHeight(), fx_, fy_, cx_, cy_, distortionParams_);
+  result->setName(this->name());
+  return result;
+}
+
+template <typename T>
+std::vector<std::string> OpenCVFisheyeIntrinsicsModelT<T>::getParameterNames() const {
+  return {"fx", "fy", "cx", "cy", "k1", "k2", "k3", "k4"};
 }
 
 template <typename T>

--- a/momentum/camera/camera.h
+++ b/momentum/camera/camera.h
@@ -16,6 +16,8 @@
 #include <Eigen/Geometry>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace momentum {
 
@@ -154,6 +156,25 @@ class IntrinsicsModelT {
   /// @return New shared pointer to a mutable copy of this model
   [[nodiscard]] virtual std::shared_ptr<IntrinsicsModelT<T>> clone() const = 0;
 
+  /// Get the name identifier for this camera.
+  ///
+  /// @return Name string (used for parameter transform naming)
+  [[nodiscard]] const std::string& name() const {
+    return name_;
+  }
+
+  /// Set the name identifier for this camera.
+  ///
+  /// @param name Name string (e.g., "cam0" produces "intrinsics_cam0_fx")
+  void setName(const std::string& name) {
+    name_ = name;
+  }
+
+  /// Get the names of intrinsic parameters for this model.
+  ///
+  /// @return Vector of parameter names (e.g., {"fx", "fy", "cx", "cy"})
+  [[nodiscard]] virtual std::vector<std::string> getParameterNames() const = 0;
+
   /// Compute the Jacobian of projection w.r.t. intrinsic parameters.
   ///
   /// @param point 3D point in camera coordinate space
@@ -169,6 +190,7 @@ class IntrinsicsModelT {
  private:
   int32_t imageWidth_ = 640;
   int32_t imageHeight_ = 480;
+  std::string name_;
 };
 
 /// Camera class that combines intrinsics and extrinsics for 3D rendering.
@@ -482,6 +504,8 @@ class OpenCVFisheyeIntrinsicsModelT : public IntrinsicsModelT<T> {
 
   [[nodiscard]] std::shared_ptr<IntrinsicsModelT<T>> clone() const final;
 
+  [[nodiscard]] std::vector<std::string> getParameterNames() const final;
+
   [[nodiscard]] std::tuple<Eigen::Vector3<T>, Eigen::Matrix<T, 3, Eigen::Dynamic>, bool>
   projectIntrinsicsJacobian(const Eigen::Vector3<T>& point) const final;
 
@@ -615,6 +639,8 @@ class PinholeIntrinsicsModelT : public IntrinsicsModelT<T> {
 
   [[nodiscard]] std::shared_ptr<IntrinsicsModelT<T>> clone() const final;
 
+  [[nodiscard]] std::vector<std::string> getParameterNames() const final;
+
   [[nodiscard]] std::tuple<Eigen::Vector3<T>, Eigen::Matrix<T, 3, Eigen::Dynamic>, bool>
   projectIntrinsicsJacobian(const Eigen::Vector3<T>& point) const final;
 
@@ -713,6 +739,8 @@ class OpenCVIntrinsicsModelT : public IntrinsicsModelT<T> {
   void setIntrinsicParameters(const Eigen::Ref<const Eigen::VectorX<T>>& params) final;
 
   [[nodiscard]] std::shared_ptr<IntrinsicsModelT<T>> clone() const final;
+
+  [[nodiscard]] std::vector<std::string> getParameterNames() const final;
 
   [[nodiscard]] std::tuple<Eigen::Vector3<T>, Eigen::Matrix<T, 3, Eigen::Dynamic>, bool>
   projectIntrinsicsJacobian(const Eigen::Vector3<T>& point) const final;

--- a/momentum/character_solver/camera_intrinsics_parameters.cpp
+++ b/momentum/character_solver/camera_intrinsics_parameters.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/character_solver/camera_intrinsics_parameters.h"
+
+#include <momentum/common/checks.h>
+
+#include <sstream>
+
+namespace momentum {
+
+namespace {
+
+std::string makePrefix(const std::string& cameraName) {
+  return std::string(kIntrinsicsParamPrefix) + cameraName + "_";
+}
+
+// Find the model parameter index for a given full parameter name, or -1 if not present.
+Eigen::Index findParamIndex(const ParameterTransform& paramTransform, const std::string& fullName) {
+  for (size_t i = 0; i < paramTransform.name.size(); ++i) {
+    if (paramTransform.name[i] == fullName) {
+      return static_cast<Eigen::Index>(i);
+    }
+  }
+  return -1;
+}
+
+} // namespace
+
+std::tuple<ParameterTransform, ParameterLimits> addCameraIntrinsicsParameters(
+    ParameterTransform paramTransform,
+    ParameterLimits paramLimits,
+    const IntrinsicsModel& intrinsicsModel) {
+  const std::string& effectiveName = intrinsicsModel.name();
+  MT_CHECK(
+      !effectiveName.empty(),
+      "Camera name must not be empty; call setName() on the intrinsics model first.");
+
+  const std::string prefix = makePrefix(effectiveName);
+  const std::string paramSetName = std::string(kIntrinsicsParamPrefix) + effectiveName;
+
+  // Strip existing params for same camera name (idempotency)
+  ParameterSet existingParams = getCameraIntrinsicsParameterSet(paramTransform, effectiveName);
+  if (existingParams.any()) {
+    std::tie(paramTransform, paramLimits) =
+        subsetParameterTransform(paramTransform, paramLimits, ~existingParams);
+  }
+
+  // Get parameter names from the intrinsics model
+  const auto paramNames = intrinsicsModel.getParameterNames();
+
+  // Build the parameter set for this camera
+  ParameterSet paramSet;
+
+  // Append parameters
+  paramTransform.name.reserve(paramTransform.name.size() + paramNames.size());
+  for (const auto& paramName : paramNames) {
+    paramSet.set(paramTransform.name.size());
+    paramTransform.name.push_back(prefix + paramName);
+  }
+
+  // Store the named parameter set
+  paramTransform.parameterSets[paramSetName] = paramSet;
+
+  // Resize the transform matrix with zero columns for the new parameters
+  paramTransform.transform.conservativeResize(
+      paramTransform.transform.rows(), paramTransform.name.size());
+  paramTransform.transform.makeCompressed();
+
+  return {paramTransform, paramLimits};
+}
+
+Eigen::VectorXf extractCameraIntrinsics(
+    const ParameterTransform& paramTransform,
+    const ModelParameters& modelParams,
+    const IntrinsicsModel& intrinsicsModel) {
+  // Start with the model's current values as defaults for any missing params
+  Eigen::VectorXf result = intrinsicsModel.getIntrinsicParameters();
+  const std::string prefix = makePrefix(intrinsicsModel.name());
+  const auto paramNames = intrinsicsModel.getParameterNames();
+
+  for (size_t i = 0; i < paramNames.size(); ++i) {
+    const auto paramIdx = findParamIndex(paramTransform, prefix + paramNames[i]);
+    if (paramIdx >= 0 && paramIdx < modelParams.size()) {
+      result(static_cast<Eigen::Index>(i)) = modelParams(paramIdx);
+    }
+  }
+  return result;
+}
+
+void setCameraIntrinsics(
+    const ParameterTransform& paramTransform,
+    const IntrinsicsModel& intrinsicsModel,
+    ModelParameters& modelParams) {
+  const std::string prefix = makePrefix(intrinsicsModel.name());
+  const auto paramNames = intrinsicsModel.getParameterNames();
+  const Eigen::VectorXf intrinsicValues = intrinsicsModel.getIntrinsicParameters();
+
+  for (size_t i = 0; i < paramNames.size(); ++i) {
+    const auto paramIdx = findParamIndex(paramTransform, prefix + paramNames[i]);
+    if (paramIdx >= 0 && paramIdx < modelParams.size()) {
+      modelParams(paramIdx) = intrinsicValues(static_cast<Eigen::Index>(i));
+    }
+  }
+}
+
+ParameterSet getCameraIntrinsicsParameterSet(
+    const ParameterTransform& paramTransform,
+    const std::string& cameraName) {
+  const std::string prefix = makePrefix(cameraName);
+  ParameterSet result;
+  for (size_t i = 0; i < paramTransform.name.size(); ++i) {
+    if (paramTransform.name[i].compare(0, prefix.size(), prefix) == 0) {
+      result.set(i);
+    }
+  }
+  return result;
+}
+
+ParameterSet getAllCameraIntrinsicsParameterSet(const ParameterTransform& paramTransform) {
+  const std::string prefix(kIntrinsicsParamPrefix);
+  ParameterSet result;
+  for (size_t i = 0; i < paramTransform.name.size(); ++i) {
+    if (paramTransform.name[i].compare(0, prefix.size(), prefix) == 0) {
+      result.set(i);
+    }
+  }
+  return result;
+}
+
+} // namespace momentum

--- a/momentum/character_solver/camera_intrinsics_parameters.h
+++ b/momentum/character_solver/camera_intrinsics_parameters.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/camera/camera.h>
+#include <momentum/character/parameter_limits.h>
+#include <momentum/character/parameter_transform.h>
+#include <momentum/character/types.h>
+
+#include <string>
+#include <tuple>
+
+namespace momentum {
+
+inline constexpr const char* kIntrinsicsParamPrefix = "intrinsics_";
+
+/// Add camera intrinsics parameters to the parameter transform.
+/// Names follow "intrinsics_{cameraName}_{paramName}" convention.
+/// Idempotent: strips existing params for same camera name first.
+/// New columns in transform matrix are zero (not mapped to joints).
+///
+/// @param paramTransform The parameter transform to augment
+/// @param paramLimits The parameter limits to augment
+/// @param intrinsicsModel The intrinsics model whose parameters to add (must have a non-empty name)
+/// @return Tuple of updated (paramTransform, paramLimits)
+/// @throws if intrinsicsModel.name() is empty
+[[nodiscard]] std::tuple<ParameterTransform, ParameterLimits> addCameraIntrinsicsParameters(
+    ParameterTransform paramTransform,
+    ParameterLimits paramLimits,
+    const IntrinsicsModel& intrinsicsModel);
+
+/// Extract camera intrinsic parameter values from model parameters.
+///
+/// Reads the values at the parameter indices corresponding to the camera's
+/// intrinsics (looked up by name in paramTransform). Parameters not present
+/// in paramTransform retain the current values from the intrinsics model.
+/// This mirrors the extractBlendWeights() pattern.
+///
+/// @param paramTransform The parameter transform with camera intrinsics parameters
+/// @param modelParams The model parameters to read from
+/// @param intrinsicsModel The intrinsics model (provides name, parameter names, and default values)
+/// @return Intrinsic parameter vector suitable for IntrinsicsModel::setIntrinsicParameters()
+[[nodiscard]] Eigen::VectorXf extractCameraIntrinsics(
+    const ParameterTransform& paramTransform,
+    const ModelParameters& modelParams,
+    const IntrinsicsModel& intrinsicsModel);
+
+/// Write camera intrinsic parameter values from an IntrinsicsModel into model parameters.
+///
+/// Copies the intrinsics model's current parameter values into the corresponding
+/// slots of modelParameters. Parameters not present in paramTransform are
+/// silently skipped.
+///
+/// @param paramTransform The parameter transform with camera intrinsics parameters
+/// @param intrinsicsModel The intrinsics model to read values from
+/// @param[in,out] modelParams The model parameters to write into
+void setCameraIntrinsics(
+    const ParameterTransform& paramTransform,
+    const IntrinsicsModel& intrinsicsModel,
+    ModelParameters& modelParams);
+
+/// Get ParameterSet for a specific camera's intrinsics parameters.
+///
+/// @param paramTransform The parameter transform to search
+/// @param cameraName The camera name to look up
+/// @return ParameterSet with bits set for the camera's intrinsics parameters
+[[nodiscard]] ParameterSet getCameraIntrinsicsParameterSet(
+    const ParameterTransform& paramTransform,
+    const std::string& cameraName);
+
+/// Get ParameterSet for ALL camera intrinsics parameters.
+///
+/// @param paramTransform The parameter transform to search
+/// @return ParameterSet with bits set for all intrinsics parameters
+[[nodiscard]] ParameterSet getAllCameraIntrinsicsParameterSet(
+    const ParameterTransform& paramTransform);
+
+} // namespace momentum

--- a/momentum/test/character_solver/camera_projection_error_function_test.cpp
+++ b/momentum/test/character_solver/camera_projection_error_function_test.cpp
@@ -12,11 +12,14 @@
 #include "momentum/character/parameter_transform.h"
 #include "momentum/character/skeleton.h"
 #include "momentum/character/skeleton_state.h"
+#include "momentum/character_solver/camera_intrinsics_parameters.h"
 #include "momentum/character_solver/camera_projection_error_function.h"
 #include "momentum/math/constants.h"
 #include "momentum/math/random.h"
 #include "momentum/test/character/character_helpers.h"
 #include "momentum/test/character_solver/error_function_helpers.h"
+
+#include <set>
 
 using namespace momentum;
 
@@ -140,4 +143,195 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, CameraProjectionError_GradientsAndJacobi
     const double error = errorFunction.getError(modelParams, skelState, MeshStateT<T>());
     EXPECT_NEAR(error, 0.0, Eps<T>(1e-10f, 1e-15));
   }
+}
+
+// ---- Tests for getParameterNames() and IntrinsicsModel name ----
+
+TEST(CameraIntrinsicsParameters, GetParameterNames) {
+  // Pinhole: 4 params
+  {
+    auto model = std::make_shared<PinholeIntrinsicsModel>(640, 480, 500.0f, 500.0f);
+    const auto names = model->getParameterNames();
+    ASSERT_EQ(names.size(), 4);
+    EXPECT_EQ(names[0], "fx");
+    EXPECT_EQ(names[1], "fy");
+    EXPECT_EQ(names[2], "cx");
+    EXPECT_EQ(names[3], "cy");
+  }
+
+  // OpenCV Fisheye: 8 params
+  {
+    auto model =
+        std::make_shared<OpenCVFisheyeIntrinsicsModel>(640, 480, 500.0f, 500.0f, 320.0f, 240.0f);
+    const auto names = model->getParameterNames();
+    ASSERT_EQ(names.size(), 8);
+    EXPECT_EQ(names[0], "fx");
+    EXPECT_EQ(names[4], "k1");
+    EXPECT_EQ(names[7], "k4");
+  }
+
+  // OpenCV: 14 params
+  {
+    auto model = std::make_shared<OpenCVIntrinsicsModel>(640, 480, 500.0f, 500.0f, 320.0f, 240.0f);
+    const auto names = model->getParameterNames();
+    ASSERT_EQ(names.size(), 14);
+    EXPECT_EQ(names[0], "fx");
+    EXPECT_EQ(names[4], "k1");
+    EXPECT_EQ(names[10], "p1");
+    EXPECT_EQ(names[13], "p4");
+  }
+}
+
+TEST(CameraIntrinsicsParameters, AddCameraIntrinsicsParameters_Pinhole) {
+  const Character character = createTestCharacter();
+  auto intrinsics = std::make_shared<PinholeIntrinsicsModel>(640, 480, 500.0f, 500.0f);
+  intrinsics->setName("cam0");
+
+  const auto origSize = character.parameterTransform.name.size();
+
+  auto [pt, pl] = addCameraIntrinsicsParameters(
+      character.parameterTransform, character.parameterLimits, *intrinsics);
+
+  // Should have added 4 params (fx, fy, cx, cy)
+  EXPECT_EQ(pt.name.size(), origSize + 4);
+  EXPECT_EQ(pt.name[origSize], "intrinsics_cam0_fx");
+  EXPECT_EQ(pt.name[origSize + 1], "intrinsics_cam0_fy");
+  EXPECT_EQ(pt.name[origSize + 2], "intrinsics_cam0_cx");
+  EXPECT_EQ(pt.name[origSize + 3], "intrinsics_cam0_cy");
+
+  // Transform matrix should have grown
+  EXPECT_EQ(pt.transform.cols(), static_cast<Eigen::Index>(pt.name.size()));
+
+  // Named parameter set should exist
+  EXPECT_TRUE(pt.parameterSets.count("intrinsics_cam0") > 0);
+
+  // Verify clone preserves name (guards against forgetting setName in clone())
+  auto cloned = intrinsics->clone();
+  EXPECT_EQ(cloned->name(), "cam0");
+}
+
+TEST(CameraIntrinsicsParameters, AddCameraIntrinsicsParameters_Idempotent) {
+  const Character character = createTestCharacter();
+  auto intrinsics = std::make_shared<PinholeIntrinsicsModel>(640, 480, 500.0f, 500.0f);
+  intrinsics->setName("cam0");
+
+  auto [pt1, pl1] = addCameraIntrinsicsParameters(
+      character.parameterTransform, character.parameterLimits, *intrinsics);
+
+  // Call again — should not duplicate
+  auto [pt2, pl2] = addCameraIntrinsicsParameters(pt1, pl1, *intrinsics);
+
+  EXPECT_EQ(pt1.name.size(), pt2.name.size());
+  EXPECT_EQ(pt1.transform.cols(), pt2.transform.cols());
+}
+
+TEST(CameraIntrinsicsParameters, AddCameraIntrinsicsParameters_MultipleCameras) {
+  const Character character = createTestCharacter();
+  auto intrinsics0 = std::make_shared<PinholeIntrinsicsModel>(640, 480, 500.0f, 500.0f);
+  intrinsics0->setName("cam0");
+
+  auto intrinsics1 =
+      std::make_shared<OpenCVFisheyeIntrinsicsModel>(640, 480, 500.0f, 500.0f, 320.0f, 240.0f);
+  intrinsics1->setName("cam1");
+
+  const auto origSize = character.parameterTransform.name.size();
+
+  auto [pt1, pl1] = addCameraIntrinsicsParameters(
+      character.parameterTransform, character.parameterLimits, *intrinsics0);
+  auto [pt2, pl2] = addCameraIntrinsicsParameters(pt1, pl1, *intrinsics1);
+
+  // cam0 has 4 params, cam1 has 8 params
+  EXPECT_EQ(pt2.name.size(), origSize + 4 + 8);
+
+  // Verify all params are distinct
+  std::set<std::string> allNames(pt2.name.begin(), pt2.name.end());
+  EXPECT_EQ(allNames.size(), pt2.name.size());
+
+  // Per-camera lookup returns correct count
+  EXPECT_EQ(getCameraIntrinsicsParameterSet(pt2, "cam0").count(), 4);
+  EXPECT_EQ(getCameraIntrinsicsParameterSet(pt2, "cam1").count(), 8);
+  EXPECT_EQ(getCameraIntrinsicsParameterSet(pt2, "nonexistent").count(), 0);
+
+  // All-cameras lookup returns union
+  EXPECT_EQ(getAllCameraIntrinsicsParameterSet(pt2).count(), 4 + 8);
+}
+
+TEST(CameraIntrinsicsParameters, ExtractAndSetCameraIntrinsics) {
+  const Character character = createTestCharacter();
+  auto intrinsics =
+      std::make_shared<PinholeIntrinsicsModel>(640, 480, 500.0f, 500.0f, 320.0f, 240.0f);
+  intrinsics->setName("cam0");
+
+  auto [pt, pl] = addCameraIntrinsicsParameters(
+      character.parameterTransform, character.parameterLimits, *intrinsics);
+
+  // setCameraIntrinsics: write intrinsics model values into model parameters
+  ModelParameters modelParams = ModelParameters::Zero(pt.numAllModelParameters());
+  setCameraIntrinsics(pt, *intrinsics, modelParams);
+
+  // The pinhole params should now be (500, 500, 320, 240) at the right indices
+  const auto fxIdx = pt.getParameterIdByName("intrinsics_cam0_fx");
+  const auto fyIdx = pt.getParameterIdByName("intrinsics_cam0_fy");
+  const auto cxIdx = pt.getParameterIdByName("intrinsics_cam0_cx");
+  const auto cyIdx = pt.getParameterIdByName("intrinsics_cam0_cy");
+  EXPECT_FLOAT_EQ(modelParams(fxIdx), 500.0f);
+  EXPECT_FLOAT_EQ(modelParams(fyIdx), 500.0f);
+  EXPECT_FLOAT_EQ(modelParams(cxIdx), 320.0f);
+  EXPECT_FLOAT_EQ(modelParams(cyIdx), 240.0f);
+
+  // Modify model parameters and extract back
+  modelParams(fxIdx) = 600.0f;
+  modelParams(cyIdx) = 250.0f;
+
+  const auto extracted = extractCameraIntrinsics(pt, modelParams, *intrinsics);
+  ASSERT_EQ(extracted.size(), 4);
+  EXPECT_FLOAT_EQ(extracted(0), 600.0f); // fx — modified
+  EXPECT_FLOAT_EQ(extracted(1), 500.0f); // fy — unchanged
+  EXPECT_FLOAT_EQ(extracted(2), 320.0f); // cx — unchanged
+  EXPECT_FLOAT_EQ(extracted(3), 250.0f); // cy — modified
+
+  // Apply extracted values to a cloned model and verify round-trip
+  auto cloned = intrinsics->clone();
+  cloned->setIntrinsicParameters(extracted);
+  EXPECT_FLOAT_EQ(cloned->fx(), 600.0f);
+}
+
+TEST(CameraIntrinsicsParameters, ExtractCameraIntrinsics_MissingParams) {
+  const Character character = createTestCharacter();
+  auto intrinsics =
+      std::make_shared<PinholeIntrinsicsModel>(640, 480, 500.0f, 500.0f, 320.0f, 240.0f);
+  intrinsics->setName("cam0");
+
+  auto [pt, pl] = addCameraIntrinsicsParameters(
+      character.parameterTransform, character.parameterLimits, *intrinsics);
+
+  // Downselect to only include fx and cy (simulating a user restricting the parameter set)
+  ParameterSet subset;
+  // Keep all non-intrinsics params
+  for (size_t i = 0; i < pt.name.size(); ++i) {
+    if (pt.name[i].substr(0, std::string(kIntrinsicsParamPrefix).size()) !=
+        std::string(kIntrinsicsParamPrefix)) {
+      subset.set(i);
+    }
+  }
+  // Also keep fx and cy
+  subset.set(pt.getParameterIdByName("intrinsics_cam0_fx"));
+  subset.set(pt.getParameterIdByName("intrinsics_cam0_cy"));
+
+  auto [ptSubset, plSubset] = subsetParameterTransform(pt, pl, subset);
+
+  // Set fx=600 in the reduced model parameters
+  ModelParameters modelParams = ModelParameters::Zero(ptSubset.numAllModelParameters());
+  const auto fxIdx = ptSubset.getParameterIdByName("intrinsics_cam0_fx");
+  modelParams(fxIdx) = 600.0f;
+  const auto cyIdx = ptSubset.getParameterIdByName("intrinsics_cam0_cy");
+  modelParams(cyIdx) = 250.0f;
+
+  // Extract: fx and cy come from modelParams, fy and cx fall back to intrinsics model defaults
+  const auto extracted = extractCameraIntrinsics(ptSubset, modelParams, *intrinsics);
+  ASSERT_EQ(extracted.size(), 4);
+  EXPECT_FLOAT_EQ(extracted(0), 600.0f); // fx — from modelParams
+  EXPECT_FLOAT_EQ(extracted(1), 500.0f); // fy — fallback to model default
+  EXPECT_FLOAT_EQ(extracted(2), 320.0f); // cx — fallback to model default
+  EXPECT_FLOAT_EQ(extracted(3), 250.0f); // cy — from modelParams
 }

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -267,6 +267,7 @@ mt_python_binding(
     ${ATEN_INCLUDE_DIR}
     ${TORCH_INCLUDE_DIRS}
   LINK_LIBRARIES
+    array_utility
     camera
     character
     character_solver

--- a/pymomentum/camera/camera_pybind.cpp
+++ b/pymomentum/camera/camera_pybind.cpp
@@ -38,6 +38,15 @@ PYBIND11_MODULE(camera, m) {
           "num_intrinsic_parameters",
           &momentum::IntrinsicsModel::numIntrinsicParameters,
           "Number of intrinsic parameters for this model")
+      .def_property(
+          "name",
+          &momentum::IntrinsicsModel::name,
+          &momentum::IntrinsicsModel::setName,
+          "Name identifier for this camera (used in parameter transform naming)")
+      .def_property_readonly(
+          "parameter_names",
+          &momentum::IntrinsicsModel::getParameterNames,
+          "List of intrinsic parameter names (e.g., ['fx', 'fy', 'cx', 'cy']).")
       .def(
           "get_intrinsic_parameters",
           &momentum::IntrinsicsModel::getIntrinsicParameters,

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -187,12 +187,14 @@ solver_sources = [
 ]
 
 solver2_public_headers = [
+    "solver2/solver2_camera_intrinsics.h",
     "solver2/solver2_error_functions.h",
     "solver2/solver2_sequence_error_functions.h",
     "solver2/solver2_utility.h",
 ]
 
 solver2_sources = [
+    "solver2/solver2_camera_intrinsics.cpp",
     "solver2/solver2_error_functions.cpp",
     "solver2/solver2_pybind.cpp",
     "solver2/solver2_sequence_error_functions.cpp",

--- a/pymomentum/solver2/solver2_camera_intrinsics.cpp
+++ b/pymomentum/solver2/solver2_camera_intrinsics.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "pymomentum/solver2/solver2_camera_intrinsics.h"
+
+#include <momentum/camera/camera.h>
+#include <momentum/character/character.h>
+#include <momentum/character_solver/camera_intrinsics_parameters.h>
+
+#include <pymomentum/array_utility/array_utility.h>
+#include <pymomentum/array_utility/batch_accessor.h>
+#include <pymomentum/array_utility/geometry_accessors.h>
+
+#include <dispenso/parallel_for.h> // @manual
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+namespace mm = momentum;
+
+namespace pymomentum {
+
+namespace {
+
+// Template implementation for extracting camera intrinsics from model parameters.
+// Supports batched arrays with shape (..., nModelParams).
+template <typename T>
+py::array_t<T> extractCameraIntrinsicsImpl(
+    const mm::ParameterTransform& paramTransform,
+    const py::buffer& modelParams,
+    const LeadingDimensions& leadingDims,
+    py::ssize_t nModelParams,
+    const mm::IntrinsicsModel& intrinsicsModel) {
+  const auto nIntrinsicParams = static_cast<py::ssize_t>(intrinsicsModel.numIntrinsicParameters());
+  const auto nBatch = leadingDims.totalBatchElements();
+
+  // Create output array with shape (..., nIntrinsicParams)
+  auto result = createOutputArray<T>(leadingDims, {nIntrinsicParams});
+
+  // Create batch indexer
+  BatchIndexer indexer(leadingDims);
+
+  // Create accessor for input model parameters
+  ModelParametersAccessor<T> inputAcc(modelParams, leadingDims, nModelParams);
+
+  // Release GIL for parallel computation
+  {
+    py::gil_scoped_release release;
+    dispenso::parallel_for(0, static_cast<int64_t>(nBatch), [&](int64_t iBatch) {
+      auto indices = indexer.decompose(iBatch);
+
+      // Get model parameters for this batch element
+      auto mp = inputAcc.get(indices);
+
+      // Extract camera intrinsics — returns Eigen::VectorXf regardless of T,
+      // so we always call with float ModelParameters
+      mm::ModelParameters mpFloat(mp.v.template cast<float>());
+      Eigen::VectorXf intrinsics =
+          mm::extractCameraIntrinsics(paramTransform, mpFloat, intrinsicsModel);
+
+      // Write output element-by-element (output array is contiguous from createOutputArray)
+      auto* outPtr = result.mutable_data();
+      const auto outOffset = iBatch * nIntrinsicParams;
+      for (py::ssize_t i = 0; i < nIntrinsicParams; ++i) {
+        outPtr[outOffset + i] = static_cast<T>(intrinsics(i));
+      }
+    });
+  }
+
+  return result;
+}
+
+// Template implementation for setting camera intrinsics into model parameters.
+// Returns a new array instead of mutating in-place.
+// Supports batched arrays with shape (..., nModelParams).
+template <typename T>
+py::array_t<T> setCameraIntrinsicsImpl(
+    const mm::ParameterTransform& paramTransform,
+    const mm::IntrinsicsModel& intrinsicsModel,
+    const py::buffer& modelParams,
+    const LeadingDimensions& leadingDims,
+    py::ssize_t nModelParams) {
+  const auto nBatch = leadingDims.totalBatchElements();
+
+  // Create output array with same shape as input (..., nModelParams)
+  auto result = createOutputArray<T>(leadingDims, {nModelParams});
+
+  // Create batch indexer
+  BatchIndexer indexer(leadingDims);
+
+  // Create accessors
+  ModelParametersAccessor<T> inputAcc(modelParams, leadingDims, nModelParams);
+  ModelParametersAccessor<T> outputAcc(result, leadingDims, nModelParams);
+
+  // Release GIL for parallel computation
+  {
+    py::gil_scoped_release release;
+    dispenso::parallel_for(0, static_cast<int64_t>(nBatch), [&](int64_t iBatch) {
+      auto indices = indexer.decompose(iBatch);
+
+      // Get input model parameters
+      auto mp = inputAcc.get(indices);
+
+      // setCameraIntrinsics works with float ModelParameters
+      mm::ModelParameters mpFloat(mp.v.template cast<float>());
+      mm::setCameraIntrinsics(paramTransform, intrinsicsModel, mpFloat);
+
+      // Convert back and write to output
+      mm::ModelParametersT<T> mpOut(mpFloat.v.template cast<T>());
+      outputAcc.set(indices, mpOut);
+    });
+  }
+
+  return result;
+}
+
+} // namespace
+
+void addCameraIntrinsicsBindings(pybind11::module_& m) {
+  m.def(
+      "add_camera_intrinsics_parameters",
+      [](const mm::Character& character,
+         const mm::IntrinsicsModel& intrinsicsModel) -> mm::Character {
+        auto [paramTransform, paramLimits] = mm::addCameraIntrinsicsParameters(
+            character.parameterTransform, character.parameterLimits, intrinsicsModel);
+        mm::Character result = character;
+        result.parameterTransform = std::move(paramTransform);
+        result.parameterLimits = std::move(paramLimits);
+        return result;
+      },
+      R"(Add camera intrinsics parameters to the character's parameter transform.
+
+Creates a new :class:`~pymomentum.geometry.Character` with additional model parameters for the
+given camera's intrinsic parameters (e.g., fx, fy, cx, cy, distortion coefficients). The parameter
+names follow the convention "intrinsics_{camera_name}_{param_name}".
+
+The intrinsics model must have a non-empty name set via the ``name`` property.
+
+This operation is idempotent: calling it twice with the same camera name will
+replace the existing parameters rather than duplicating them.
+
+:param character: The character whose parameter transform to augment.
+:param intrinsics_model: The camera intrinsics model whose parameters to add (must have a name set).
+:return: A new Character with the augmented parameter transform.)",
+      py::arg("character"),
+      py::arg("intrinsics_model"));
+
+  m.def(
+      "extract_camera_intrinsics",
+      [](const mm::Character& character,
+         const py::buffer& modelParameters,
+         const mm::IntrinsicsModel& intrinsicsModel) -> py::array {
+        const auto& pt = character.parameterTransform;
+        const auto nModelParams = static_cast<int>(pt.numAllModelParameters());
+
+        ArrayChecker checker("extract_camera_intrinsics");
+        checker.validateBuffer(
+            modelParameters, "model_parameters", {nModelParams}, {"nModelParams"});
+
+        const auto& leadingDims = checker.getLeadingDimensions();
+
+        if (checker.isFloat64()) {
+          return extractCameraIntrinsicsImpl<double>(
+              pt, modelParameters, leadingDims, nModelParams, intrinsicsModel);
+        } else {
+          return extractCameraIntrinsicsImpl<float>(
+              pt, modelParameters, leadingDims, nModelParams, intrinsicsModel);
+        }
+      },
+      R"(Extract camera intrinsic parameter values from model parameters.
+
+Reads the values corresponding to the camera's intrinsics from the model parameter
+vector. Parameters not present in the parameter transform retain the current values
+from the intrinsics model (useful when working with a downselected parameter set).
+
+Supports batched input with shape ``(..., n_model_params)``.
+
+:param character: The character with camera intrinsics in its parameter transform.
+:param model_parameters: The model parameter array with shape ``(..., n_model_params)``.
+:param intrinsics_model: The intrinsics model (provides name and default values).
+:return: Array of intrinsic parameters with shape ``(..., n_intrinsic_params)`` suitable
+    for :meth:`~pymomentum.camera.IntrinsicsModel.set_intrinsic_parameters`.)",
+      py::arg("character"),
+      py::arg("model_parameters"),
+      py::arg("intrinsics_model"));
+
+  m.def(
+      "set_camera_intrinsics",
+      [](const mm::Character& character,
+         const mm::IntrinsicsModel& intrinsicsModel,
+         const py::buffer& modelParameters) -> py::array {
+        const auto& pt = character.parameterTransform;
+        const auto nModelParams = static_cast<int>(pt.numAllModelParameters());
+
+        ArrayChecker checker("set_camera_intrinsics");
+        checker.validateBuffer(
+            modelParameters, "model_parameters", {nModelParams}, {"nModelParams"});
+
+        const auto& leadingDims = checker.getLeadingDimensions();
+
+        if (checker.isFloat64()) {
+          return setCameraIntrinsicsImpl<double>(
+              pt, intrinsicsModel, modelParameters, leadingDims, nModelParams);
+        } else {
+          return setCameraIntrinsicsImpl<float>(
+              pt, intrinsicsModel, modelParameters, leadingDims, nModelParams);
+        }
+      },
+      R"(Write camera intrinsic parameter values into model parameters.
+
+Copies the intrinsics model's current parameter values into the corresponding
+slots of the model parameter vector, returning a new array. Parameters not
+present in the parameter transform are silently skipped.
+
+Supports batched input with shape ``(..., n_model_params)``.
+
+:param character: The character with camera intrinsics in its parameter transform.
+:param intrinsics_model: The intrinsics model to read values from.
+:param model_parameters: The model parameter array with shape ``(..., n_model_params)``.
+:return: A new model parameter array with the intrinsics values written in.)",
+      py::arg("character"),
+      py::arg("intrinsics_model"),
+      py::arg("model_parameters"));
+}
+
+} // namespace pymomentum

--- a/pymomentum/solver2/solver2_camera_intrinsics.h
+++ b/pymomentum/solver2/solver2_camera_intrinsics.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace pymomentum {
+
+/// Adds camera intrinsics pybind bindings to the given module.
+void addCameraIntrinsicsBindings(pybind11::module_& m);
+
+} // namespace pymomentum

--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -25,6 +25,7 @@
 #include <pybind11/stl.h>
 #include <Eigen/Core>
 
+#include <pymomentum/solver2/solver2_camera_intrinsics.h>
 #include <pymomentum/solver2/solver2_error_functions.h>
 #include <pymomentum/solver2/solver2_sequence_error_functions.h>
 #include <pymomentum/solver2/solver2_utility.h>
@@ -756,6 +757,8 @@ Note that if you're trying to actually solve a problem using SGD, you should con
       py::arg("solver_function"),
       py::arg("model_params"),
       py::arg("options") = std::optional<mm::SequenceSolverOptions>{});
+
+  addCameraIntrinsicsBindings(m);
 }
 
 } // namespace pymomentum

--- a/pymomentum/test/test_camera.py
+++ b/pymomentum/test/test_camera.py
@@ -533,6 +533,51 @@ class TestCamera(unittest.TestCase):
         # Depth should be unchanged
         np.testing.assert_allclose(crop_proj[:, 2], orig_proj[:, 2], atol=1e-5)
 
+    def test_intrinsics_model_name_and_parameter_names(self) -> None:
+        """Test name property, clone preserving name, and parameter_names for all model types."""
+        # Name property
+        pinhole = pym_camera.PinholeIntrinsicsModel(
+            image_width=640,
+            image_height=480,
+            fx=500.0,
+            fy=500.0,
+        )
+        self.assertEqual(pinhole.name, "")
+        pinhole.name = "cam0"
+        self.assertEqual(pinhole.clone().name, "cam0")
+
+        # parameter_names for each model type
+        self.assertEqual(
+            pinhole.parameter_names,
+            ["fx", "fy", "cx", "cy"],
+        )
+
+        opencv = pym_camera.OpenCVIntrinsicsModel(
+            image_width=640,
+            image_height=480,
+            fx=500.0,
+            fy=500.0,
+            cx=320.0,
+            cy=240.0,
+        )
+        self.assertEqual(len(opencv.parameter_names), 14)
+        self.assertEqual(opencv.parameter_names[:4], ["fx", "fy", "cx", "cy"])
+        self.assertEqual(
+            opencv.parameter_names[4:10], ["k1", "k2", "k3", "k4", "k5", "k6"]
+        )
+        self.assertEqual(opencv.parameter_names[10:14], ["p1", "p2", "p3", "p4"])
+
+        fisheye = pym_camera.OpenCVFisheyeIntrinsicsModel(
+            image_width=640,
+            image_height=480,
+            fx=500.0,
+            fy=500.0,
+        )
+        self.assertEqual(
+            fisheye.parameter_names,
+            ["fx", "fy", "cx", "cy", "k1", "k2", "k3", "k4"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Allow camera intrinsic parameters (fx, fy, cx, cy, distortion coefficients) to participate in the momentum parameter transform system. This adds:

- `name` field and `getParameterNames()` virtual method on `IntrinsicsModelT`, with implementations for Pinhole (4 params), OpenCVFisheye (8 params), and OpenCV (14 params). `clone()` now copies the name.

- `addCameraIntrinsicsParameters()` in a new `camera_intrinsics_parameters.h/.cpp` file in `character_solver/`, following the `addBlendShapeParameters` pattern. Creates named parameter slots ("intrinsics_{cameraName}_{paramName}") with zero transform columns. Idempotent via `subsetParameterTransform`.

- `extractCameraIntrinsics()` and `setCameraIntrinsics()` for reading/writing intrinsic values from/to `ModelParameters`, following the `extractBlendWeights` pattern. Missing parameters gracefully fall back to the model's current values, supporting downselected parameter transforms.

- `getCameraIntrinsicsParameterSet()` / `getAllCameraIntrinsicsParameterSet()` for bitset-based parameter lookup.

- Python bindings: `parameter_names` read-only property and `name` read-write property on `IntrinsicsModel`; `add_camera_intrinsics_parameters()`, `extract_camera_intrinsics()`, and `set_camera_intrinsics()` module functions on `solver2`.

Scope is infrastructure only — Jacobian computation in CameraProjectionErrorFunction is deferred to a follow-up.

Reviewed By: cstollmeta

Differential Revision: D93160000


