### PR TITLE
Add validation and overflow guards to binary I/O parsers

### DIFF
--- a/momentum/io/motion/mmo_io.cpp
+++ b/momentum/io/motion/mmo_io.cpp
@@ -11,6 +11,7 @@
 #include "momentum/common/log.h"
 
 #include <fstream>
+#include <limits>
 
 namespace momentum {
 
@@ -134,6 +135,10 @@ void saveMmo(
   }
 
   std::ofstream fs(filename, std::ios::out | std::ios::binary);
+  if (!fs.is_open()) {
+    MT_LOGW("{}: Failed to open file for writing: {}", __func__, filename);
+    return;
+  }
   // write out sizes
   size_t data = 0;
   data = parameterNames.size(); // number of parameters
@@ -269,11 +274,44 @@ std::tuple<MatrixXf, VectorXf, std::vector<std::string>, std::vector<std::string
   fs.read((char*)&nJoints, sizeof(size_t));
   fs.read((char*)&nFrames, sizeof(size_t));
 
+  if (!fs.good()) {
+    MT_LOGW("{}: Failed to read header from file {}", __func__, filename);
+    return result;
+  }
+
+  // Validate sizes to prevent excessive allocation from malformed files
+  constexpr size_t kMaxDimension = 10'000'000;
+  constexpr size_t kMaxStringLength = 10'000;
+  if (nParams > kMaxDimension || nJoints > kMaxDimension || nFrames > kMaxDimension) {
+    MT_LOGW(
+        "{}: Unreasonable dimensions in file {}: nParams={}, nJoints={}, nFrames={}",
+        __func__,
+        filename,
+        nParams,
+        nJoints,
+        nFrames);
+    return result;
+  }
+
+  // Guard against integer overflow in size calculations
+  if (nJoints != 0 && nJoints > std::numeric_limits<size_t>::max() / kParametersPerJoint) {
+    MT_LOGW("{}: Integer overflow in scale size for file {}", __func__, filename);
+    return result;
+  }
+  if (nParams != 0 && nFrames != 0 && nParams > std::numeric_limits<size_t>::max() / nFrames) {
+    MT_LOGW("{}: Integer overflow in pose matrix size for file {}", __func__, filename);
+    return result;
+  }
+
   // load parameter names
   for (size_t i = 0; i < nParams; i++) {
     // read parameter name
     size_t count = 0;
     fs.read((char*)&count, sizeof(size_t));
+    if (!fs.good() || count > kMaxStringLength) {
+      MT_LOGW("{}: Invalid parameter name length in file {}", __func__, filename);
+      return result;
+    }
     std::string name;
     name.resize(count);
     fs.read((char*)name.data(), count);
@@ -282,9 +320,13 @@ std::tuple<MatrixXf, VectorXf, std::vector<std::string>, std::vector<std::string
 
   // load joint names
   for (size_t i = 0; i < nJoints; i++) {
-    // read parameter name
+    // read joint name
     size_t count = 0;
     fs.read((char*)&count, sizeof(size_t));
+    if (!fs.good() || count > kMaxStringLength) {
+      MT_LOGW("{}: Invalid joint name length in file {}", __func__, filename);
+      return result;
+    }
     std::string name;
     name.resize(count);
     fs.read((char*)name.data(), count);
@@ -294,10 +336,18 @@ std::tuple<MatrixXf, VectorXf, std::vector<std::string>, std::vector<std::string
   // read offsets and re-arrange them according to the map
   scale = VectorXf(nJoints * kParametersPerJoint);
   fs.read((char*)scale.data(), scale.size() * sizeof(float));
+  if (!fs.good()) {
+    MT_LOGW("{}: Failed to read scale data from file {}", __func__, filename);
+    return result;
+  }
 
   // read frames and re-arrange them according to the map
   poses = MatrixXf(nParams, nFrames);
   fs.read((char*)poses.data(), poses.size() * sizeof(float));
+  if (!fs.good()) {
+    MT_LOGW("{}: Failed to read pose data from file {}", __func__, filename);
+    return result;
+  }
 
   return result;
 }

--- a/momentum/io/shape/blend_shape_io.cpp
+++ b/momentum/io/shape/blend_shape_io.cpp
@@ -16,6 +16,7 @@
 
 #include <fstream>
 #include <istream>
+#include <limits>
 #include <vector>
 
 namespace momentum {
@@ -42,9 +43,15 @@ void readShapeVectors(
     uint64_t numCols,
     int expectedShapes,
     int expectedVertices) {
+  // Guard against integer overflow in numRows * numCols
+  MT_THROW_IF(
+      numRows != 0 && numCols > std::numeric_limits<uint64_t>::max() / numRows,
+      "Integer overflow in shape vectors size calculation.");
+
   // load shapeVectors
   shapeVectors.resize(numRows, numCols);
   data.read((char*)shapeVectors.data(), sizeof(float) * numRows * numCols);
+  MT_THROW_IF(!data.good(), "Failed to read shape vectors data.");
 
   // resize to few shapes
   if (expectedShapes > 0) {
@@ -76,6 +83,14 @@ BlendShapeBase loadBlendShapeBase(std::istream& data, int expectedShapes, int ex
   uint64_t numCols = 0;
   data.read((char*)&numRows, sizeof(numRows));
   data.read((char*)&numCols, sizeof(numCols));
+  MT_THROW_IF(!data.good(), "Failed to read blend shape base dimensions.");
+
+  constexpr uint64_t kMaxDimension = 10'000'000;
+  MT_THROW_IF(
+      numRows > kMaxDimension || numCols > kMaxDimension,
+      "Unreasonable blend shape base dimensions: numRows={}, numCols={}.",
+      numRows,
+      numCols);
 
   // read shape vectors
   readShapeVectors(data, shapeVectors, numRows, numCols, expectedShapes, expectedVertices);
@@ -100,10 +115,19 @@ BlendShape loadBlendShape(std::istream& data, int expectedShapes, int expectedVe
   uint64_t numCols = 0;
   data.read((char*)&numRows, sizeof(numRows));
   data.read((char*)&numCols, sizeof(numCols));
+  MT_THROW_IF(!data.good(), "Failed to read blend shape dimensions.");
+
+  constexpr uint64_t kMaxDimension = 10'000'000;
+  MT_THROW_IF(
+      numRows > kMaxDimension || numCols > kMaxDimension,
+      "Unreasonable blend shape dimensions: numRows={}, numCols={}.",
+      numRows,
+      numCols);
 
   // read mean shape
   baseShape.resize(numRows / 3);
   data.read((char*)baseShape.data(), sizeof(float) * numRows);
+  MT_THROW_IF(!data.good(), "Failed to read blend shape base shape data.");
 
   if (expectedVertices > 0) {
     baseShape.resize(std::min(baseShape.size(), gsl::narrow<size_t>(expectedVertices)));

--- a/momentum/io/shape/pose_shape_io.cpp
+++ b/momentum/io/shape/pose_shape_io.cpp
@@ -8,10 +8,12 @@
 #include "momentum/io/shape/pose_shape_io.h"
 
 #include "momentum/character/character.h"
+#include "momentum/common/exception.h"
 #include "momentum/common/log.h"
 #include "momentum/math/mesh.h"
 
 #include <fstream>
+#include <limits>
 
 namespace momentum {
 
@@ -30,7 +32,37 @@ PoseShape loadPoseShape(const std::string& filename, const Character& character)
   uint64_t numJoints = 0;
   data.read((char*)&numRows, sizeof(numRows));
   data.read((char*)&numJoints, sizeof(numJoints));
+
+  if (!data.good()) {
+    MT_LOGW("{}: Failed to read dimensions from file {}", __func__, filename);
+    return result;
+  }
+
+  // Validate sizes to prevent excessive allocation from malformed files
+  constexpr uint64_t kMaxDimension = 10'000'000;
+  constexpr uint64_t kMaxStringLength = 10'000;
+  if (numRows > kMaxDimension || numJoints > kMaxDimension) {
+    MT_LOGW(
+        "{}: Unreasonable dimensions in file {}: numRows={}, numJoints={}",
+        __func__,
+        filename,
+        numRows,
+        numJoints);
+    return result;
+  }
+
+  // Guard against integer overflow in numJoints * 4
+  if (numJoints > std::numeric_limits<uint64_t>::max() / 4) {
+    MT_LOGW("{}: Integer overflow in numCols calculation for file {}", __func__, filename);
+    return result;
+  }
   const uint64_t numCols = numJoints * 4;
+
+  // Guard against integer overflow in numRows * numCols
+  if (numRows != 0 && numCols != 0 && numRows > std::numeric_limits<uint64_t>::max() / numCols) {
+    MT_LOGW("{}: Integer overflow in shape matrix size for file {}", __func__, filename);
+    return result;
+  }
 
   MT_CHECK(
       character.mesh->vertices.size() * 3 == numRows,
@@ -40,6 +72,10 @@ PoseShape loadPoseShape(const std::string& filename, const Character& character)
 
   uint64_t count = 0;
   data.read((char*)&count, sizeof(uint64_t));
+  if (!data.good() || count > kMaxStringLength) {
+    MT_LOGW("{}: Invalid base joint name length in file {}", __func__, filename);
+    return result;
+  }
   std::string base;
   base.resize(count);
   data.read((char*)base.data(), count);
@@ -55,6 +91,10 @@ PoseShape loadPoseShape(const std::string& filename, const Character& character)
   std::vector<std::string> names(numJoints);
   for (size_t i = 0; i < numJoints; i++) {
     data.read((char*)&count, sizeof(uint64_t));
+    if (!data.good() || count > kMaxStringLength) {
+      MT_LOGW("{}: Invalid joint name length in file {}", __func__, filename);
+      return result;
+    }
     names[i].resize(count);
     data.read((char*)names[i].data(), count);
   }
@@ -62,6 +102,10 @@ PoseShape loadPoseShape(const std::string& filename, const Character& character)
   // read mean shape
   result.baseShape.resize(numRows);
   data.read((char*)result.baseShape.data(), sizeof(float) * numRows);
+  if (!data.good()) {
+    MT_LOGW("{}: Failed to read base shape data from file {}", __func__, filename);
+    return result;
+  }
 
   // add character vertices
   const Map<const VectorXf> mesh(
@@ -71,6 +115,10 @@ PoseShape loadPoseShape(const std::string& filename, const Character& character)
   // load shapeVectors
   result.shapeVectors.resize(numRows, numCols);
   data.read((char*)result.shapeVectors.data(), sizeof(float) * numRows * numCols);
+  if (!data.good()) {
+    MT_LOGW("{}: Failed to read shape vectors data from file {}", __func__, filename);
+    return result;
+  }
 
   // generate mapping from names
   result.jointMap.resize(numJoints);

--- a/momentum/io/skeleton/mppca_io.cpp
+++ b/momentum/io/skeleton/mppca_io.cpp
@@ -12,6 +12,7 @@
 #include "momentum/math/mppca.h"
 
 #include <fstream>
+#include <limits>
 
 namespace momentum {
 
@@ -46,6 +47,27 @@ std::shared_ptr<const Mppca> loadMppca(std::istream& inputStream) {
     inputStream.read((char*)&od, sizeof(od));
     inputStream.read((char*)&op, sizeof(op));
 
+    MT_THROW_IF(!inputStream.good(), "Error loading Mppca model: failed to read dimensions.");
+
+    // Validate sizes to prevent excessive allocation from malformed files
+    constexpr uint64_t kMaxDimension = 10'000'000;
+    constexpr uint64_t kMaxStringLength = 10'000;
+    MT_THROW_IF(
+        od > kMaxDimension || op > kMaxDimension,
+        "Error loading Mppca model: unreasonable dimensions od={}, op={}.",
+        od,
+        op);
+
+    // Guard against integer overflow in od * od (used for Cinv matrices)
+    MT_THROW_IF(
+        od != 0 && od > std::numeric_limits<uint64_t>::max() / od,
+        "Error loading Mppca model: integer overflow in Cinv size calculation.");
+
+    // Guard against integer overflow in op * od (used for mu matrix)
+    MT_THROW_IF(
+        op != 0 && od != 0 && op > std::numeric_limits<uint64_t>::max() / od,
+        "Error loading Mppca model: integer overflow in mu size calculation.");
+
     // set data on result
     result->d = od;
     result->p = op;
@@ -55,6 +77,9 @@ std::shared_ptr<const Mppca> loadMppca(std::istream& inputStream) {
     for (size_t i = 0; i < od; i++) {
       uint64_t count = 0;
       inputStream.read((char*)&count, sizeof(uint64_t));
+      MT_THROW_IF(
+          !inputStream.good() || count > kMaxStringLength,
+          "Error loading Mppca model: invalid name length.");
       result->names[i].resize(count);
       inputStream.read((char*)result->names[i].data(), count);
     }
@@ -67,12 +92,15 @@ std::shared_ptr<const Mppca> loadMppca(std::istream& inputStream) {
 
     // load Rpre, Cinv, and mu
     inputStream.read((char*)result->Rpre.data(), sizeof(float) * op);
+    MT_THROW_IF(!inputStream.good(), "Error loading Mppca model: failed to read Rpre data.");
     for (size_t i = 0; i < op; i++) {
       result->Cinv[i] = MatrixXf(od, od);
       inputStream.read((char*)result->Cinv[i].data(), sizeof(float) * od * od);
+      MT_THROW_IF(!inputStream.good(), "Error loading Mppca model: failed to read Cinv data.");
       result->L[i] = result->Cinv[i].llt().matrixL().transpose();
     }
     inputStream.read((char*)result->mu.data(), sizeof(float) * op * od);
+    MT_THROW_IF(!inputStream.good(), "Error loading Mppca model: failed to read mu data.");
 
     return result;
   } catch (std::exception& e) {


### PR DESCRIPTION
Summary:
Multiple binary file parsers (mmo_io, mppca_io, blend_shape_io, pose_shape_io) shared the same class of vulnerability: file-supplied size values were used directly for memory allocation and read sizing without validation or overflow checking. A crafted file could cause heap buffer overflow via integer overflow in size calculations, or return uninitialized data from truncated files.

This diff adds the following protections to all affected parsers:

- Reasonable size validation (max 10M per dimension) to prevent excessive allocation from malformed files
- Integer overflow guards before all size multiplications used for allocation/reads (e.g. nParams*nFrames, od*od, numRows*numCols)
- Stream state checks (fs.good()) after all read operations to detect truncated files
- String length validation in name-reading loops to prevent huge allocations from malicious string counts
- fs.is_open() check in the mmo_io save path

Fixes T264806314.

Differential Revision: D100858684


