### PR TITLE
Fix TRC parser using per-frame data as unit string (#1278)

### DIFF
--- a/momentum/io/marker/trc_io.cpp
+++ b/momentum/io/marker/trc_io.cpp
@@ -47,6 +47,7 @@ MarkerSequence loadTrc(const std::string& filename, UpVector up) {
   }
   const double frameRate = std::stod(tokens[0]);
   const size_t numMarkers = std::stoi(tokens[3]);
+  const std::string unitStr = tokens[4];
   res.fps = static_cast<float>(frameRate);
 
   // get line with marker names and parse it
@@ -86,7 +87,7 @@ MarkerSequence loadTrc(const std::string& filename, UpVector up) {
         markers[i].occluded = false;
         Vector3d p{
             std::stod(tokens[pos + 0]), std::stod(tokens[pos + 1]), std::stod(tokens[pos + 2])};
-        p = toMomentumVector3(p, up, tokens[4]);
+        p = toMomentumVector3(p, up, unitStr);
         markers[i].pos = p;
       }
     }


### PR DESCRIPTION
Summary:

In `loadTrc()`, the `tokens` variable is first set to the tokenized header line (line 44), where `tokens[4]` is the unit string (e.g. "mm"). However, inside the frame loop (line 68), `tokens` is reassigned to per-frame data columns. At line 89, `tokens[4]` then refers to the Z-coordinate of the first marker (e.g. "1.234") instead of the unit string.

This causes `toUnit("1.234")` to return `Unit::Unknown`, which defaults to centimeters, effectively disabling unit conversion for ALL TRC files. Files with mm/m/dm units are silently treated as centimeters.

The fix saves the unit string from the header into a local variable (`unitStr`) before `tokens` is reassigned, and uses that variable in the `toMomentumVector3()` call inside the loop.

Reviewed By: yutingye

Differential Revision: D100855471
