### PR TITLE
Joint focal length + pose optimization in IK refinement: cpp headers and function

### DIFF
--- a/momentum/character_solver/camera_intrinsics_parameters.cpp
+++ b/momentum/character_solver/camera_intrinsics_parameters.cpp
@@ -34,7 +34,8 @@ Eigen::Index findParamIndex(const ParameterTransform& paramTransform, const std:
 std::tuple<ParameterTransform, ParameterLimits> addCameraIntrinsicsParameters(
     ParameterTransform paramTransform,
     ParameterLimits paramLimits,
-    const IntrinsicsModel& intrinsicsModel) {
+    const IntrinsicsModel& intrinsicsModel,
+    bool tieFocalLength) {
   const std::string& effectiveName = intrinsicsModel.name();
   MT_CHECK(
       !effectiveName.empty(),
@@ -56,11 +57,26 @@ std::tuple<ParameterTransform, ParameterLimits> addCameraIntrinsicsParameters(
   // Build the parameter set for this camera
   ParameterSet paramSet;
 
-  // Append parameters
-  paramTransform.name.reserve(paramTransform.name.size() + paramNames.size());
+  // When tieFocalLength is true, replace separate "fx"/"fy" with a single "f"
+  std::vector<std::string> addedNames;
+  bool fAdded = false;
   for (const auto& paramName : paramNames) {
+    if (tieFocalLength && (paramName == "fx" || paramName == "fy")) {
+      if (!fAdded) {
+        addedNames.push_back(std::string(kTiedFocalLengthSuffix));
+        fAdded = true;
+      }
+      // skip fy (already covered by "f")
+    } else {
+      addedNames.push_back(paramName);
+    }
+  }
+
+  // Append parameters
+  paramTransform.name.reserve(paramTransform.name.size() + addedNames.size());
+  for (const auto& name : addedNames) {
     paramSet.set(paramTransform.name.size());
-    paramTransform.name.push_back(prefix + paramName);
+    paramTransform.name.push_back(prefix + name);
   }
 
   // Store the named parameter set
@@ -82,9 +98,13 @@ Eigen::VectorXf extractCameraIntrinsics(
   Eigen::VectorXf result = intrinsicsModel.getIntrinsicParameters();
   const std::string prefix = makePrefix(intrinsicsModel.name());
   const auto paramNames = intrinsicsModel.getParameterNames();
+  const Eigen::Index tiedFIdx = findParamIndex(paramTransform, prefix + kTiedFocalLengthSuffix);
 
   for (size_t i = 0; i < paramNames.size(); ++i) {
-    const auto paramIdx = findParamIndex(paramTransform, prefix + paramNames[i]);
+    auto paramIdx = findParamIndex(paramTransform, prefix + paramNames[i]);
+    if (paramIdx < 0 && tiedFIdx >= 0 && (paramNames[i] == "fx" || paramNames[i] == "fy")) {
+      paramIdx = tiedFIdx;
+    }
     if (paramIdx >= 0 && paramIdx < modelParams.size()) {
       result(static_cast<Eigen::Index>(i)) = modelParams(paramIdx);
     }
@@ -99,9 +119,13 @@ void setCameraIntrinsics(
   const std::string prefix = makePrefix(intrinsicsModel.name());
   const auto paramNames = intrinsicsModel.getParameterNames();
   const Eigen::VectorXf intrinsicValues = intrinsicsModel.getIntrinsicParameters();
+  const Eigen::Index tiedFIdx = findParamIndex(paramTransform, prefix + kTiedFocalLengthSuffix);
 
   for (size_t i = 0; i < paramNames.size(); ++i) {
-    const auto paramIdx = findParamIndex(paramTransform, prefix + paramNames[i]);
+    auto paramIdx = findParamIndex(paramTransform, prefix + paramNames[i]);
+    if (paramIdx < 0 && tiedFIdx >= 0 && (paramNames[i] == "fx" || paramNames[i] == "fy")) {
+      paramIdx = tiedFIdx;
+    }
     if (paramIdx >= 0 && paramIdx < modelParams.size()) {
       modelParams(paramIdx) = intrinsicValues(static_cast<Eigen::Index>(i));
     }
@@ -140,8 +164,17 @@ CameraIntrinsicsMapping<T>::CameraIntrinsicsMapping(
   const std::string prefix = makePrefix(intrinsicsModel.name());
   const auto paramNames = intrinsicsModel.getParameterNames();
   modelParamIndices.resize(paramNames.size());
+
+  // Check for tied focal length: a single "f" parameter that controls both fx and fy.
+  const Eigen::Index tiedFIdx = findParamIndex(paramTransform, prefix + kTiedFocalLengthSuffix);
+
   for (size_t i = 0; i < paramNames.size(); ++i) {
     modelParamIndices[i] = findParamIndex(paramTransform, prefix + paramNames[i]);
+    // Fall back to tied "f" for fx/fy if separate params not found
+    if (modelParamIndices[i] < 0 && tiedFIdx >= 0 &&
+        (paramNames[i] == "fx" || paramNames[i] == "fy")) {
+      modelParamIndices[i] = tiedFIdx;
+    }
   }
 }
 

--- a/momentum/character_solver/camera_intrinsics_parameters.h
+++ b/momentum/character_solver/camera_intrinsics_parameters.h
@@ -18,6 +18,7 @@
 namespace momentum {
 
 inline constexpr const char* kIntrinsicsParamPrefix = "intrinsics_";
+inline constexpr const char* kTiedFocalLengthSuffix = "f";
 
 /// Add camera intrinsics parameters to the parameter transform.
 /// Names follow "intrinsics_{cameraName}_{paramName}" convention.
@@ -27,12 +28,16 @@ inline constexpr const char* kIntrinsicsParamPrefix = "intrinsics_";
 /// @param paramTransform The parameter transform to augment
 /// @param paramLimits The parameter limits to augment
 /// @param intrinsicsModel The intrinsics model whose parameters to add (must have a non-empty name)
+/// @param tieFocalLength If true, add a single "f" parameter instead of separate "fx"/"fy".
+///   The single parameter controls both fx and fy, combining gradients from horizontal and
+///   vertical residuals. Recommended for cameras with square pixels.
 /// @return Tuple of updated (paramTransform, paramLimits)
 /// @throws if intrinsicsModel.name() is empty
 [[nodiscard]] std::tuple<ParameterTransform, ParameterLimits> addCameraIntrinsicsParameters(
     ParameterTransform paramTransform,
     ParameterLimits paramLimits,
-    const IntrinsicsModel& intrinsicsModel);
+    const IntrinsicsModel& intrinsicsModel,
+    bool tieFocalLength = false);
 
 /// Extract camera intrinsic parameter values from model parameters.
 ///

--- a/momentum/character_solver/camera_projection_error_function.cpp
+++ b/momentum/character_solver/camera_projection_error_function.cpp
@@ -23,7 +23,15 @@ CameraProjectionErrorFunctionT<T>::CameraProjectionErrorFunctionT(
       intrinsicsModel_(std::move(intrinsicsModel)),
       cameraParent_(cameraParent),
       cameraOffset_(cameraOffset),
-      skeletonDerivative_(skel, pt, this->activeJointParams_, this->enabledParameters_) {}
+      skeletonDerivative_(skel, pt, this->activeJointParams_, this->enabledParameters_) {
+  // Initialize intrinsics mapping for joint intrinsics optimization.
+  // If the parameter transform contains intrinsics parameters for this camera,
+  // the mapping will have active params and getGradient/getJacobian will compute
+  // derivatives w.r.t. those parameters.
+  if (!intrinsicsModel_->name().empty()) {
+    intrinsicsMapping_.emplace(pt, *intrinsicsModel_);
+  }
+}
 
 template <typename T>
 CameraProjectionErrorFunctionT<T>::CameraProjectionErrorFunctionT(
@@ -35,7 +43,11 @@ CameraProjectionErrorFunctionT<T>::CameraProjectionErrorFunctionT(
       intrinsicsModel_(camera.intrinsicsModel()),
       cameraParent_(cameraParent),
       cameraOffset_(camera.eyeFromWorld()),
-      skeletonDerivative_(skel, pt, this->activeJointParams_, this->enabledParameters_) {}
+      skeletonDerivative_(skel, pt, this->activeJointParams_, this->enabledParameters_) {
+  if (!intrinsicsModel_->name().empty()) {
+    intrinsicsMapping_.emplace(pt, *intrinsicsModel_);
+  }
+}
 
 template <typename T>
 void CameraProjectionErrorFunctionT<T>::addConstraint(const ProjectionConstraintT<T>& constraint) {
@@ -44,10 +56,15 @@ void CameraProjectionErrorFunctionT<T>::addConstraint(const ProjectionConstraint
 
 template <typename T>
 double CameraProjectionErrorFunctionT<T>::getError(
-    const ModelParametersT<T>& /*params*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& skeletonState,
     const MeshStateT<T>& /*meshState*/) {
   double error = 0;
+
+  // Update intrinsics from model parameters if the mapping is active
+  const auto& intrinsics = (intrinsicsMapping_ && intrinsicsMapping_->hasActiveParams())
+      ? intrinsicsMapping_->updateIntrinsics(params)
+      : *intrinsicsModel_;
 
   const auto& jointState = skeletonState.jointState;
 
@@ -70,7 +87,7 @@ double CameraProjectionErrorFunctionT<T>::getError(
     const Eigen::Vector3<T> p_eye = eyeFromWorld * p_world;
 
     // Project through intrinsics
-    const auto [projected, valid] = intrinsicsModel_->project(p_eye);
+    const auto [projected, valid] = intrinsics.project(p_eye);
     if (!valid) {
       continue;
     }
@@ -84,11 +101,16 @@ double CameraProjectionErrorFunctionT<T>::getError(
 
 template <typename T>
 double CameraProjectionErrorFunctionT<T>::getGradient(
-    const ModelParametersT<T>& /*params*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& skeletonState,
     const MeshStateT<T>& /*meshState*/,
     Eigen::Ref<Eigen::VectorX<T>> gradient) {
   double error = 0;
+
+  // Update intrinsics from model parameters if the mapping is active
+  const bool hasIntrinsics = intrinsicsMapping_ && intrinsicsMapping_->hasActiveParams();
+  const auto& intrinsics =
+      hasIntrinsics ? intrinsicsMapping_->updateIntrinsics(params) : *intrinsicsModel_;
 
   const auto& jointState = skeletonState.jointState;
 
@@ -116,7 +138,7 @@ double CameraProjectionErrorFunctionT<T>::getGradient(
     const Eigen::Vector3<T> p_eye = eyeFromWorld * p_world;
 
     // Project through intrinsics with Jacobian
-    const auto [projected, J_eye_3x3, valid] = intrinsicsModel_->projectJacobian(p_eye);
+    const auto [projected, J_eye_3x3, valid] = intrinsics.projectJacobian(p_eye);
     if (!valid) {
       continue;
     }
@@ -148,10 +170,6 @@ double CameraProjectionErrorFunctionT<T>::getGradient(
     }
 
     // Walk 2: Camera-parent chain (negative sign)
-    // The lever arm uses p_world because we differentiate eyeFromWorld * p_world
-    // w.r.t. q through eyeFromWorld. The negative sign is because increasing
-    // camera joint parameters moves the camera, which has the opposite effect
-    // on the projected point.
     if (cameraParent_ != kInvalidIndex) {
       const Eigen::Vector2<T> weightedResidual = -wgt * residual;
       std::array<Eigen::Vector3<T>, 1> worldVecs = {p_world};
@@ -167,6 +185,14 @@ double CameraProjectionErrorFunctionT<T>::getGradient(
           jointState,
           jointGrad);
     }
+
+    // Intrinsics gradient: accumulate d(error)/d(intrinsics)
+    if (hasIntrinsics) {
+      const auto [proj_intr, J_intr, valid_intr] = intrinsics.projectIntrinsicsJacobian(p_eye);
+      if (valid_intr) {
+        intrinsicsMapping_->addGradient(J_intr, residual, wgt, jointGrad);
+      }
+    }
   }
 
   gradient += jointGrad;
@@ -175,13 +201,18 @@ double CameraProjectionErrorFunctionT<T>::getGradient(
 
 template <typename T>
 double CameraProjectionErrorFunctionT<T>::getJacobian(
-    const ModelParametersT<T>& /*params*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& skeletonState,
     const MeshStateT<T>& /*meshState*/,
     Eigen::Ref<Eigen::MatrixX<T>> jacobian,
     Eigen::Ref<Eigen::VectorX<T>> residual,
     int& usedRows) {
   double error = 0;
+
+  // Update intrinsics from model parameters if the mapping is active
+  const bool hasIntrinsics = intrinsicsMapping_ && intrinsicsMapping_->hasActiveParams();
+  const auto& intrinsics =
+      hasIntrinsics ? intrinsicsMapping_->updateIntrinsics(params) : *intrinsicsModel_;
 
   const auto& jointState = skeletonState.jointState;
 
@@ -205,7 +236,7 @@ double CameraProjectionErrorFunctionT<T>::getJacobian(
     const Eigen::Vector3<T> p_eye = eyeFromWorld * p_world;
 
     // Project through intrinsics with Jacobian
-    const auto [projected, J_eye_3x3, valid] = intrinsicsModel_->projectJacobian(p_eye);
+    const auto [projected, J_eye_3x3, valid] = intrinsics.projectJacobian(p_eye);
     if (!valid) {
       continue;
     }
@@ -252,6 +283,14 @@ double CameraProjectionErrorFunctionT<T>::getJacobian(
           jointState,
           jacobian,
           rowIndex);
+    }
+
+    // Intrinsics Jacobian: populate columns for camera intrinsic parameters
+    if (hasIntrinsics) {
+      const auto [proj_intr, J_intr, valid_intr] = intrinsics.projectIntrinsicsJacobian(p_eye);
+      if (valid_intr) {
+        intrinsicsMapping_->addJacobian(J_intr, wgt, rowIndex, jacobian);
+      }
     }
   }
 

--- a/momentum/character_solver/camera_projection_error_function.h
+++ b/momentum/character_solver/camera_projection_error_function.h
@@ -8,10 +8,12 @@
 #pragma once
 
 #include <momentum/camera/camera.h>
+#include <momentum/character_solver/camera_intrinsics_parameters.h>
 #include <momentum/character_solver/skeleton_derivative.h>
 #include <momentum/character_solver/skeleton_error_function.h>
 
 #include <memory>
+#include <optional>
 
 namespace momentum {
 
@@ -101,6 +103,7 @@ class CameraProjectionErrorFunctionT : public SkeletonErrorFunctionT<T> {
  protected:
   std::vector<ProjectionConstraintT<T>> constraints_;
   std::shared_ptr<const IntrinsicsModelT<T>> intrinsicsModel_;
+  std::optional<CameraIntrinsicsMapping<T>> intrinsicsMapping_;
   size_t cameraParent_;
   Eigen::Transform<T, 3, Eigen::Affine> cameraOffset_;
   SkeletonDerivativeT<T> skeletonDerivative_;

--- a/pymomentum/solver2/solver2_camera_intrinsics.cpp
+++ b/pymomentum/solver2/solver2_camera_intrinsics.cpp
@@ -126,9 +126,13 @@ void addCameraIntrinsicsBindings(pybind11::module_& m) {
   m.def(
       "add_camera_intrinsics_parameters",
       [](const mm::Character& character,
-         const mm::IntrinsicsModel& intrinsicsModel) -> mm::Character {
+         const mm::IntrinsicsModel& intrinsicsModel,
+         bool tieFocalLength) -> mm::Character {
         auto [paramTransform, paramLimits] = mm::addCameraIntrinsicsParameters(
-            character.parameterTransform, character.parameterLimits, intrinsicsModel);
+            character.parameterTransform,
+            character.parameterLimits,
+            intrinsicsModel,
+            tieFocalLength);
         mm::Character result = character;
         result.parameterTransform = std::move(paramTransform);
         result.parameterLimits = std::move(paramLimits);
@@ -147,9 +151,13 @@ replace the existing parameters rather than duplicating them.
 
 :param character: The character whose parameter transform to augment.
 :param intrinsics_model: The camera intrinsics model whose parameters to add (must have a name set).
+:param tie_focal_length: If True, add a single "f" parameter instead of separate "fx"/"fy".
+    The single parameter controls both fx and fy, combining gradients from horizontal and
+    vertical residuals. Recommended for cameras with square pixels.
 :return: A new Character with the augmented parameter transform.)",
       py::arg("character"),
-      py::arg("intrinsics_model"));
+      py::arg("intrinsics_model"),
+      py::arg("tie_focal_length") = false);
 
   m.def(
       "extract_camera_intrinsics",


### PR DESCRIPTION
Summary: Add C++ support for joint focal length optimization during IK refinement. Introduces a `tieFocalLength` option that merges separate fx/fy intrinsics into a single "f" parameter, reducing degrees of freedom for square-pixel cameras. Wires intrinsics gradient and Jacobian computation into CameraProjectionErrorFunction so focal length derivatives are accumulated alongside pose during optimization. Exposes the new flag through the pymomentum Python bindings.

Differential Revision: D101018205


