### PR TITLE
Fix TensorAccessor dimension error in rasterize_transforms

### DIFF
--- a/pymomentum/renderer/software_rasterizer.cpp
+++ b/pymomentum/renderer/software_rasterizer.cpp
@@ -1735,7 +1735,8 @@ void rasterizeTransforms(
   // We don't expect batched to be the common case, so don't try to process
   // the batches in parallel
 
-  auto a = transforms.accessor<float, 3>();
+  const auto transformsCur = transforms.select(0, 0);
+  const auto a = transformsCur.accessor<float, 3>();
 
   for (int i = 0; i < nTransforms; ++i) {
     const Eigen::Vector3f origin(a[i][0][3], a[i][1][3], a[i][2][3]);


### PR DESCRIPTION
Summary:
Fixes RuntimeError "TensorAccessor expected 3 dims but tensor has 4" in `rasterize_transforms` when passing transform tensors.

The bug occurred because the code was creating a 3D accessor directly on the `transforms` tensor, but the tensor after `checker.validateAndFixTensor` is unsqueezed to have a leading batch dimension. The fix selects the first element (index 0) from the batch dimension using `transforms.select(0, 0)` before creating the accessor, ensuring the accessor receives a 3D tensor as expected.

Differential Revision: D93453081


