### PR TITLE
Clean up torch C++ deps from geometry, solver2, marker_tracking, marker_tracking_extensions

### DIFF
--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -186,9 +186,6 @@ mt_python_binding(
   NAME geometry
   PYMOMENTUM_HEADERS_VARS geometry_public_headers
   PYMOMENTUM_SOURCES_VARS geometry_sources
-  INCLUDE_DIRECTORIES
-    ${ATEN_INCLUDE_DIR}
-    ${TORCH_INCLUDE_DIRS}
   LINK_LIBRARIES
     array_utility
     character
@@ -202,14 +199,6 @@ mt_python_binding(
     io_skeleton
     io_urdf
     python_utility
-    tensor_momentum
-    tensor_utility
-    torch_bridge
-    ${ATEN_LIBRARIES}
-    ${TORCH_LIBRARIES}
-    ${torch_python}
-  COMPILE_OPTIONS
-    ${TORCH_CXX_FLAGS}
 )
 
 if(MOMENTUM_BUILD_IO_USD)
@@ -281,9 +270,6 @@ mt_python_binding(
   NAME solver2
   PYMOMENTUM_HEADERS_VARS solver2_public_headers
   PYMOMENTUM_SOURCES_VARS solver2_sources
-  INCLUDE_DIRECTORIES
-    ${ATEN_INCLUDE_DIR}
-    ${TORCH_INCLUDE_DIRS}
   LINK_LIBRARIES
     array_utility
     camera
@@ -291,14 +277,9 @@ mt_python_binding(
     character_solver
     character_sequence_solver
     math
+    python_utility
     skeleton
     solver
-    torch_bridge
-    ${ATEN_LIBRARIES}
-    ${TORCH_LIBRARIES}
-    ${torch_python}
-  COMPILE_OPTIONS
-    ${TORCH_CXX_FLAGS}
 )
 
 mt_python_binding(
@@ -310,7 +291,7 @@ mt_python_binding(
     marker_tracker
     math
     process_markers
-    torch_bridge
+    python_utility
 )
 
 mt_python_binding(

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -27,7 +27,6 @@
 #include <pybind11/stl.h>
 #include <pymomentum/python_utility/eigen_quaternion.h>
 #include <Eigen/Core>
-#include "pymomentum/tensor_momentum/tensor_parameter_transform.h"
 
 #include <algorithm>
 #include <limits>

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -11,9 +11,6 @@
 #include "pymomentum/array_utility/batch_accessor.h"
 #include "pymomentum/array_utility/geometry_accessors.h"
 #include "pymomentum/python_utility/python_utility.h"
-#include "pymomentum/tensor_momentum/tensor_parameter_transform.h"
-#include "pymomentum/tensor_utility/autograd_utility.h"
-#include "pymomentum/tensor_utility/tensor_utility.h"
 
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>

--- a/pymomentum/geometry/parameter_transform_pybind.h
+++ b/pymomentum/geometry/parameter_transform_pybind.h
@@ -12,8 +12,6 @@
 
 #include <pybind11/pybind11.h>
 
-#include <ATen/ATen.h>
-
 namespace pymomentum {
 
 void registerParameterTransformBindings(

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -65,11 +65,8 @@ PYBIND11_MODULE(marker_tracking, m) {
   m.doc() = "Module for exposing the C++ APIs of the marker tracking pipeline ";
   m.attr("__name__") = "pymomentum.marker_tracking";
 
-#ifdef PYMOMENTUM_LIMITED_TORCH_API
+  // Torch C++ deps removed from this target; autograd is never available.
   m.attr("AUTOGRAD_ENABLED") = false;
-#else
-  m.attr("AUTOGRAD_ENABLED") = true;
-#endif
 
   pybind11::module_::import(
       "pymomentum.geometry"); // @dep=fbsource//arvr/libraries/pymomentum:geometry


### PR DESCRIPTION
Summary: The geometry module was migrated from tensor-based to array-based (numpy) APIs but the old torch C++ includes and dependencies were never cleaned up. This diff removes all unnecessary dependencies to these modules. After clean up, these modules are more compatible on different platforms. They only require vanilla numpy and/or pytorch to be available.

Differential Revision: D101094048


