### PR TITLE
Fix unchecked array bounds access (#1277)

### DIFF
--- a/momentum/character/inverse_parameter_transform.cpp
+++ b/momentum/character/inverse_parameter_transform.cpp
@@ -9,6 +9,7 @@
 
 #include "momentum/character/parameter_transform.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/exception.h"
 #include "momentum/common/log.h"
 
 namespace momentum {
@@ -80,8 +81,18 @@ ModelParameters applyModelParameterScales(
         parameterTransform.numAllModelParameters());
     for (Eigen::Index iParam = 0; iParam < parameterTransform.numAllModelParameters(); iParam++) {
       if (scalingParams.test(iParam)) {
+        MT_THROW_IF(
+            static_cast<size_t>(iParam) >= parameterTransform.name.size(),
+            "Parameter index {} exceeds parameter name count {}",
+            iParam,
+            parameterTransform.name.size());
         auto subsetParamIdx =
             scalingTransform.getParameterIdByName(parameterTransform.name[iParam]);
+        MT_THROW_IF(
+            subsetParamIdx >= static_cast<size_t>(scaleParametersSubset.size()),
+            "Subset parameter index {} exceeds scaleParametersSubset size {}",
+            subsetParamIdx,
+            scaleParametersSubset.size());
         modelIdentity[iParam] = scaleParametersSubset(subsetParamIdx);
 
         // Add the identity parameters into the motion:

--- a/momentum/character/linear_skinning.cpp
+++ b/momentum/character/linear_skinning.cpp
@@ -10,6 +10,7 @@
 #include "momentum/character/skeleton_state.h"
 #include "momentum/character/skin_weights.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/exception.h"
 #include "momentum/common/profile.h"
 #include "momentum/math/mesh.h"
 
@@ -556,6 +557,12 @@ Vector3<T> getSkinnedLocatorPosition(
       break;
     }
     const auto boneIndex = locator.parents[k];
+    MT_THROW_IF(
+        boneIndex >= state.jointState.size() || boneIndex >= inverseBindPose.size(),
+        "Bone index {} exceeds jointState size {} or inverseBindPose size {}",
+        boneIndex,
+        state.jointState.size(),
+        inverseBindPose.size());
     const auto& jointState = state.jointState[boneIndex];
 
     worldPos +=

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -107,6 +107,11 @@ void createLocatorNodes(
 
     // set parent if it has one
     if (loc.parent != kInvalidIndex) {
+      MT_THROW_IF(
+          loc.parent >= skeletonNodes.size(),
+          "Locator parent index {} exceeds skeletonNodes size {}",
+          loc.parent,
+          skeletonNodes.size());
       skeletonNodes[loc.parent]->AddChild(locatorNode);
     }
   }
@@ -150,6 +155,11 @@ void createCollisionGeometryNodes(
     collisionNode->LclScaling.Set(FbxDouble3(1));
 
     if (collision.parent != kInvalidIndex) {
+      MT_THROW_IF(
+          collision.parent >= skeletonNodes.size(),
+          "Collision parent index {} exceeds skeletonNodes size {}",
+          collision.parent,
+          skeletonNodes.size());
       skeletonNodes[collision.parent]->AddChild(collisionNode);
     } else {
       MT_LOGE("Found a collision node with no parent");
@@ -762,6 +772,11 @@ SkeletonNodeResult createSkeletonNodes(const Character& character, ::fbxsdk::Fbx
     const auto& joint = character.skeleton.joints[i];
     auto* skeletonNode = result.jointToNodeMap[i];
     if (joint.parent != kInvalidIndex) {
+      MT_THROW_IF(
+          joint.parent >= result.nodes.size(),
+          "Joint parent index {} exceeds nodes size {}",
+          joint.parent,
+          result.nodes.size());
       result.nodes[joint.parent]->AddChild(skeletonNode);
     }
   }

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -12,6 +12,7 @@
 #include "momentum/character/collision_geometry_state.h"
 #include "momentum/character/skin_weights.h"
 #include "momentum/character/types.h"
+#include "momentum/common/exception.h"
 #include "momentum/common/filesystem.h"
 #include "momentum/common/log.h"
 #include "momentum/io/common/gsl_utils.h"
@@ -986,6 +987,11 @@ MatrixXf parseAnimation(
   const size_t numFrames = ceil(totalSeconds * fps) + 1;
   motion.setZero(skeleton.joints.size() * kParametersPerJoint, numFrames);
 
+  MT_THROW_IF(
+      boneFbxNodes.size() < skeleton.joints.size(),
+      "boneFbxNodes size {} is less than skeleton joints size {}",
+      boneFbxNodes.size(),
+      skeleton.joints.size());
   for (size_t i = 0; i < skeleton.joints.size(); ++i) {
     // Load the rest pose into the animation; for channels that aren't animated, Maya
     // won't export a curve node and so this is the only way to get the rest pose set

--- a/momentum/io/gltf/gltf_animation_io.cpp
+++ b/momentum/io/gltf/gltf_animation_io.cpp
@@ -243,16 +243,17 @@ size_t validateAndResolveChannel(
     return kInvalidIndex;
   }
 
-  const auto boneIdx = nodeToObjectMap[channel.target.node];
+  // Bounds already validated above
+  const auto boneIdx = nodeToObjectMap.at(channel.target.node);
   MT_THROW_IF(
       boneIdx >= skeleton.joints.size(),
       "Bone index {} is larger than the number of joints in the skeleton ({})",
       boneIdx,
       skeleton.joints.size());
 
-  const auto& node = model.nodes[channel.target.node];
+  const auto& node = model.nodes.at(channel.target.node);
   MT_THROW_IF(
-      node.name != skeleton.joints[boneIdx].name,
+      node.name != skeleton.joints.at(boneIdx).name,
       "Bone mismatch between gltf and character; GLTF: {}, Character: {}",
       node.name,
       skeleton.joints[boneIdx].name);
@@ -310,16 +311,31 @@ bool applyChannelDataToStates(
   // Apply the transform component to each frame
   if (translations_m.size() == states.size()) {
     for (size_t i = 0; i < states.size(); ++i) {
+      MT_THROW_IF(
+          boneIdx >= states[i].jointState.size(),
+          "Bone index {} exceeds jointState size {}",
+          boneIdx,
+          states[i].jointState.size());
       states[i].jointState[boneIdx].localTransform.translation = toCm() * translations_m[i];
     }
   }
   if (rotations.size() == states.size()) {
     for (size_t i = 0; i < states.size(); ++i) {
+      MT_THROW_IF(
+          boneIdx >= states[i].jointState.size(),
+          "Bone index {} exceeds jointState size {}",
+          boneIdx,
+          states[i].jointState.size());
       states[i].jointState[boneIdx].localTransform.rotation = rotations[i];
     }
   }
   if (scales.size() == states.size()) {
     for (size_t i = 0; i < states.size(); ++i) {
+      MT_THROW_IF(
+          boneIdx >= states[i].jointState.size(),
+          "Bone index {} exceeds jointState size {}",
+          boneIdx,
+          states[i].jointState.size());
       states[i].jointState[boneIdx].localTransform.scale = scales[i].x();
     }
   }

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -14,6 +14,7 @@
 #include "momentum/character/character_utility.h"
 #include "momentum/character/collision_geometry_state.h"
 #include "momentum/character/skin_weights.h"
+#include "momentum/common/exception.h"
 #include "momentum/common/filesystem.h"
 #include "momentum/common/log.h"
 #include "momentum/io/common/json_utils.h"
@@ -790,7 +791,12 @@ void addLocatorsToModel(
     auto& node = model.nodes.back();
 
     // add node as child to parent joint
-    model.nodes[jointToNodeMap[loc.parent]].children.push_back(static_cast<int32_t>(nodeIndex));
+    MT_THROW_IF(
+        loc.parent >= jointToNodeMap.size(),
+        "Locator parent index {} exceeds jointToNodeMap size {}",
+        loc.parent,
+        jointToNodeMap.size());
+    model.nodes.at(jointToNodeMap[loc.parent]).children.push_back(static_cast<int32_t>(nodeIndex));
 
     // add values for the tapered capsule
     node.name = loc.name;

--- a/momentum/io/gltf/gltf_mesh_io.cpp
+++ b/momentum/io/gltf/gltf_mesh_io.cpp
@@ -353,6 +353,7 @@ void addSkinWeights(
             jointIdxInSkin,
             skin.joints.size());
         const auto& nodeIdx = skin.joints[jointIdxInSkin];
+        MT_CHECK(nodeIdx < nodeToObjectMap.size(), "{}: {}", nodeIdx, nodeToObjectMap.size());
         const auto& jointIndex = nodeToObjectMap[nodeIdx];
         if (jointIndex != kInvalidIndex) {
           skinWeights->index(kVertexOffset + v, i * 4 + d) = (uint32_t)jointIndex;

--- a/momentum/io/skeleton/parameter_transform_io.cpp
+++ b/momentum/io/skeleton/parameter_transform_io.cpp
@@ -8,6 +8,7 @@
 #include "momentum/io/skeleton/parameter_transform_io.h"
 
 #include "momentum/character/skeleton.h"
+#include "momentum/common/exception.h"
 #include "momentum/common/log.h"
 #include "momentum/common/string.h"
 #include "momentum/io/common/stream_utils.h"
@@ -697,7 +698,7 @@ std::string writeModelDefinition(
       // Write all parameter=value pairs
       for (const auto& [paramIndex, value] : constraint.parameterIdValue) {
         if (paramIndex < parameterTransform.name.size()) {
-          oss << " " << parameterTransform.name[paramIndex] << "=" << value;
+          oss << " " << parameterTransform.name.at(paramIndex) << "=" << value;
         }
       }
       oss << "\n";

--- a/momentum/io/usd/usd_skeleton_io.cpp
+++ b/momentum/io/usd/usd_skeleton_io.cpp
@@ -8,6 +8,7 @@
 #include "momentum/io/usd/usd_skeleton_io.h"
 
 #include "momentum/common/checks.h"
+#include "momentum/common/exception.h"
 #include "momentum/common/log.h"
 #include "momentum/io/usd/usd_utils.h"
 
@@ -96,6 +97,12 @@ std::vector<std::string> buildHierarchicalPaths(const Skeleton& skeleton) {
     if (skeleton.joints[i].parent == kInvalidIndex) {
       paths[i] = skeleton.joints[i].name;
     } else {
+      MT_THROW_IF(
+          skeleton.joints[i].parent >= paths.size(),
+          "Parent joint index {} exceeds paths size {} for joint {}",
+          skeleton.joints[i].parent,
+          paths.size(),
+          i);
       paths[i] = paths[skeleton.joints[i].parent] + "/" + skeleton.joints[i].name;
     }
   }
@@ -167,6 +174,11 @@ Skeleton loadSkeletonFromUsd(const UsdStageRefPtr& stage) {
           // Convert world-space to local-space by removing parent's world transform
           Eigen::Matrix4f localMatrix;
           if (skeleton.joints[i].parent != kInvalidIndex) {
+            MT_THROW_IF(
+                skeleton.joints[i].parent >= bindTransforms.size(),
+                "Parent joint index {} exceeds bindTransforms size {}",
+                skeleton.joints[i].parent,
+                bindTransforms.size());
             Eigen::Matrix4f parentWorld =
                 toEigenMatrix4f(bindTransforms[skeleton.joints[i].parent]);
             localMatrix = parentWorld.inverse() * worldMatrix;
@@ -228,7 +240,7 @@ void saveCollisionGeometryToUsd(
   for (size_t i = 0; i < collision.size(); ++i) {
     const auto& capsule = collision[i];
     const std::string jointName = (capsule.parent < skeleton.joints.size())
-        ? skeleton.joints[capsule.parent].name
+        ? skeleton.joints.at(capsule.parent).name
         : "unknown";
     const std::string primName = sanitizePrimName(jointName + "_col_" + std::to_string(i));
 
@@ -344,7 +356,7 @@ void saveLocatorsToUsd(
     prim.CreateAttribute(_tokens->momentumName, SdfValueTypeNames->String).Set(loc.name);
 
     const std::string parentName =
-        (loc.parent < skeleton.joints.size()) ? skeleton.joints[loc.parent].name : "";
+        (loc.parent < skeleton.joints.size()) ? skeleton.joints.at(loc.parent).name : "";
     prim.CreateAttribute(_tokens->momentumParent, SdfValueTypeNames->String).Set(parentName);
 
     prim.CreateAttribute(_tokens->momentumOffset, SdfValueTypeNames->Float3)

--- a/momentum/marker_tracking/tracker_utils.cpp
+++ b/momentum/marker_tracking/tracker_utils.cpp
@@ -93,6 +93,11 @@ std::vector<std::vector<SkinnedLocatorConstraint>> createSkinnedConstraintData(
       }
       size_t locatorIdx = query->second;
 
+      MT_THROW_IF(
+          locatorIdx >= locators.size(),
+          "Skinned locator index {} exceeds locators size {}",
+          locatorIdx,
+          locators.size());
       SkinnedLocatorConstraint skinnedConstraint;
       skinnedConstraint.locatorIndex = gsl::narrow_cast<int>(locatorIdx);
       skinnedConstraint.targetPosition = jMarker.pos.cast<float>();


### PR DESCRIPTION
Summary:

Add bounds checks before array/vector access via [], front(), or back(). Uses
MT_THROW_IF for precondition checks and .at() for bounds-checked access.

SIMD error functions in character_solver/ were handled conservatively —
only adding checks for parameter validation, not inside tight computation
loops which are already bounded by constraint counts.

Reviewed By: cstollmeta

Differential Revision: D99161365
