### PR TITLE
Remove unused AUTOGRAD_ENABLED flag from solver2

### DIFF
--- a/pymomentum/solver2/solver2_pybind.cpp
+++ b/pymomentum/solver2/solver2_pybind.cpp
@@ -109,12 +109,6 @@ PYBIND11_MODULE(solver2, m) {
   m.attr("__name__") = "pymomentum.solver2";
   m.doc() = "Inverse kinematics and other optimizations for momentum models.";
 
-#ifdef PYMOMENTUM_LIMITED_TORCH_API
-  m.attr("AUTOGRAD_ENABLED") = false;
-#else
-  m.attr("AUTOGRAD_ENABLED") = true;
-#endif
-
   pybind11::module_::import(
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry
   pybind11::module_::import("pymomentum.camera"); // @dep=fbsource//arvr/libraries/pymomentum:camera


### PR DESCRIPTION
Summary: The solver2 module is not differentiable and doesn't use torch autograd, so the AUTOGRAD_ENABLED flag was unnecessary. This removes the flag from the C++ pybind module, removes the PYMOMENTUM_LIMITED_TORCH_API_FLAGS compiler flag from the solver2 BUCK target (since it was only used for this flag), and regenerates the .pyi stub file.

Reviewed By: fbogo

Differential Revision: D93671255
