### PR TITLE
Fix ARM64 build: add -fsigned-char for aarch64

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -347,7 +347,8 @@ build_py = { cmd = "pip install . -v --no-build-isolation", env = { CMAKE_ARGS =
     -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON \
     -DMOMENTUM_USE_SYSTEM_PYBIND11=OFF \
     -DMOMENTUM_USE_SYSTEM_RERUN_CPP_SDK=ON \
-    -DBUILD_SHARED_LIBS=OFF
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_CXX_FLAGS=-fsigned-char
 """, MOMENTUM_ENABLE_SIMD = "ON" } }
 # TODO(T219163027): Skip TestRendering entirely on Linux — drjit segfaults in scalar SIMD mode
 test_py = { cmd = "pytest pymomentum/test/ -k 'not TestRendering'", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [


### PR DESCRIPTION
Summary:
The `fx-gltf` header (`fx/gltf.h`) initializes a base64 decode table with
`-1` literals in a `char` array. On ARM64, `char` is unsigned by default
(unlike x86 where it's signed), causing `-Wnarrowing` errors because `-1`
cannot be narrowed from `int` to `unsigned char`.

Fix: add `-DCMAKE_CXX_FLAGS=-fsigned-char` to the `linux-aarch64` `build_py`
task in pixi.toml. This makes `char` behave consistently with x86, which is
the standard approach for ARM64 portability with third-party libraries that
assume signed `char`.

Differential Revision: D100219237


