### PR TITLE
Fix multiple bugs across momentum (#1292)

### DIFF
--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -262,6 +262,9 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
       // find the last not disabled parent joint
       while (currentParent == kInvalidIndex && sIndex != kInvalidIndex) {
         sIndex = skeleton.joints[sIndex].parent;
+        if (sIndex == kInvalidIndex) {
+          break;
+        }
         currentParent = lastJoint[sIndex];
       }
       // calculate the new offset of the joint in the new parent space

--- a/momentum/common/checks.h
+++ b/momentum/common/checks.h
@@ -17,11 +17,10 @@
 
 #else
 
-#include <cassert>
+#include <momentum/common/exception.h>
 
-// TODO: Support asserts with messages as XR_CHECK does
-#define MT_CHECK(condition, ...) assert(condition)
-#define MT_CHECK_LT(val1, val2, ...) assert(val1 < val2)
-#define MT_CHECK_NOTNULL(ptr, ...) assert(ptr != nullptr)
+#define MT_CHECK(condition, ...) MT_THROW_IF(!(condition), ##__VA_ARGS__)
+#define MT_CHECK_LT(val1, val2, ...) MT_THROW_IF(!((val1) < (val2)), ##__VA_ARGS__)
+#define MT_CHECK_NOTNULL(ptr, ...) MT_THROW_IF((ptr) == nullptr, ##__VA_ARGS__)
 
 #endif

--- a/momentum/common/exception.h
+++ b/momentum/common/exception.h
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <stdexcept>
+#include <type_traits>
 
 /// Throws an exception of a specified type with a formatted message.
 /// @param Exception The type of exception to throw.
@@ -64,11 +65,17 @@ template <typename Exception = DefaultException, typename... Args>
   throw Exception{fmt::format(format, std::forward<Args>(args)...)};
 }
 
-// Overload for throwing exceptions that do not require any message or whose constructors do not
-// take any arguments.
+// Overload for throwing exceptions without a message.
+// Uses if-constexpr to handle both default-constructible exceptions (e.g.
+// std::bad_array_new_length) and exceptions that require a string argument (e.g.
+// std::runtime_error, std::logic_error).
 template <typename Exception>
 [[noreturn]] void throwImpl() {
-  throw Exception{};
+  if constexpr (std::is_constructible_v<Exception>) {
+    throw Exception{};
+  } else {
+    throw Exception{""};
+  }
 }
 
 #else

--- a/momentum/io/character_io.cpp
+++ b/momentum/io/character_io.cpp
@@ -55,7 +55,12 @@ namespace {
     const filesystem::path& filepath,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No) {
   if (format == CharacterFormat::Gltf) {
-    return loadGltfCharacter(filepath);
+    auto character = loadGltfCharacter(filepath);
+    if (loadBlendShapes == LoadBlendShapes::No) {
+      character.blendShape.reset();
+      character.faceExpressionBlendShape.reset();
+    }
+    return character;
   } else if (format == CharacterFormat::Fbx) {
     return loadFbxCharacter(filepath, KeepLocators::Yes, Permissive::No, loadBlendShapes);
   } else if (format == CharacterFormat::Usd) {
@@ -74,7 +79,12 @@ namespace {
     const std::span<const std::byte> fileBuffer,
     LoadBlendShapes loadBlendShapes = LoadBlendShapes::No) {
   if (format == CharacterFormat::Gltf) {
-    return loadGltfCharacter(fileBuffer);
+    auto character = loadGltfCharacter(fileBuffer);
+    if (loadBlendShapes == LoadBlendShapes::No) {
+      character.blendShape.reset();
+      character.faceExpressionBlendShape.reset();
+    }
+    return character;
   } else if (format == CharacterFormat::Fbx) {
     return loadFbxCharacter(fileBuffer, KeepLocators::Yes, Permissive::No, loadBlendShapes);
   } else if (format == CharacterFormat::Usd) {

--- a/pymomentum/renderer/momentum_render.cpp
+++ b/pymomentum/renderer/momentum_render.cpp
@@ -411,14 +411,15 @@ buildCamerasForHand(at::Tensor wristTransformation, int imageHeight, int imageWi
     //   x points up
     //   y points forward
     //   z points to the hand's left
-    Eigen::Affine3f wristLocalToWorldXF = Eigen::Affine3f::Identity();
+    at::Tensor batchMat = wristTransformation.select(0, iBatch).contiguous();
+    Eigen::Affine3f wristLocalToWorldXF;
+    wristLocalToWorldXF.matrix() =
+        Eigen::Map<const Eigen::Matrix<float, 4, 4, Eigen::RowMajor>>(batchMat.data_ptr<float>());
     const Eigen::Vector3f hand_up_world = wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitY();
     const Eigen::Vector3f hand_forward_world =
         -1.0 * wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitZ();
 
-    at::Tensor wristtranslation_mm =
-        wristTransformation.select(0, iBatch).select(1, iBatch).slice(0, 0, 3).contiguous();
-    const Eigen::Vector3f hand_center_world_cm = toEigenMap<float>(wristtranslation_mm) * 0.1;
+    const Eigen::Vector3f hand_center_world_cm = wristLocalToWorldXF.translation() * 0.1;
 
     const float cameraDistanceToHand_cm = 0.5f * 100; // 0.5 meters away.
     const Eigen::Vector3f& camera_up_world = hand_up_world;
@@ -457,7 +458,10 @@ buildCamerasForHandSurface(at::Tensor wristTransformation, int imageHeight, int 
     //   x points up
     //   y points forward
     //   z points to the hand's left
-    Eigen::Affine3f wristLocalToWorldXF = Eigen::Affine3f::Identity();
+    at::Tensor batchMat = wristTransformation.select(0, iBatch).contiguous();
+    Eigen::Affine3f wristLocalToWorldXF;
+    wristLocalToWorldXF.matrix() =
+        Eigen::Map<const Eigen::Matrix<float, 4, 4, Eigen::RowMajor>>(batchMat.data_ptr<float>());
     const Eigen::Vector3f hand_up_world = wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitY();
     const Eigen::Vector3f hand_forward_world =
         -1.0 * wristLocalToWorldXF.rotation() * Eigen::Vector3f::UnitZ();


### PR DESCRIPTION
Summary:

1. Fix simplifySkeleton() UB when an active joint has no active ancestor below root. The while loop walking up the parent chain could set sIndex to kInvalidIndex via skeleton.joints[sIndex].parent, then immediately index lastJoint[sIndex] causing out-of-bounds access. Added a break check after getting the parent index.

2. Fix MT_CHECK in non-XR/OSS builds using assert() which is compiled away in NDEBUG builds. Changed to use MT_THROW_IF from exception.h, ensuring runtime validation is always active. This fixes unsafe paths in math/transform.cpp (scale check before division) and io/usd/usd_animation_io.cpp (emptiness guard before size()-1).

3. Fix buildCamerasForHand and buildCamerasForHandSurface leaving wristLocalToWorldXF as identity instead of extracting the actual transformation from the input tensor. Also fix buildCamerasForHand selecting matrix column iBatch instead of extracting translation from the affine transform.

4. Fix loadFullCharacter ignoring loadBlendShapes flag for glTF format. The flag was only forwarded on the FBX path. Now glTF-loaded characters have blend shapes cleared when loadBlendShapes is No.

5. (Skipped - already guarded by early return at line 345)

6. Fix null-deref on optional Character::mesh in downstream consumers: fit.cpp now guards mesh->colors.clear() with a null check, and cloth_simulation_module.cpp throws a descriptive error if mesh is missing.

7. Fix throwImpl<Exception>() compilation failure on GCC/Clang when Exception is not default-constructible (e.g. std::runtime_error). The zero-argument overload used throw Exception{} which fails for types requiring a string argument. Use if-constexpr to fall back to throw Exception{""} for non-default-constructible types.

Reviewed By: cstollmeta

Differential Revision: D101125593
