### PR TITLE
Simplify global_trs_to_local_trs with vectorized parallel implementation

### DIFF
--- a/pymomentum/backend/trs_backend.py
+++ b/pymomentum/backend/trs_backend.py
@@ -195,49 +195,6 @@ def global_trs_state_from_local_trs_state_no_grad(
 
 
 @th.jit.script
-def ik_from_global_state(
-    global_state_t: th.Tensor,
-    global_state_r: th.Tensor,
-    global_state_s: th.Tensor,
-    prefix_mul_indices: List[th.Tensor],
-    use_double_precision: bool = True,
-) -> Tuple[th.Tensor, th.Tensor, th.Tensor]:
-    dtype = global_state_t.dtype
-
-    if use_double_precision:
-        local_state_t = global_state_t.clone().double()
-        local_state_r = global_state_r.clone().double()
-        local_state_s = global_state_s.clone().double()
-    else:
-        local_state_t = global_state_t.clone()
-        local_state_r = global_state_r.clone()
-        local_state_s = global_state_s.clone()
-
-    # Compose the inverse of the FK transforms, in reverse order.
-    for prefix_mul_index in prefix_mul_indices[::-1]:
-        joint = prefix_mul_index[0]
-        parent = prefix_mul_index[1]
-
-        s1 = local_state_s[:, parent].reciprocal()
-        r1 = trs.rotmat_inverse(local_state_r[:, parent])
-        t1 = local_state_t[:, parent]
-
-        s2 = local_state_s[:, joint]
-        r2 = local_state_r[:, joint]
-        t2 = local_state_t[:, joint]
-
-        local_state_s[:, joint] = s1 * s2
-        local_state_r[:, joint] = trs.rotmat_multiply(r1, r2)
-        local_state_t[:, joint] = trs.rotmat_rotate_vector(r1, (t2 - t1) * s1)
-
-    return (
-        local_state_t.to(dtype),
-        local_state_r.to(dtype),
-        local_state_s.to(dtype),
-    )
-
-
-@th.jit.script
 def global_trs_state_from_local_trs_state_backprop(
     joint_state_t: th.Tensor,
     joint_state_r: th.Tensor,

--- a/pymomentum/test/test_trs.py
+++ b/pymomentum/test/test_trs.py
@@ -637,6 +637,137 @@ class TestTRS(unittest.TestCase):
             torch.allclose(batch_rotmat[2], self._rotation_y(math.pi / 2), atol=1e-6)
         )
 
+    def test_index_select(self) -> None:
+        """Test selecting elements from a TRS transform along a dimension."""
+        batch_size = 2
+        num_joints = 6
+
+        # Create a TRS transform with known values
+        t = (
+            torch.arange(batch_size * num_joints * 3)
+            .view(batch_size, num_joints, 3)
+            .float()
+        )
+        r = (
+            torch.eye(3)
+            .unsqueeze(0)
+            .unsqueeze(0)
+            .expand(batch_size, num_joints, 3, 3)
+            .clone()
+        )
+        # Make each joint's rotation matrix slightly different for verification
+        for j in range(num_joints):
+            r[:, j, 0, 0] = float(j)  # Mark each joint's rotation
+        s = (
+            torch.arange(batch_size * num_joints)
+            .view(batch_size, num_joints, 1)
+            .float()
+            + 1
+        )
+
+        trs_input = (t, r, s)
+
+        # Select specific indices along the joint dimension
+        indices = torch.tensor([0, 2, 4])
+        result = pym_trs.index_select(trs_input, -2, indices)
+
+        # Check shapes
+        self.assertEqual(result[0].shape, (batch_size, 3, 3))  # translation
+        self.assertEqual(result[1].shape, (batch_size, 3, 3, 3))  # rotation
+        self.assertEqual(result[2].shape, (batch_size, 3, 1))  # scale
+
+        # Check values - should have selected joints 0, 2, 4
+        # For translation (shape batch, joints, 3): dim -2 selects on joints
+        expected_t = t.index_select(-2, indices)
+        # For rotation (shape batch, joints, 3, 3): dim -3 selects on joints
+        expected_r = r.index_select(-3, indices)
+        # For scale (shape batch, joints, 1): dim -2 selects on joints
+        expected_s = s.index_select(-2, indices)
+
+        self.assertTrue(torch.allclose(result[0], expected_t))
+        self.assertTrue(torch.allclose(result[1], expected_r))
+        self.assertTrue(torch.allclose(result[2], expected_s))
+
+        # Verify the rotation matrices have the expected joint indices
+        self.assertEqual(result[1][0, 0, 0, 0].item(), 0.0)  # joint 0
+        self.assertEqual(result[1][0, 1, 0, 0].item(), 2.0)  # joint 2
+        self.assertEqual(result[1][0, 2, 0, 0].item(), 4.0)  # joint 4
+
+    def test_where(self) -> None:
+        """Test conditional selection between two TRS transforms."""
+        batch_size = 2
+        num_joints = 4
+
+        # Create two TRS transforms with distinct values
+        t_true = torch.ones(batch_size, num_joints, 3)
+        r_true = (
+            torch.eye(3)
+            .unsqueeze(0)
+            .unsqueeze(0)
+            .expand(batch_size, num_joints, 3, 3)
+            .clone()
+        )
+        s_true = torch.ones(batch_size, num_joints, 1) * 2.0
+
+        t_false = torch.zeros(batch_size, num_joints, 3)
+        r_false = torch.zeros(batch_size, num_joints, 3, 3)
+        s_false = torch.zeros(batch_size, num_joints, 1)
+
+        trs_true = (t_true, r_true, s_true)
+        trs_false = (t_false, r_false, s_false)
+
+        # Condition: first two joints are True, last two are False
+        condition = torch.tensor([True, True, False, False])
+
+        result = pym_trs.where(condition, trs_true, trs_false)
+
+        # Check that first two joints have trs_true values
+        self.assertTrue(torch.allclose(result[0][:, :2], t_true[:, :2]))
+        self.assertTrue(torch.allclose(result[1][:, :2], r_true[:, :2]))
+        self.assertTrue(torch.allclose(result[2][:, :2], s_true[:, :2]))
+
+        # Check that last two joints have trs_false values
+        self.assertTrue(torch.allclose(result[0][:, 2:], t_false[:, 2:]))
+        self.assertTrue(torch.allclose(result[1][:, 2:], r_false[:, 2:]))
+        self.assertTrue(torch.allclose(result[2][:, 2:], s_false[:, 2:]))
+
+    def test_where_with_batched_condition(self) -> None:
+        """Test where with a condition that has batch dimensions."""
+        batch_size = 2
+        num_joints = 3
+
+        t_true = torch.ones(batch_size, num_joints, 3)
+        r_true = (
+            torch.eye(3)
+            .unsqueeze(0)
+            .unsqueeze(0)
+            .expand(batch_size, num_joints, 3, 3)
+            .clone()
+        )
+        s_true = torch.ones(batch_size, num_joints, 1)
+
+        t_false = torch.zeros(batch_size, num_joints, 3)
+        r_false = torch.zeros(batch_size, num_joints, 3, 3)
+        s_false = torch.zeros(batch_size, num_joints, 1)
+
+        trs_true = (t_true, r_true, s_true)
+        trs_false = (t_false, r_false, s_false)
+
+        # Condition varies per batch element
+        condition = torch.tensor([[True, False, True], [False, True, False]])
+
+        result = pym_trs.where(condition, trs_true, trs_false)
+
+        # Check batch 0: joints 0,2 should be true, joint 1 should be false
+        self.assertTrue(torch.allclose(result[0][0, 0], t_true[0, 0]))
+        self.assertTrue(torch.allclose(result[0][0, 1], t_false[0, 1]))
+        self.assertTrue(torch.allclose(result[0][0, 2], t_true[0, 2]))
+
+        # Check batch 1: joint 1 should be true, joints 0,2 should be false
+        self.assertTrue(torch.allclose(result[0][1, 0], t_false[1, 0]))
+        self.assertTrue(torch.allclose(result[0][1, 1], t_true[1, 1]))
+        self.assertTrue(torch.allclose(result[0][1, 2], t_false[1, 2]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -227,12 +227,14 @@ class Skeleton(torch.nn.Module):
         global_trs: pym_trs.TRSTransform,
     ) -> pym_trs.TRSTransform:
         """
-        Convert global TRS state to local TRS state using inverse kinematics.
+        Convert global TRS state to local TRS state.
 
-        This function performs inverse kinematics on the global TRS transformations
-        to compute the local joint transformations. This is the TRS equivalent of
-        skeleton_state_to_local_skeleton_state(). It's useful when you have global
-        TRS states and need to extract the local transformations for each joint.
+        This function computes local joint transformations from global TRS transformations
+        by multiplying each joint's global transform by the inverse of its parent's global
+        transform. This is the TRS equivalent of skeleton_state_to_local_skeleton_state().
+
+        The computation is fully vectorized and parallel across all joints, making it
+        efficient for GPU execution.
 
         Args:
             global_trs: Global TRS transform tuple (translation, rotation_matrix, scale) where:
@@ -247,22 +249,25 @@ class Skeleton(torch.nn.Module):
                 - scale: Local joint scales, shape (batch_size, num_joints, 1)
 
         Note:
-            This function uses the TRS backend's ik_from_global_state for efficient
-            inverse kinematics computation. It's the inverse operation of
-            local_trs_to_global_trs().
+            For root joints (parent index == -1), the global transform is returned as-is
+            since they have no parent. This is the inverse operation of local_trs_to_global_trs().
         """
-        global_state_t, global_state_r, global_state_s = global_trs
-        return trs_backend.ik_from_global_state(
-            global_state_t=global_state_t,
-            global_state_r=global_state_r,
-            global_state_s=global_state_s,
-            prefix_mul_indices=list(
-                self.pmi.split(
-                    split_size=self._pmi_buffer_sizes,
-                    dim=1,
-                )
-            ),
-        )
+        joint_parents = self.joint_parents
+
+        # Get parent TRS states (clamp to handle root joints with parent=-1)
+        parent_indices = torch.clamp(joint_parents, min=0)
+        parent_trs = pym_trs.index_select(global_trs, -2, parent_indices)
+
+        # local = parent^(-1) * global
+        local_trs = pym_trs.multiply(pym_trs.inverse(parent_trs), global_trs)
+
+        # Expand joint_parents for broadcasting
+        jp = joint_parents
+        while jp.ndim + 1 < global_trs[0].ndim:
+            jp = jp[None, ...]
+
+        # For root joints (parent == -1), keep the global state
+        return pym_trs.where(jp >= 0, local_trs, global_trs)
 
     def local_skeleton_state_to_skeleton_state(
         self, local_skel_state: torch.Tensor

--- a/pymomentum/trs.py
+++ b/pymomentum/trs.py
@@ -497,6 +497,80 @@ def rotmat_rotate_vector(r: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
     return torch.einsum("...ij,...j->...i", r, v)
 
 
+def index_select(trs: TRSTransform, dim: int, indices: torch.Tensor) -> TRSTransform:
+    """
+    Select elements from a TRS transform along a dimension.
+
+    This is equivalent to calling torch.index_select on each component of the TRS
+    transform. The dimension is interpreted consistently across all components:
+    for translation and scale, the dimension is used directly; for rotation matrices
+    (which have one extra dimension for the 3x3 matrix rows), the dimension is
+    adjusted to account for the extra matrix dimension.
+
+    :parameter trs: The TRS transform tuple to select from.
+    :type trs: TRSTransform
+    :parameter dim: The dimension to select along. This should be a batch/joint dimension,
+                    not a dimension within the transformation itself (e.g., the 3 in
+                    translation or the 3x3 in rotation). Negative indexing is supported.
+    :type dim: int
+    :parameter indices: The indices to select.
+    :type indices: torch.Tensor
+    :return: The selected TRS transform tuple.
+    :rtype: TRSTransform
+    """
+    t, r, s = trs
+
+    # For rotation matrices, we need to adjust the dimension since they have
+    # shape [..., 3, 3] instead of [..., 3] or [..., 1]
+    # Translation/scale have one trailing dim, rotation has two trailing dims
+    # So if dim is negative, we subtract 1 to account for the extra dimension
+    if dim < 0:
+        r_dim = dim - 1  # Adjust for the one extra dimension (row vs just the 3)
+    else:
+        r_dim = dim
+
+    return (
+        t.index_select(dim, indices),
+        r.index_select(r_dim, indices),
+        s.index_select(dim, indices),
+    )
+
+
+def where(
+    condition: torch.Tensor, trs_true: TRSTransform, trs_false: TRSTransform
+) -> TRSTransform:
+    """
+    Select elements from two TRS transforms based on a condition.
+
+    This is equivalent to calling torch.where on each component of the TRS transforms,
+    with appropriate broadcasting for translation, rotation matrix, and scale.
+
+    :parameter condition: Boolean condition tensor. Will be broadcast to match
+                          the shapes of the TRS components.
+    :type condition: torch.Tensor
+    :parameter trs_true: TRS transform to select from where condition is True.
+    :type trs_true: TRSTransform
+    :parameter trs_false: TRS transform to select from where condition is False.
+    :type trs_false: TRSTransform
+    :return: The resulting TRS transform tuple.
+    :rtype: TRSTransform
+    """
+    t_true, r_true, s_true = trs_true
+    t_false, r_false, s_false = trs_false
+
+    # Expand condition for broadcasting with each component
+    # Translation and scale: [..., 3] and [..., 1] need condition [..., 1]
+    # Rotation: [..., 3, 3] needs condition [..., 1, 1]
+    cond_ts = condition[..., None]  # for translation and scale
+    cond_r = condition[..., None, None]  # for rotation
+
+    return (
+        torch.where(cond_ts, t_true, t_false),
+        torch.where(cond_r, r_true, r_false),
+        torch.where(cond_ts, s_true, s_false),
+    )
+
+
 def rotmat_from_euler_xyz(euler: torch.Tensor) -> torch.Tensor:
     """
     Create rotation matrices from XYZ Euler angles.


### PR DESCRIPTION
Summary:
Replace the iterative in-place ik_from_global_state approach with a simple
vectorized implementation that computes local = parent_inverse * global for
all joints in parallel. This is cleaner and more efficient for GPU execution.

Add two new utility functions to trs.py:
- index_select: Select elements from TRS transform along a dimension
- where: Conditionally select between two TRS transforms

Reviewed By: jeongseok-meta

Differential Revision: D89314132


