### PR TITLE
Add SphericalCap hole filling method

### DIFF
--- a/axel/axel/math/MeshHoleFilling.h
+++ b/axel/axel/math/MeshHoleFilling.h
@@ -27,6 +27,8 @@ enum class HoleFillingMethod {
   Centroid,
   /// Use ear clipping without adding new vertices
   EarClipping,
+  /// Fill with a smooth hemispherical cap (produces smoother SDF gradients near cut boundaries)
+  SphericalCap,
   /// Automatically choose based on hole size (centroid for ≤8 vertices, ear clipping for larger)
   Auto
 };
@@ -88,13 +90,16 @@ std::vector<HoleBoundary> detectMeshHoles(
  * @param vertices Original mesh vertices
  * @param triangles Original mesh triangles
  * @param method Hole filling method (default: Centroid for best triangle quality)
+ * @param capHeightRatio Cap height ratio for SphericalCap method, as a fraction of hole radius
+ *   (0.0 = flat fill, 0.5 = half-hemisphere, 1.0 = full hemisphere). Ignored for other methods.
  * @return Result containing new vertices and triangles, or failure info
  */
 template <typename ScalarType>
 HoleFillingResult fillMeshHoles(
     std::span<const Eigen::Vector3<ScalarType>> vertices,
     std::span<const Eigen::Vector3i> triangles,
-    HoleFillingMethod method = HoleFillingMethod::Centroid);
+    HoleFillingMethod method = HoleFillingMethod::Centroid,
+    float capHeightRatio = 0.5f);
 
 /**
  * Convenience function that fills holes and returns complete mesh.
@@ -102,6 +107,8 @@ HoleFillingResult fillMeshHoles(
  * @param vertices Original mesh vertices
  * @param triangles Original mesh triangles
  * @param method Hole filling method (default: Centroid for best triangle quality)
+ * @param capHeightRatio Cap height ratio for SphericalCap method, as a fraction of hole radius
+ *   (0.0 = flat fill, 0.5 = half-hemisphere, 1.0 = full hemisphere). Ignored for other methods.
  * @return Pair of (all_vertices, all_triangles) with holes filled
  */
 template <typename ScalarType>
@@ -109,7 +116,8 @@ std::pair<std::vector<Eigen::Vector3<ScalarType>>, std::vector<Eigen::Vector3i>>
 fillMeshHolesComplete(
     std::span<const Eigen::Vector3<ScalarType>> vertices,
     std::span<const Eigen::Vector3i> triangles,
-    HoleFillingMethod method = HoleFillingMethod::Centroid);
+    HoleFillingMethod method = HoleFillingMethod::Centroid,
+    float capHeightRatio = 0.5f);
 
 /**
  * Apply Laplacian smoothing to mesh vertices with optional masking.

--- a/axel/axel/math/test/MeshHoleFillingTest.cpp
+++ b/axel/axel/math/test/MeshHoleFillingTest.cpp
@@ -7,6 +7,7 @@
 
 #include "axel/math/MeshHoleFilling.h"
 
+#include <cmath>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -17,25 +18,20 @@ using namespace axel;
 
 class MeshHoleFillingTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    // Set up test data
-  }
-
   /**
-   * Get detailed manifold and winding order statistics using directed edges.
-   * This unified approach checks both manifold properties and winding consistency.
+   * Directed-edge topology statistics for a triangle mesh.
    */
-  struct ManifoldStats {
+  struct TopologyStats {
     size_t totalUndirectedEdges = 0;
     size_t boundaryEdges = 0; // edges with only one direction
-    size_t manifoldEdges = 0; // edges with both directions appearing once each
-    size_t nonManifoldEdges = 0; // edges with duplicate directions
-    size_t inconsistentWindingEdges = 0; // manifold edges where directions don't match properly
-    bool isManifold = false;
+    size_t interiorEdges = 0; // edges with both directions appearing once each
+    size_t nonWatertightEdges = 0; // edges with duplicate directions
+    size_t inconsistentWindingEdges = 0; // edges where winding directions don't match
+    bool isWatertight = false;
     bool hasConsistentWinding = false;
   };
 
-  static ManifoldStats getMeshManifoldStats(
+  static TopologyStats getMeshTopologyStats(
       const std::vector<Eigen::Vector3f>& /*vertices*/,
       const std::vector<Eigen::Vector3i>& triangles) {
     using DirectedEdge = std::pair<Index, Index>;
@@ -45,216 +41,96 @@ class MeshHoleFillingTest : public ::testing::Test {
       }
     };
 
-    ManifoldStats stats;
+    TopologyStats stats;
 
     // Count occurrences of each directed edge
     std::unordered_map<DirectedEdge, size_t, DirectedEdgeHash> directedEdgeCount;
-
     for (const auto& triangle : triangles) {
       const std::array<DirectedEdge, 3> edges = {
           {{triangle[0], triangle[1]}, {triangle[1], triangle[2]}, {triangle[2], triangle[0]}}};
-
       for (const auto& edge : edges) {
         directedEdgeCount[edge]++;
       }
     }
 
-    // Process each undirected edge (check both directions)
+    // Process each undirected edge by checking both directions
     std::unordered_set<DirectedEdge, DirectedEdgeHash> processedEdges;
-
     for (const auto& [directedEdge, forwardCount] : directedEdgeCount) {
       const auto v1 = directedEdge.first;
       const auto v2 = directedEdge.second;
-
-      // Create normalized edge to avoid processing same edge twice
       const auto normalizedEdge = std::make_pair(std::min(v1, v2), std::max(v1, v2));
-
       if (processedEdges.count(normalizedEdge) > 0) {
         continue;
       }
       processedEdges.insert(normalizedEdge);
-
       stats.totalUndirectedEdges++;
 
-      // Check reverse direction
       const DirectedEdge reverseEdge = {v2, v1};
       const size_t reverseCount =
           directedEdgeCount.count(reverseEdge) ? directedEdgeCount[reverseEdge] : 0;
 
-      // Classify the edge based on directed edge counts
       if ((forwardCount == 0 && reverseCount == 1) || (forwardCount == 1 && reverseCount == 0)) {
-        // Boundary edge (only reverse direction)
+        // Boundary edge: appears in only one direction (belongs to one triangle)
         stats.boundaryEdges++;
       } else if (forwardCount == 1 && reverseCount == 1) {
-        // Perfect manifold edge with consistent winding
-        stats.manifoldEdges++;
+        // Interior edge: shared by exactly 2 triangles with opposite winding
+        stats.interiorEdges++;
       } else {
-        // All other cases are non-manifold (shared by != 2 triangles)
-        stats.nonManifoldEdges++;
-
-        // Check if this is specifically a winding issue
-        // Winding is inconsistent when triangles share an edge but all face the same direction
-        // This happens when we have counts like (2, 0), (0, 2), (3, 0), etc.
-        // But (2, 2) or (1, 2) are more general non-manifold issues
+        // Degenerate: edge shared by >2 triangles, or duplicated in the same direction
+        stats.nonWatertightEdges++;
         const size_t totalCount = forwardCount + reverseCount;
+        // Winding-specific issue: all triangles sharing this edge face the same way,
+        // e.g. counts (2,0) or (0,3), rather than a general over-sharing like (1,2).
         if ((totalCount == 2 && (forwardCount == 2 || reverseCount == 2)) ||
             (totalCount > 2 && (forwardCount == 0 || reverseCount == 0))) {
-          // Multiple triangles all facing the same way - also a winding problem
           stats.inconsistentWindingEdges++;
         }
       }
     }
 
-    stats.isManifold = (stats.boundaryEdges == 0 && stats.nonManifoldEdges == 0);
+    stats.isWatertight = (stats.boundaryEdges == 0 && stats.nonWatertightEdges == 0);
     stats.hasConsistentWinding =
         (stats.inconsistentWindingEdges == 0 && stats.totalUndirectedEdges > 0);
-
     return stats;
   }
 
   /**
-   * Check if a mesh is manifold (watertight) with consistent winding.
+   * Verify that hole filling on the given mesh produces a watertight result with consistent
+   * winding.
    */
-  static bool isMeshManifold(
+  static void verifyWatertightAfterFilling(
       const std::vector<Eigen::Vector3f>& vertices,
-      const std::vector<Eigen::Vector3i>& triangles) {
-    const auto stats = getMeshManifoldStats(vertices, triangles);
-    return stats.isManifold;
-  }
+      const std::vector<Eigen::Vector3i>& triangles,
+      HoleFillingMethod method = HoleFillingMethod::Centroid,
+      float capHeightRatio = 0.5f) {
+    const auto originalStats = getMeshTopologyStats(vertices, triangles);
+    ASSERT_GT(originalStats.boundaryEdges, 0) << "Input mesh should have holes for this test";
+    ASSERT_TRUE(originalStats.hasConsistentWinding) << "Input mesh must have consistent winding";
 
-  /**
-   * Helper to verify that hole filling produces manifold meshes.
-   */
-  static void verifyMeshAfterHoleFilling(
-      const std::vector<Eigen::Vector3f>& originalVertices,
-      const std::vector<Eigen::Vector3i>& originalTriangles,
-      const std::string& testName = "") {
-    // Get original mesh stats
-    const auto originalStats = getMeshManifoldStats(originalVertices, originalTriangles);
-
-    std::cout << "\n" << std::string(50, '=') << "\n";
-    std::cout << "MANIFOLD VERIFICATION: " << testName << "\n";
-    std::cout << std::string(50, '=') << "\n";
-
-    std::cout << "\nOriginal mesh:\n";
-    std::cout << "  Total edges: " << originalStats.totalUndirectedEdges << "\n";
-    std::cout << "  Boundary edges (holes): " << originalStats.boundaryEdges << "\n";
-    std::cout << "  Manifold edges: " << originalStats.manifoldEdges << "\n";
-    std::cout << "  Non-manifold edges: " << originalStats.nonManifoldEdges << "\n";
-    std::cout << "  Inconsistent winding edges: " << originalStats.inconsistentWindingEdges << "\n";
-    std::cout << "  Is manifold: " << (originalStats.isManifold ? "YES" : "NO") << "\n";
-    std::cout << "  Has consistent winding: " << (originalStats.hasConsistentWinding ? "YES" : "NO")
-              << "\n";
-
-    // Original mesh should have holes (boundary edges > 0) for this test to be meaningful
-    if (originalStats.boundaryEdges == 0) {
-      std::cout << "  NOTE: Original mesh has no holes - test may not be meaningful\n";
-    }
-
-    // CRITICAL: Input mesh must have consistent winding order
-    // If the input has winding problems, we can't expect the hole filling to fix them
-    EXPECT_TRUE(originalStats.hasConsistentWinding)
-        << "Input mesh must have consistent winding order before hole filling. "
-        << "Inconsistent winding edges: " << originalStats.inconsistentWindingEdges;
-
-    // Fill holes - first get the result to check stats
     const auto result = fillMeshHoles(
-        std::span<const Eigen::Vector3f>(originalVertices),
-        std::span<const Eigen::Vector3i>(originalTriangles));
+        std::span<const Eigen::Vector3f>(vertices),
+        std::span<const Eigen::Vector3i>(triangles),
+        method,
+        capHeightRatio);
+    EXPECT_TRUE(result.success);
+    EXPECT_GT(result.holesFilledCount, 0);
 
-    // Combine into complete mesh for manifold checking
     const auto [filledVertices, filledTriangles] = fillMeshHolesComplete(
-        std::span<const Eigen::Vector3f>(originalVertices),
-        std::span<const Eigen::Vector3i>(originalTriangles));
+        std::span<const Eigen::Vector3f>(vertices),
+        std::span<const Eigen::Vector3i>(triangles),
+        method,
+        capHeightRatio);
+    const auto filledStats = getMeshTopologyStats(filledVertices, filledTriangles);
 
-    // Get filled mesh stats
-    const auto filledStats = getMeshManifoldStats(filledVertices, filledTriangles);
-
-    std::cout << "\nFilled mesh:\n";
-    std::cout << "  Total edges: " << filledStats.totalUndirectedEdges << "\n";
-    std::cout << "  Boundary edges (holes): " << filledStats.boundaryEdges << "\n";
-    std::cout << "  Manifold edges: " << filledStats.manifoldEdges << "\n";
-    std::cout << "  Non-manifold edges: " << filledStats.nonManifoldEdges << "\n";
-    std::cout << "  Inconsistent winding edges: " << filledStats.inconsistentWindingEdges << "\n";
-    std::cout << "  Is manifold: " << (filledStats.isManifold ? "YES" : "NO") << "\n";
-    std::cout << "  Has consistent winding: " << (filledStats.hasConsistentWinding ? "YES" : "NO")
-              << "\n";
-
-    std::cout << "\nChanges:\n";
-    std::cout << "  Added vertices: " << (filledVertices.size() - originalVertices.size()) << "\n";
-    std::cout << "  Added triangles: " << (filledTriangles.size() - originalTriangles.size())
-              << "\n";
-    std::cout << "  Holes filled: " << originalStats.boundaryEdges - filledStats.boundaryEdges
-              << " boundary edges\n";
-
-    // Assertions - Note: Our basic algorithm may not create perfectly manifold meshes in all cases
-    // but should significantly improve the mesh quality
-
-    // The filled mesh should have fewer boundary edges (holes reduced)
-    if (originalStats.boundaryEdges > 0) {
-      EXPECT_LT(filledStats.boundaryEdges, originalStats.boundaryEdges)
-          << "Hole filling should reduce boundary edges";
-    }
-
-    // Should have no non-manifold edges (intersections)
-    EXPECT_EQ(filledStats.nonManifoldEdges, 0) << "Filled mesh should have no non-manifold edges";
-
-    // Should have some manifold edges
-    EXPECT_GT(filledStats.manifoldEdges, 0) << "Filled mesh should have manifold edges";
-
-    // Should preserve or increase manifold edges
-    EXPECT_GE(filledStats.manifoldEdges, originalStats.manifoldEdges)
-        << "Hole filling should preserve or increase manifold edges";
-
-    // Check winding order consistency - this is now part of the manifold stats
-    EXPECT_TRUE(filledStats.hasConsistentWinding)
-        << "Filled mesh should have consistent winding order. Inconsistent winding edges: "
-        << filledStats.inconsistentWindingEdges;
-
-    // Verify holes were actually filled
-    EXPECT_GT(result.holesFilledCount, 0) << "Should have detected and filled at least one hole";
-    EXPECT_GT(result.newTriangles.size(), 0) << "Should have added new triangles to fill holes";
-
-    // For simple cases, expect fully manifold results with ALL holes filled
-    if (originalStats.boundaryEdges <= 6 && originalStats.nonManifoldEdges == 0) {
-      EXPECT_TRUE(filledStats.isManifold) << "Simple cases should produce fully manifold meshes";
-      EXPECT_EQ(filledStats.boundaryEdges, 0)
-          << "Simple cases should have no remaining boundary edges - all holes should be filled";
-    }
+    EXPECT_EQ(filledStats.boundaryEdges, 0)
+        << "Filled mesh should be watertight (no boundary edges)";
+    EXPECT_EQ(filledStats.nonWatertightEdges, 0) << "Filled mesh should have no degenerate edges";
+    EXPECT_TRUE(filledStats.hasConsistentWinding) << "Filled mesh should have consistent winding";
+    EXPECT_TRUE(filledStats.isWatertight) << "Filled mesh should be watertight";
   }
 
-  // Helper to create a simple triangle (no holes)
-  static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>> createTriangle() {
-    std::vector<Eigen::Vector3f> vertices = {
-        Eigen::Vector3f(0.0f, 0.0f, 0.0f),
-        Eigen::Vector3f(1.0f, 0.0f, 0.0f),
-        Eigen::Vector3f(0.5f, 1.0f, 0.0f)};
+  // Helper meshes
 
-    std::vector<Eigen::Vector3i> triangles = {Eigen::Vector3i(0, 1, 2)};
-
-    return {vertices, triangles};
-  }
-
-  // Helper to create a square with a hole (missing one triangle)
-  static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>>
-  createSquareWithHole() {
-    std::vector<Eigen::Vector3f> vertices = {
-        Eigen::Vector3f(0.0f, 0.0f, 0.0f), // 0
-        Eigen::Vector3f(1.0f, 0.0f, 0.0f), // 1
-        Eigen::Vector3f(1.0f, 1.0f, 0.0f), // 2
-        Eigen::Vector3f(0.0f, 1.0f, 0.0f) // 3
-    };
-
-    // Only one triangle, creating a hole
-    std::vector<Eigen::Vector3i> triangles = {
-        Eigen::Vector3i(0, 1, 2)
-        // Missing: Eigen::Vector3i(0, 2, 3)
-    };
-
-    return {vertices, triangles};
-  }
-
-  // Helper to create a tetrahedron with one face missing
   static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>>
   createTetrahedronWithHole() {
     std::vector<Eigen::Vector3f> vertices = {
@@ -263,176 +139,145 @@ class MeshHoleFillingTest : public ::testing::Test {
         Eigen::Vector3f(0.5f, 1.0f, 0.0f),
         Eigen::Vector3f(0.5f, 0.5f, 1.0f)};
 
-    // Three faces of tetrahedron with consistent winding (all facing outward)
-    // For proper winding, adjacent triangles should share edges in opposite directions
+    // Three of four tetrahedron faces, consistent outward-facing winding.
+    // Missing face (2, 3, 0) creates one triangular hole.
     std::vector<Eigen::Vector3i> triangles = {
-        Eigen::Vector3i(0, 1, 2), // Base triangle (looking from above, CCW)
-        Eigen::Vector3i(0, 3, 1), // Side face 1 (shares edge 0-1, reversed)
-        Eigen::Vector3i(1, 3, 2) // Side face 2 (shares edge 1-2 with base, reversed)
-                                 // Missing: Eigen::Vector3i(2, 3, 0) - creates hole
+        Eigen::Vector3i(0, 1, 2), Eigen::Vector3i(0, 3, 1), Eigen::Vector3i(1, 3, 2)};
+
+    return {vertices, triangles};
+  }
+
+  /**
+   * Create an open cylinder (tube) along the Z axis with two circular holes at the ends.
+   * nSegments controls the number of vertices around each ring (≥ 3).
+   */
+  static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>>
+  createOpenCylinder(size_t nSegments = 16, float radius = 1.0f, float halfHeight = 2.0f) {
+    // Bottom ring: vertices [0, nSegments)
+    // Top ring:    vertices [nSegments, 2*nSegments)
+    std::vector<Eigen::Vector3f> vertices;
+    vertices.reserve(2 * nSegments);
+    for (size_t i = 0; i < nSegments; ++i) {
+      const float angle =
+          2.0f * static_cast<float>(M_PI) * static_cast<float>(i) / static_cast<float>(nSegments);
+      const float x = radius * std::cos(angle);
+      const float y = radius * std::sin(angle);
+      vertices.emplace_back(x, y, -halfHeight); // bottom
+    }
+    for (size_t i = 0; i < nSegments; ++i) {
+      const float angle =
+          2.0f * static_cast<float>(M_PI) * static_cast<float>(i) / static_cast<float>(nSegments);
+      const float x = radius * std::cos(angle);
+      const float y = radius * std::sin(angle);
+      vertices.emplace_back(x, y, halfHeight); // top
+    }
+
+    // Side quads split into two triangles each, with consistent outward-facing winding.
+    std::vector<Eigen::Vector3i> triangles;
+    triangles.reserve(2 * nSegments);
+    for (size_t i = 0; i < nSegments; ++i) {
+      const auto i0 = static_cast<int>(i);
+      const auto i1 = static_cast<int>((i + 1) % nSegments);
+      const auto t0 = static_cast<int>(i + nSegments);
+      const auto t1 = static_cast<int>(((i + 1) % nSegments) + nSegments);
+
+      // Two triangles per quad; winding so that normals point outward (radially).
+      triangles.emplace_back(i0, t0, i1);
+      triangles.emplace_back(i1, t0, t1);
+    }
+
+    return {vertices, triangles};
+  }
+
+  /**
+   * Create a flat rectangular frame with a rectangular hole in the center.
+   *
+   *    3-----------2
+   *    |           |
+   *    | 7-------6 |
+   *    | |  HOLE | |
+   *    | |       | |
+   *    | 4-------5 |
+   *    |           |
+   *    0-----------1
+   */
+  static std::pair<std::vector<Eigen::Vector3f>, std::vector<Eigen::Vector3i>>
+  createRectangularFrameWithHole() {
+    std::vector<Eigen::Vector3f> vertices = {
+        // Outer rectangle
+        Eigen::Vector3f(0.0f, 0.0f, 0.0f), // 0 - bottom-left
+        Eigen::Vector3f(4.0f, 0.0f, 0.0f), // 1 - bottom-right
+        Eigen::Vector3f(4.0f, 4.0f, 0.0f), // 2 - top-right
+        Eigen::Vector3f(0.0f, 4.0f, 0.0f), // 3 - top-left
+        // Inner rectangle (forms hole boundary)
+        Eigen::Vector3f(1.0f, 1.0f, 0.0f), // 4 - inner bottom-left
+        Eigen::Vector3f(3.0f, 1.0f, 0.0f), // 5 - inner bottom-right
+        Eigen::Vector3f(3.0f, 3.0f, 0.0f), // 6 - inner top-right
+        Eigen::Vector3f(1.0f, 3.0f, 0.0f), // 7 - inner top-left
+    };
+
+    // Triangles connecting outer and inner rectangles, all with consistent CCW winding.
+    // The inner rectangle edges form a closed loop of boundary edges (the hole).
+    std::vector<Eigen::Vector3i> triangles = {
+        // Bottom strip
+        Eigen::Vector3i(0, 1, 5),
+        Eigen::Vector3i(0, 5, 4),
+        // Right strip
+        Eigen::Vector3i(1, 2, 6),
+        Eigen::Vector3i(1, 6, 5),
+        // Top strip
+        Eigen::Vector3i(2, 3, 7),
+        Eigen::Vector3i(2, 7, 6),
+        // Left strip
+        Eigen::Vector3i(3, 0, 4),
+        Eigen::Vector3i(3, 4, 7),
     };
 
     return {vertices, triangles};
   }
 };
 
-// ================================================================================================
-// HOLE DETECTION TESTS
-// ================================================================================================
+// =============================================================================
+// Sanity: verify topology checker on a known-good closed mesh
+// =============================================================================
 
-TEST_F(MeshHoleFillingTest, DetectNoHoles) {
-  const auto [vertices, triangles] = createTriangle();
-
-  const auto holes = detectMeshHoles(vertices, triangles);
-
-  // A single triangle actually has boundary edges, so it will be detected as having holes
-  // This is correct behavior for our algorithm - it's an "open surface"
-  EXPECT_EQ(holes.size(), 1);
-
-  // But the single hole should be the perimeter of the triangle
-  ASSERT_EQ(holes.size(), 1);
-  const auto& hole = holes[0];
-  EXPECT_EQ(hole.vertices.size(), 3); // Triangle has 3 boundary vertices
-}
-
-TEST_F(MeshHoleFillingTest, DetectSingleHole) {
-  const auto [vertices, triangles] = createSquareWithHole();
-
-  const auto holes = detectMeshHoles(vertices, triangles);
-
-  ASSERT_EQ(holes.size(), 1);
-
-  const auto& hole = holes[0];
-  EXPECT_EQ(hole.vertices.size(), 3); // Three boundary vertices
-  EXPECT_GT(hole.radius, 0.0f);
-
-  // Check that boundary vertices are reasonable
-  for (const auto vertexIdx : hole.vertices) {
-    EXPECT_GE(vertexIdx, 0);
-    EXPECT_LT(vertexIdx, vertices.size());
-  }
-}
-
-TEST_F(MeshHoleFillingTest, DetectMultipleHoles) {
-  const auto [vertices, triangles] = createTetrahedronWithHole();
-
-  const auto holes = detectMeshHoles(vertices, triangles);
-
-  ASSERT_EQ(holes.size(), 1);
-
-  const auto& hole = holes[0];
-  EXPECT_EQ(hole.vertices.size(), 3); // Triangular hole
-  EXPECT_GT(hole.radius, 0.0f);
-}
-
-// ================================================================================================
-// HOLE FILLING TESTS
-// ================================================================================================
-
-TEST_F(MeshHoleFillingTest, FillNoHoles) {
-  const auto [vertices, triangles] = createTriangle();
-
-  const auto result = fillMeshHoles(
-      std::span<const Eigen::Vector3f>(vertices), std::span<const Eigen::Vector3i>(triangles));
-
-  EXPECT_TRUE(result.success);
-  // A single triangle will be detected as having a hole (the perimeter), so it will be filled
-  EXPECT_EQ(result.holesFilledCount, 1);
-  EXPECT_EQ(result.newVertices.size(), 0); // Centroid vertex added
-  EXPECT_EQ(result.newTriangles.size(), 1); // Fan triangulation from centroid
-}
-
-TEST_F(MeshHoleFillingTest, FillSingleSmallHole) {
-  const auto [vertices, triangles] = createSquareWithHole();
-
-  const auto result = fillMeshHoles(
-      std::span<const Eigen::Vector3f>(vertices), std::span<const Eigen::Vector3i>(triangles));
-
-  EXPECT_TRUE(result.success);
-  EXPECT_EQ(result.holesFilledCount, 1);
-
-  // For 3-vertex holes, algorithm uses direct triangulation (more efficient)
-  EXPECT_EQ(result.newVertices.size(), 0);
-  EXPECT_EQ(result.newTriangles.size(), 1); // Direct triangulation
-
-  // Validate new triangles reference valid vertices
-  for (const auto& triangle : result.newTriangles) {
-    for (int i = 0; i < 3; ++i) {
-      const auto vertexIdx = triangle[i];
-      EXPECT_TRUE(
-          vertexIdx < vertices.size() || // Original vertex
-          vertexIdx >= vertices.size() // New vertex (adjusted later)
-      );
-    }
-  }
-
-  // Verify that hole filling produces a manifold mesh
-  verifyMeshAfterHoleFilling(vertices, triangles, "Single Small Hole");
-}
-
-TEST_F(MeshHoleFillingTest, FillLargerHole) {
-  // Create a larger hole scenario
-  std::vector<Eigen::Vector3f> vertices = {
-      Eigen::Vector3f(0.0f, 0.0f, 0.0f), // 0
-      Eigen::Vector3f(1.0f, 0.0f, 0.0f), // 1
-      Eigen::Vector3f(2.0f, 0.0f, 0.0f), // 2
-      Eigen::Vector3f(2.0f, 1.0f, 0.0f), // 3
-      Eigen::Vector3f(1.0f, 1.0f, 0.0f), // 4
-      Eigen::Vector3f(0.0f, 1.0f, 0.0f), // 5
-      Eigen::Vector3f(0.0f, 2.0f, 0.0f), // 6
-      Eigen::Vector3f(1.0f, 2.0f, 0.0f) // 7
+TEST_F(MeshHoleFillingTest, TopologyStatsOnClosedCube) {
+  std::vector<Eigen::Vector3f> cubeVertices = {
+      Eigen::Vector3f(-1, -1, -1),
+      Eigen::Vector3f(1, -1, -1),
+      Eigen::Vector3f(1, 1, -1),
+      Eigen::Vector3f(-1, 1, -1),
+      Eigen::Vector3f(-1, -1, 1),
+      Eigen::Vector3f(1, -1, 1),
+      Eigen::Vector3f(1, 1, 1),
+      Eigen::Vector3f(-1, 1, 1),
   };
 
-  // Create triangles around a hexagonal hole
-  std::vector<Eigen::Vector3i> triangles = {
-      Eigen::Vector3i(0, 1, 4),
-      Eigen::Vector3i(0, 4, 5),
-      Eigen::Vector3i(5, 4, 7),
-      Eigen::Vector3i(5, 7, 6)
-      // Center area forms a hole bounded by vertices 1,2,3,4,7,6,5,0 (or subset)
+  std::vector<Eigen::Vector3i> cubeTriangles = {
+      Eigen::Vector3i(0, 2, 1),
+      Eigen::Vector3i(0, 3, 2), // bottom
+      Eigen::Vector3i(4, 5, 6),
+      Eigen::Vector3i(4, 6, 7), // top
+      Eigen::Vector3i(0, 1, 5),
+      Eigen::Vector3i(0, 5, 4), // front
+      Eigen::Vector3i(2, 7, 6),
+      Eigen::Vector3i(2, 3, 7), // back
+      Eigen::Vector3i(0, 4, 7),
+      Eigen::Vector3i(0, 7, 3), // left
+      Eigen::Vector3i(1, 2, 6),
+      Eigen::Vector3i(1, 6, 5), // right
   };
 
-  const auto result = fillMeshHoles(
-      std::span<const Eigen::Vector3f>(vertices), std::span<const Eigen::Vector3i>(triangles));
-
-  EXPECT_TRUE(result.success);
-  EXPECT_GT(result.holesFilledCount, 0);
-  EXPECT_GT(result.newTriangles.size(), 0);
-
-  // Verify manifold properties
-  verifyMeshAfterHoleFilling(vertices, triangles, "Larger Hole");
+  const auto stats = getMeshTopologyStats(cubeVertices, cubeTriangles);
+  EXPECT_TRUE(stats.isWatertight);
+  EXPECT_EQ(stats.boundaryEdges, 0);
+  EXPECT_EQ(stats.nonWatertightEdges, 0);
+  EXPECT_TRUE(stats.hasConsistentWinding);
 }
 
-// ================================================================================================
-// COMPLETE MESH TESTS
-// ================================================================================================
-
-TEST_F(MeshHoleFillingTest, FillMeshHolesComplete) {
-  const auto [vertices, triangles] = createSquareWithHole();
-
-  const auto [allVertices, allTriangles] = fillMeshHolesComplete(
-      std::span<const Eigen::Vector3f>(vertices), std::span<const Eigen::Vector3i>(triangles));
-
-  // Should have original + new triangles (vertices may be same for small holes using direct
-  // triangulation)
-  EXPECT_GE(
-      allVertices.size(), vertices.size()); // Greater or equal (no new vertices for 3-vertex holes)
-  EXPECT_GT(allTriangles.size(), triangles.size()); // Should always have more triangles
-
-  // Original vertices should be preserved at the beginning
-  for (size_t i = 0; i < vertices.size(); ++i) {
-    EXPECT_EQ(allVertices[i], vertices[i]);
-  }
-
-  // Original triangles should be preserved at the beginning
-  for (size_t i = 0; i < triangles.size(); ++i) {
-    EXPECT_EQ(allTriangles[i], triangles[i]);
-  }
-}
-
-// ================================================================================================
-// EDGE CASE TESTS
-// ================================================================================================
+// =============================================================================
+// Edge case: empty mesh
+// =============================================================================
 
 TEST_F(MeshHoleFillingTest, EmptyMesh) {
   std::vector<Eigen::Vector3f> vertices;
@@ -443,177 +288,242 @@ TEST_F(MeshHoleFillingTest, EmptyMesh) {
 
   const auto result = fillMeshHoles(
       std::span<const Eigen::Vector3f>(vertices), std::span<const Eigen::Vector3i>(triangles));
-
-  EXPECT_TRUE(result.success); // Should succeed with no work to do
+  EXPECT_TRUE(result.success);
   EXPECT_EQ(result.holesFilledCount, 0);
 }
 
-TEST_F(MeshHoleFillingTest, SingleTriangleMesh) {
-  const auto [vertices, triangles] = createTriangle();
+// =============================================================================
+// Watertight after Centroid fill
+// =============================================================================
 
-  // Single triangle has boundary edges, so it will be detected as having holes
-  const auto holes = detectMeshHoles(vertices, triangles);
-  EXPECT_EQ(holes.size(), 1);
-
-  // Hole filling will fill the perimeter
-  const auto result = fillMeshHoles(
-      std::span<const Eigen::Vector3f>(vertices), std::span<const Eigen::Vector3i>(triangles));
-
-  EXPECT_TRUE(result.success);
-  EXPECT_EQ(result.holesFilledCount, 1);
+TEST_F(MeshHoleFillingTest, WatertightAfterCentroidFill_Tetrahedron) {
+  const auto [vertices, triangles] = createTetrahedronWithHole();
+  verifyWatertightAfterFilling(vertices, triangles, HoleFillingMethod::Centroid);
 }
 
-TEST_F(MeshHoleFillingTest, DegenerateTriangles) {
-  // Create mesh with degenerate triangles (collinear points)
-  std::vector<Eigen::Vector3f> vertices = {
-      Eigen::Vector3f(0.0f, 0.0f, 0.0f),
-      Eigen::Vector3f(1.0f, 0.0f, 0.0f),
-      Eigen::Vector3f(2.0f, 0.0f, 0.0f) // Collinear with previous two
-  };
-
-  std::vector<Eigen::Vector3i> triangles = {Eigen::Vector3i(0, 1, 2)};
-
-  // Should handle gracefully without crashing
-  const auto holes = detectMeshHoles(vertices, triangles);
-  // May or may not detect holes depending on tolerance, but shouldn't crash
-
-  const auto result = fillMeshHoles(
-      std::span<const Eigen::Vector3f>(vertices), std::span<const Eigen::Vector3i>(triangles));
-
-  // Should not crash, may or may not succeed
-  // Just check that result is valid and doesn't crash accessing it
-  EXPECT_TRUE(result.success || !result.success); // Always true, but accesses result.success
+TEST_F(MeshHoleFillingTest, WatertightAfterCentroidFill_RectangularFrame) {
+  const auto [vertices, triangles] = createRectangularFrameWithHole();
+  verifyWatertightAfterFilling(vertices, triangles, HoleFillingMethod::Centroid);
 }
 
-// ================================================================================================
-// MANIFOLD VERIFICATION TESTS
-// ================================================================================================
+// =============================================================================
+// Watertight after SphericalCap fill
+// =============================================================================
 
-TEST_F(MeshHoleFillingTest, TetrahedronHoleFillingManifoldCheck) {
+TEST_F(MeshHoleFillingTest, WatertightAfterSphericalCapFill_Tetrahedron) {
+  const auto [vertices, triangles] = createTetrahedronWithHole();
+  verifyWatertightAfterFilling(vertices, triangles, HoleFillingMethod::SphericalCap, 0.5f);
+}
+
+TEST_F(MeshHoleFillingTest, WatertightAfterSphericalCapFill_RectangularFrame) {
+  const auto [vertices, triangles] = createRectangularFrameWithHole();
+  verifyWatertightAfterFilling(vertices, triangles, HoleFillingMethod::SphericalCap, 0.5f);
+}
+
+// =============================================================================
+// SphericalCap: new vertices should lie on a spherical cap surface
+// =============================================================================
+
+TEST_F(MeshHoleFillingTest, SphericalCapVerticesOnSphere) {
   const auto [vertices, triangles] = createTetrahedronWithHole();
 
-  // Verify tetrahedron with hole filling produces manifold mesh
-  verifyMeshAfterHoleFilling(vertices, triangles, "Tetrahedron with Missing Face");
+  const auto holes = detectMeshHoles(vertices, triangles);
+  ASSERT_EQ(holes.size(), 1);
+  const auto& hole = holes[0];
+
+  // Compute centroid, radius, and normal of the hole boundary
+  Eigen::Vector3f centroid = Eigen::Vector3f::Zero();
+  for (const auto idx : hole.vertices) {
+    centroid += vertices[idx];
+  }
+  centroid /= static_cast<float>(hole.vertices.size());
+
+  float avgRadius = 0.0f;
+  for (const auto idx : hole.vertices) {
+    avgRadius += (vertices[idx] - centroid).norm();
+  }
+  avgRadius /= static_cast<float>(hole.vertices.size());
+
+  const float capHeightRatio = 0.5f;
+  const auto result = fillMeshHoles(
+      std::span<const Eigen::Vector3f>(vertices),
+      std::span<const Eigen::Vector3i>(triangles),
+      HoleFillingMethod::SphericalCap,
+      capHeightRatio);
+
+  ASSERT_TRUE(result.success);
+  ASSERT_GT(result.newVertices.size(), 0);
+
+  // The spherical cap creates ring vertices that interpolate between the boundary
+  // and a pole at distance capHeightRatio * radius along the normal.  Each ring k
+  // (out of nRings) has radius factor cos(theta) and offset capH * R * sin(theta)
+  // where theta = k/nRings * pi/2.  This means each ring vertex, when projected
+  // back, satisfies:   (r/R)^2 + (h / (capH * R))^2  ≈  1
+  // where r = distance from centroid projected onto boundary plane,
+  //       h = distance along normal from boundary plane.
+  // We verify this invariant for every new vertex (excluding the pole, which
+  // sits at (0, capH * R) and trivially satisfies it).
+
+  // Compute hole normal
+  const auto& v0 = vertices[hole.vertices[0]];
+  const auto& v1 = vertices[hole.vertices[1]];
+  const auto& v2 = vertices[hole.vertices[2]];
+  const Eigen::Vector3f holeNormal = (v1 - v0).cross(v2 - v0).normalized();
+
+  for (size_t i = 0; i < result.newVertices.size(); ++i) {
+    const auto& v = result.newVertices[i];
+    const Eigen::Vector3f diff = v - centroid;
+    const float h = std::abs(diff.dot(holeNormal));
+    const Eigen::Vector3f inPlane = diff - diff.dot(holeNormal) * holeNormal;
+    const float r = inPlane.norm();
+
+    // For the pole vertex (r ≈ 0), the "sphere" relation degenerates; just check
+    // that it's at approximately capHeightRatio * radius distance along the normal.
+    if (r < 1e-4f) {
+      EXPECT_NEAR(h, capHeightRatio * avgRadius, avgRadius * 0.15f)
+          << "Pole vertex should be at capHeightRatio * radius from centroid";
+      continue;
+    }
+
+    // Check that (r/R)^2 + (h / (capH*R))^2 ≈ 1
+    const float rNorm = r / avgRadius;
+    const float hNorm = h / (capHeightRatio * avgRadius);
+    const float sphereEq = rNorm * rNorm + hNorm * hNorm;
+    EXPECT_NEAR(sphereEq, 1.0f, 0.15f)
+        << "New vertex " << i << " should lie on the spherical cap surface";
+  }
 }
 
-TEST_F(MeshHoleFillingTest, FillRectangularInteriorHole) {
-  // Create a rectangular frame mesh with an interior rectangular hole
-  //
-  // Visual representation (looking down at XY plane, Z=0):
-  //
-  //   Outer rectangle: 0-1-2-3
-  //   Inner rectangle: 4-5-6-7 (forms the hole boundary)
-  //
-  //    3-----------2
-  //    |           |
-  //    | 7-------6 |
-  //    | |  HOLE | |
-  //    | |       | |
-  //    | 4-------5 |
-  //    |           |
-  //    0-----------1
-  //
-  //   The mesh is constructed with triangles connecting outer and inner rectangles,
-  //   leaving the center open (hole). All triangles have consistent CCW winding.
+// =============================================================================
+// SphericalCap: capHeightRatio=0 produces vertices in the hole plane
+// =============================================================================
 
-  std::vector<Eigen::Vector3f> vertices = {
-      // Outer rectangle (larger)
-      Eigen::Vector3f(0.0f, 0.0f, 0.0f), // 0 - bottom-left
-      Eigen::Vector3f(4.0f, 0.0f, 0.0f), // 1 - bottom-right
-      Eigen::Vector3f(4.0f, 4.0f, 0.0f), // 2 - top-right
-      Eigen::Vector3f(0.0f, 4.0f, 0.0f), // 3 - top-left
-      // Inner rectangle (forms hole boundary)
-      Eigen::Vector3f(1.0f, 1.0f, 0.0f), // 4 - inner bottom-left
-      Eigen::Vector3f(3.0f, 1.0f, 0.0f), // 5 - inner bottom-right
-      Eigen::Vector3f(3.0f, 3.0f, 0.0f), // 6 - inner top-right
-      Eigen::Vector3f(1.0f, 3.0f, 0.0f), // 7 - inner top-left
-  };
+TEST_F(MeshHoleFillingTest, SphericalCapFlatWhenHeightZero) {
+  const auto [vertices, triangles] = createTetrahedronWithHole();
 
-  std::vector<Eigen::Vector3i> triangles = {
-      // Bottom strip (between outer[0-1] and inner[4-5])
-      Eigen::Vector3i(0, 1, 5), // CCW winding
-      Eigen::Vector3i(0, 5, 4), // CCW winding, shares edge 0-5 reversed
+  const auto [capVertices, capTriangles] = fillMeshHolesComplete(
+      std::span<const Eigen::Vector3f>(vertices),
+      std::span<const Eigen::Vector3i>(triangles),
+      HoleFillingMethod::SphericalCap,
+      0.0f);
 
-      // Right strip (between outer[1-2] and inner[5-6])
-      Eigen::Vector3i(1, 2, 6), // CCW winding
-      Eigen::Vector3i(1, 6, 5), // CCW winding, shares edge 1-6 reversed
+  // Should still be watertight
+  const auto stats = getMeshTopologyStats(capVertices, capTriangles);
+  EXPECT_TRUE(stats.isWatertight);
+  EXPECT_TRUE(stats.hasConsistentWinding);
+  EXPECT_EQ(stats.boundaryEdges, 0);
 
-      // Top strip (between outer[2-3] and inner[6-7])
-      Eigen::Vector3i(2, 3, 7), // CCW winding
-      Eigen::Vector3i(2, 7, 6), // CCW winding, shares edge 2-7 reversed
+  // All new vertices should lie in the plane of the hole boundary
+  const auto holes = detectMeshHoles(vertices, triangles);
+  ASSERT_EQ(holes.size(), 1);
+  const auto& hole = holes[0];
 
-      // Left strip (between outer[3-0] and inner[7-4])
-      Eigen::Vector3i(3, 0, 4), // CCW winding
-      Eigen::Vector3i(3, 4, 7), // CCW winding, shares edge 3-4 reversed
+  const auto& v0 = vertices[hole.vertices[0]];
+  const auto& v1 = vertices[hole.vertices[1]];
+  const auto& v2 = vertices[hole.vertices[2]];
+  const Eigen::Vector3f holeNormal = (v1 - v0).cross(v2 - v0).normalized();
+  const float planeDist = holeNormal.dot(v0);
 
-      // The inner rectangle (4-5-6-7) edges form a closed loop of boundary edges
-      // This is the HOLE that should be detected and filled
-  };
-
-  // Verify the original mesh has the expected properties
-  const auto originalStats = getMeshManifoldStats(vertices, triangles);
-
-  // Should have boundary edges: 4 on outer perimeter + 4 on inner hole = 8 total
-  EXPECT_GT(originalStats.boundaryEdges, 0) << "Should have boundary edges";
-  EXPECT_EQ(originalStats.boundaryEdges, 8)
-      << "Should have 8 boundary edges (4 outer + 4 inner hole)";
-
-  // Should not be manifold due to the holes (outer perimeter and inner hole)
-  EXPECT_FALSE(originalStats.isManifold) << "Original mesh should not be manifold (has holes)";
-
-  // Should have consistent winding
-  EXPECT_TRUE(originalStats.hasConsistentWinding) << "Input mesh should have consistent winding";
-
-  // Verify hole filling works correctly
-  verifyMeshAfterHoleFilling(vertices, triangles, "Rectangular Frame with Interior Hole");
+  for (size_t i = vertices.size(); i < capVertices.size(); ++i) {
+    const float dist = std::abs(holeNormal.dot(capVertices[i]) - planeDist);
+    EXPECT_NEAR(dist, 0.0f, 0.01f)
+        << "With capHeightRatio=0, new vertex " << i << " should be in the hole plane";
+  }
 }
 
-TEST_F(MeshHoleFillingTest, ManifoldStatsAccuracy) {
-  // Test our manifold checking on a known good mesh (closed cube)
-  std::vector<Eigen::Vector3f> cubeVertices = {
-      Eigen::Vector3f(-1.0f, -1.0f, -1.0f), // 0
-      Eigen::Vector3f(1.0f, -1.0f, -1.0f), // 1
-      Eigen::Vector3f(1.0f, 1.0f, -1.0f), // 2
-      Eigen::Vector3f(-1.0f, 1.0f, -1.0f), // 3
-      Eigen::Vector3f(-1.0f, -1.0f, 1.0f), // 4
-      Eigen::Vector3f(1.0f, -1.0f, 1.0f), // 5
-      Eigen::Vector3f(1.0f, 1.0f, 1.0f), // 6
-      Eigen::Vector3f(-1.0f, 1.0f, 1.0f), // 7
-  };
+// =============================================================================
+// Cylinder capped with hemispheres: watertight + cap vertices on sphere
+// =============================================================================
 
-  std::vector<Eigen::Vector3i> cubeTriangles = {
-      // Bottom face (z = -1)
-      Eigen::Vector3i(0, 2, 1),
-      Eigen::Vector3i(0, 3, 2),
-      // Top face (z = 1)
-      Eigen::Vector3i(4, 5, 6),
-      Eigen::Vector3i(4, 6, 7),
-      // Front face (y = -1)
-      Eigen::Vector3i(0, 1, 5),
-      Eigen::Vector3i(0, 5, 4),
-      // Back face (y = 1)
-      Eigen::Vector3i(2, 7, 6),
-      Eigen::Vector3i(2, 3, 7),
-      // Left face (x = -1)
-      Eigen::Vector3i(0, 4, 7),
-      Eigen::Vector3i(0, 7, 3),
-      // Right face (x = 1)
-      Eigen::Vector3i(1, 2, 6),
-      Eigen::Vector3i(1, 6, 5),
-  };
+TEST_F(MeshHoleFillingTest, CylinderCappedWithHemispheres) {
+  const float radius = 1.0f;
+  const float halfHeight = 2.0f;
+  const float capHeightRatio = 1.0f; // full hemisphere
+  const auto [vertices, triangles] = createOpenCylinder(16, radius, halfHeight);
 
-  const auto cubeStats = getMeshManifoldStats(cubeVertices, cubeTriangles);
+  // The open cylinder should have two holes (top and bottom rings)
+  const auto holes = detectMeshHoles(vertices, triangles);
+  EXPECT_EQ(holes.size(), 2);
 
-  // A closed cube should be perfectly manifold
-  EXPECT_TRUE(cubeStats.isManifold) << "Closed cube should be manifold";
-  EXPECT_EQ(cubeStats.boundaryEdges, 0) << "Closed cube should have no boundary edges";
-  EXPECT_EQ(cubeStats.nonManifoldEdges, 0) << "Closed cube should have no non-manifold edges";
-  EXPECT_GT(cubeStats.manifoldEdges, 0) << "Closed cube should have manifold edges";
-  EXPECT_EQ(cubeStats.totalUndirectedEdges, cubeStats.manifoldEdges)
-      << "All edges should be manifold";
+  // Fill with spherical caps
+  const auto [filledVertices, filledTriangles] = fillMeshHolesComplete(
+      std::span<const Eigen::Vector3f>(vertices),
+      std::span<const Eigen::Vector3i>(triangles),
+      HoleFillingMethod::SphericalCap,
+      capHeightRatio);
 
-  std::cout << "Closed cube manifold stats:\n";
-  std::cout << "  Total edges: " << cubeStats.totalUndirectedEdges << "\n";
-  std::cout << "  Manifold edges: " << cubeStats.manifoldEdges << "\n";
-  std::cout << "  Expected edges for cube: 18 (6 faces × 3 edges/face ÷ 2 shared)\n";
+  // Should be watertight
+  const auto stats = getMeshTopologyStats(filledVertices, filledTriangles);
+  EXPECT_TRUE(stats.isWatertight) << "Capped cylinder should be watertight";
+  EXPECT_EQ(stats.boundaryEdges, 0) << "Capped cylinder should have no boundary edges";
+  EXPECT_EQ(stats.nonWatertightEdges, 0);
+  EXPECT_TRUE(stats.hasConsistentWinding);
+
+  // Verify that the new cap vertices lie on hemispheres.
+  // Each cap is centered at the centroid of a circular ring (which is on the Z axis)
+  // with radius equal to the cylinder radius.  For capHeightRatio=1, vertices should
+  // satisfy  (r/R)^2 + (h/(capH*R))^2 ≈ 1  where r is the in-plane distance from
+  // the ring centroid and h is the distance along the cap normal.
+  // Since fillMeshHoles returns vertices for all caps combined, we check each new
+  // vertex against the nearest cap centroid.
+  std::vector<Eigen::Vector3f> capCentroids;
+  std::vector<float> capRadii;
+  for (const auto& hole : holes) {
+    Eigen::Vector3f centroid = Eigen::Vector3f::Zero();
+    for (const auto idx : hole.vertices) {
+      centroid += vertices[idx];
+    }
+    centroid /= static_cast<float>(hole.vertices.size());
+    capCentroids.push_back(centroid);
+
+    float avgR = 0.0f;
+    for (const auto idx : hole.vertices) {
+      avgR += (vertices[idx] - centroid).norm();
+    }
+    avgR /= static_cast<float>(hole.vertices.size());
+    capRadii.push_back(avgR);
+  }
+
+  const auto result = fillMeshHoles(
+      std::span<const Eigen::Vector3f>(vertices),
+      std::span<const Eigen::Vector3i>(triangles),
+      HoleFillingMethod::SphericalCap,
+      capHeightRatio);
+
+  for (size_t vi = 0; vi < result.newVertices.size(); ++vi) {
+    const auto& v = result.newVertices[vi];
+
+    // Find the nearest cap centroid
+    size_t nearest = 0;
+    float nearestDist = (v - capCentroids[0]).squaredNorm();
+    for (size_t ci = 1; ci < capCentroids.size(); ++ci) {
+      const float d = (v - capCentroids[ci]).squaredNorm();
+      if (d < nearestDist) {
+        nearestDist = d;
+        nearest = ci;
+      }
+    }
+
+    const auto& centroid = capCentroids[nearest];
+    const float avgR = capRadii[nearest];
+    // Cap normal points outward along Z
+    const Eigen::Vector3f normal = Eigen::Vector3f(0.0f, 0.0f, centroid.z() > 0 ? 1.0f : -1.0f);
+
+    const Eigen::Vector3f diff = v - centroid;
+    const float h = std::abs(diff.dot(normal));
+    const Eigen::Vector3f inPlane = diff - diff.dot(normal) * normal;
+    const float r = inPlane.norm();
+
+    if (r < 1e-4f) {
+      EXPECT_NEAR(h, capHeightRatio * avgR, avgR * 0.15f)
+          << "Pole vertex should be at capHeightRatio * radius from cap centroid";
+      continue;
+    }
+
+    const float rNorm = r / avgR;
+    const float hNorm = h / (capHeightRatio * avgR);
+    const float sphereEq = rNorm * rNorm + hNorm * hNorm;
+    EXPECT_NEAR(sphereEq, 1.0f, 0.15f)
+        << "Cap vertex " << vi << " should lie on hemisphere surface";
+  }
 }


### PR DESCRIPTION
Summary:
Add a new SphericalCap hole filling method that fills mesh holes with a smooth hemispherical cap surface. This produces smoother SDF gradients near cut boundaries compared to centroid or ear clipping methods. The cap height is configurable (0.0 = flat fill, 1.0 = full hemisphere, default 0.5).

Also updates the Python bindings and .pyi stubs for the new method and cap_height parameter.

Reviewed By: jeongseok-meta

Differential Revision: D92902750


