### PR TITLE
Fix numerical stability: division-by-zero and epsilon guards across momentum (#1281)

### DIFF
--- a/momentum/character/linear_skinning.cpp
+++ b/momentum/character/linear_skinning.cpp
@@ -231,7 +231,10 @@ void applySSD(
             // add up normals
             outputn.noalias() += topLeft * nml * weight;
           }
-          outputn.normalize();
+          const T nmlNorm = outputn.norm();
+          if (nmlNorm > T(0)) {
+            outputn /= nmlNorm;
+          }
         }
       },
       options);

--- a/momentum/character/skeleton_state.cpp
+++ b/momentum/character/skeleton_state.cpp
@@ -175,7 +175,7 @@ StateSimilarity SkeletonStateT<T>::compare(
   result.positionRMSE = std::sqrt(
       result.positionError.squaredNorm() / static_cast<float>(result.positionError.size()));
   result.orientationRMSE = std::sqrt(
-      result.orientationError.squaredNorm() / static_cast<float>(result.positionError.size()));
+      result.orientationError.squaredNorm() / static_cast<float>(result.orientationError.size()));
   result.positionMax = result.positionError.maxCoeff();
   result.orientationMax = result.orientationError.maxCoeff();
 

--- a/momentum/character_solver/distance_error_function.h
+++ b/momentum/character_solver/distance_error_function.h
@@ -18,7 +18,7 @@ struct DistanceConstraintDataT {
   Eigen::Vector3<T> origin = Eigen::Vector3<T>::Zero(); // origin in world space
   T target{}; // distance target in world space
   size_t parent{}; // parent joint of the constraint
-  Eigen::Vector3<T> offset; // relative offset to the parent
+  Eigen::Vector3<T> offset = Eigen::Vector3<T>::Zero(); // relative offset to the parent
   T weight{}; // constraint weight
   // comment for now
   static DistanceConstraintDataT<T> createFromLocator(const momentum::Locator& locator);

--- a/momentum/character_solver/model_parameters_error_function.cpp
+++ b/momentum/character_solver/model_parameters_error_function.cpp
@@ -88,7 +88,13 @@ double ModelParametersErrorFunctionT<T>::getGradient(
 
 template <typename T>
 size_t ModelParametersErrorFunctionT<T>::getJacobianSize() const {
-  return (targetWeights_.array() > T(0)).count();
+  size_t count = 0;
+  for (Eigen::Index i = 0; i < targetWeights_.size(); ++i) {
+    if (this->enabledParameters_.test(i) && targetWeights_(i) > T(0)) {
+      ++count;
+    }
+  }
+  return count;
 }
 
 template <typename T>

--- a/momentum/character_solver/trust_region_qr.cpp
+++ b/momentum/character_solver/trust_region_qr.cpp
@@ -242,7 +242,8 @@ void TrustRegionQRT<T>::doIteration() {
     // This is the decrease of the function relative to what we _expected_ the function to
     // decrease by.  It is eq. 4.4 in Nocedal and Wright.
     const T quadraticModelEval = evalQuadraticModel(searchDir_sub);
-    const T rho = (this->error_ - error_new) / (this->error_ - quadraticModelEval);
+    const T denominator = this->error_ - quadraticModelEval;
+    const T rho = (denominator == T(0)) ? T(0) : (this->error_ - error_new) / denominator;
     MT_LOGI_IF(
         this->verbose_,
         "Error orig: {}; error new: {}; quadratic model: {}; rho: {}",

--- a/momentum/character_solver/vertex_vertex_distance_error_function.cpp
+++ b/momentum/character_solver/vertex_vertex_distance_error_function.cpp
@@ -13,6 +13,7 @@
 #include "momentum/character_solver/skeleton_derivative.h"
 #include "momentum/common/checks.h"
 #include "momentum/common/profile.h"
+#include "momentum/math/constants.h"
 #include "momentum/math/mesh.h"
 
 namespace momentum {
@@ -149,7 +150,7 @@ double VertexVertexDistanceErrorFunctionT<T>::calculateJacobian(
   const T actualDistance = diff.norm();
 
   // Handle degenerate case where vertices are at the same position
-  if (actualDistance == T(0)) {
+  if (actualDistance < Eps<T>(1e-8f, 1e-14)) {
     residual = T(0);
     return T(0); // No meaningful jacobian when distance is zero
   }
@@ -201,7 +202,7 @@ double VertexVertexDistanceErrorFunctionT<T>::calculateGradient(
   const T actualDistance = diff.norm();
 
   // Handle degenerate case where vertices are at the same position
-  if (actualDistance == T(0)) {
+  if (actualDistance < Eps<T>(1e-8f, 1e-14)) {
     return T(0); // No meaningful gradient when distance is zero
   }
 

--- a/momentum/math/intersection.cpp
+++ b/momentum/math/intersection.cpp
@@ -101,7 +101,10 @@ std::vector<std::pair<int32_t, int32_t>> intersectMeshBruteForce(const MeshT<T>&
     const Eigen::Vector3<T> v0 = mesh.vertices[faceVerts[0]];
     const Eigen::Vector3<T> v1 = mesh.vertices[faceVerts[1]];
     const Eigen::Vector3<T> v2 = mesh.vertices[faceVerts[2]];
-    faceNormals[iFace] = (v1 - v0).cross(v2 - v0).normalized();
+    const auto cross = (v1 - v0).cross(v2 - v0);
+    const T crossNorm = cross.norm();
+    faceNormals[iFace] =
+        (crossNorm > T(0)) ? (cross / crossNorm).eval() : Eigen::Vector3<T>::Zero();
   }
   // calculate all face intersections brute force
   for (size_t iFace0 = 0; iFace0 < mesh.faces.size(); iFace0++) {
@@ -130,7 +133,10 @@ std::vector<std::pair<int32_t, int32_t>> intersectMesh(const MeshT<T>& mesh) {
     const Eigen::Vector3<T> v0 = mesh.vertices[faceVerts[0]];
     const Eigen::Vector3<T> v1 = mesh.vertices[faceVerts[1]];
     const Eigen::Vector3<T> v2 = mesh.vertices[faceVerts[2]];
-    faceNormals[iFace] = (v1 - v0).cross(v2 - v0).normalized();
+    const auto cross = (v1 - v0).cross(v2 - v0);
+    const T crossNorm = cross.norm();
+    faceNormals[iFace] =
+        (crossNorm > T(0)) ? (cross / crossNorm).eval() : Eigen::Vector3<T>::Zero();
 
     auto& aabb = aabbs[iFace];
     aabb.aabb.min() = v0;


### PR DESCRIPTION
Summary:

Fix seven numerical stability issues across the solver and character code:

1. vertex_vertex_distance_error_function.cpp: Replace exact == 0 check with epsilon guard (Eps<T>(1e-8f, 1e-14)) matching the pattern used in joint_to_joint_distance_error_function.cpp. Near-coincident vertices were bypassing the check and producing huge distanceGradient values.

2. trust_region_qr.cpp: Guard against division by zero in rho calculation when the denominator (error_ - quadraticModelEval) is zero. Previously produced NaN which silently disabled trust region adaptation.

3. linear_skinning.cpp: Replace outputn.normalize() with a safe normalization that checks for zero-length normals before dividing, preventing NaN normals in skinned meshes.

4. math/intersection.cpp: Replace .normalized() on cross products with safe normalization that returns zero vector for degenerate triangles, preventing NaN face normals in both brute-force and BVH intersection paths.

5. distance_error_function.h: Add default initializer (Zero()) for DistanceConstraintDataT::offset to match all other fields which have default initializers.

6. skeleton_state.cpp: Fix orientationRMSE to use orientationError.size() instead of positionError.size() as the denominator (copy-paste bug).

7. model_parameters_error_function.cpp: Fix getJacobianSize() to check both enabledParameters_ and positive weight, matching the condition used in getJacobian(). The mismatch could cause buffer overrun when enabledParameters_ is restricted.

Reviewed By: cdtwigg

Differential Revision: D100866725
