### PR TITLE
Fix FBX parsing stack overflow, OOB seek, and type mismatch

### DIFF
--- a/momentum/io/fbx/fbx_memory_stream.cpp
+++ b/momentum/io/fbx/fbx_memory_stream.cpp
@@ -88,6 +88,12 @@ void FbxMemoryStream::Seek(const FbxInt64& pOffset, const FbxFile::ESeekPos& pSe
       position_ = offset;
       break;
   }
+  // Clamp position to valid range to prevent out-of-bounds reads
+  if (position_ < 0) {
+    position_ = 0;
+  } else if (position_ > length_) {
+    position_ = length_;
+  }
 }
 
 #if FBX_VERSION_GE(2020, 3, 2)

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -228,10 +228,10 @@ std::string resolveStringProperty(const ofbx::Object& object, const char* name) 
   const ofbx::IElementProperty* x = getElementProperty(element, 4);
   MT_THROW_IF(x == nullptr, "Unable to find property {} in {}", name, object.name);
   if (x->getType() == ofbx::IElementProperty::STRING) {
-    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-    char result[65536];
-    x->getValue().toString(result);
-    return {result};
+    const auto& val = x->getValue();
+    const size_t len = val.end - val.begin;
+    std::string result(reinterpret_cast<const char*>(val.begin), len);
+    return result;
   } else {
     MT_THROW("For property {}, expected string but got {}.", name, propertyTypeStr(x->getType()));
   }
@@ -257,7 +257,7 @@ VecArray extractPropertyArrayImp(const ofbx::IElementProperty* prop, const char*
       int(vecLength),
       nScalar);
 
-  std::vector<double> vals(nScalar);
+  std::vector<EltType> vals(nScalar);
   prop->getValues(vals.data(), (int)(sizeof(EltType) * vals.size()));
 
   VecArray result;


### PR DESCRIPTION
Summary:
Fix three security issues in FBX file parsing:

1. Stack buffer overflow in resolveStringProperty: Replace fixed 64KB stack buffer with std::string constructed directly from DataView begin/end pointers, eliminating the possibility of overflow from oversized FBX string properties.

2. OOB read in FbxMemoryStream::Seek: Add bounds clamping after seek operations to ensure position_ stays within [0, length_], preventing out-of-bounds memcpy in subsequent Read() calls.

3. Float/double type mismatch in extractPropertyArrayImp: Change buffer from vector<double> to vector<EltType> so that when EltType=float, getValues writes into a correctly-sized buffer and values are read back as the correct type.

Differential Revision: D100856319


