### PR TITLE
clang-diagnostic-unused-parameter in momentum_ik_autograd.cpp

### DIFF
--- a/pymomentum/solver/momentum_ik_autograd.cpp
+++ b/pymomentum/solver/momentum_ik_autograd.cpp
@@ -893,7 +893,7 @@ std::tuple<at::Tensor, at::Tensor, std::vector<at::Tensor>> ResidualFunction<T>:
     const std::vector<at::Tensor>& dLoss_dResults,
     const std::vector<std::unique_ptr<TensorErrorFunction<T>>>& errorFunctions,
     at::Tensor errorFunctionWeights,
-    size_t numActiveErrorFunctions,
+    [[maybe_unused]] size_t numActiveErrorFunctions,
     const std::vector<int>& weightsMap) {
   const at::Tensor& grad_resid = dLoss_dResults[0];
   const at::Tensor& jacobian = results[1];


### PR DESCRIPTION
Differential Revision: D100457108


