### PR TITLE
Fix missing limitWeight in computeHalfPlaneGradient

### DIFF
--- a/momentum/character_solver/limit_error_function.cpp
+++ b/momentum/character_solver/limit_error_function.cpp
@@ -270,10 +270,10 @@ T computeHalfPlaneGradient(
   }
   const T error = residual * residual * limitWeight * tWeight;
   if (enabledParameters.test(data.param1)) {
-    gradient[data.param1] += T(2) * residual * T(data.normal[0]) * tWeight;
+    gradient[data.param1] += T(2) * residual * T(data.normal[0]) * limitWeight * tWeight;
   }
   if (enabledParameters.test(data.param2)) {
-    gradient[data.param2] += T(2) * residual * T(data.normal[1]) * tWeight;
+    gradient[data.param2] += T(2) * residual * T(data.normal[1]) * limitWeight * tWeight;
   }
   return error;
 }


### PR DESCRIPTION
Summary:
The gradient computation in computeHalfPlaneGradient was missing the limitWeight multiplier. The error was correctly computed as residual^2 * limitWeight * tWeight, but the gradient lines only used tWeight, omitting limitWeight. This caused incorrect gradient magnitudes for half-plane limits with non-unity weight, leading to wrong solver step sizes.

Added the missing * limitWeight to both gradient accumulation lines to match the error formula and be consistent with other gradient functions like computeMinMaxGradient.

Differential Revision: D100857233


