### PR TITLE
Fix ParameterTransform Python constructor missing activeJointParams

### DIFF
--- a/pymomentum/geometry/parameter_transform_pybind.cpp
+++ b/pymomentum/geometry/parameter_transform_pybind.cpp
@@ -74,6 +74,7 @@ void registerParameterTransformBindings(
             }
 
             parameterTransform.offsets.setZero(nJointParams);
+            parameterTransform.activeJointParams = parameterTransform.computeActiveJointParams();
             return parameterTransform;
           }),
           R"(Create a parameter transform from a sparse matrix.
@@ -128,6 +129,7 @@ void registerParameterTransformBindings(
             parameterTransform.transform.resize(nJointParams, nModelParams);
             parameterTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
             parameterTransform.offsets.setZero(nJointParams);
+            parameterTransform.activeJointParams = parameterTransform.computeActiveJointParams();
             return parameterTransform;
           }),
           R"(Create a parameter transform from a dense numpy array.

--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -11,7 +11,11 @@ import numpy as np
 import torch
 from pymomentum.geometry import (
     Character,
+    Joint,
+    Locator,
+    PARAMETERS_PER_JOINT,
     ParameterTransform,
+    Skeleton,
     uniform_random_to_model_parameters,
 )
 from pymomentum.geometry_test_utils import create_test_character
@@ -70,6 +74,115 @@ class TestParameterTransform(unittest.TestCase):
 
         # Verify size is preserved
         self.assertEqual(original_pt.size, new_pt.size)
+
+    def test_active_joint_params_initialized_dense(self) -> None:
+        """Test that activeJointParams is initialized when constructing
+        ParameterTransform from a dense numpy array."""
+        character: Character = create_test_character()
+        original_pt = character.parameter_transform
+
+        new_pt = ParameterTransform(
+            names=original_pt.names,
+            skeleton=character.skeleton,
+            transform=original_pt.transform,
+        )
+
+        # pose_parameters requires activeJointParams to be properly sized;
+        # if it were empty, the solver would crash with an Eigen assertion.
+        pose_params = new_pt.pose_parameters
+        self.assertEqual(len(pose_params), new_pt.size)
+        self.assertTrue(pose_params.any())
+
+    def test_active_joint_params_single_joint(self) -> None:
+        """Test that a 1-joint character built from Python can be used with
+        the marker tracking solver (regression test for activeJointParams
+        not being initialized in the Python ParameterTransform constructor)."""
+        from pymomentum.marker_tracking import (
+            CalibrationConfig,
+            process_markers,
+            TrackingConfig,
+        )
+
+        root_joint = Joint(
+            name="root",
+            parent=-1,
+            pre_rotation=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+            translation_offset=np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        )
+        skeleton = Skeleton(joint_list=[root_joint])
+        n_joint_params = PARAMETERS_PER_JOINT * skeleton.size
+        transform = np.eye(n_joint_params, dtype=np.float32)
+        names = [
+            "root_tx",
+            "root_ty",
+            "root_tz",
+            "root_rx",
+            "root_ry",
+            "root_rz",
+            "scale_global",
+        ]
+        pt = ParameterTransform(names=names, skeleton=skeleton, transform=transform)
+
+        character = Character(
+            name="test_rigid",
+            skeleton=skeleton,
+            parameter_transform=pt,
+        )
+        locators = [
+            Locator(
+                name=f"m{i}",
+                parent=0,
+                offset=np.array(
+                    [float(i), 0.0, 0.0],
+                    dtype=np.float32,
+                ),
+                weight=1.0,
+                locked=np.array([1, 1, 1], dtype=np.int32),
+            )
+            for i in range(4)
+        ]
+        character = character.with_locators(locators)
+
+        # Build synthetic marker data: 4 markers, 5 frames, at known positions
+        from pymomentum.geometry import Marker
+
+        marker_data = []
+        for _frame in range(5):
+            frame_markers = []
+            for i in range(4):
+                frame_markers.append(
+                    Marker(
+                        name=f"m{i}",
+                        pos=np.array(
+                            [float(i) + 10.0, 5.0, 0.0],
+                            dtype=np.float32,
+                        ),
+                        occluded=False,
+                    )
+                )
+            marker_data.append(frame_markers)
+
+        identity = np.zeros(pt.size, dtype=np.float64)
+        tracking_config = TrackingConfig(max_iter=5, regularization=0.1)
+        calibration_config = CalibrationConfig(
+            max_iter=5,
+            calib_frames=5,
+            locators_only=False,
+        )
+
+        # This would crash with "Assertion index >= 0 && index < size()"
+        # if activeJointParams was not initialized.
+        motion = process_markers(
+            character,
+            identity,
+            marker_data,
+            tracking_config,
+            calibration_config,
+            calibrate=True,
+            max_frames=5,
+        )
+        self.assertEqual(motion.shape[0], 5)
+        self.assertEqual(motion.shape[1], pt.size)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The ParameterTransform pybind11 constructor (both sparse and dense
variants) did not initialize `activeJointParams`. This field was left as
an empty VectorX<bool> (size 0), causing an Eigen assertion failure
(`index >= 0 && index < size()`) whenever the character was used with any
solver error function that indexes `activeJointParams_`.

The fix adds `computeActiveJointParams()` after setting the transform,
matching the pattern used by D98022741 (removeJoints fix) and the C++
`ParameterTransform::identity()` factory.

This was discovered while building rigid body characters programmatically
from Python for marker tracking — any character constructed via
`ParameterTransform(names, skeleton, transform)` would crash in
`process_markers`, `calibrate_markers`, or any solver path.

Differential Revision: D98361877


