### PR TITLE
Fix -Wnontrivial-memcall warnings by adding void* cast

### DIFF
--- a/momentum/io/gltf/utils/accessor_utils.h
+++ b/momentum/io/gltf/utils/accessor_utils.h
@@ -79,7 +79,7 @@ std::vector<T> copyAccessorBuffer(const fx::gltf::Document& model, int32_t id) {
 
   std::vector<T> r(accessor.count);
   for (size_t i = 0; i < accessor.count; i++) {
-    std::memcpy(&r[i], &bytes[i * stride], elsize);
+    std::memcpy(static_cast<void*>(&r[i]), &bytes[i * stride], elsize);
   }
 
   return r;
@@ -117,7 +117,7 @@ std::vector<T> copyAlignedAccessorBuffer(const fx::gltf::Document& model, int32_
 
   std::vector<T> r(accessor.count);
   for (size_t i = 0; i < accessor.count; i++) {
-    std::memcpy(&r[i], &bytes[i * stride], elsize);
+    std::memcpy(static_cast<void*>(&r[i]), &bytes[i * stride], elsize);
   }
 
   return r;


### PR DESCRIPTION
Summary:
Clang 21 introduces `-Wnontrivial-memcall` which warns when memcpy/memset is used on non-trivially copyable types. These are all cases where POD-like types (math vectors, matrices, UBOs, structs) are intentionally treated as raw bytes.
The fix is to cast the first argument to `void*` to explicitly acknowledge the raw byte operation.

Differential Revision: D94173256


