### PR TITLE
Fix UnicodeDecodeError in multithreaded logging callback on macOS (#1295)

### DIFF
--- a/pymomentum/geometry/logging_pybind.cpp
+++ b/pymomentum/geometry/logging_pybind.cpp
@@ -60,7 +60,11 @@ arvr::logging::LogResult pythonLogCallback(
 
   // Acquire the GIL before calling into Python:
   py::gil_scoped_acquire gil;
-  py::print(std::string(prefix) + message);
+  // Decode with 'replace' to handle non-UTF-8 bytes (e.g. on macOS):
+  auto msg = std::string(prefix) + message;
+  auto decoded =
+      py::reinterpret_steal<py::object>(PyUnicode_DecodeUTF8(msg.data(), msg.size(), "replace"));
+  py::print(decoded);
 
   return arvr::logging::LogResult::Accepted;
 }


### PR DESCRIPTION
Summary:

The pythonLogCallback used py::print with a raw std::string, which assumes valid UTF-8. On macOS, C++ log messages from MT_LOGW may contain non-UTF-8 bytes, causing pybind11 to throw UnicodeDecodeError and crash the process.

Use PyUnicode_DecodeUTF8 with "replace" error handling to safely decode the message, replacing invalid bytes with the Unicode replacement character instead of crashing.

Differential Revision: D101094049


