### PR TITLE
Fix ParameterTransform Python constructor missing activeJointParams

### DIFF
--- a/pymomentum/geometry/parameter_transform_pybind.cpp
+++ b/pymomentum/geometry/parameter_transform_pybind.cpp
@@ -74,6 +74,7 @@ void registerParameterTransformBindings(
             }
 
             parameterTransform.offsets.setZero(nJointParams);
+            parameterTransform.activeJointParams = parameterTransform.computeActiveJointParams();
             return parameterTransform;
           }),
           R"(Create a parameter transform from a sparse matrix.
@@ -128,6 +129,7 @@ void registerParameterTransformBindings(
             parameterTransform.transform.resize(nJointParams, nModelParams);
             parameterTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
             parameterTransform.offsets.setZero(nJointParams);
+            parameterTransform.activeJointParams = parameterTransform.computeActiveJointParams();
             return parameterTransform;
           }),
           R"(Create a parameter transform from a dense numpy array.


### PR DESCRIPTION
Summary:
The ParameterTransform pybind11 constructor (both sparse and dense
variants) did not initialize activeJointParams. This field was left as
an empty VectorX<bool> (size 0), causing an Eigen assertion failure
(index >= 0 && index < size()) whenever the character was used with any
solver error function that indexes activeJointParams.

The fix adds computeActiveJointParams() after setting the transform,
matching the pattern used by the C++ ParameterTransform::identity()
factory.

Reviewed By: marcdavid415

Differential Revision: D101000658


