### PR TITLE
Fix geometry stubgen for SDFCollider types

### DIFF
--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -77,6 +77,10 @@ PYBIND11_MODULE(geometry, m) {
   m.doc() = "Geometry and forward kinematics for momentum models.  ";
   m.attr("__name__") = "pymomentum.geometry";
 
+  // Import the axel module so pybind11 can resolve axel types
+  // (e.g. axel::SignedDistanceField<float> used by SDFCollider).
+  py::module_::import("pymomentum.axel");
+
   m.attr("PARAMETERS_PER_JOINT") = mm::kParametersPerJoint;
 
   py::enum_<mm::FbxUpVector>(m, "FbxUpVector")

--- a/pymomentum/geometry/sdf_collider_pybind.cpp
+++ b/pymomentum/geometry/sdf_collider_pybind.cpp
@@ -10,6 +10,7 @@
 #include <axel/SignedDistanceField.h>
 #include <momentum/character/sdf_collision_geometry.h>
 #include <momentum/math/constants.h>
+#include <pymomentum/python_utility/eigen_quaternion.h>
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>


### PR DESCRIPTION
Summary:
The geometry stubgen was emitting raw C++ type names (`Eigen::Quaternion<float, 0>` and `axel::SignedDistanceField<float>`) in geometry.pyi, causing a syntax error during formatting. Two root causes:

1. `sdf_collider_pybind.cpp` was missing `#include <pymomentum/python_utility/eigen_quaternion.h>`, so pybind11 didn't know to convert `Eigen::Quaternionf` to a numpy array. Adding this include registers the type caster that maps quaternions to `[x, y, z, w]` numpy arrays.

2. The `pymomentum.axel` module wasn't imported when geometry loaded, so pybind11 couldn't resolve `axel::SignedDistanceField<float>` to its registered Python type. Adding `py::module_::import("pymomentum.axel")` in the geometry module init and adding `:axel` to `python_typing_deps` and `stub_deps` fixes the cross-module type resolution.

Reviewed By: fbogo

Differential Revision: D93700500


