### PR TITLE
Support kInvalidIndex parent in capsule collision and fix scale-radius gradient (#1065)

### DIFF
--- a/momentum/character/collision_geometry_state.cpp
+++ b/momentum/character/collision_geometry_state.cpp
@@ -8,6 +8,7 @@
 #include "momentum/character/collision_geometry_state.h"
 
 #include "momentum/character/skeleton_state.h"
+#include "momentum/character/types.h"
 
 namespace momentum {
 
@@ -25,11 +26,13 @@ void CollisionGeometryStateT<T>::update(
   // calculate data from the geometry (can be parallelized)
   for (size_t i = 0; i < numElements; ++i) {
     const auto& tc = collisionGeometry[i];
-    const auto& js = skeletonState.jointState[tc.parent];
-    const TransformT<T> transform = js.transform * tc.transformation.cast<T>();
+    const TransformT<T> parentTransform = (tc.parent == kInvalidIndex)
+        ? TransformT<T>()
+        : skeletonState.jointState[tc.parent].transform;
+    const TransformT<T> transform = parentTransform * tc.transformation.cast<T>();
     origin[i] = transform.translation;
     direction[i].noalias() = transform.getAxisX() * transform.scale * tc.length;
-    radius[i].noalias() = tc.radius.cast<T>() * js.transform.scale;
+    radius[i].noalias() = tc.radius.cast<T>() * parentTransform.scale;
     delta[i] = radius[i][1] - radius[i][0];
   }
 }

--- a/momentum/character/collision_geometry_state.h
+++ b/momentum/character/collision_geometry_state.h
@@ -9,6 +9,7 @@
 
 #include <momentum/character/collision_geometry.h>
 #include <momentum/character/fwd.h>
+#include <momentum/character/skeleton.h>
 
 #include <axel/BoundingBox.h>
 
@@ -125,6 +126,68 @@ void updateAabb(
 
   aabb.aabb.min() = minA.cwiseMin(minB);
   aabb.aabb.max() = maxA.cwiseMax(maxB);
+}
+
+/// Determines whether a pair of collision geometry capsules should be included as a valid
+/// collision pair.
+///
+/// A pair is excluded if:
+/// - The capsules overlap in rest pose (permanently overlapping, e.g. adjacent body parts),
+///   unless @p filterRestPoseOverlaps is false
+/// - The capsules are attached to the same joint or directly adjacent joints
+///
+/// @param collisionState The collision geometry state in rest pose
+/// @param collisionGeometry The collision geometry definition
+/// @param skeleton The skeleton used for adjacency checks
+/// @param i Index of the first capsule
+/// @param j Index of the second capsule
+/// @param filterRestPoseOverlaps When true, exclude pairs that overlap in rest pose
+/// @return True if the pair is a valid collision pair (should be checked for collisions)
+template <typename T, typename S>
+[[nodiscard]] bool isValidCollisionPair(
+    const CollisionGeometryStateT<T>& collisionState,
+    const CollisionGeometry& collisionGeometry,
+    const SkeletonT<S>& skeleton,
+    size_t i,
+    size_t j,
+    bool filterRestPoseOverlaps = true) {
+  const size_t p0 = collisionGeometry[i].parent;
+  const size_t p1 = collisionGeometry[j].parent;
+
+  // World-fixed capsules (kInvalidIndex parent):
+  // - If both are world-fixed, they can't collide with each other in a meaningful way.
+  // - If exactly one is world-fixed, it's always a valid collision pair (no rest-pose
+  //   overlap or adjacency checks apply since the world geometry is independent of
+  //   the character's skeleton).
+  if (p0 == kInvalidIndex || p1 == kInvalidIndex) {
+    return p0 != p1;
+  }
+
+  // Check for same or adjacent joints
+  if (skeleton.isSameOrAdjacentJoints(p0, p1)) {
+    return false;
+  }
+
+  if (!filterRestPoseOverlaps) {
+    return true;
+  }
+
+  // Check for rest-pose overlap (permanently overlapping pairs like adjacent body parts)
+  T distance;
+  Vector2<T> cp;
+  T overlap;
+  return !overlaps(
+      collisionState.origin[i],
+      collisionState.direction[i],
+      collisionState.radius[i],
+      collisionState.delta[i],
+      collisionState.origin[j],
+      collisionState.direction[j],
+      collisionState.radius[j],
+      collisionState.delta[j],
+      distance,
+      cp,
+      overlap);
 }
 
 } // namespace momentum

--- a/momentum/character/skeleton.cpp
+++ b/momentum/character/skeleton.cpp
@@ -82,6 +82,16 @@ bool SkeletonT<T>::isAncestor(size_t jointId, size_t ancestorJointId) const {
 }
 
 template <typename T>
+bool SkeletonT<T>::isSameOrAdjacentJoints(size_t joint1, size_t joint2) const {
+  if (joint1 == kInvalidIndex || joint2 == kInvalidIndex) {
+    return false;
+  }
+  MT_CHECK(joint1 < joints.size(), "{} vs {}", joint1, joints.size());
+  MT_CHECK(joint2 < joints.size(), "{} vs {}", joint2, joints.size());
+  return joint1 == joint2 || joints[joint1].parent == joint2 || joints[joint2].parent == joint1;
+}
+
+template <typename T>
 size_t SkeletonT<T>::commonAncestor(size_t joint1, size_t joint2) const {
   MT_CHECK(joint1 == kInvalidIndex || joint1 < joints.size());
   MT_CHECK(joint2 == kInvalidIndex || joint2 < joints.size());

--- a/momentum/character/skeleton.h
+++ b/momentum/character/skeleton.h
@@ -64,6 +64,13 @@ struct SkeletonT {
   /// A joint is considered to be its own ancestor (isAncestor(id, id) returns true).
   [[nodiscard]] bool isAncestor(size_t jointId, size_t ancestorJointId) const;
 
+  /// Checks if two joints are the same joint or directly adjacent (one is the direct parent
+  /// of the other) in the skeleton hierarchy.
+  ///
+  /// Returns false if either joint is kInvalidIndex, since world-fixed entities have no
+  /// joint ancestry and are never considered adjacent to skeleton joints.
+  [[nodiscard]] bool isSameOrAdjacentJoints(size_t joint1, size_t joint2) const;
+
   /// Finds the closest common ancestor of two joints in the hierarchy.
   ///
   /// Returns the index of the joint that is the lowest common ancestor

--- a/momentum/character_solver/collision_error_function.cpp
+++ b/momentum/character_solver/collision_error_function.cpp
@@ -10,9 +10,11 @@
 #include "momentum/character/character.h"
 #include "momentum/character/skeleton.h"
 #include "momentum/character/skeleton_state.h"
+#include "momentum/character_solver/error_function_utils.h"
 #include "momentum/common/checks.h"
 #include "momentum/common/log.h"
 #include "momentum/common/profile.h"
+#include "momentum/math/constants.h"
 #include "momentum/math/utility.h"
 
 namespace momentum {
@@ -66,43 +68,13 @@ void CollisionErrorFunctionT<T>::updateCollisionPairs(bool filterRestPoseOverlap
     return;
   }
 
-  T distance;
-  Vector2<T> cp;
-  T overlap;
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
-      // Skip pairs that already overlap in rest pose (unless disabled).
-      if (filterRestPoseOverlaps &&
-          overlaps(
-              collisionState_.origin[i],
-              collisionState_.direction[i],
-              collisionState_.radius[i],
-              collisionState_.delta[i],
-              collisionState_.origin[j],
-              collisionState_.direction[j],
-              collisionState_.radius[j],
-              collisionState_.delta[j],
-              distance,
-              cp,
-              overlap)) {
-        continue;
-      }
-
-      // Skip adjacent joints (common ancestor distance <= 1).
-      size_t p0 = collisionGeometry_[i].parent;
-      size_t p1 = collisionGeometry_[j].parent;
-      size_t count = 0;
-      while (p0 != p1) {
-        if (p0 > p1) {
-          p0 = this->skeleton_.joints[p0].parent;
-        } else {
-          p1 = this->skeleton_.joints[p1].parent;
-        }
-        count++;
-      }
-
-      if (count > 1) {
-        validPairs_.push_back({i, j, p0});
+      if (isValidCollisionPair(
+              collisionState_, collisionGeometry_, this->skeleton_, i, j, filterRestPoseOverlaps)) {
+        const size_t lca = this->skeleton_.commonAncestor(
+            collisionGeometry_[i].parent, collisionGeometry_[j].parent);
+        validPairs_.push_back({i, j, lca});
       }
     }
   }
@@ -157,7 +129,8 @@ void CollisionErrorFunctionT<T>::accumulateGradientAlongChain(
     T weight,
     size_t startJoint,
     size_t stopJoint,
-    Ref<VectorX<T>> gradient) const {
+    Ref<VectorX<T>> gradient,
+    T scaleCorrection) const {
   size_t jointIndex = startJoint;
   while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
     const auto& jointState = state.jointState[jointIndex];
@@ -167,31 +140,18 @@ void CollisionErrorFunctionT<T>::accumulateGradientAlongChain(
     for (size_t d = 0; d < 3; d++) {
       if (this->activeJointParams_[paramIndex + d]) {
         const T val = direction.dot(jointState.getTranslationDerivative(d)) * weight;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-             ++index) {
-          gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        gradient_jointParams_to_modelParams(
+            val, paramIndex + d, this->parameterTransform_, gradient);
       }
       if (this->activeJointParams_[paramIndex + 3 + d]) {
         const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * weight;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-             ++index) {
-          gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        gradient_jointParams_to_modelParams(
+            val, paramIndex + 3 + d, this->parameterTransform_, gradient);
       }
     }
     if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = direction.dot(jointState.getScaleDerivative(posd)) * weight;
-      for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-           index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-           ++index) {
-        gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-            val * this->parameterTransform_.transform.valuePtr()[index];
-      }
+      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * weight;
+      gradient_jointParams_to_modelParams(val, paramIndex + 6, this->parameterTransform_, gradient);
     }
 
     jointIndex = this->skeleton_.joints[jointIndex].parent;
@@ -207,7 +167,8 @@ void CollisionErrorFunctionT<T>::accumulateJacobianAlongChain(
     size_t startJoint,
     size_t stopJoint,
     Ref<MatrixX<T>> jacobian,
-    int row) const {
+    int row,
+    T scaleCorrection) const {
   size_t jointIndex = startJoint;
   while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
     const auto& jointState = state.jointState[jointIndex];
@@ -217,31 +178,19 @@ void CollisionErrorFunctionT<T>::accumulateJacobianAlongChain(
     for (size_t d = 0; d < 3; d++) {
       if (this->activeJointParams_[paramIndex + d]) {
         const T val = direction.dot(jointState.getTranslationDerivative(d)) * factor;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-             ++index) {
-          jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        jacobian_jointParams_to_modelParams(
+            val, paramIndex + d, row, this->parameterTransform_, jacobian);
       }
       if (this->activeJointParams_[paramIndex + 3 + d]) {
         const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * factor;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-             ++index) {
-          jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        jacobian_jointParams_to_modelParams(
+            val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
       }
     }
     if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = direction.dot(jointState.getScaleDerivative(posd)) * factor;
-      for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-           index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-           ++index) {
-        jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-            val * this->parameterTransform_.transform.valuePtr()[index];
-      }
+      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * factor;
+      jacobian_jointParams_to_modelParams(
+          val, paramIndex + 6, row, this->parameterTransform_, jacobian);
     }
 
     jointIndex = this->skeleton_.joints[jointIndex].parent;
@@ -334,6 +283,12 @@ double CollisionErrorFunctionT<T>::getGradient(
     const Vector3<T> direction = position_i - position_j;
     const T wgt = -T(2) * kCollisionWeight * this->weight_ * (overlap / distance);
 
+    // Effective radii at the closest points (for scale derivative correction)
+    const T radiusA_at_cp =
+        collisionState_.radius[pair.indexA][0] + cp[0] * collisionState_.delta[pair.indexA];
+    const T radiusB_at_cp =
+        collisionState_.radius[pair.indexB][0] + cp[1] * collisionState_.delta[pair.indexB];
+
     accumulateGradientAlongChain(
         state,
         position_i,
@@ -341,7 +296,8 @@ double CollisionErrorFunctionT<T>::getGradient(
         wgt,
         collisionGeometry_[pair.indexA].parent,
         pair.commonAncestor,
-        gradient);
+        gradient,
+        -distance * radiusA_at_cp * ln2<T>());
     accumulateGradientAlongChain(
         state,
         position_j,
@@ -349,7 +305,26 @@ double CollisionErrorFunctionT<T>::getGradient(
         -wgt,
         collisionGeometry_[pair.indexB].parent,
         pair.commonAncestor,
-        gradient);
+        gradient,
+        distance * radiusB_at_cp * ln2<T>());
+
+    // Scale derivatives above the common ancestor: translation and rotation derivatives cancel
+    // above the LCA (both capsule endpoints move identically), but scale derivatives do not
+    // because the two endpoints are at different distances from the scaled joint, and scaling
+    // also changes capsule radii.
+    {
+      const T netScaleVal =
+          (direction.squaredNorm() - distance * (radiusA_at_cp + radiusB_at_cp)) * ln2<T>() * wgt;
+      size_t ancestorIndex = pair.commonAncestor;
+      while (ancestorIndex != kInvalidIndex) {
+        const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+        if (this->activeJointParams_[paramIndex + 6]) {
+          gradient_jointParams_to_modelParams(
+              netScaleVal, paramIndex + 6, this->parameterTransform_, gradient);
+        }
+        ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+      }
+    }
   }
 
   return error;
@@ -404,8 +379,14 @@ double CollisionErrorFunctionT<T>::getJacobian(
     const Vector3<T> position_j =
         collisionState_.origin[pair.indexB] + collisionState_.direction[pair.indexB] * cp[1];
     const Vector3<T> direction = position_i - position_j;
-    const T fac = T(2) / distance * wgt;
+    const T fac = wgt / distance;
     const int row = pos++;
+
+    // Effective radii at the closest points (for scale derivative correction)
+    const T radiusA_at_cp =
+        collisionState_.radius[pair.indexA][0] + cp[0] * collisionState_.delta[pair.indexA];
+    const T radiusB_at_cp =
+        collisionState_.radius[pair.indexB][0] + cp[1] * collisionState_.delta[pair.indexB];
 
     accumulateJacobianAlongChain(
         state,
@@ -415,7 +396,8 @@ double CollisionErrorFunctionT<T>::getJacobian(
         collisionGeometry_[pair.indexA].parent,
         pair.commonAncestor,
         jacobian,
-        row);
+        row,
+        -distance * radiusA_at_cp * ln2<T>());
     accumulateJacobianAlongChain(
         state,
         position_j,
@@ -424,7 +406,23 @@ double CollisionErrorFunctionT<T>::getJacobian(
         collisionGeometry_[pair.indexB].parent,
         pair.commonAncestor,
         jacobian,
-        row);
+        row,
+        distance * radiusB_at_cp * ln2<T>());
+
+    // Scale derivatives above the common ancestor
+    {
+      const T netScaleVal = -fac * ln2<T>() * direction.squaredNorm() +
+          wgt * (radiusA_at_cp + radiusB_at_cp) * ln2<T>();
+      size_t ancestorIndex = pair.commonAncestor;
+      while (ancestorIndex != kInvalidIndex) {
+        const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+        if (this->activeJointParams_[paramIndex + 6]) {
+          jacobian_jointParams_to_modelParams(
+              netScaleVal, paramIndex + 6, row, this->parameterTransform_, jacobian);
+        }
+        ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+      }
+    }
 
     residual(row) = overlap * wgt;
   }

--- a/momentum/character_solver/collision_error_function.h
+++ b/momentum/character_solver/collision_error_function.h
@@ -74,6 +74,7 @@ class CollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
 
   /// Accumulate gradient contributions along a joint chain from startJoint up to (but not
   /// including) stopJoint. The sign of weight controls the push direction.
+  /// scaleCorrection is an additive term for the scale derivative (for capsule radius correction).
   void accumulateGradientAlongChain(
       const SkeletonStateT<T>& state,
       const Vector3<T>& position,
@@ -81,10 +82,12 @@ class CollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
       T weight,
       size_t startJoint,
       size_t stopJoint,
-      Ref<VectorX<T>> gradient) const;
+      Ref<VectorX<T>> gradient,
+      T scaleCorrection = T(0)) const;
 
   /// Accumulate Jacobian contributions along a joint chain from startJoint up to (but not
   /// including) stopJoint. The sign of factor controls the push direction.
+  /// scaleCorrection is an additive term for the scale derivative (for capsule radius correction).
   void accumulateJacobianAlongChain(
       const SkeletonStateT<T>& state,
       const Vector3<T>& position,
@@ -93,7 +96,8 @@ class CollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
       size_t startJoint,
       size_t stopJoint,
       Ref<MatrixX<T>> jacobian,
-      int row) const;
+      int row,
+      T scaleCorrection = T(0)) const;
 
   /// Pre-computed valid collision pair with common ancestor.
   struct CollisionPairInfo {

--- a/momentum/character_solver/collision_error_function_stateless.cpp
+++ b/momentum/character_solver/collision_error_function_stateless.cpp
@@ -10,8 +10,10 @@
 #include "momentum/character/character.h"
 #include "momentum/character/skeleton.h"
 #include "momentum/character/skeleton_state.h"
+#include "momentum/character_solver/error_function_utils.h"
 #include "momentum/common/checks.h"
 #include "momentum/common/profile.h"
+#include "momentum/math/constants.h"
 #include "momentum/math/utility.h"
 
 namespace momentum {
@@ -58,40 +60,12 @@ void CollisionErrorFunctionStatelessT<T>::updateCollisionPairs() {
     return;
   }
 
-  T distance;
-  Vector2<T> cp;
-  T overlap;
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
-      if (overlaps(
-              collisionState.origin[i],
-              collisionState.direction[i],
-              collisionState.radius[i],
-              collisionState.delta[i],
-              collisionState.origin[j],
-              collisionState.direction[j],
-              collisionState.radius[j],
-              collisionState.delta[j],
-              distance,
-              cp,
-              overlap)) {
-        continue;
-      }
-
-      size_t p0 = collisionGeometry[i].parent;
-      size_t p1 = collisionGeometry[j].parent;
-      size_t count = 0;
-      while (p0 != p1) {
-        if (p0 > p1) {
-          p0 = this->skeleton_.joints[p0].parent;
-        } else {
-          p1 = this->skeleton_.joints[p1].parent;
-        }
-        count++;
-      }
-
-      if (count > 1) {
-        validPairs_.push_back({i, j, p0});
+      if (isValidCollisionPair(collisionState, collisionGeometry, this->skeleton_, i, j)) {
+        const size_t lca = this->skeleton_.commonAncestor(
+            collisionGeometry[i].parent, collisionGeometry[j].parent);
+        validPairs_.push_back({i, j, lca});
       }
     }
   }
@@ -143,7 +117,8 @@ void CollisionErrorFunctionStatelessT<T>::accumulateGradientAlongChain(
     T weight,
     size_t startJoint,
     size_t stopJoint,
-    Ref<VectorX<T>> gradient) const {
+    Ref<VectorX<T>> gradient,
+    T scaleCorrection) const {
   size_t jointIndex = startJoint;
   while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
     const auto& jointState = state.jointState[jointIndex];
@@ -153,31 +128,18 @@ void CollisionErrorFunctionStatelessT<T>::accumulateGradientAlongChain(
     for (size_t d = 0; d < 3; d++) {
       if (this->activeJointParams_[paramIndex + d]) {
         const T val = direction.dot(jointState.getTranslationDerivative(d)) * weight;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-             ++index) {
-          gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        gradient_jointParams_to_modelParams(
+            val, paramIndex + d, this->parameterTransform_, gradient);
       }
       if (this->activeJointParams_[paramIndex + 3 + d]) {
         const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * weight;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-             ++index) {
-          gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        gradient_jointParams_to_modelParams(
+            val, paramIndex + 3 + d, this->parameterTransform_, gradient);
       }
     }
     if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = direction.dot(jointState.getScaleDerivative(posd)) * weight;
-      for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-           index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-           ++index) {
-        gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-            val * this->parameterTransform_.transform.valuePtr()[index];
-      }
+      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * weight;
+      gradient_jointParams_to_modelParams(val, paramIndex + 6, this->parameterTransform_, gradient);
     }
 
     jointIndex = this->skeleton_.joints[jointIndex].parent;
@@ -193,7 +155,8 @@ void CollisionErrorFunctionStatelessT<T>::accumulateJacobianAlongChain(
     size_t startJoint,
     size_t stopJoint,
     Ref<MatrixX<T>> jacobian,
-    int row) const {
+    int row,
+    T scaleCorrection) const {
   size_t jointIndex = startJoint;
   while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
     const auto& jointState = state.jointState[jointIndex];
@@ -203,31 +166,19 @@ void CollisionErrorFunctionStatelessT<T>::accumulateJacobianAlongChain(
     for (size_t d = 0; d < 3; d++) {
       if (this->activeJointParams_[paramIndex + d]) {
         const T val = direction.dot(jointState.getTranslationDerivative(d)) * factor;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-             ++index) {
-          jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        jacobian_jointParams_to_modelParams(
+            val, paramIndex + d, row, this->parameterTransform_, jacobian);
       }
       if (this->activeJointParams_[paramIndex + 3 + d]) {
         const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * factor;
-        for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-             index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-             ++index) {
-          jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-              val * this->parameterTransform_.transform.valuePtr()[index];
-        }
+        jacobian_jointParams_to_modelParams(
+            val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
       }
     }
     if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = direction.dot(jointState.getScaleDerivative(posd)) * factor;
-      for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-           index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-           ++index) {
-        jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-            val * this->parameterTransform_.transform.valuePtr()[index];
-      }
+      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * factor;
+      jacobian_jointParams_to_modelParams(
+          val, paramIndex + 6, row, this->parameterTransform_, jacobian);
     }
 
     jointIndex = this->skeleton_.joints[jointIndex].parent;
@@ -311,6 +262,12 @@ double CollisionErrorFunctionStatelessT<T>::getGradient(
     const Vector3<T> direction = position_i - position_j;
     const T wgt = -T(2) * kCollisionWeight * this->weight_ * (overlap / distance);
 
+    // Effective radii at the closest points (for scale derivative correction)
+    const T radiusA_at_cp =
+        collisionState.radius[pair.indexA][0] + cp[0] * collisionState.delta[pair.indexA];
+    const T radiusB_at_cp =
+        collisionState.radius[pair.indexB][0] + cp[1] * collisionState.delta[pair.indexB];
+
     accumulateGradientAlongChain(
         state,
         position_i,
@@ -318,7 +275,8 @@ double CollisionErrorFunctionStatelessT<T>::getGradient(
         wgt,
         collisionGeometry[pair.indexA].parent,
         pair.commonAncestor,
-        gradient);
+        gradient,
+        -distance * radiusA_at_cp * ln2<T>());
     accumulateGradientAlongChain(
         state,
         position_j,
@@ -326,7 +284,23 @@ double CollisionErrorFunctionStatelessT<T>::getGradient(
         -wgt,
         collisionGeometry[pair.indexB].parent,
         pair.commonAncestor,
-        gradient);
+        gradient,
+        distance * radiusB_at_cp * ln2<T>());
+
+    // Scale derivatives above the common ancestor
+    {
+      const T netScaleVal =
+          (direction.squaredNorm() - distance * (radiusA_at_cp + radiusB_at_cp)) * ln2<T>() * wgt;
+      size_t ancestorIndex = pair.commonAncestor;
+      while (ancestorIndex != kInvalidIndex) {
+        const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+        if (this->activeJointParams_[paramIndex + 6]) {
+          gradient_jointParams_to_modelParams(
+              netScaleVal, paramIndex + 6, this->parameterTransform_, gradient);
+        }
+        ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+      }
+    }
   }
 
   return error;
@@ -381,8 +355,14 @@ double CollisionErrorFunctionStatelessT<T>::getJacobian(
     const Vector3<T> position_j =
         collisionState.origin[pair.indexB] + collisionState.direction[pair.indexB] * cp[1];
     const Vector3<T> direction = position_i - position_j;
-    const T fac = T(2) / distance * wgt;
+    const T fac = wgt / distance;
     const int row = pos++;
+
+    // Effective radii at the closest points (for scale derivative correction)
+    const T radiusA_at_cp =
+        collisionState.radius[pair.indexA][0] + cp[0] * collisionState.delta[pair.indexA];
+    const T radiusB_at_cp =
+        collisionState.radius[pair.indexB][0] + cp[1] * collisionState.delta[pair.indexB];
 
     accumulateJacobianAlongChain(
         state,
@@ -392,7 +372,8 @@ double CollisionErrorFunctionStatelessT<T>::getJacobian(
         collisionGeometry[pair.indexA].parent,
         pair.commonAncestor,
         jacobian,
-        row);
+        row,
+        -distance * radiusA_at_cp * ln2<T>());
     accumulateJacobianAlongChain(
         state,
         position_j,
@@ -401,7 +382,23 @@ double CollisionErrorFunctionStatelessT<T>::getJacobian(
         collisionGeometry[pair.indexB].parent,
         pair.commonAncestor,
         jacobian,
-        row);
+        row,
+        distance * radiusB_at_cp * ln2<T>());
+
+    // Scale derivatives above the common ancestor
+    {
+      const T netScaleVal = -fac * ln2<T>() * direction.squaredNorm() +
+          wgt * (radiusA_at_cp + radiusB_at_cp) * ln2<T>();
+      size_t ancestorIndex = pair.commonAncestor;
+      while (ancestorIndex != kInvalidIndex) {
+        const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+        if (this->activeJointParams_[paramIndex + 6]) {
+          jacobian_jointParams_to_modelParams(
+              netScaleVal, paramIndex + 6, row, this->parameterTransform_, jacobian);
+        }
+        ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+      }
+    }
 
     residual(row) = overlap * wgt;
   }

--- a/momentum/character_solver/collision_error_function_stateless.h
+++ b/momentum/character_solver/collision_error_function_stateless.h
@@ -75,6 +75,7 @@ class CollisionErrorFunctionStatelessT : public SkeletonErrorFunctionT<T> {
       T& overlap) const;
 
   /// Accumulate gradient contributions along a joint chain.
+  /// scaleCorrection is an additive term for the scale derivative (for capsule radius correction).
   void accumulateGradientAlongChain(
       const SkeletonStateT<T>& state,
       const Vector3<T>& position,
@@ -82,9 +83,11 @@ class CollisionErrorFunctionStatelessT : public SkeletonErrorFunctionT<T> {
       T weight,
       size_t startJoint,
       size_t stopJoint,
-      Ref<VectorX<T>> gradient) const;
+      Ref<VectorX<T>> gradient,
+      T scaleCorrection = T(0)) const;
 
   /// Accumulate Jacobian contributions along a joint chain.
+  /// scaleCorrection is an additive term for the scale derivative (for capsule radius correction).
   void accumulateJacobianAlongChain(
       const SkeletonStateT<T>& state,
       const Vector3<T>& position,
@@ -93,7 +96,8 @@ class CollisionErrorFunctionStatelessT : public SkeletonErrorFunctionT<T> {
       size_t startJoint,
       size_t stopJoint,
       Ref<MatrixX<T>> jacobian,
-      int row) const;
+      int row,
+      T scaleCorrection = T(0)) const;
 
   /// Pre-computed valid collision pair with common ancestor.
   struct CollisionPairInfo {

--- a/momentum/character_solver_simd/simd_collision_error_function.cpp
+++ b/momentum/character_solver_simd/simd_collision_error_function.cpp
@@ -10,6 +10,7 @@
 #include "momentum/character/character.h"
 #include "momentum/character/skeleton.h"
 #include "momentum/character/skeleton_state.h"
+#include "momentum/character_solver/error_function_utils.h"
 #include "momentum/common/checks.h"
 #include "momentum/common/profile.h"
 #include "momentum/math/constants.h"
@@ -105,17 +106,12 @@ template <typename T>
 void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
   validPairs_.clear();
 
-  // Get the size of collisionGeometry_
   const auto n = collisionGeometry_.size();
 
-  // create zero state
   const SkeletonStateT<T> state(
       this->parameterTransform_.zero().template cast<T>(), this->skeleton_);
-
-  // Update the collision state based on the zero state and collision geometry
   collisionState_.update(state, collisionGeometry_);
 
-  // Build initial AABBs
   aabbs_.resize(n);
   for (size_t i = 0; i < n; ++i) {
     aabbs_[i].id = gsl::narrow_cast<axel::Index>(i);
@@ -126,60 +122,21 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
         collisionState_.radius[i]);
   }
 
-  // Exit early as there are no geometry objects to process
   if (n == 0) {
     return;
   }
 
-  // Initialize common ancestor lookup table
   commonAncestors_.assign(n * n, kInvalidIndex);
-
-  // Initialize per-capsule collision pair lists
   collisionPairs_.resize(n);
 
-  // Iterate over all possible pairs of geometry objects
-  T distance = NAN;
-  Vector2<T> cp;
-  T overlap = NAN;
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
-      // Check if the pair intersects in the initial pose
-      if (overlaps(
-              collisionState_.origin[i],
-              collisionState_.direction[i],
-              collisionState_.radius[i],
-              collisionState_.delta[i],
-              collisionState_.origin[j],
-              collisionState_.direction[j],
-              collisionState_.radius[j],
-              collisionState_.delta[j],
-              distance,
-              cp,
-              overlap)) {
-        continue;
-      }
-
-      // walk down the skeleton hierarchy for the collision pair until we find a common ancestor
-      size_t p0 = collisionGeometry_[i].parent;
-      size_t p1 = collisionGeometry_[j].parent;
-      size_t count = 0;
-
-      // Find the common ancestor. We can always just walk up the higher joint index because the
-      // parent always has to have a lower index than the child joint.
-      while (p0 != p1) {
-        if (p0 > p1) {
-          p0 = this->skeleton_.joints[p0].parent;
-        } else {
-          p1 = this->skeleton_.joints[p1].parent;
-        }
-        count++;
-      }
-
-      // Store collision pairs excluding those with the same parent or adjacent joints
-      if (count > 1) {
-        validPairs_.push_back({i, j, p0});
-        commonAncestors_[i * n + j] = p0;
-        commonAncestors_[j * n + i] = p0;
+      if (isValidCollisionPair(collisionState_, collisionGeometry_, this->skeleton_, i, j)) {
+        const size_t lca = this->skeleton_.commonAncestor(
+            collisionGeometry_[i].parent, collisionGeometry_[j].parent);
+        validPairs_.push_back({i, j, lca});
+        commonAncestors_[i * n + j] = lca;
+        commonAncestors_[j * n + i] = lca;
       }
     }
   }
@@ -187,13 +144,11 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
 
 template <typename T>
 void SimdCollisionErrorFunctionT<T>::computeBroadPhase(const SkeletonStateT<T>& state) {
-  // Update collision state
   {
     MT_PROFILE_EVENT("Collision: updateState");
     collisionState_.update(state, collisionGeometry_);
   }
 
-  // Update the AABBs for each geometry object
   for (size_t i = 0; i < aabbs_.size(); ++i) {
     updateAabb(
         aabbs_[i],
@@ -202,7 +157,6 @@ void SimdCollisionErrorFunctionT<T>::computeBroadPhase(const SkeletonStateT<T>& 
         collisionState_.radius[i]);
   }
 
-  // Build per-capsule collision pair lists via AABB broadphase filtering
   for (auto& pairs : collisionPairs_) {
     pairs.clear();
   }
@@ -222,7 +176,6 @@ double SimdCollisionErrorFunctionT<T>::getError(
     return 0.0;
   }
 
-  // check all is valid
   MT_CHECK(
       state.jointParameters.size() ==
       gsl::narrow<Eigen::Index>(this->skeleton_.joints.size() * kParametersPerJoint));
@@ -231,7 +184,6 @@ double SimdCollisionErrorFunctionT<T>::getError(
 
   auto error = drjit::zeros<DoubleP>();
 
-  // For each joint, consider all the other joints:
   for (size_t iCol = 0; iCol < collisionPairs_.size(); ++iCol) {
     const auto& candidatesCur = collisionPairs_[iCol];
 
@@ -254,7 +206,6 @@ double SimdCollisionErrorFunctionT<T>::getError(
       const Packet<T> radius = (radius_i.x() * (1.0f - t_i) + radius_i.y() * t_i) +
           (radius_j.x() * (1.0f - t_j) + radius_j.y() * t_j);
 
-      // Skip degenerate cases where capsules are nearly coincident
       const auto validMask =
           drjit::PacketMask<int, kSimdPacketSize>(mask) && distance >= Eps<T>(1e-8f, 1e-17);
       drjit::masked(error, validMask) += drjit::square(drjit::maximum(radius - distance, 0));
@@ -279,7 +230,6 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
   const auto numCapsules = collisionGeometry_.size();
   auto error = drjit::zeros<DoubleP>();
 
-  // For each joint, consider all the other joints:
   for (size_t iCol = 0; iCol < collisionPairs_.size(); ++iCol) {
     const auto& candidatesCur = collisionPairs_[iCol];
 
@@ -304,7 +254,6 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
           (radius_j.x() * (1.0f - t_j) + radius_j.y() * t_j);
       const Packet<T> overlap = radius - distance;
 
-      // Skip degenerate cases where capsules are nearly coincident
       const auto finalMask = drjit::PacketMask<int, kSimdPacketSize>(mask) &&
           distance >= Eps<T>(1e-8f, 1e-17) && distance < radius;
 
@@ -313,8 +262,6 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
       }
 
       const Packet<T> overlapFraction = overlap / distance;
-
-      // calculate weight
       const Packet<T> wgt = -2.0f * kCollisionWeight * this->weight_ * overlapFraction;
 
       drjit::masked(error, finalMask) +=
@@ -333,6 +280,15 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
         const Eigen::Vector3<T> position_ik = extractSingleElement(position_i, k);
         const Eigen::Vector3<T> position_jk = extractSingleElement(position_j, k);
         const T wgt_k = wgt[k];
+        const T distance_k = distance[k];
+
+        // Effective radii at closest points (scalar extraction)
+        const T radiusA_at_cp_k =
+            collisionState_.radius[iCol][0] + t_i[k] * collisionState_.delta[iCol];
+        const T radiusB_at_cp_k =
+            collisionState_.radius[jCol[k]][0] + t_j[k] * collisionState_.delta[jCol[k]];
+        const T scaleCorr_A = -distance_k * radiusA_at_cp_k * ln2<T>();
+        const T scaleCorr_B = distance_k * radiusB_at_cp_k * ln2<T>();
 
         // -----------------------------------
         //  process first joint
@@ -343,49 +299,25 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
           const size_t paramIndex = jointIndex * kParametersPerJoint;
           const Vector3<T> posd = position_ik - jointState.translation();
 
-          // calculate derivatives based on active joints
           for (size_t d = 0; d < 3; d++) {
             if (this->activeJointParams_[paramIndex + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * wgt_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-                   index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-                   ++index) {
-                gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              gradient_jointParams_to_modelParams(
+                  val, paramIndex + d, this->parameterTransform_, gradient);
             }
             if (this->activeJointParams_[paramIndex + 3 + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * wgt_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              for (auto index =
-                       this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-                   index <
-                   this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-                   ++index) {
-                gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              gradient_jointParams_to_modelParams(
+                  val, paramIndex + 3 + d, this->parameterTransform_, gradient);
             }
           }
           if (this->activeJointParams_[paramIndex + 6]) {
-            // calculate joint gradient
-            const T val = direction_k.dot(jointState.getScaleDerivative(posd)) * wgt_k;
-            // explicitly multiply with the parameter transform to generate parameter space
-            // gradients
-            for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-                 index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-                 ++index) {
-              gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-                  val * this->parameterTransform_.transform.valuePtr()[index];
-            }
+            const T val =
+                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_A) * wgt_k;
+            gradient_jointParams_to_modelParams(
+                val, paramIndex + 6, this->parameterTransform_, gradient);
           }
 
-          // go to the next joint
           jointIndex = this->skeleton_.joints[jointIndex].parent;
         }
 
@@ -398,64 +330,53 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
           const size_t paramIndex = jointIndex * kParametersPerJoint;
           const Vector3<T> posd = position_jk - jointState.translation();
 
-          // calculate derivatives based on active joints
           for (size_t d = 0; d < 3; d++) {
             if (this->activeJointParams_[paramIndex + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * -wgt_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-                   index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-                   ++index) {
-                gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              gradient_jointParams_to_modelParams(
+                  val, paramIndex + d, this->parameterTransform_, gradient);
             }
             if (this->activeJointParams_[paramIndex + 3 + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * -wgt_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              const auto maxIndex =
-                  this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-              for (auto index =
-                       this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-                   index < maxIndex;
-                   ++index) {
-                gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              gradient_jointParams_to_modelParams(
+                  val, paramIndex + 3 + d, this->parameterTransform_, gradient);
             }
           }
           if (this->activeJointParams_[paramIndex + 6]) {
-            // calculate joint gradient
-            const T val = direction_k.dot(jointState.getScaleDerivative(posd)) * -wgt_k;
-            // explicitly multiply with the parameter transform to generate parameter space
-            // gradients
-            const auto maxIndex =
-                this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-            for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-                 index < maxIndex;
-                 ++index) {
-              gradient[this->parameterTransform_.transform.innerIndexPtr()[index]] +=
-                  val * this->parameterTransform_.transform.valuePtr()[index];
-            }
+            const T val =
+                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_B) * -wgt_k;
+            gradient_jointParams_to_modelParams(
+                val, paramIndex + 6, this->parameterTransform_, gradient);
           }
 
-          // go to the next joint
           jointIndex = this->skeleton_.joints[jointIndex].parent;
+        }
+
+        // -----------------------------------
+        //  process scale derivatives above common ancestor
+        // -----------------------------------
+        {
+          const T netScaleVal =
+              (direction_k.squaredNorm() - distance_k * (radiusA_at_cp_k + radiusB_at_cp_k)) *
+              ln2<T>() * wgt_k;
+          size_t ancestorIndex = commonAncestor;
+          while (ancestorIndex != kInvalidIndex) {
+            const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+            if (this->activeJointParams_[paramIndex + 6]) {
+              gradient_jointParams_to_modelParams(
+                  netScaleVal, paramIndex + 6, this->parameterTransform_, gradient);
+            }
+            ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+          }
         }
       }
     }
   }
 
-  // check all is valid
   MT_CHECK(
       state.jointParameters.size() ==
       gsl::narrow<Eigen::Index>(this->skeleton_.joints.size() * kParametersPerJoint));
 
-  // return error
   return drjit::sum(error);
 }
 
@@ -474,7 +395,6 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
 
   auto error = drjit::zeros<DoubleP>();
 
-  // For each joint, consider all the other joints:
   int row = 0;
   for (size_t iCol = 0; iCol < collisionPairs_.size(); ++iCol) {
     const auto& candidatesCur = collisionPairs_[iCol];
@@ -500,7 +420,6 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
           (radius_j.x() * (1.0f - t_j) + radius_j.y() * t_j);
       const Packet<T> overlap = radius - distance;
 
-      // Skip degenerate cases where capsules are nearly coincident
       const auto finalMask = drjit::PacketMask<int, kSimdPacketSize>(mask) &&
           distance >= Eps<T>(1e-8f, 1e-17) && distance < radius;
 
@@ -511,12 +430,8 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
       drjit::masked(error, finalMask) +=
           kCollisionWeight * this->weight_ * drjit::square(radius - distance);
 
-      // calculate collision resolve direction. this is what we need to push joint parent i in.
-      // the direction for joint parent j is the inverse
       const Packet<T> inverseDistance = 1.0 / distance;
-
-      // calculate constant factor
-      const Packet<T> fac = 2.0f * inverseDistance * wgt;
+      const Packet<T> fac = inverseDistance * wgt;
 
       const size_t iJoint = collisionGeometry_[iCol].parent;
       for (uint32_t k = 0; k < kSimdPacketSize; ++k) {
@@ -529,6 +444,15 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
 
         const Eigen::Vector3<T> direction_k = extractSingleElement(direction, k);
         const T fac_k = fac[k];
+        const T distance_k = distance[k];
+
+        // Effective radii at closest points (scalar extraction)
+        const T radiusA_at_cp_k =
+            collisionState_.radius[iCol][0] + t_i[k] * collisionState_.delta[iCol];
+        const T radiusB_at_cp_k =
+            collisionState_.radius[jCol[k]][0] + t_j[k] * collisionState_.delta[jCol[k]];
+        const T scaleCorr_A = -distance_k * radiusA_at_cp_k * ln2<T>();
+        const T scaleCorr_B = distance_k * radiusB_at_cp_k * ln2<T>();
 
         // -----------------------------------
         //  process first joint
@@ -540,49 +464,25 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
           const Eigen::Vector3<T> posd =
               extractSingleElement(position_i, k) - jointState.translation();
 
-          // calculate derivatives based on active joints
           for (size_t d = 0; d < 3; d++) {
             if (this->activeJointParams_[paramIndex + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * -fac_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-                   index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-                   ++index) {
-                jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              jacobian_jointParams_to_modelParams(
+                  val, paramIndex + d, row, this->parameterTransform_, jacobian);
             }
             if (this->activeJointParams_[paramIndex + 3 + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * -fac_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              for (auto index =
-                       this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-                   index <
-                   this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-                   ++index) {
-                jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              jacobian_jointParams_to_modelParams(
+                  val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
             }
           }
           if (this->activeJointParams_[paramIndex + 6]) {
-            // calculate joint gradient
-            const T val = direction_k.dot(jointState.getScaleDerivative(posd)) * -fac_k;
-            // explicitly multiply with the parameter transform to generate parameter space
-            // gradients
-            for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-                 index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-                 ++index) {
-              jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-                  val * this->parameterTransform_.transform.valuePtr()[index];
-            }
+            const T val =
+                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_A) * -fac_k;
+            jacobian_jointParams_to_modelParams(
+                val, paramIndex + 6, row, this->parameterTransform_, jacobian);
           }
 
-          // go to the next joint
           jointIndex = this->skeleton_.joints[jointIndex].parent;
         }
 
@@ -595,50 +495,43 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
           const size_t paramIndex = jointIndex * kParametersPerJoint;
           const Vector3<T> posd = extractSingleElement(position_j, k) - jointState.translation();
 
-          // calculate derivatives based on active joints
           for (size_t d = 0; d < 3; d++) {
             if (this->activeJointParams_[paramIndex + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * fac_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d];
-                   index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 1];
-                   ++index) {
-                jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              jacobian_jointParams_to_modelParams(
+                  val, paramIndex + d, row, this->parameterTransform_, jacobian);
             }
             if (this->activeJointParams_[paramIndex + 3 + d]) {
-              // calculate joint gradient
               const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * fac_k;
-              // explicitly multiply with the parameter transform to generate parameter space
-              // gradients
-              for (auto index =
-                       this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 3 + d];
-                   index <
-                   this->parameterTransform_.transform.outerIndexPtr()[paramIndex + d + 3 + 1];
-                   ++index) {
-                jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-                    val * this->parameterTransform_.transform.valuePtr()[index];
-              }
+              jacobian_jointParams_to_modelParams(
+                  val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
             }
           }
           if (this->activeJointParams_[paramIndex + 6]) {
-            // calculate joint gradient
-            const T val = direction_k.dot(jointState.getScaleDerivative(posd)) * fac_k;
-            // explicitly multiply with the parameter transform to generate parameter space
-            // gradients
-            for (auto index = this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6];
-                 index < this->parameterTransform_.transform.outerIndexPtr()[paramIndex + 6 + 1];
-                 ++index) {
-              jacobian(row, this->parameterTransform_.transform.innerIndexPtr()[index]) +=
-                  val * this->parameterTransform_.transform.valuePtr()[index];
-            }
+            const T val =
+                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_B) * fac_k;
+            jacobian_jointParams_to_modelParams(
+                val, paramIndex + 6, row, this->parameterTransform_, jacobian);
           }
 
-          // go to the next joint
           jointIndex = this->skeleton_.joints[jointIndex].parent;
+        }
+
+        // -----------------------------------
+        //  process scale derivatives above common ancestor
+        // -----------------------------------
+        {
+          const T netScaleVal = -fac_k * ln2<T>() * direction_k.squaredNorm() +
+              wgt * (radiusA_at_cp_k + radiusB_at_cp_k) * ln2<T>();
+          size_t ancestorIndex = commonAncestor;
+          while (ancestorIndex != kInvalidIndex) {
+            const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+            if (this->activeJointParams_[paramIndex + 6]) {
+              jacobian_jointParams_to_modelParams(
+                  netScaleVal, paramIndex + 6, row, this->parameterTransform_, jacobian);
+            }
+            ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+          }
         }
 
         residual(row) = overlap[k] * wgt;
@@ -649,7 +542,6 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
 
   usedRows = row;
 
-  // return error
   return drjit::sum(error);
 }
 

--- a/momentum/test/character_solver/collision_error_function_test.cpp
+++ b/momentum/test/character_solver/collision_error_function_test.cpp
@@ -13,6 +13,7 @@
 #include "momentum/character/skeleton.h"
 #include "momentum/character/skeleton_state.h"
 #include "momentum/character_solver/collision_error_function.h"
+#include "momentum/character_solver/collision_error_function_stateless.h"
 #include "momentum/character_solver/sdf_collision_error_function.h"
 #include "momentum/math/random.h"
 #include "momentum/test/character/character_helpers.h"
@@ -147,4 +148,249 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, SDFCollisionError_WorldSDF_GradientsAndJ
       previousError = error;
     }
   }
+}
+
+TYPED_TEST(Momentum_ErrorFunctionsTest, CapsuleCollisionError_GradientsAndJacobians) {
+  using T = typename TestFixture::Type;
+
+  // Build a collision setup with a single skeleton capsule on joint 0 and a world-fixed
+  // capsule. Using a single skeleton capsule avoids interference from other collision
+  // pairs while focusing on testing world-fixed capsule support.
+  const size_t nJoints = 3;
+  const Character baseCharacter = createTestCharacter(nJoints);
+
+  CollisionGeometry cg;
+
+  // Skeleton capsule on joint 0: uniform radius, extends along +X
+  TaperedCapsule jointCapsule;
+  jointCapsule.parent = 0;
+  jointCapsule.length = 1.0f;
+  jointCapsule.radius = Eigen::Vector2f(1.0f, 1.0f);
+  cg.push_back(jointCapsule);
+
+  // World-fixed capsule: uniform radius, extends along +Y, offset in Z just inside
+  // the sum of radii so there's a small overlap at rest (overlap = 1.0 + 0.8 - 1.75 = 0.05).
+  // This ensures most random perturbations produce collisions for reliable gradient testing.
+  TaperedCapsule worldCapsule;
+  worldCapsule.parent = kInvalidIndex;
+  worldCapsule.length = 3.0f;
+  worldCapsule.radius = Eigen::Vector2f(0.8f, 0.8f);
+  worldCapsule.transformation.rotation =
+      Eigen::Quaternionf::FromTwoVectors(Eigen::Vector3f::UnitX(), Eigen::Vector3f::UnitY());
+  worldCapsule.transformation.translation = Eigen::Vector3f(0.0f, 0.0f, 1.75f);
+  cg.push_back(worldCapsule);
+
+  const Character character(
+      baseCharacter.skeleton,
+      baseCharacter.parameterTransform,
+      baseCharacter.parameterLimits,
+      baseCharacter.locators,
+      baseCharacter.mesh.get(),
+      baseCharacter.skinWeights.get(),
+      &cg);
+
+  CollisionErrorFunctionT<T> errorFunction(character);
+  CollisionErrorFunctionStatelessT<T> errorFunctionStateless(character);
+
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+
+  // Use perturbations large enough to bridge the small gap and create deep overlaps,
+  // but small enough that collision topology is stable during finite differences.
+  size_t numTestedPoses = 0;
+  for (size_t iTrial = 0; iTrial < 10; ++iTrial) {
+    const ModelParametersT<T> mp = uniform<VectorX<T>>(
+        transform.numAllModelParameters(), static_cast<T>(-0.3), static_cast<T>(0.3));
+    const SkeletonStateT<T> state(transform.apply(mp), character.skeleton);
+    if (errorFunction.getError(mp, state, MeshStateT<T>()) <= 0.0) {
+      continue;
+    }
+    SCOPED_TRACE("trial=" + std::to_string(iTrial));
+    // Use a slightly relaxed numerical gradient threshold because the collision
+    // error involves subtracting similar-magnitude values (radius_sum - distance),
+    // causing cancellation error that limits float finite-difference accuracy.
+    const T numThreshold = std::is_same_v<T, float> ? T(0.02) : TestFixture::getNumThreshold();
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunction,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/true);
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunctionStateless,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/true);
+    VALIDATE_IDENTICAL(
+        T, errorFunction, errorFunctionStateless, character.skeleton, transform, mp.v);
+    ++numTestedPoses;
+  }
+  ASSERT_GE(numTestedPoses, 3) << "Too few poses produced collisions";
+}
+
+// Test capsule collision gradients on a shared skeleton with global scaling.
+// Uses a double-branch skeleton (root → joint1 → joint2, root → joint3 → joint4)
+// so that:
+// 1. Both branches share the same scale_global parameter through the root
+// 2. LCA(joint2, joint4) = root ≠ either parent, so the pair is not excluded
+// 3. Rotating joint1/joint3 swings joint2/joint4 into each other
+// 4. Capsules are non-parallel for stable closest-point computation
+TYPED_TEST(Momentum_ErrorFunctionsTest, CapsuleCollisionError_ScaleGradient) {
+  using T = typename TestFixture::Type;
+
+  // Build a double-branch skeleton: root at origin, each branch has 2 joints.
+  // Joint1/3 are children of root at (0, ±0.5, 0). Joint2/4 are grandchildren
+  // at (0, ±0.5, 0) relative to their parents. At rest, joint2 is at (0, 1, 0)
+  // and joint4 is at (0, -1, 0). Rotating joint1/joint3 around Z can swing
+  // joint2/joint4 toward each other.
+  Skeleton skeleton;
+  {
+    Joint root;
+    root.name = "root";
+    root.parent = kInvalidIndex;
+    root.preRotation = Eigen::Quaternionf::Identity();
+    root.translationOffset = Eigen::Vector3f::Zero();
+    skeleton.joints.push_back(root);
+
+    Joint j1;
+    j1.name = "joint1";
+    j1.parent = 0;
+    j1.preRotation = Eigen::Quaternionf::Identity();
+    j1.translationOffset = Eigen::Vector3f(0.0f, 0.5f, 0.0f);
+    skeleton.joints.push_back(j1);
+
+    Joint j2;
+    j2.name = "joint2";
+    j2.parent = 1;
+    j2.preRotation = Eigen::Quaternionf::Identity();
+    j2.translationOffset = Eigen::Vector3f(0.0f, 0.5f, 0.0f);
+    skeleton.joints.push_back(j2);
+
+    Joint j3;
+    j3.name = "joint3";
+    j3.parent = 0;
+    j3.preRotation = Eigen::Quaternionf::Identity();
+    j3.translationOffset = Eigen::Vector3f(0.0f, -0.5f, 0.0f);
+    skeleton.joints.push_back(j3);
+
+    Joint j4;
+    j4.name = "joint4";
+    j4.parent = 3;
+    j4.preRotation = Eigen::Quaternionf::Identity();
+    j4.translationOffset = Eigen::Vector3f(0.0f, -0.5f, 0.0f);
+    skeleton.joints.push_back(j4);
+  }
+
+  // Parameter transform: root 6-DOF + scale_global + joint1_rz + joint3_rz
+  ParameterTransform pt;
+  const auto numJointParams = skeleton.joints.size() * kParametersPerJoint;
+  pt.name = {
+      "root_tx",
+      "root_ty",
+      "root_tz",
+      "root_rx",
+      "root_ry",
+      "root_rz",
+      "scale_global",
+      "joint1_rz",
+      "joint3_rz"};
+  pt.offsets = Eigen::VectorXf::Zero(numJointParams);
+  pt.transform.resize(numJointParams, static_cast<int>(pt.name.size()));
+  std::vector<Eigen::Triplet<float>> triplets;
+  triplets.emplace_back(0 * kParametersPerJoint + 0, 0, 1.0f); // root_tx
+  triplets.emplace_back(0 * kParametersPerJoint + 1, 1, 1.0f); // root_ty
+  triplets.emplace_back(0 * kParametersPerJoint + 2, 2, 1.0f); // root_tz
+  triplets.emplace_back(0 * kParametersPerJoint + 3, 3, 1.0f); // root_rx
+  triplets.emplace_back(0 * kParametersPerJoint + 4, 4, 1.0f); // root_ry
+  triplets.emplace_back(0 * kParametersPerJoint + 5, 5, 1.0f); // root_rz
+  triplets.emplace_back(0 * kParametersPerJoint + 6, 6, 1.0f); // scale_global
+  triplets.emplace_back(1 * kParametersPerJoint + 5, 7, 1.0f); // joint1_rz
+  triplets.emplace_back(3 * kParametersPerJoint + 5, 8, 1.0f); // joint3_rz
+  pt.transform.setFromTriplets(triplets.begin(), triplets.end());
+  pt.activeJointParams = pt.computeActiveJointParams();
+
+  // Two capsules on the tip joints (joint2 and joint4), with ±15° tilt around X
+  // so they aren't parallel. Uniform radius 0.3, length 0.5.
+  // At rest (joint2 at (0,1,0), joint4 at (0,-1,0)): distance 2.0, radius sum 0.6,
+  // gap = 1.4. Setting joint1_rz ≈ π/2 swings joint2 from (0,1,0) toward (~0.5, 0.5, 0),
+  // and joint3_rz ≈ -π/2 swings joint4 toward (~0.5, -0.5, 0). These are close enough
+  // that small additional perturbation creates collisions.
+  CollisionGeometry cg;
+  {
+    TaperedCapsule cap1;
+    cap1.parent = 2;
+    cap1.length = 0.5f;
+    cap1.radius = Eigen::Vector2f(0.3f, 0.3f);
+    cap1.transformation.rotation =
+        Eigen::Quaternionf(Eigen::AngleAxisf(0.2618f, Eigen::Vector3f::UnitX())); // +15° tilt
+    cg.push_back(cap1);
+
+    TaperedCapsule cap2;
+    cap2.parent = 4;
+    cap2.length = 0.5f;
+    cap2.radius = Eigen::Vector2f(0.3f, 0.3f);
+    cap2.transformation.rotation =
+        Eigen::Quaternionf(Eigen::AngleAxisf(-0.2618f, Eigen::Vector3f::UnitX())); // -15° tilt
+    cg.push_back(cap2);
+  }
+
+  const Character character(skeleton, pt, ParameterLimits(), LocatorList(), nullptr, nullptr, &cg);
+
+  CollisionErrorFunctionT<T> errorFunction(character);
+  CollisionErrorFunctionStatelessT<T> errorFunctionStateless(character);
+
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+
+  // Start from a base pose where joint1/joint3 are rotated to swing the tips
+  // toward each other, then add small random perturbation.
+  ModelParametersT<T> baseMp = ModelParametersT<T>::Zero(transform.numAllModelParameters());
+  baseMp.v[7] = static_cast<T>(2.5); // joint1_rz: fold arm1 inward toward center
+  baseMp.v[8] = static_cast<T>(-2.5); // joint3_rz: fold arm2 inward toward center
+
+  size_t numTestedPoses = 0;
+  for (size_t iTrial = 0; iTrial < 20; ++iTrial) {
+    ModelParametersT<T> mp = baseMp;
+    const auto perturbation = uniform<VectorX<T>>(
+        transform.numAllModelParameters(), static_cast<T>(-0.1), static_cast<T>(0.1));
+    mp.v += perturbation;
+    const SkeletonStateT<T> state(transform.apply(mp), character.skeleton);
+    if (errorFunction.getError(mp, state, MeshStateT<T>()) <= 0.0) {
+      continue;
+    }
+    SCOPED_TRACE("trial=" + std::to_string(iTrial));
+    // Use a relaxed threshold for float because the large rotation angles (≈2.5 rad)
+    // amplify float cancellation error in finite differences.
+    const T numThreshold = std::is_same_v<T, float> ? T(0.03) : TestFixture::getNumThreshold();
+    // Disable numerical Jacobian check for float — the multi-joint chain with large
+    // rotations exceeds float finite-difference accuracy. Double validates correctness.
+    const bool checkJac = !std::is_same_v<T, float>;
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunction,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/checkJac);
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunctionStateless,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/checkJac);
+    VALIDATE_IDENTICAL(
+        T, errorFunction, errorFunctionStateless, character.skeleton, transform, mp.v);
+    ++numTestedPoses;
+  }
+  ASSERT_GE(numTestedPoses, 3) << "Too few poses produced collisions";
 }


### PR DESCRIPTION
Summary:

The capsule collision system did not support world-fixed capsules (parent == kInvalidIndex)
and had incorrect gradients when global scale affects capsule radii.

Changes:
- CollisionGeometryStateT::update(): handle kInvalidIndex parent with identity transform
- All 3 collision error function variants (CollisionErrorFunction, SimdCollisionErrorFunction,
  CollisionErrorFunctionStateless): replace unsafe manual ancestor walk with
  skeleton.commonAncestor() which handles kInvalidIndex safely; fix adjacency check for
  world-fixed capsules
- Fix scale-radius gradient coupling: capsule radius = tc.radius * parentTransform.scale,
  so d(radius)/d(scale) = radius_at_cp * ln2. Added this correction to getGradient and
  getJacobian in all 3 variants, for both per-chain and above-LCA scale accumulation

Reviewed By: yutingye

Differential Revision: D94292010


