### PR TITLE
Fix size_t underflow in sampleFrames when numFrames is 0

### DIFF
--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -81,13 +81,12 @@ std::vector<size_t> sampleFrames(
     const size_t numSamples) {
   // sample frames so that we get the most variance from the initial input
   const auto numFrames = static_cast<size_t>(initialMotion.cols());
+  if (numFrames == 0) {
+    return {};
+  }
   MT_CHECK(frameStride > 0, "frameStride must be > 0.");
   size_t solvedFrames = (numFrames - 1) / frameStride + 1;
-
   std::vector<size_t> frameIndices;
-  if (solvedFrames == 0) {
-    return frameIndices;
-  }
   const size_t numActualSamples = std::min(numSamples, solvedFrames);
 
   // get the indices of the parameters to be used


### PR DESCRIPTION
Summary:
When initialMotion.cols() == 0, the expression (numFrames - 1) in sampleFrames() wraps to SIZE_MAX due to unsigned integer underflow on size_t, producing a massive solvedFrames value. The subsequent check (solvedFrames == 0) never triggers, leading to OOB accesses or huge allocation attempts.

Fix: Add an early return when numFrames == 0 before the subtraction, preventing the underflow entirely. The now-unreachable (solvedFrames == 0) check is removed since with numFrames >= 1 and frameStride >= 1, solvedFrames is always >= 1.

Differential Revision: D100857738


