### PR TITLE
Add mesh loading to URDF loader and preserve URDF link frame convention (#1293)

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -617,10 +617,12 @@ io_usd_gltf_roundtrip_test_sources = [
 
 io_urdf_public_headers = [
     "io/urdf/urdf_io.h",
+    "io/urdf/urdf_mesh_io.h",
 ]
 
 io_urdf_sources = [
     "io/urdf/urdf_io.cpp",
+    "io/urdf/urdf_mesh_io.cpp",
 ]
 
 io_urdf_test_sources = [

--- a/momentum/examples/urdf_viewer/urdf_viewer.cpp
+++ b/momentum/examples/urdf_viewer/urdf_viewer.cpp
@@ -18,6 +18,7 @@
 #include <rerun.hpp>
 
 #include <string>
+#include <unordered_map>
 
 using namespace rerun;
 using namespace momentum;
@@ -67,22 +68,44 @@ int main(int argc, char* argv[]) {
 
     const auto kNumModelParams = character.parameterTransform.numAllModelParameters();
 
-    // Sinusoidal motion for each joint, one at a time
+    // Build a lookup from model parameter index to its min/max limits.
+    std::unordered_map<Eigen::Index, std::pair<float, float>> paramLimitsMap;
+    for (const auto& limit : character.parameterLimits) {
+      if (limit.type == MinMax) {
+        paramLimitsMap[limit.data.minMax.parameterIndex] = {
+            limit.data.minMax.limits[0], limit.data.minMax.limits[1]};
+      }
+    }
+
+    // Sinusoidal motion for each joint, one at a time.
+    // Each DOF sweeps within its parameter limits (or a default range if no limits).
     const int framesPerDoF = 100;
     const auto totalDoFs = character.parameterTransform.transform.cols();
     const auto kNumFrames = framesPerDoF * totalDoFs;
     MatrixXf motion = MatrixXf::Zero(kNumModelParams, kNumFrames);
     const float fps = 30.0f;
     const float frequency = 1.0f;
-    const float amplitude = 1.0f;
-    for (auto j = 0; j < totalDoFs; ++j) {
-      for (auto i = 0; i < framesPerDoF; ++i) {
-        int frameIndex = j * framesPerDoF + i;
+    const float defaultAmplitude = 0.5f; // radians, for DOFs without limits
+    for (Eigen::Index j = 0; j < totalDoFs; ++j) {
+      float lower = -defaultAmplitude;
+      float upper = defaultAmplitude;
+      auto it = paramLimitsMap.find(j);
+      if (it != paramLimitsMap.end()) {
+        lower = it->second.first;
+        upper = it->second.second;
+      }
+
+      // Sweep from lower to upper: midpoint + half_range * sin(...)
+      const float midpoint = (lower + upper) * 0.5f;
+      const float halfRange = (upper - lower) * 0.5f;
+
+      for (int i = 0; i < framesPerDoF; ++i) {
+        const auto frameIndex = static_cast<int>(j) * framesPerDoF + i;
         if (frameIndex >= kNumFrames) {
-          break; // Prevent exceeding total frames
+          break;
         }
-        const float time = i / fps;
-        motion(j, frameIndex) = amplitude * std::sin(2.0f * pi() * frequency * time);
+        const float time = static_cast<float>(i) / fps;
+        motion(j, frameIndex) = midpoint + halfRange * std::sin(twopi<float>() * frequency * time);
       }
     }
 

--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -6,15 +6,39 @@
  */
 
 #include "momentum/io/urdf/urdf_io.h"
+#include "momentum/io/urdf/urdf_mesh_io.h"
+
+#include "momentum/character/skeleton_state.h"
+#include "momentum/common/log.h"
 #include "momentum/math/constants.h"
 
 #include <urdf_model/link.h>
+#include <urdf_model/model.h>
 #include <urdf_model/pose.h>
 #include <urdf_parser/urdf_parser.h>
+
+#include <unordered_map>
 
 namespace momentum {
 
 namespace {
+
+/// Per-link visual data collected during skeleton parsing.
+struct LinkVisualData {
+  size_t jointIndex{};
+  std::vector<urdf::VisualSharedPtr> visuals;
+};
+
+/// Deferred mimic joint data, resolved after the full skeleton is built.
+struct MimicData {
+  std::string mimickedJointName; // URDF joint name to mimic
+  float multiplier{};
+  float offset{}; // radians for revolute, meters for prismatic
+  Eigen::Index jointParamsBaseIndex{}; // this joint's parameter base index
+  int axisIdx{}; // principal axis index (0=X, 1=Y, 2=Z)
+  float sign{}; // axis sign (+1/-1)
+  bool isRotation{}; // true for revolute/continuous, false for prismatic
+};
 
 template <typename T>
 struct ParsingData {
@@ -23,6 +47,14 @@ struct ParsingData {
   std::vector<Eigen::Triplet<float>> triplets;
   ParameterLimits limits;
   size_t totalDoFs = 0;
+
+  std::vector<LinkVisualData> linkVisuals;
+
+  /// Maps URDF joint name → model parameter index (for mimic joint resolution).
+  std::unordered_map<std::string, Eigen::Index> urdfJointNameToModelParamIdx;
+
+  /// Mimic joints deferred until all joints are processed.
+  std::vector<MimicData> mimicJoints;
 };
 
 template <typename S>
@@ -58,11 +90,119 @@ template <typename S>
   }
 }
 
+/// Returns the principal axis index (0=X, 1=Y, 2=Z) and sign (+1/-1) for a URDF axis vector.
+///
+/// URDF joints specify an arbitrary axis direction, but Momentum's joint parameters are
+/// defined along fixed principal axes (tx/ty/tz, rx/ry/rz). Rather than aligning the URDF
+/// axis to Momentum's X axis via preRotation (which would create a rotated internal frame
+/// that differs from the URDF link frame), we map the DOF directly to the matching principal
+/// axis. This preserves frame compatibility with URDF visual meshes and animation data.
+///
+/// For negative axes (e.g., (0,0,-1)), the sign is -1 and the parameter transform coefficient
+/// is negated, so that a positive URDF joint angle still corresponds to rotation around the
+/// positive axis direction.
+///
+/// @return A pair of (axis index, sign): axis index 0=X, 1=Y, 2=Z; sign is +1 or -1.
+/// @throws If the axis is not aligned with a principal axis (e.g., (0.707, 0, 0.707)).
+[[nodiscard]] std::pair<int, float> getPrincipalAxis(const urdf::Vector3& axis) {
+  const auto ax = static_cast<float>(axis.x);
+  const auto ay = static_cast<float>(axis.y);
+  const auto az = static_cast<float>(axis.z);
+  constexpr float kTol = 1e-4f;
+
+  if (std::abs(std::abs(ax) - 1.0f) < kTol && std::abs(ay) < kTol && std::abs(az) < kTol) {
+    return {0, ax > 0 ? 1.0f : -1.0f};
+  }
+  if (std::abs(ax) < kTol && std::abs(std::abs(ay) - 1.0f) < kTol && std::abs(az) < kTol) {
+    return {1, ay > 0 ? 1.0f : -1.0f};
+  }
+  if (std::abs(ax) < kTol && std::abs(ay) < kTol && std::abs(std::abs(az) - 1.0f) < kTol) {
+    return {2, az > 0 ? 1.0f : -1.0f};
+  }
+
+  MT_THROW(
+      "Non-principal joint axis ({}, {}, {}) is not supported. "
+      "Only axes aligned with X, Y, or Z are supported.",
+      ax,
+      ay,
+      az);
+}
+
+/// Loads a single mesh from a URDF visual geometry element.
+///
+/// For mesh file references, resolves the path and loads STL or OBJ files.
+/// For primitive geometries (box, cylinder, sphere), generates the mesh procedurally.
+/// Returns std::nullopt if the geometry type is unsupported or the mesh file cannot be loaded.
+std::optional<Mesh> loadVisualMesh(
+    const urdf::Geometry& geometry,
+    const filesystem::path& urdfDir) {
+  switch (geometry.type) {
+    case urdf::Geometry::MESH: {
+      const auto& urdfMesh = dynamic_cast<const urdf::Mesh&>(geometry);
+      if (urdfDir.empty()) {
+        MT_LOGW("Cannot resolve mesh path without URDF directory: {}", urdfMesh.filename);
+        return std::nullopt;
+      }
+      const auto resolvedPath = resolveMeshPath(urdfMesh.filename, urdfDir);
+      if (!resolvedPath) {
+        return std::nullopt;
+      }
+
+      const auto ext = resolvedPath->extension().string();
+      std::optional<Mesh> mesh;
+      if (ext == ".stl" || ext == ".STL") {
+        mesh = loadStlMesh(*resolvedPath);
+      } else if (ext == ".obj" || ext == ".OBJ") {
+        mesh = loadObjMesh(*resolvedPath);
+      } else {
+        MT_LOGW("Unsupported mesh format '{}': {}", ext, resolvedPath->string());
+        return std::nullopt;
+      }
+
+      if (!mesh) {
+        return std::nullopt;
+      }
+
+      // Apply scale from URDF mesh element
+      const Eigen::Vector3f scale(
+          static_cast<float>(urdfMesh.scale.x),
+          static_cast<float>(urdfMesh.scale.y),
+          static_cast<float>(urdfMesh.scale.z));
+      if (!scale.isApprox(Eigen::Vector3f::Ones())) {
+        for (auto& v : mesh->vertices) {
+          v = v.cwiseProduct(scale);
+        }
+      }
+      return mesh;
+    }
+    case urdf::Geometry::BOX: {
+      const auto& box = dynamic_cast<const urdf::Box&>(geometry);
+      return generateBoxMesh(
+          static_cast<float>(box.dim.x),
+          static_cast<float>(box.dim.y),
+          static_cast<float>(box.dim.z));
+    }
+    case urdf::Geometry::CYLINDER: {
+      const auto& cyl = dynamic_cast<const urdf::Cylinder&>(geometry);
+      return generateCylinderMesh(static_cast<float>(cyl.radius), static_cast<float>(cyl.length));
+    }
+    case urdf::Geometry::SPHERE: {
+      const auto& sphere = dynamic_cast<const urdf::Sphere&>(geometry);
+      return generateSphereMesh(static_cast<float>(sphere.radius));
+    }
+    default:
+      MT_LOGW("Unknown URDF geometry type: {}", static_cast<int>(geometry.type));
+      return std::nullopt;
+  }
+}
+
+constexpr std::array<const char*, 3> kTranslationNames = {"tx", "ty", "tz"};
+constexpr std::array<const char*, 3> kRotationNames = {"rx", "ry", "rz"};
+
 template <typename T>
 bool loadUrdfSkeletonRecursive(
     ParsingData<T>& data,
     size_t parentJointId,
-    const Quaternionf& parentJointAxis,
     const urdf::ModelInterface* urdfModel,
     const urdf::Link* urdfLink) {
   MT_THROW_IF(urdfLink == nullptr, "URDF link is null.");
@@ -78,7 +218,7 @@ bool loadUrdfSkeletonRecursive(
       urdfLink->name);
 
   Joint joint;
-  joint.name = urdfLink->name; // Use link name or joint name?
+  joint.name = urdfLink->name;
   joint.parent = parentJointId;
 
   const Eigen::Index jointId = data.skeleton.joints.size();
@@ -88,53 +228,109 @@ bool loadUrdfSkeletonRecursive(
   //---------------------------
   // Parse Parameter transform
   //---------------------------
-
-  Quaternionf jointAxis = Quaternionf::Identity();
+  //
+  // URDF joints specify an arbitrary axis direction for their DOF. Instead of aligning that
+  // axis to Momentum's X axis via preRotation (which would create a rotated internal frame),
+  // we map the DOF directly to the corresponding principal axis parameter (rx/ry/rz for
+  // revolute, tx/ty/tz for prismatic). This preserves the URDF link frame as the joint's
+  // local frame, making visual meshes and animation data directly compatible.
 
   if (urdfJoint != nullptr) {
-    // Set parameter transform based on joint type
+    // Check if this joint mimics another joint. Mimic joints don't create their own model
+    // parameter — they reuse the mimicked joint's parameter with a multiplier and offset.
+    const bool isMimic = urdfJoint->mimic != nullptr;
+
     switch (urdfJoint->type) {
       case urdf::Joint::PRISMATIC: {
-        data.parameterTransform.name.push_back(fmt::format("joint{}_tx", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 0, modelParamsBaseIndex, 1.0f);
-        data.totalDoFs += 1;
+        const auto [axisIdx, sign] = getPrincipalAxis(urdfJoint->axis);
+        if (isMimic) {
+          MimicData mimic;
+          mimic.mimickedJointName = urdfJoint->mimic->joint_name;
+          mimic.multiplier = static_cast<float>(urdfJoint->mimic->multiplier);
+          mimic.offset = static_cast<float>(urdfJoint->mimic->offset);
+          mimic.jointParamsBaseIndex = jointParamsBaseIndex;
+          mimic.axisIdx = axisIdx;
+          mimic.sign = sign;
+          mimic.isRotation = false;
+          data.mimicJoints.push_back(mimic);
+        } else {
+          data.parameterTransform.name.push_back(urdfJoint->name);
+          data.triplets.emplace_back(jointParamsBaseIndex + axisIdx, modelParamsBaseIndex, sign);
+          data.urdfJointNameToModelParamIdx[urdfJoint->name] = modelParamsBaseIndex;
+          data.totalDoFs += 1;
+        }
         break;
       }
       case urdf::Joint::REVOLUTE:
       case urdf::Joint::CONTINUOUS: {
-        data.parameterTransform.name.push_back(fmt::format("joint{}_rx", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 3, modelParamsBaseIndex, 1.0f);
-        data.totalDoFs += 1;
+        const auto [axisIdx, sign] = getPrincipalAxis(urdfJoint->axis);
+        if (isMimic) {
+          MimicData mimic;
+          mimic.mimickedJointName = urdfJoint->mimic->joint_name;
+          mimic.multiplier = static_cast<float>(urdfJoint->mimic->multiplier);
+          mimic.offset = static_cast<float>(urdfJoint->mimic->offset);
+          mimic.jointParamsBaseIndex = jointParamsBaseIndex;
+          mimic.axisIdx = axisIdx;
+          mimic.sign = sign;
+          mimic.isRotation = true;
+          data.mimicJoints.push_back(mimic);
+        } else {
+          data.parameterTransform.name.push_back(urdfJoint->name);
+          data.triplets.emplace_back(
+              jointParamsBaseIndex + 3 + axisIdx, modelParamsBaseIndex, sign);
+          data.urdfJointNameToModelParamIdx[urdfJoint->name] = modelParamsBaseIndex;
+          data.totalDoFs += 1;
+        }
         break;
       }
       case urdf::Joint::FLOATING: {
-        data.parameterTransform.name.push_back(fmt::format("joint{}_tx", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 0, modelParamsBaseIndex + 0, 1.0f);
-        data.parameterTransform.name.push_back(fmt::format("joint{}_ty", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 1, modelParamsBaseIndex + 1, 1.0f);
-        data.parameterTransform.name.push_back(fmt::format("joint{}_tz", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 2, modelParamsBaseIndex + 2, 1.0f);
-        data.parameterTransform.name.push_back(fmt::format("joint{}_rx", jointId));
+        // Floating joints have 6 DOFs; use the URDF joint name with axis suffixes.
+        // Translation parameters use a 10x scaling factor so that a unit change in
+        // model parameter space produces 10 cm of translation. This makes translation
+        // easier to change relative to rotation in optimization.
+        constexpr float kFloatingTranslationScale = 10.0f;
+        const auto& jn = urdfJoint->name;
+        data.parameterTransform.name.push_back(fmt::format("{}_tx", jn));
+        data.triplets.emplace_back(
+            jointParamsBaseIndex + 0, modelParamsBaseIndex + 0, kFloatingTranslationScale);
+        data.parameterTransform.name.push_back(fmt::format("{}_ty", jn));
+        data.triplets.emplace_back(
+            jointParamsBaseIndex + 1, modelParamsBaseIndex + 1, kFloatingTranslationScale);
+        data.parameterTransform.name.push_back(fmt::format("{}_tz", jn));
+        data.triplets.emplace_back(
+            jointParamsBaseIndex + 2, modelParamsBaseIndex + 2, kFloatingTranslationScale);
+        data.parameterTransform.name.push_back(fmt::format("{}_rx", jn));
         data.triplets.emplace_back(jointParamsBaseIndex + 3, modelParamsBaseIndex + 3, 1.0f);
-        data.parameterTransform.name.push_back(fmt::format("joint{}_ry", jointId));
+        data.parameterTransform.name.push_back(fmt::format("{}_ry", jn));
         data.triplets.emplace_back(jointParamsBaseIndex + 4, modelParamsBaseIndex + 4, 1.0f);
-        data.parameterTransform.name.push_back(fmt::format("joint{}_rz", jointId));
+        data.parameterTransform.name.push_back(fmt::format("{}_rz", jn));
         data.triplets.emplace_back(jointParamsBaseIndex + 5, modelParamsBaseIndex + 5, 1.0f);
         data.totalDoFs += 6;
         break;
       }
       case urdf::Joint::PLANAR: {
-        data.parameterTransform.name.push_back(fmt::format("joint{}_tx", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 1, modelParamsBaseIndex + 0, 1.0f);
-        data.parameterTransform.name.push_back(fmt::format("joint{}_ty", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 2, modelParamsBaseIndex + 1, 1.0f);
-        data.parameterTransform.name.push_back(fmt::format("joint{}_tz", jointId));
-        data.triplets.emplace_back(jointParamsBaseIndex + 3, modelParamsBaseIndex + 2, 1.0f);
+        // The axis defines the plane normal. DOFs are translation along the two in-plane
+        // axes and rotation around the normal.
+        const auto [normalIdx, sign] = getPrincipalAxis(urdfJoint->axis);
+        const int planeAxis0 = (normalIdx + 1) % 3;
+        const int planeAxis1 = (normalIdx + 2) % 3;
+        const auto& jn = urdfJoint->name;
+        data.parameterTransform.name.push_back(
+            fmt::format("{}_{}", jn, kTranslationNames[planeAxis0]));
+        data.triplets.emplace_back(
+            jointParamsBaseIndex + planeAxis0, modelParamsBaseIndex + 0, 1.0f);
+        data.parameterTransform.name.push_back(
+            fmt::format("{}_{}", jn, kTranslationNames[planeAxis1]));
+        data.triplets.emplace_back(
+            jointParamsBaseIndex + planeAxis1, modelParamsBaseIndex + 1, 1.0f);
+        data.parameterTransform.name.push_back(fmt::format("{}_{}", jn, kRotationNames[normalIdx]));
+        data.triplets.emplace_back(
+            jointParamsBaseIndex + 3 + normalIdx, modelParamsBaseIndex + 2, sign);
         data.totalDoFs += 3;
         break;
       }
       case urdf::Joint::FIXED: {
-        // Do nothing
+        // No degrees of freedom
         break;
       }
       default: {
@@ -142,42 +338,41 @@ bool loadUrdfSkeletonRecursive(
       }
     }
 
-    // Update pre-rotation based on joint axis
-    switch (urdfJoint->type) {
-      case urdf::Joint::REVOLUTE:
-      case urdf::Joint::CONTINUOUS:
-      case urdf::Joint::PRISMATIC:
-      case urdf::Joint::PLANAR: {
-        jointAxis = Quaternionf::FromTwoVectors(
-            Vector3f::UnitX(), toMomentumVector3<float>(urdfJoint->axis));
-        break;
-      }
-      default: {
-        // Do nothing
-        break;
-      }
-    }
-
-    // Parse joint limits (required only for revolute and prismatic joint)
-    if (auto urdfJointLimits = urdfJoint->limits) {
+    // Parse joint limits (required only for non-mimic revolute and prismatic joints).
+    // Mimic joints are driven by the mimicked joint's parameter, so their limits don't
+    // correspond to an independent model parameter.
+    if (!isMimic && urdfJoint->limits) {
+      auto urdfJointLimits = urdfJoint->limits;
       switch (urdfJoint->type) {
         case urdf::Joint::REVOLUTE: {
+          const auto [axisIdx, sign] = getPrincipalAxis(urdfJoint->axis);
           ParameterLimit jointLimits;
           jointLimits.type = MinMax;
           jointLimits.data.minMax.parameterIndex = modelParamsBaseIndex;
-          jointLimits.data.minMax.limits[0] = urdfJointLimits->lower; // rad
-          jointLimits.data.minMax.limits[1] = urdfJointLimits->upper;
+          if (sign > 0) {
+            jointLimits.data.minMax.limits[0] = urdfJointLimits->lower; // rad
+            jointLimits.data.minMax.limits[1] = urdfJointLimits->upper;
+          } else {
+            // Negative axis: model param = -urdf_angle, so limits are negated and swapped
+            jointLimits.data.minMax.limits[0] = -urdfJointLimits->upper;
+            jointLimits.data.minMax.limits[1] = -urdfJointLimits->lower;
+          }
           jointLimits.weight = 1.0f;
           data.limits.push_back(jointLimits);
           break;
         }
         case urdf::Joint::PRISMATIC: {
+          const auto [axisIdx, sign] = getPrincipalAxis(urdfJoint->axis);
           ParameterLimit jointLimits;
           jointLimits.type = MinMax;
           jointLimits.data.minMax.parameterIndex = modelParamsBaseIndex;
-          // meters in URDF, centimeters in Momentum
-          jointLimits.data.minMax.limits[0] = toCm<float>(urdfJointLimits->lower);
-          jointLimits.data.minMax.limits[1] = toCm<float>(urdfJointLimits->upper);
+          if (sign > 0) {
+            jointLimits.data.minMax.limits[0] = toCm<float>(urdfJointLimits->lower);
+            jointLimits.data.minMax.limits[1] = toCm<float>(urdfJointLimits->upper);
+          } else {
+            jointLimits.data.minMax.limits[0] = -toCm<float>(urdfJointLimits->upper);
+            jointLimits.data.minMax.limits[1] = -toCm<float>(urdfJointLimits->lower);
+          }
           jointLimits.weight = 1.0f;
           data.limits.push_back(jointLimits);
           break;
@@ -192,55 +387,34 @@ bool loadUrdfSkeletonRecursive(
 
   // Set Joint Offset
   //
-  // In Momentum, the joint transformation from parent to child is defined as:
-  //   T(x; p) = T_offset(p) * T(x)
-  // where:
-  //   x represents the model parameters, corresponding to the URDF's joint angles.
-  //   p represents the joint properties, parsed from the URDF joint properties.
+  // The preRotation is simply the URDF joint origin rotation — the transform from the parent
+  // link frame to the child link frame at bind pose. No axis alignment is applied because DOFs
+  // are mapped directly to the corresponding principal axis parameter (rx/ry/rz).
   //
-  // The URDF defines joint transformations differently, involving both link frames and joint
-  // frames. The link frame transformation is defined as:
-  //   T_child(x; p) = T_parent(x; p) * T_offset(p)
-  // when x is assumed to be zero.
-  //
-  // The joint frame transformation is defined as:
-  //   T_parent(x; p) * T_offset(p) * T_joint_axis(p)
-  //
-  // The final joint transformation from parent to child is:
-  //   T_child = T_parent * T_offset(p) * T(x)
-  //
-  // However, T(x) is applied in the "joint frame," defined by:
-  //   T_parent * T_joint_origin * T_joint_axis
-  // rather than just:
-  //   T_parent * T_joint_origin
-  //
-  // Therefore, the final joint transformation from parent to child is:
-  //   T = (T_parent_axis(p))^(-1) * T_joint_origin(p) * T_axis(p) * T(x)
-  //
-  // To align with Momentum's convention, T_offset should be calculated as:
-  //   T_offset = (T_parent_axis(p))^(-1) * T_joint_origin(p) * T_axis(p)
-  //
-  // For 1-DOF joints, such as revolute and prismatic joints, the joint frame is aligned with the
-  // axis along its x-axis, according to the URDF convention. Similarly, for planar joints, the
-  // plane normal is aligned with the x-axis.
-  //
-  // Reference: https://wiki.ros.org/urdf/XML/joint
+  // This means the Momentum joint frame coincides with the URDF link frame, which makes visual
+  // meshes and animation data directly compatible without any frame correction.
   if (urdfJoint != nullptr) {
     const urdf::Pose& urdfPose = urdfJoint->parent_to_joint_origin_transform;
-    joint.preRotation =
-        parentJointAxis.inverse() * toMomentumQuaternion<float>(urdfPose.rotation) * jointAxis;
-    joint.translationOffset =
-        parentJointAxis.inverse() * toMomentumVector3<float>(urdfPose.position) * toCm<float>();
+    joint.preRotation = toMomentumQuaternion<float>(urdfPose.rotation);
+    joint.translationOffset = toMomentumVector3<float>(urdfPose.position) * toCm<float>();
   } else {
-    joint.preRotation = parentJointAxis.inverse() * jointAxis;
+    joint.preRotation = Quaternionf::Identity();
     joint.translationOffset.setZero();
   }
 
   data.skeleton.joints.push_back(joint);
 
+  // Collect visual elements for mesh loading
+  if (!urdfLink->visual_array.empty()) {
+    LinkVisualData visualData;
+    visualData.jointIndex = static_cast<size_t>(jointId);
+    visualData.visuals = urdfLink->visual_array;
+    data.linkVisuals.push_back(std::move(visualData));
+  }
+
   // Continue parsing child links and joints
   for (const auto& childLink : urdfLink->child_links) {
-    if (!loadUrdfSkeletonRecursive(data, jointId, jointAxis, urdfModel, childLink.get())) {
+    if (!loadUrdfSkeletonRecursive(data, jointId, urdfModel, childLink.get())) {
       return false;
     }
   }
@@ -248,8 +422,135 @@ bool loadUrdfSkeletonRecursive(
   return true;
 }
 
+/// Resolves mimic joints by mapping each mimic joint's DOF to the mimicked joint's model
+/// parameter via the parameter transform.
 template <typename T>
-CharacterT<T> loadUrdfCharacterFromUrdfModel(urdf::ModelInterfaceSharedPtr urdfModel) {
+void resolveMimicJoints(ParsingData<T>& data) {
+  for (const auto& mimic : data.mimicJoints) {
+    auto it = data.urdfJointNameToModelParamIdx.find(mimic.mimickedJointName);
+    if (it == data.urdfJointNameToModelParamIdx.end()) {
+      MT_LOGW("Mimic joint references unknown joint '{}', skipping.", mimic.mimickedJointName);
+      continue;
+    }
+    const Eigen::Index mimickedModelParamIdx = it->second;
+    const float coefficient = mimic.sign * mimic.multiplier;
+
+    if (mimic.isRotation) {
+      data.triplets.emplace_back(
+          mimic.jointParamsBaseIndex + 3 + mimic.axisIdx, mimickedModelParamIdx, coefficient);
+      data.parameterTransform.offsets[mimic.jointParamsBaseIndex + 3 + mimic.axisIdx] =
+          mimic.sign * mimic.offset;
+    } else {
+      data.triplets.emplace_back(
+          mimic.jointParamsBaseIndex + mimic.axisIdx, mimickedModelParamIdx, coefficient);
+      data.parameterTransform.offsets[mimic.jointParamsBaseIndex + mimic.axisIdx] =
+          mimic.sign * toCm<float>(mimic.offset);
+    }
+  }
+}
+
+/// Extracts per-vertex color from a URDF visual's material, returning white if no color is set.
+/// Sets hasColor to true if the material has a non-black color.
+Eigen::Vector3b extractVertexColor(const urdf::Visual& visual, bool& hasColor) {
+  if (visual.material &&
+      (visual.material->color.r > 0 || visual.material->color.g > 0 ||
+       visual.material->color.b > 0)) {
+    const auto& c = visual.material->color;
+    hasColor = true;
+    return {
+        static_cast<uint8_t>(std::clamp(c.r, 0.0f, 1.0f) * 255.0f),
+        static_cast<uint8_t>(std::clamp(c.g, 0.0f, 1.0f) * 255.0f),
+        static_cast<uint8_t>(std::clamp(c.b, 0.0f, 1.0f) * 255.0f)};
+  }
+  return {255, 255, 255};
+}
+
+/// Builds a combined mesh and skin weights from per-link visual data.
+/// Returns nullopt if no visual meshes were loaded.
+template <typename T>
+std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
+    const ParsingData<T>& data,
+    const filesystem::path& urdfDir) {
+  if (data.linkVisuals.empty()) {
+    return std::nullopt;
+  }
+
+  const SkeletonStateT<float> bindState(data.parameterTransform.bindPose(), data.skeleton, false);
+
+  Mesh combinedMesh;
+  SkinWeights skinWeights;
+  bool hasAnyColor = false;
+
+  for (const auto& linkVisual : data.linkVisuals) {
+    const size_t jointIdx = linkVisual.jointIndex;
+    const auto& jointWorldTransform = bindState.jointState[jointIdx].transform;
+
+    for (const auto& visual : linkVisual.visuals) {
+      if (!visual || !visual->geometry) {
+        continue;
+      }
+
+      auto meshOpt = loadVisualMesh(*visual->geometry, urdfDir);
+      if (!meshOpt) {
+        continue;
+      }
+
+      // Convert from meters (URDF) to centimeters (Momentum) and apply transforms
+      for (auto& v : meshOpt->vertices) {
+        v *= toCm<float>();
+      }
+      const auto visualOrigin = toMomentumTransform<float>(visual->origin);
+      const Eigen::Vector3f visualTranslation = visualOrigin.translation * toCm<float>();
+      for (auto& v : meshOpt->vertices) {
+        v = visualOrigin.rotation * v + visualTranslation;
+      }
+      for (auto& v : meshOpt->vertices) {
+        v = jointWorldTransform.rotation * v + jointWorldTransform.translation;
+      }
+
+      const Eigen::Vector3b vertexColor = extractVertexColor(*visual, hasAnyColor);
+
+      // Merge into the combined mesh
+      const auto vertexOffset = static_cast<int32_t>(combinedMesh.vertices.size());
+      combinedMesh.vertices.insert(
+          combinedMesh.vertices.end(), meshOpt->vertices.begin(), meshOpt->vertices.end());
+      for (const auto& face : meshOpt->faces) {
+        combinedMesh.faces.push_back(
+            {face[0] + vertexOffset, face[1] + vertexOffset, face[2] + vertexOffset});
+      }
+      combinedMesh.colors.resize(combinedMesh.vertices.size(), vertexColor);
+
+      // Extend skin weights: all new vertices are rigidly bound to this joint
+      const auto prevVertexCount = skinWeights.index.rows();
+      const auto newVertexCount =
+          prevVertexCount + static_cast<Eigen::Index>(meshOpt->vertices.size());
+      skinWeights.index.conservativeResize(newVertexCount, Eigen::NoChange);
+      skinWeights.weight.conservativeResize(newVertexCount, Eigen::NoChange);
+      skinWeights.index.bottomRows(newVertexCount - prevVertexCount).setZero();
+      skinWeights.weight.bottomRows(newVertexCount - prevVertexCount).setZero();
+      for (auto vi = prevVertexCount; vi < newVertexCount; ++vi) {
+        skinWeights.index(vi, 0) = static_cast<uint32_t>(jointIdx);
+        skinWeights.weight(vi, 0) = 1.0f;
+      }
+    }
+  }
+
+  if (!hasAnyColor) {
+    combinedMesh.colors.clear();
+  }
+
+  if (combinedMesh.vertices.empty()) {
+    return std::nullopt;
+  }
+
+  combinedMesh.updateNormals();
+  return std::make_pair(std::move(combinedMesh), std::move(skinWeights));
+}
+
+template <typename T>
+CharacterT<T> loadUrdfCharacterFromUrdfModel(
+    urdf::ModelInterfaceSharedPtr urdfModel,
+    const filesystem::path& urdfDir) {
   const urdf::Link* root = urdfModel->getRoot().get();
   MT_THROW_IF(!root, "Failed to parse URDF file from. No root link found.");
 
@@ -271,26 +572,52 @@ CharacterT<T> loadUrdfCharacterFromUrdfModel(urdf::ModelInterfaceSharedPtr urdfM
     root = root->child_links[0].get();
   }
 
-  if (!loadUrdfSkeletonRecursive(
-          data, kInvalidIndex, Quaternionf::Identity(), urdfModel.get(), root)) {
+  if (!loadUrdfSkeletonRecursive(data, kInvalidIndex, urdfModel.get(), root)) {
     MT_THROW("Failed to parse URDF.");
   }
 
-  Skeleton& skeleton = data.skeleton;
-  ParameterTransform& parameterTransform = data.parameterTransform;
-  auto& triplets = data.triplets;
-
-  const size_t numJoints = skeleton.joints.size();
+  const size_t numJoints = data.skeleton.joints.size();
   const size_t numJointParameters = numJoints * kParametersPerJoint;
   const size_t numModelParameters = data.totalDoFs;
-  parameterTransform.offsets.setZero(numJointParameters);
-  parameterTransform.transform.resize(numJointParameters, numModelParameters);
-  parameterTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
-  parameterTransform.activeJointParams = parameterTransform.computeActiveJointParams();
+  data.parameterTransform.offsets.setZero(numJointParameters);
 
-  // TODO: Parse collision geometries
+  resolveMimicJoints(data);
 
-  return CharacterT<T>(data.skeleton, data.parameterTransform, data.limits);
+  data.parameterTransform.transform.resize(numJointParameters, numModelParameters);
+  data.parameterTransform.transform.setFromTriplets(data.triplets.begin(), data.triplets.end());
+  data.parameterTransform.activeJointParams = data.parameterTransform.computeActiveJointParams();
+
+  const std::string robotName = urdfModel->getName();
+
+  auto meshResult = buildCombinedMesh(data, urdfDir);
+  if (meshResult) {
+    auto& [mesh, skinWeights] = *meshResult;
+    return CharacterT<T>(
+        data.skeleton,
+        data.parameterTransform,
+        data.limits,
+        LocatorList{},
+        &mesh,
+        &skinWeights,
+        nullptr, // collision
+        nullptr, // poseShapes
+        {}, // blendShapes
+        {}, // faceExpressionBlendShapes
+        robotName);
+  }
+
+  return CharacterT<T>(
+      data.skeleton,
+      data.parameterTransform,
+      data.limits,
+      LocatorList{},
+      nullptr, // mesh
+      nullptr, // skinWeights
+      nullptr, // collision
+      nullptr, // poseShapes
+      {}, // blendShapes
+      {}, // faceExpressionBlendShapes
+      robotName);
 }
 
 } // namespace
@@ -308,7 +635,7 @@ CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath) {
   }
 
   try {
-    return loadUrdfCharacterFromUrdfModel<T>(urdfModel);
+    return loadUrdfCharacterFromUrdfModel<T>(urdfModel, filepath.parent_path());
   } catch (const std::exception& e) {
     MT_THROW(
         "Failed to create Character from URDF file: {}. Error: {}", filepath.string(), e.what());
@@ -336,7 +663,7 @@ CharacterT<T> loadUrdfCharacter(std::span<const std::byte> bytes) {
   }
 
   try {
-    return loadUrdfCharacterFromUrdfModel<T>(urdfModel);
+    return loadUrdfCharacterFromUrdfModel<T>(urdfModel, {});
   } catch (const std::exception& e) {
     MT_THROW("Failed to create Character from URDF bytes. Error: {}", e.what());
   } catch (...) {
@@ -346,5 +673,36 @@ CharacterT<T> loadUrdfCharacter(std::span<const std::byte> bytes) {
 
 template CharacterT<float> loadUrdfCharacter(std::span<const std::byte> bytes);
 template CharacterT<double> loadUrdfCharacter(std::span<const std::byte> bytes);
+
+template <typename T>
+CharacterT<T> loadUrdfCharacter(
+    std::span<const std::byte> bytes,
+    const filesystem::path& meshBasePath) {
+  urdf::ModelInterfaceSharedPtr urdfModel;
+
+  try {
+    std::string urdfString(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    urdfModel = urdf::parseURDF(urdfString);
+  } catch (const std::exception& e) {
+    MT_THROW("Failed to read URDF file from URDF bytes. Error: {}", e.what());
+  } catch (...) {
+    MT_THROW("Failed to read URDF file from URDF bytes");
+  }
+
+  try {
+    return loadUrdfCharacterFromUrdfModel<T>(urdfModel, meshBasePath);
+  } catch (const std::exception& e) {
+    MT_THROW("Failed to create Character from URDF bytes. Error: {}", e.what());
+  } catch (...) {
+    MT_THROW("Failed to create Character from URDF bytes");
+  }
+}
+
+template CharacterT<float> loadUrdfCharacter(
+    std::span<const std::byte> bytes,
+    const filesystem::path& meshBasePath);
+template CharacterT<double> loadUrdfCharacter(
+    std::span<const std::byte> bytes,
+    const filesystem::path& meshBasePath);
 
 } // namespace momentum

--- a/momentum/io/urdf/urdf_io.h
+++ b/momentum/io/urdf/urdf_io.h
@@ -15,12 +15,78 @@
 
 namespace momentum {
 
+/// @file urdf_io.h
+/// @brief URDF character loader for Momentum.
+///
+/// ## URDF-to-Momentum Frame Convention
+///
+/// URDF and Momentum have different conventions for representing joint degrees of freedom.
+/// This loader maps between them as follows:
+///
+/// **URDF convention:**
+/// - Each joint specifies an arbitrary `axis` direction (e.g., `<axis xyz="0 0 1"/>`)
+///   that defines the direction of rotation (revolute) or translation (prismatic).
+/// - The axis is just a direction vector — it does NOT define the local coordinate system.
+/// - The link frame is defined solely by the joint's `<origin>` transform (xyz + rpy).
+/// - Visual meshes are positioned relative to the link frame.
+///
+/// **Momentum convention:**
+/// - Joint DOFs are applied along fixed local axes: `rx`/`ry`/`rz` for rotation,
+///   `tx`/`ty`/`tz` for translation.
+/// - `preRotation` defines the parent-to-child frame rotation at bind pose.
+///
+/// **How this loader bridges the two:**
+/// - DOFs are mapped to the **natural principal axis** matching the URDF axis direction.
+///   For example, a revolute joint with axis `(0,0,1)` maps to `rz`, not `rx`.
+/// - `preRotation` is set to the URDF joint origin rotation **only** — no axis alignment
+///   rotation is baked in. This means the Momentum joint frame coincides with the URDF
+///   link frame.
+/// - Visual meshes can be transformed using the joint world transform directly, with no
+///   frame correction needed.
+///
+/// **Why this matters for animation:**
+/// - URDF has no official animation format. Motion data typically comes from BVH or other
+///   formats that express rotations in the joint's local frame.
+/// - Because we preserve the URDF link frame (no axis remapping), animation data can be
+///   applied directly to the corresponding `rx`/`ry`/`rz` parameter without any frame
+///   conversion.
+/// - If axis alignment were baked into `preRotation`, external animation data would need
+///   to account for the internal frame rotation, which no external tool would know to do.
+///
+/// **Limitation:** Only principal axes (±X, ±Y, ±Z) are supported. Non-principal axes
+/// (e.g., `(0.707, 0, 0.707)`) will throw an error.
+///
+/// **Units:** URDF uses meters; Momentum uses centimeters. All positions are converted
+/// automatically.
+
 /// Loads a character from a URDF file.
+///
+/// Parses the skeleton (joints, hierarchy, limits), parameter transform, and visual meshes.
+/// Mesh files referenced by `<visual>` elements (STL, OBJ) are resolved relative to the
+/// URDF file's directory.
+///
+/// @param filepath Path to the URDF file.
+/// @return The loaded character with skeleton, parameter transform, limits, and optionally
+///   mesh with skin weights.
 template <typename T = float>
 CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath);
 
 /// Loads a character from a URDF file using the provided byte data.
+///
+/// Mesh loading is not supported when loading from bytes because there is no
+/// file path to resolve relative mesh references. Use the overload with
+/// meshBasePath to enable mesh loading.
 template <typename T = float>
 [[nodiscard]] CharacterT<T> loadUrdfCharacter(std::span<const std::byte> bytes);
+
+/// Loads a character from a URDF file using the provided byte data, with a base
+/// path for resolving mesh file references.
+///
+/// @param bytes The raw URDF file contents.
+/// @param meshBasePath The directory to use for resolving relative mesh file paths.
+template <typename T = float>
+[[nodiscard]] CharacterT<T> loadUrdfCharacter(
+    std::span<const std::byte> bytes,
+    const filesystem::path& meshBasePath);
 
 } // namespace momentum

--- a/momentum/io/urdf/urdf_mesh_io.cpp
+++ b/momentum/io/urdf/urdf_mesh_io.cpp
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/urdf/urdf_mesh_io.h"
+
+#include <cmath>
+#include "momentum/common/log.h"
+#include "momentum/math/constants.h"
+
+#include <array>
+#include <fstream>
+#include <sstream>
+#include <unordered_map>
+
+namespace momentum {
+
+namespace {
+
+// Hash for Eigen::Vector3f to support vertex deduplication in STL loading.
+struct Vector3fHash {
+  size_t operator()(const Eigen::Vector3f& v) const {
+    size_t h = 0;
+    for (int i = 0; i < 3; ++i) {
+      // Combine bits of each float component
+      uint32_t bits = 0;
+      std::memcpy(&bits, &v[i], sizeof(float));
+      h ^= std::hash<uint32_t>{}(bits) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    }
+    return h;
+  }
+};
+
+// Approximate equality for vertex deduplication.
+struct Vector3fEqual {
+  bool operator()(const Eigen::Vector3f& a, const Eigen::Vector3f& b) const {
+    return a.isApprox(b, 1e-7f);
+  }
+};
+
+// Returns the deduplicated vertex index, inserting a new vertex if needed.
+int32_t deduplicateVertex(
+    const Eigen::Vector3f& v,
+    std::unordered_map<Eigen::Vector3f, int32_t, Vector3fHash, Vector3fEqual>& vertexMap,
+    std::vector<Eigen::Vector3f>& vertices) {
+  auto it = vertexMap.find(v);
+  if (it != vertexMap.end()) {
+    return it->second;
+  }
+  const auto idx = static_cast<int32_t>(vertices.size());
+  vertexMap[v] = idx;
+  vertices.push_back(v);
+  return idx;
+}
+
+// Try to detect if an STL file is binary (as opposed to ASCII).
+// A binary STL has an 80-byte header + 4-byte triangle count, then
+// 50 bytes per triangle. If the file size matches, it's binary.
+bool isBinaryStl(const filesystem::path& filepath) {
+  std::ifstream file(filepath, std::ios::binary | std::ios::ate);
+  if (!file.is_open()) {
+    return false;
+  }
+
+  const auto fileSize = file.tellg();
+  if (fileSize < 84) {
+    return false; // Too small for binary STL
+  }
+
+  // Read triangle count from bytes 80-83
+  file.seekg(80);
+  uint32_t numTriangles = 0;
+  file.read(reinterpret_cast<char*>(&numTriangles), sizeof(uint32_t));
+
+  // Binary STL: 80 (header) + 4 (count) + numTriangles * 50
+  const auto expectedSize =
+      static_cast<std::streamoff>(84) + static_cast<std::streamoff>(numTriangles) * 50;
+  return fileSize == expectedSize;
+}
+
+std::optional<Mesh> loadBinaryStl(const filesystem::path& filepath) {
+  std::ifstream file(filepath, std::ios::binary);
+  if (!file.is_open()) {
+    return std::nullopt;
+  }
+
+  // Skip 80-byte header
+  file.seekg(80);
+
+  uint32_t numTriangles = 0;
+  file.read(reinterpret_cast<char*>(&numTriangles), sizeof(uint32_t));
+  if (!file.good() || numTriangles == 0) {
+    return std::nullopt;
+  }
+
+  Mesh mesh;
+  std::unordered_map<Eigen::Vector3f, int32_t, Vector3fHash, Vector3fEqual> vertexMap;
+
+  for (uint32_t i = 0; i < numTriangles; ++i) {
+    // Read normal (3 floats) — we'll recompute normals later
+    std::array<float, 3> normal{};
+    file.read(reinterpret_cast<char*>(normal.data()), sizeof(float) * 3);
+
+    // Read 3 vertices (9 floats)
+    std::array<Eigen::Vector3f, 3> v;
+    for (auto& j : v) {
+      std::array<float, 3> coords{};
+      file.read(reinterpret_cast<char*>(coords.data()), sizeof(float) * 3);
+      j = Eigen::Vector3f(coords[0], coords[1], coords[2]);
+    }
+
+    // Skip attribute byte count (2 bytes)
+    uint16_t attrByteCount = 0;
+    file.read(reinterpret_cast<char*>(&attrByteCount), sizeof(uint16_t));
+
+    if (!file.good()) {
+      return std::nullopt;
+    }
+
+    // Deduplicate vertices and add face
+    Eigen::Vector3i face;
+    for (int j = 0; j < 3; ++j) {
+      face[j] = deduplicateVertex(v[j], vertexMap, mesh.vertices);
+    }
+    mesh.faces.push_back(face);
+  }
+
+  mesh.updateNormals();
+  return mesh;
+}
+
+std::optional<Mesh> loadAsciiStl(const filesystem::path& filepath) {
+  std::ifstream file(filepath);
+  if (!file.is_open()) {
+    return std::nullopt;
+  }
+
+  Mesh mesh;
+  std::unordered_map<Eigen::Vector3f, int32_t, Vector3fHash, Vector3fEqual> vertexMap;
+  std::string line;
+  std::string token;
+
+  while (std::getline(file, line)) {
+    std::istringstream iss(line);
+    iss >> token;
+
+    if (token == "vertex") {
+      // Read three vertex lines for one facet
+      std::array<Eigen::Vector3f, 3> v;
+      float x = NAN, y = NAN, z = NAN;
+      iss >> x >> y >> z;
+      v[0] = Eigen::Vector3f(x, y, z);
+
+      for (int j = 1; j < 3; ++j) {
+        if (!std::getline(file, line)) {
+          return std::nullopt;
+        }
+        std::istringstream viss(line);
+        viss >> token; // "vertex"
+        viss >> x >> y >> z;
+        v[j] = Eigen::Vector3f(x, y, z);
+      }
+
+      Eigen::Vector3i face;
+      for (int j = 0; j < 3; ++j) {
+        face[j] = deduplicateVertex(v[j], vertexMap, mesh.vertices);
+      }
+      mesh.faces.push_back(face);
+    }
+  }
+
+  if (mesh.faces.empty()) {
+    return std::nullopt;
+  }
+
+  mesh.updateNormals();
+  return mesh;
+}
+
+} // namespace
+
+Mesh generateBoxMesh(float dimX, float dimY, float dimZ) {
+  const float hx = dimX * 0.5f;
+  const float hy = dimY * 0.5f;
+  const float hz = dimZ * 0.5f;
+
+  Mesh mesh;
+  mesh.vertices = {
+      {-hx, -hy, -hz},
+      {hx, -hy, -hz},
+      {hx, hy, -hz},
+      {-hx, hy, -hz},
+      {-hx, -hy, hz},
+      {hx, -hy, hz},
+      {hx, hy, hz},
+      {-hx, hy, hz},
+  };
+
+  // Two triangles per face, 6 faces = 12 triangles.
+  // Winding order: counter-clockwise when viewed from outside.
+  mesh.faces = {
+      // -Z face
+      {0, 2, 1},
+      {0, 3, 2},
+      // +Z face
+      {4, 5, 6},
+      {4, 6, 7},
+      // -Y face
+      {0, 1, 5},
+      {0, 5, 4},
+      // +Y face
+      {2, 3, 7},
+      {2, 7, 6},
+      // -X face
+      {0, 4, 7},
+      {0, 7, 3},
+      // +X face
+      {1, 2, 6},
+      {1, 6, 5},
+  };
+
+  mesh.updateNormals();
+  return mesh;
+}
+
+Mesh generateCylinderMesh(float radius, float length, int segments) {
+  Mesh mesh;
+
+  const float halfLen = length * 0.5f;
+
+  // Bottom center vertex (index 0)
+  mesh.vertices.emplace_back(0.0f, 0.0f, -halfLen);
+  // Top center vertex (index 1)
+  mesh.vertices.emplace_back(0.0f, 0.0f, halfLen);
+
+  // Ring vertices: bottom ring starts at index 2, top ring at index 2 + segments
+  for (int i = 0; i < segments; ++i) {
+    const float angle = twopi<float>() * static_cast<float>(i) / static_cast<float>(segments);
+    const float x = radius * std::cos(angle);
+    const float y = radius * std::sin(angle);
+    mesh.vertices.emplace_back(x, y, -halfLen); // bottom ring
+  }
+  for (int i = 0; i < segments; ++i) {
+    const float angle = twopi<float>() * static_cast<float>(i) / static_cast<float>(segments);
+    const float x = radius * std::cos(angle);
+    const float y = radius * std::sin(angle);
+    mesh.vertices.emplace_back(x, y, halfLen); // top ring
+  }
+
+  const int bottomRingStart = 2;
+  const int topRingStart = 2 + segments;
+
+  for (int i = 0; i < segments; ++i) {
+    const int next = (i + 1) % segments;
+
+    // Bottom cap (winding: center, next, current — looking from -Z)
+    mesh.faces.emplace_back(0, bottomRingStart + next, bottomRingStart + i);
+
+    // Top cap (winding: center, current, next — looking from +Z)
+    mesh.faces.emplace_back(1, topRingStart + i, topRingStart + next);
+
+    // Side quads (two triangles each)
+    const int b0 = bottomRingStart + i;
+    const int b1 = bottomRingStart + next;
+    const int t0 = topRingStart + i;
+    const int t1 = topRingStart + next;
+    mesh.faces.emplace_back(b0, b1, t1);
+    mesh.faces.emplace_back(b0, t1, t0);
+  }
+
+  mesh.updateNormals();
+  return mesh;
+}
+
+Mesh generateSphereMesh(float radius, int latSegments, int lonSegments) {
+  Mesh mesh;
+
+  // Top pole (index 0)
+  mesh.vertices.emplace_back(0.0f, 0.0f, radius);
+
+  // Latitude rings (from top to bottom, excluding poles)
+  for (int lat = 1; lat < latSegments; ++lat) {
+    const float phi = pi<float>() * static_cast<float>(lat) / static_cast<float>(latSegments);
+    const float sinPhi = std::sin(phi);
+    const float cosPhi = std::cos(phi);
+
+    for (int lon = 0; lon < lonSegments; ++lon) {
+      const float theta =
+          twopi<float>() * static_cast<float>(lon) / static_cast<float>(lonSegments);
+      const float x = radius * sinPhi * std::cos(theta);
+      const float y = radius * sinPhi * std::sin(theta);
+      const float z = radius * cosPhi;
+      mesh.vertices.emplace_back(x, y, z);
+    }
+  }
+
+  // Bottom pole (last vertex)
+  const auto bottomPole = static_cast<int32_t>(mesh.vertices.size());
+  mesh.vertices.emplace_back(0.0f, 0.0f, -radius);
+
+  // Top cap triangles (pole to first ring)
+  for (int lon = 0; lon < lonSegments; ++lon) {
+    const int next = (lon + 1) % lonSegments;
+    mesh.faces.emplace_back(0, 1 + lon, 1 + next);
+  }
+
+  // Middle quad strips between rings
+  for (int lat = 0; lat < latSegments - 2; ++lat) {
+    const int ringStart = 1 + lat * lonSegments;
+    const int nextRingStart = 1 + (lat + 1) * lonSegments;
+    for (int lon = 0; lon < lonSegments; ++lon) {
+      const int next = (lon + 1) % lonSegments;
+      const int a = ringStart + lon;
+      const int b = ringStart + next;
+      const int c = nextRingStart + next;
+      const int d = nextRingStart + lon;
+      mesh.faces.emplace_back(a, d, c);
+      mesh.faces.emplace_back(a, c, b);
+    }
+  }
+
+  // Bottom cap triangles (last ring to pole)
+  const int lastRingStart = 1 + (latSegments - 2) * lonSegments;
+  for (int lon = 0; lon < lonSegments; ++lon) {
+    const int next = (lon + 1) % lonSegments;
+    mesh.faces.emplace_back(lastRingStart + lon, bottomPole, lastRingStart + next);
+  }
+
+  mesh.updateNormals();
+  return mesh;
+}
+
+std::optional<Mesh> loadStlMesh(const filesystem::path& filepath) {
+  if (!filesystem::exists(filepath)) {
+    MT_LOGW("STL file not found: {}", filepath.string());
+    return std::nullopt;
+  }
+
+  if (isBinaryStl(filepath)) {
+    return loadBinaryStl(filepath);
+  }
+  return loadAsciiStl(filepath);
+}
+
+std::optional<Mesh> loadObjMesh(const filesystem::path& filepath) {
+  if (!filesystem::exists(filepath)) {
+    MT_LOGW("OBJ file not found: {}", filepath.string());
+    return std::nullopt;
+  }
+
+  std::ifstream file(filepath);
+  if (!file.is_open()) {
+    MT_LOGW("Failed to open OBJ file: {}", filepath.string());
+    return std::nullopt;
+  }
+
+  Mesh mesh;
+  std::string line;
+
+  while (std::getline(file, line)) {
+    if (line.empty() || line[0] == '#') {
+      continue;
+    }
+
+    std::istringstream iss(line);
+    std::string token;
+    iss >> token;
+
+    if (token == "v") {
+      float x = NAN, y = NAN, z = NAN;
+      iss >> x >> y >> z;
+      mesh.vertices.emplace_back(x, y, z);
+    } else if (token == "f") {
+      // Parse face indices. Supports formats:
+      //   f v1 v2 v3 ...
+      //   f v1/vt1 v2/vt2 v3/vt3 ...
+      //   f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3 ...
+      //   f v1//vn1 v2//vn2 v3//vn3 ...
+      std::vector<int32_t> faceIndices;
+      std::string vertexToken;
+      while (iss >> vertexToken) {
+        // Extract vertex index (everything before the first '/')
+        const auto slashPos = vertexToken.find('/');
+        const std::string indexStr =
+            (slashPos != std::string::npos) ? vertexToken.substr(0, slashPos) : vertexToken;
+        const int idx = std::stoi(indexStr);
+        // OBJ indices are 1-based; negative indices are relative to current vertex count
+        const int32_t resolvedIdx =
+            (idx > 0) ? (idx - 1) : static_cast<int32_t>(mesh.vertices.size()) + idx;
+        faceIndices.push_back(resolvedIdx);
+      }
+
+      // Triangulate polygon faces using fan triangulation
+      if (faceIndices.size() >= 3) {
+        for (size_t i = 2; i < faceIndices.size(); ++i) {
+          mesh.faces.emplace_back(
+              faceIndices[0], faceIndices[static_cast<int32_t>(i) - 1], faceIndices[i]);
+        }
+      }
+    }
+  }
+
+  if (mesh.vertices.empty() || mesh.faces.empty()) {
+    MT_LOGW("OBJ file contains no geometry: {}", filepath.string());
+    return std::nullopt;
+  }
+
+  mesh.updateNormals();
+  return mesh;
+}
+
+std::optional<filesystem::path> resolveMeshPath(
+    const std::string& filename,
+    const filesystem::path& urdfDir) {
+  // Handle file:// URI
+  const std::string fileScheme = "file://";
+  if (filename.substr(0, fileScheme.size()) == fileScheme) {
+    const filesystem::path resolved(filename.substr(fileScheme.size()));
+    if (filesystem::exists(resolved)) {
+      return resolved;
+    }
+    MT_LOGW("Mesh file not found: {}", resolved.string());
+    return std::nullopt;
+  }
+
+  // Handle package:// URI — strip scheme and package name, resolve relative to URDF dir
+  const std::string packageScheme = "package://";
+  if (filename.substr(0, packageScheme.size()) == packageScheme) {
+    // Find the end of the package name (next '/' after "package://")
+    const auto pathStart = filename.find('/', packageScheme.size());
+    if (pathStart == std::string::npos) {
+      MT_LOGW("Invalid package:// URI: {}", filename);
+      return std::nullopt;
+    }
+    const std::string relativePath = filename.substr(pathStart + 1);
+
+    // Try resolving relative to URDF directory
+    filesystem::path resolved = urdfDir / relativePath;
+    if (filesystem::exists(resolved)) {
+      return resolved;
+    }
+
+    // Try resolving relative to parent of URDF directory
+    // (common layout: pkg/urdf/robot.urdf and pkg/meshes/part.stl)
+    resolved = urdfDir.parent_path() / relativePath;
+    if (filesystem::exists(resolved)) {
+      return resolved;
+    }
+
+    MT_LOGW("Could not resolve package:// mesh path: {}", filename);
+    return std::nullopt;
+  }
+
+  // Handle absolute paths
+  const filesystem::path path(filename);
+  if (path.is_absolute()) {
+    if (filesystem::exists(path)) {
+      return path;
+    }
+    MT_LOGW("Mesh file not found: {}", path.string());
+    return std::nullopt;
+  }
+
+  // Handle relative paths — resolve relative to URDF directory
+  const filesystem::path resolved = urdfDir / path;
+  if (filesystem::exists(resolved)) {
+    return resolved;
+  }
+
+  MT_LOGW("Mesh file not found: {}", resolved.string());
+  return std::nullopt;
+}
+
+} // namespace momentum

--- a/momentum/io/urdf/urdf_mesh_io.h
+++ b/momentum/io/urdf/urdf_mesh_io.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/common/filesystem.h>
+#include <momentum/math/mesh.h>
+
+#include <optional>
+
+namespace momentum {
+
+/// Generates a box mesh with the given dimensions centered at the origin.
+///
+/// @param dimX Full extent along the X axis (in the caller's units).
+/// @param dimY Full extent along the Y axis.
+/// @param dimZ Full extent along the Z axis.
+/// @return A mesh with 8 vertices and 12 triangular faces.
+Mesh generateBoxMesh(float dimX, float dimY, float dimZ);
+
+/// Generates a cylinder mesh centered at the origin with the Z axis as its axis.
+///
+/// @param radius Cylinder radius.
+/// @param length Cylinder length along the Z axis.
+/// @param segments Number of segments around the circumference.
+/// @return A triangulated cylinder mesh with top and bottom caps.
+Mesh generateCylinderMesh(float radius, float length, int segments = 32);
+
+/// Generates a UV sphere mesh centered at the origin.
+///
+/// @param radius Sphere radius.
+/// @param latSegments Number of latitude bands (stacks).
+/// @param lonSegments Number of longitude segments (slices).
+/// @return A triangulated sphere mesh.
+Mesh generateSphereMesh(float radius, int latSegments = 16, int lonSegments = 32);
+
+/// Loads a mesh from an STL file (binary or ASCII).
+///
+/// Binary STL vertices are deduplicated to produce an indexed mesh.
+///
+/// @param filepath Path to the STL file.
+/// @return The loaded mesh, or std::nullopt if the file cannot be read.
+std::optional<Mesh> loadStlMesh(const filesystem::path& filepath);
+
+/// Loads a mesh from a Wavefront OBJ file (vertices and triangular/polygon faces).
+///
+/// Only `v` (vertex) and `f` (face) records are parsed. Face vertex indices may use
+/// `v`, `v/vt`, `v/vt/vn`, or `v//vn` notation; only vertex indices are used.
+///
+/// @param filepath Path to the OBJ file.
+/// @return The loaded mesh, or std::nullopt if the file cannot be read.
+std::optional<Mesh> loadObjMesh(const filesystem::path& filepath);
+
+/// Resolves a mesh filename from a URDF visual element to a filesystem path.
+///
+/// Handles absolute paths, paths relative to the URDF directory,
+/// `package://` URIs (strips scheme and package name), and `file://` URIs.
+///
+/// @param filename The mesh filename string from the URDF (e.g., "meshes/part.stl" or
+///   "package://robot/meshes/part.stl").
+/// @param urdfDir The directory containing the URDF file, used as the base for
+///   relative path resolution.
+/// @return The resolved filesystem path, or std::nullopt if the file cannot be found.
+std::optional<filesystem::path> resolveMeshPath(
+    const std::string& filename,
+    const filesystem::path& urdfDir);
+
+} // namespace momentum

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -6,11 +6,15 @@
  */
 
 #include "momentum/io/urdf/urdf_io.h"
+#include "momentum/io/urdf/urdf_mesh_io.h"
 #include "momentum/test/character/character_helpers.h"
 #include "momentum/test/character/character_helpers_gtest.h"
 #include "momentum/test/io/io_helpers.h"
 
 #include <gtest/gtest.h>
+
+#include <array>
+#include <fstream>
 
 using namespace momentum;
 
@@ -54,6 +58,603 @@ TEST(IoUrdfTest, LoadCharacter) {
   EXPECT_EQ(parameterLimits[0].data.minMax.parameterIndex, 6); // the first joint parameter
   EXPECT_FLOAT_EQ(parameterLimits[0].data.minMax.limits[0], -2.095);
   EXPECT_FLOAT_EQ(parameterLimits[0].data.minMax.limits[1], 0.785);
+}
+
+// Test that the existing character.urdf (which has no visual meshes) still works
+// and produces a character without a mesh.
+TEST(IoUrdfTest, LoadCharacterNoMesh) {
+  auto urdfPath = getTestFilePath("character.urdf");
+  if (!urdfPath.has_value()) {
+    GTEST_SKIP() << "Environment variable 'TEST_MOMENTUM_MODELS_PATH' is not set.";
+  }
+
+  const auto& character = loadUrdfCharacter(*urdfPath);
+  EXPECT_EQ(character.mesh, nullptr);
+  EXPECT_EQ(character.skinWeights, nullptr);
+}
+
+TEST(IoUrdfTest, GenerateBoxMesh) {
+  const auto mesh = generateBoxMesh(2.0f, 3.0f, 4.0f);
+  EXPECT_EQ(mesh.vertices.size(), 8);
+  EXPECT_EQ(mesh.faces.size(), 12);
+  EXPECT_EQ(mesh.normals.size(), 8);
+
+  // Check that all vertices are within the expected bounds
+  for (const auto& v : mesh.vertices) {
+    EXPECT_NEAR(v.x(), 0.0f, 1.0f + 1e-6f);
+    EXPECT_NEAR(v.y(), 0.0f, 1.5f + 1e-6f);
+    EXPECT_NEAR(v.z(), 0.0f, 2.0f + 1e-6f);
+  }
+}
+
+TEST(IoUrdfTest, GenerateCylinderMesh) {
+  const int segments = 16;
+  const auto mesh = generateCylinderMesh(1.0f, 2.0f, segments);
+
+  // 2 center vertices + 2 * segments ring vertices
+  EXPECT_EQ(mesh.vertices.size(), 2 + 2 * segments);
+  // segments bottom cap + segments top cap + 2 * segments side
+  EXPECT_EQ(mesh.faces.size(), 4 * segments);
+  EXPECT_EQ(mesh.normals.size(), mesh.vertices.size());
+}
+
+TEST(IoUrdfTest, GenerateSphereMesh) {
+  const int lat = 8;
+  const int lon = 16;
+  const auto mesh = generateSphereMesh(1.0f, lat, lon);
+
+  // 2 poles + (lat - 1) * lon ring vertices
+  EXPECT_EQ(mesh.vertices.size(), 2 + (lat - 1) * lon);
+  // lon top cap + lon bottom cap + (lat - 2) * lon * 2 middle
+  EXPECT_EQ(mesh.faces.size(), 2 * lon + (lat - 2) * lon * 2);
+  EXPECT_EQ(mesh.normals.size(), mesh.vertices.size());
+}
+
+TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
+  // Create a simple URDF with primitive visual geometries
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="test_robot">
+      <link name="base_link">
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.2 0.3"/>
+          </geometry>
+        </visual>
+      </link>
+      <link name="child_link">
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <cylinder radius="0.05" length="0.2"/>
+          </geometry>
+        </visual>
+      </link>
+      <joint name="joint1" type="revolute">
+        <parent link="base_link"/>
+        <child link="child_link"/>
+        <origin xyz="0.1 0 0" rpy="0 0 0"/>
+        <axis xyz="0 0 1"/>
+        <limit lower="-1.57" upper="1.57" effort="100" velocity="1"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  // Should have 2 joints
+  EXPECT_EQ(character.skeleton.joints.size(), 2);
+
+  // Should have a mesh (from the primitive visuals)
+  ASSERT_NE(character.mesh, nullptr);
+  EXPECT_GT(character.mesh->vertices.size(), 0);
+  EXPECT_GT(character.mesh->faces.size(), 0);
+  EXPECT_EQ(character.mesh->normals.size(), character.mesh->vertices.size());
+
+  // Should have skin weights
+  ASSERT_NE(character.skinWeights, nullptr);
+  EXPECT_EQ(character.skinWeights->index.rows(), character.mesh->vertices.size());
+  EXPECT_EQ(character.skinWeights->weight.rows(), character.mesh->vertices.size());
+
+  // Box has 8 vertices, cylinder (32 segments) has 66 vertices
+  const size_t boxVertices = 8;
+  const size_t cylinderVertices = 2 + 2 * 32; // 2 centers + 2 rings of 32
+  EXPECT_EQ(character.mesh->vertices.size(), boxVertices + cylinderVertices);
+
+  // Verify skin weights: first 8 vertices should be bound to joint 0 (base_link),
+  // remaining to joint 1 (child_link)
+  for (Eigen::Index i = 0; i < static_cast<Eigen::Index>(boxVertices); ++i) {
+    EXPECT_EQ(character.skinWeights->index(i, 0), 0);
+    EXPECT_FLOAT_EQ(character.skinWeights->weight(i, 0), 1.0f);
+  }
+  for (auto i = static_cast<Eigen::Index>(boxVertices); i < character.skinWeights->index.rows();
+       ++i) {
+    EXPECT_EQ(character.skinWeights->index(i, 0), 1);
+    EXPECT_FLOAT_EQ(character.skinWeights->weight(i, 0), 1.0f);
+  }
+}
+
+TEST(IoUrdfTest, LoadUrdfWithSphereVisual) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="test_robot">
+      <link name="base_link">
+        <visual>
+          <origin xyz="0 0 0.5" rpy="0 0 0"/>
+          <geometry>
+            <sphere radius="0.1"/>
+          </geometry>
+        </visual>
+      </link>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  EXPECT_EQ(character.skeleton.joints.size(), 1);
+  ASSERT_NE(character.mesh, nullptr);
+  EXPECT_GT(character.mesh->vertices.size(), 0);
+  EXPECT_GT(character.mesh->faces.size(), 0);
+
+  // Sphere with default 16 lat, 32 lon: 2 + 15*32 = 482 vertices
+  EXPECT_EQ(character.mesh->vertices.size(), 2 + 15 * 32);
+}
+
+TEST(IoUrdfTest, LoadStlMesh) {
+  auto tempDir = temporaryDirectory("urdf_stl_test");
+
+  // Write a minimal binary STL file with 1 triangle
+  const auto stlPath = tempDir.path() / "test.stl";
+  {
+    std::ofstream file(stlPath, std::ios::binary);
+    // 80-byte header (zeros)
+    std::array<char, 80> header = {};
+    file.write(header.data(), 80);
+    // Triangle count
+    uint32_t numTriangles = 1;
+    file.write(reinterpret_cast<const char*>(&numTriangles), sizeof(uint32_t));
+    // Normal
+    std::array<float, 3> normal = {0.0f, 0.0f, 1.0f};
+    file.write(reinterpret_cast<const char*>(normal.data()), sizeof(float) * 3);
+    // Vertex 1
+    std::array<float, 3> v1 = {0.0f, 0.0f, 0.0f};
+    file.write(reinterpret_cast<const char*>(v1.data()), sizeof(float) * 3);
+    // Vertex 2
+    std::array<float, 3> v2 = {1.0f, 0.0f, 0.0f};
+    file.write(reinterpret_cast<const char*>(v2.data()), sizeof(float) * 3);
+    // Vertex 3
+    std::array<float, 3> v3 = {0.0f, 1.0f, 0.0f};
+    file.write(reinterpret_cast<const char*>(v3.data()), sizeof(float) * 3);
+    // Attribute byte count
+    uint16_t attrByteCount = 0;
+    file.write(reinterpret_cast<const char*>(&attrByteCount), sizeof(uint16_t));
+  }
+
+  const auto meshOpt = loadStlMesh(stlPath);
+  ASSERT_TRUE(meshOpt.has_value());
+  EXPECT_EQ(meshOpt->vertices.size(), 3);
+  EXPECT_EQ(meshOpt->faces.size(), 1);
+  EXPECT_EQ(meshOpt->normals.size(), 3);
+}
+
+TEST(IoUrdfTest, LoadObjMesh) {
+  auto tempDir = temporaryDirectory("urdf_obj_test");
+
+  // Write a minimal OBJ file with 1 triangle
+  const auto objPath = tempDir.path() / "test.obj";
+  {
+    std::ofstream file(objPath);
+    file << "# Simple triangle\n";
+    file << "v 0.0 0.0 0.0\n";
+    file << "v 1.0 0.0 0.0\n";
+    file << "v 0.0 1.0 0.0\n";
+    file << "f 1 2 3\n";
+  }
+
+  const auto meshOpt = loadObjMesh(objPath);
+  ASSERT_TRUE(meshOpt.has_value());
+  EXPECT_EQ(meshOpt->vertices.size(), 3);
+  EXPECT_EQ(meshOpt->faces.size(), 1);
+  EXPECT_EQ(meshOpt->normals.size(), 3);
+
+  // Verify vertex positions
+  EXPECT_TRUE(meshOpt->vertices[0].isApprox(Eigen::Vector3f(0, 0, 0)));
+  EXPECT_TRUE(meshOpt->vertices[1].isApprox(Eigen::Vector3f(1, 0, 0)));
+  EXPECT_TRUE(meshOpt->vertices[2].isApprox(Eigen::Vector3f(0, 1, 0)));
+}
+
+TEST(IoUrdfTest, LoadObjMeshWithSlashNotation) {
+  auto tempDir = temporaryDirectory("urdf_obj_slash_test");
+
+  const auto objPath = tempDir.path() / "test.obj";
+  {
+    std::ofstream file(objPath);
+    file << "v 0 0 0\n";
+    file << "v 1 0 0\n";
+    file << "v 0 1 0\n";
+    file << "v 1 1 0\n";
+    file << "vn 0 0 1\n";
+    file << "f 1//1 2//1 3//1\n";
+    file << "f 2//1 4//1 3//1\n";
+  }
+
+  const auto meshOpt = loadObjMesh(objPath);
+  ASSERT_TRUE(meshOpt.has_value());
+  EXPECT_EQ(meshOpt->vertices.size(), 4);
+  EXPECT_EQ(meshOpt->faces.size(), 2);
+}
+
+TEST(IoUrdfTest, LoadUrdfWithStlMesh) {
+  auto tempDir = temporaryDirectory("urdf_stl_load_test");
+
+  // Write a binary STL triangle
+  const auto stlPath = tempDir.path() / "mesh.stl";
+  {
+    std::ofstream file(stlPath, std::ios::binary);
+    std::array<char, 80> header = {};
+    file.write(header.data(), 80);
+    uint32_t numTriangles = 1;
+    file.write(reinterpret_cast<const char*>(&numTriangles), sizeof(uint32_t));
+    std::array<float, 3> normal = {0, 0, 1};
+    file.write(reinterpret_cast<const char*>(normal.data()), sizeof(float) * 3);
+    std::array<float, 3> v1 = {0, 0, 0};
+    file.write(reinterpret_cast<const char*>(v1.data()), sizeof(float) * 3);
+    std::array<float, 3> v2 = {1, 0, 0};
+    file.write(reinterpret_cast<const char*>(v2.data()), sizeof(float) * 3);
+    std::array<float, 3> v3 = {0, 1, 0};
+    file.write(reinterpret_cast<const char*>(v3.data()), sizeof(float) * 3);
+    uint16_t attr = 0;
+    file.write(reinterpret_cast<const char*>(&attr), sizeof(uint16_t));
+  }
+
+  // Write a URDF that references the STL file
+  const auto urdfPath = tempDir.path() / "robot.urdf";
+  {
+    std::ofstream file(urdfPath);
+    file << R"(<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="mesh.stl"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>
+)";
+  }
+
+  const auto character = loadUrdfCharacter(urdfPath);
+  EXPECT_EQ(character.skeleton.joints.size(), 1);
+  ASSERT_NE(character.mesh, nullptr);
+  EXPECT_EQ(character.mesh->vertices.size(), 3);
+  EXPECT_EQ(character.mesh->faces.size(), 1);
+  ASSERT_NE(character.skinWeights, nullptr);
+  EXPECT_EQ(character.skinWeights->index.rows(), 3);
+}
+
+TEST(IoUrdfTest, LoadUrdfWithMeshScale) {
+  auto tempDir = temporaryDirectory("urdf_mesh_scale_test");
+
+  // Write a simple OBJ
+  const auto objPath = tempDir.path() / "mesh.obj";
+  {
+    std::ofstream file(objPath);
+    file << "v 1 0 0\n";
+    file << "v 0 1 0\n";
+    file << "v 0 0 1\n";
+    file << "f 1 2 3\n";
+  }
+
+  // URDF with scale
+  const auto urdfPath = tempDir.path() / "robot.urdf";
+  {
+    std::ofstream file(urdfPath);
+    file << R"(<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="mesh.obj" scale="2 3 4"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>
+)";
+  }
+
+  const auto character = loadUrdfCharacter(urdfPath);
+  ASSERT_NE(character.mesh, nullptr);
+  EXPECT_EQ(character.mesh->vertices.size(), 3);
+
+  // Vertices should be scaled (from meters to cm), then multiplied by scale.
+  // Original: (1,0,0) -> scaled: (2,0,0) -> in cm: (200,0,0)
+  // Original: (0,1,0) -> scaled: (0,3,0) -> in cm: (0,300,0)
+  // Original: (0,0,1) -> scaled: (0,0,4) -> in cm: (0,0,400)
+  // (These are then transformed to bind-pose world space, which for a root joint
+  // with identity transform is the same.)
+  EXPECT_NEAR(character.mesh->vertices[0].x(), 200.0f, 1e-3f);
+  EXPECT_NEAR(character.mesh->vertices[1].y(), 300.0f, 1e-3f);
+  EXPECT_NEAR(character.mesh->vertices[2].z(), 400.0f, 1e-3f);
+}
+
+TEST(IoUrdfTest, LoadUrdfBytesWithMeshBasePath) {
+  auto tempDir = temporaryDirectory("urdf_bytes_mesh_test");
+
+  // Write a simple OBJ
+  const auto objPath = tempDir.path() / "mesh.obj";
+  {
+    std::ofstream file(objPath);
+    file << "v 0 0 0\n";
+    file << "v 1 0 0\n";
+    file << "v 0 1 0\n";
+    file << "f 1 2 3\n";
+  }
+
+  const std::string urdfContent = R"(<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="mesh.obj"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>
+)";
+
+  // Without base path — mesh should not be loaded
+  {
+    const auto bytes = std::as_bytes(std::span(urdfContent));
+    const auto character = loadUrdfCharacter(bytes);
+    EXPECT_EQ(character.mesh, nullptr);
+  }
+
+  // With base path — mesh should be loaded
+  {
+    const auto bytes = std::as_bytes(std::span(urdfContent));
+    const auto character = loadUrdfCharacter(bytes, tempDir.path());
+    ASSERT_NE(character.mesh, nullptr);
+    EXPECT_EQ(character.mesh->vertices.size(), 3);
+    EXPECT_EQ(character.mesh->faces.size(), 1);
+  }
+}
+
+TEST(IoUrdfTest, ResolveMeshPath) {
+  auto tempDir = temporaryDirectory("urdf_resolve_path_test");
+
+  // Create a subdirectory and mesh file
+  const auto meshDir = tempDir.path() / "meshes";
+  filesystem::create_directory(meshDir);
+  const auto meshFile = meshDir / "part.stl";
+  {
+    std::ofstream file(meshFile);
+    file << "placeholder";
+  }
+
+  // Relative path
+  EXPECT_TRUE(resolveMeshPath("meshes/part.stl", tempDir.path()).has_value());
+
+  // Absolute path
+  EXPECT_TRUE(resolveMeshPath(meshFile.string(), tempDir.path()).has_value());
+
+  // Non-existent file
+  EXPECT_FALSE(resolveMeshPath("nonexistent.stl", tempDir.path()).has_value());
+
+  // package:// URI — resolve relative to URDF dir
+  EXPECT_TRUE(resolveMeshPath("package://robot/meshes/part.stl", tempDir.path()).has_value());
+}
+
+TEST(IoUrdfTest, LoadUrdfWithMultipleVisuals) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="test_robot">
+      <link name="base_link">
+        <visual>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </visual>
+        <visual>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </visual>
+      </link>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_NE(character.mesh, nullptr);
+
+  // Box: 8 vertices, Sphere (16 lat, 32 lon): 482 vertices
+  const size_t expectedVertices = 8 + (2 + 15 * 32);
+  EXPECT_EQ(character.mesh->vertices.size(), expectedVertices);
+
+  // All vertices should be bound to joint 0
+  ASSERT_NE(character.skinWeights, nullptr);
+  for (Eigen::Index i = 0; i < character.skinWeights->index.rows(); ++i) {
+    EXPECT_EQ(character.skinWeights->index(i, 0), 0);
+    EXPECT_FLOAT_EQ(character.skinWeights->weight(i, 0), 1.0f);
+  }
+}
+
+TEST(IoUrdfTest, FloatingJoint) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="floating_robot">
+      <link name="world"/>
+      <link name="base_link"/>
+      <link name="child_link"/>
+      <joint name="floating_base" type="floating">
+        <parent link="world"/>
+        <child link="base_link"/>
+      </joint>
+      <joint name="arm_joint" type="revolute">
+        <parent link="base_link"/>
+        <child link="child_link"/>
+        <origin xyz="0 0 0.5" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-1.57" upper="1.57" effort="100" velocity="1"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  // 2 joints: base_link (floating) and child_link (revolute)
+  EXPECT_EQ(character.skeleton.joints.size(), 2);
+
+  // 7 model parameters: 6 floating + 1 revolute
+  const auto& pt = character.parameterTransform;
+  EXPECT_EQ(pt.name.size(), 7);
+
+  // Floating joint parameter names use the URDF joint name
+  EXPECT_EQ(pt.name[0], "floating_base_tx");
+  EXPECT_EQ(pt.name[1], "floating_base_ty");
+  EXPECT_EQ(pt.name[2], "floating_base_tz");
+  EXPECT_EQ(pt.name[3], "floating_base_rx");
+  EXPECT_EQ(pt.name[4], "floating_base_ry");
+  EXPECT_EQ(pt.name[5], "floating_base_rz");
+  EXPECT_EQ(pt.name[6], "arm_joint");
+
+  // Translation parameters have 10x scaling factor
+  constexpr float kTranslationScale = 10.0f;
+  EXPECT_FLOAT_EQ(pt.transform.coeff(0 * kParametersPerJoint + 0, 0), kTranslationScale); // tx
+  EXPECT_FLOAT_EQ(pt.transform.coeff(0 * kParametersPerJoint + 1, 1), kTranslationScale); // ty
+  EXPECT_FLOAT_EQ(pt.transform.coeff(0 * kParametersPerJoint + 2, 2), kTranslationScale); // tz
+
+  // Rotation parameters have 1x scaling
+  EXPECT_FLOAT_EQ(pt.transform.coeff(0 * kParametersPerJoint + 3, 3), 1.0f); // rx
+  EXPECT_FLOAT_EQ(pt.transform.coeff(0 * kParametersPerJoint + 4, 4), 1.0f); // ry
+  EXPECT_FLOAT_EQ(pt.transform.coeff(0 * kParametersPerJoint + 5, 5), 1.0f); // rz
+
+  // Only 1 parameter limit (the revolute joint)
+  EXPECT_EQ(character.parameterLimits.size(), 1);
+}
+
+TEST(IoUrdfTest, RobotName) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="my_robot">
+      <link name="base_link"/>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+  EXPECT_EQ(character.name, "my_robot");
+}
+
+TEST(IoUrdfTest, MimicJoint) {
+  // Create a URDF with a mimic joint: joint2 mimics joint1 with multiplier=2, offset=0.1
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="mimic_robot">
+      <link name="base_link"/>
+      <link name="link1"/>
+      <link name="link2"/>
+      <joint name="joint1" type="revolute">
+        <parent link="base_link"/>
+        <child link="link1"/>
+        <origin xyz="0.1 0 0" rpy="0 0 0"/>
+        <axis xyz="0 0 1"/>
+        <limit lower="-1.57" upper="1.57" effort="100" velocity="1"/>
+      </joint>
+      <joint name="joint2" type="revolute">
+        <parent link="base_link"/>
+        <child link="link2"/>
+        <origin xyz="-0.1 0 0" rpy="0 0 0"/>
+        <axis xyz="0 0 1"/>
+        <limit lower="-3.14" upper="3.14" effort="100" velocity="1"/>
+        <mimic joint="joint1" multiplier="2" offset="0.1"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  // Should have 3 joints (base_link, link1, link2)
+  EXPECT_EQ(character.skeleton.joints.size(), 3);
+
+  // Only 1 model parameter (joint1's rz) — joint2 is a mimic, no independent DOF
+  const auto& pt = character.parameterTransform;
+  EXPECT_EQ(pt.name.size(), 1);
+  EXPECT_EQ(pt.name[0], "joint1");
+
+  // Only 1 parameter limit (joint1's limits) — mimic joints don't get limits
+  EXPECT_EQ(character.parameterLimits.size(), 1);
+
+  // The mimic joint's offset should be stored in parameterTransform.offsets.
+  // joint2 is skeleton joint index 2, its rz is at joint param index 2*7+5 = 19
+  EXPECT_FLOAT_EQ(pt.offsets[2 * kParametersPerJoint + 5], 0.1f);
+
+  // The transform matrix should have an entry mapping model param 0 to joint2's rz
+  // with coefficient = sign * multiplier = 1 * 2 = 2
+  EXPECT_FLOAT_EQ(pt.transform.coeff(2 * kParametersPerJoint + 5, 0), 2.0f);
+}
+
+TEST(IoUrdfTest, MaterialColors) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="colored_robot">
+      <link name="base_link">
+        <visual>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+          <material name="red">
+            <color rgba="1.0 0.0 0.0 1.0"/>
+          </material>
+        </visual>
+      </link>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_NE(character.mesh, nullptr);
+  EXPECT_EQ(character.mesh->vertices.size(), 8); // box
+
+  // Should have per-vertex colors matching the red material
+  EXPECT_EQ(character.mesh->colors.size(), 8);
+  for (const auto& c : character.mesh->colors) {
+    EXPECT_EQ(c.x(), 255); // red
+    EXPECT_EQ(c.y(), 0); // green
+    EXPECT_EQ(c.z(), 0); // blue
+  }
+}
+
+TEST(IoUrdfTest, NoMaterialColorsEmpty) {
+  // When no visuals have material colors, colors vector should be empty
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="no_color_robot">
+      <link name="base_link">
+        <visual>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </visual>
+      </link>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_NE(character.mesh, nullptr);
+  EXPECT_TRUE(character.mesh->colors.empty());
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Add visual mesh loading support to the URDF character loader. The loader now parses <visual> elements on URDF links and loads mesh geometry from STL files (binary and ASCII), OBJ files, and primitive shapes (box, cylinder, sphere). Per-link meshes are combined into a single unified mesh with rigid skin weights binding each link's vertices to its joint.

The URDF joint axis is mapped directly to the corresponding principal axis parameter (rx/ry/rz for revolute, tx/ty/tz for prismatic) instead of aligning the axis to Momentum's X axis via preRotation. This means preRotation contains only the URDF joint origin rotation, so the Momentum joint frame coincides with the URDF link frame. This design choice is important for animation interoperability: URDF has no official animation format, and motion data from BVH or other formats typically expresses rotations in the joint's local frame. By preserving the URDF link frame, animation data can be applied directly without frame conversion.

New files:
- io/urdf/urdf_mesh_io.h/.cpp: STL loader, OBJ loader, primitive geometry generators, mesh path resolution (package://, file://, relative paths)

Differential Revision: D100713259


