### PR TITLE
Fix off-by-one bounds checks and bare throw in core solver

### DIFF
--- a/momentum/character/parameter_limits.cpp
+++ b/momentum/character/parameter_limits.cpp
@@ -9,6 +9,7 @@
 
 #include "momentum/character/parameter_transform.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/exception.h"
 
 namespace momentum {
 
@@ -47,9 +48,9 @@ JointParameters applyPassiveJointParameterLimits(
 
     const auto& data = limit.data.minMaxJoint;
     const size_t parameterIndex = data.jointIndex * kParametersPerJoint + data.jointParameter;
-    MT_CHECK(
-        parameterIndex <= static_cast<size_t>(jointParams.size()),
-        "{} vs {}",
+    MT_THROW_IF(
+        parameterIndex >= static_cast<size_t>(jointParams.size()),
+        "Parameter index {} out of bounds (size: {})",
         parameterIndex,
         jointParams.size());
     if (res(parameterIndex) < data.limits[0]) {

--- a/momentum/character_solver/skeleton_error_function.h
+++ b/momentum/character_solver/skeleton_error_function.h
@@ -11,6 +11,7 @@
 #include <momentum/character/parameter_transform.h>
 #include <momentum/character/types.h>
 #include <momentum/character_solver/fwd.h>
+#include <momentum/common/exception.h>
 
 namespace momentum {
 
@@ -87,7 +88,7 @@ class SkeletonErrorFunctionT {
       const SkeletonStateT<T>& /* state */,
       const MeshStateT<T>& /* meshState */,
       Eigen::Ref<Eigen::MatrixX<T>> /* hessian */) {
-    throw;
+    MT_THROW("getHessian is not implemented for this error function");
   }
 
   virtual double getSolverDerivatives(

--- a/momentum/io/gltf/gltf_skeleton_io.cpp
+++ b/momentum/io/gltf/gltf_skeleton_io.cpp
@@ -86,7 +86,7 @@ void loadHierarchyRecursive(
     std::vector<size_t>& nodeToObjectMap,
     bool useExtension) {
   MT_THROW_IF(
-      (nodeId < 0) || (nodeId > model.nodes.size()),
+      (nodeId < 0) || (nodeId >= model.nodes.size()),
       "Invalid node id found in the gltf hierarchy: {}",
       nodeId);
   const auto& node = model.nodes[nodeId];


### PR DESCRIPTION
Summary:
Three correctness fixes in momentum's core solver/character code:

1. parameter_limits.cpp: Fixed off-by-one in bounds check (changed <= to <) and upgraded from MT_CHECK (assert, no-op in release) to MT_THROW_IF for release-mode safety.

2. skeleton_error_function.h: Replaced bare `throw;` with `MT_THROW(...)`. A bare throw outside a catch block calls std::terminate() instead of throwing a catchable exception.

3. gltf_skeleton_io.cpp: Fixed off-by-one in bounds check (changed > to >=). When nodeId == model.nodes.size(), the check passed but model.nodes[nodeId] was out-of-bounds.

Differential Revision: D100855886


