### PR TITLE
Add save_locators pybind for Character

### DIFF
--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -93,6 +93,7 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
   // - simplify(enabled_parameters)
   // - load_locators(filename)
   // - load_locators_from_bytes(locator_bytes)
+  // - save_locators(filename, space)
   // - load_model_definition(filename)
   // - load_model_definition_from_bytes(model_bytes)
   //
@@ -710,6 +711,23 @@ motion's scale parameters.
 :param locator_bytes: A byte array containing the locators.
 :return: A valid :class:`Character`.)",
           py::arg("locator_bytes"))
+      // saveLocatorsToFile(character, filename, space)
+      .def(
+          "save_locators",
+          &pymomentum::saveLocatorsToFile,
+          py::call_guard<py::gil_scoped_release>(),
+          R"(Save this character's locators to a .locators file.
+
+The output format matches momentum's canonical .locators JSON produced by the C++
+``momentum::saveLocators`` function, including optional ``limitWeight`` and
+``skinOffset`` fields when set.
+
+:param filename: Output path for the .locators file.
+:param space: Coordinate space for locator positions. :class:`LocatorSpace.Global`
+              (default) writes FK-computed world-space positions using the character's
+              bind pose; :class:`LocatorSpace.Local` writes raw joint-space offsets.)",
+          py::arg("filename"),
+          py::arg("space") = momentum::LocatorSpace::Global)
       // localModelDefinitionFromFile(character, modelFile)
       .def(
           "load_model_definition",

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -43,6 +43,7 @@
 #include <momentum/io/legacy_json/legacy_json_io.h>
 #include <momentum/io/marker/coordinate_system.h>
 #include <momentum/io/shape/blend_shape_io.h>
+#include <momentum/io/skeleton/locator_io.h>
 #include <momentum/math/intersection.h>
 #include <momentum/math/mesh.h>
 #include <momentum/math/mppca.h>
@@ -89,6 +90,16 @@ PYBIND11_MODULE(geometry, m) {
   py::enum_<mm::FbxCoordSystem>(m, "FbxCoordSystem")
       .value("RightHanded", mm::FbxCoordSystem::RightHanded)
       .value("LeftHanded", mm::FbxCoordSystem::LeftHanded);
+
+  py::enum_<mm::LocatorSpace>(
+      m,
+      "LocatorSpace",
+      "Coordinate space used when writing locators to a .locators file. "
+      "Global writes forward-kinematically-computed world-space positions "
+      "(useful for authoring in Maya/Blender without parenting). "
+      "Local writes raw joint-space offsets (useful for transferring locators between models).")
+      .value("Global", mm::LocatorSpace::Global)
+      .value("Local", mm::LocatorSpace::Local);
 
   // =====================================================
   // momentum::GltfFileFormat enum

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -204,6 +204,15 @@ momentum::Character loadLocatorsFromBytes(
   return result;
 }
 
+void saveLocatorsToFile(
+    const momentum::Character& character,
+    const std::string& locatorsPath,
+    momentum::LocatorSpace space) {
+  MT_THROW_IF(locatorsPath.empty(), "Missing locators path.");
+  momentum::saveLocators(
+      filesystem::path(locatorsPath), character.locators, character.skeleton, space);
+}
+
 momentum::Character loadURDFCharacterFromFile(const std::string& urdfPath) {
   return momentum::loadUrdfCharacter<float>(urdfPath);
 }

--- a/pymomentum/geometry/momentum_geometry.h
+++ b/pymomentum/geometry/momentum_geometry.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <momentum/character/character.h>
+#include <momentum/io/skeleton/locator_io.h>
 #include <momentum/math/mppca.h>
 
 #include <pybind11/numpy.h>
@@ -61,6 +62,11 @@ momentum::Character loadLocatorsFromBytes(
 momentum::Character loadConfigFromBytes(
     const momentum::Character& character,
     const pybind11::bytes& bytes);
+
+void saveLocatorsToFile(
+    const momentum::Character& character,
+    const std::string& locatorsPath,
+    momentum::LocatorSpace space = momentum::LocatorSpace::Global);
 
 momentum::Character loadURDFCharacterFromFile(const std::string& urdfPath);
 momentum::Character loadURDFCharacterFromBytes(const pybind11::bytes& urdfBytes);


### PR DESCRIPTION
Summary:
# Motivation
Some of our older mocap data have solved motion but not the locators asset. We want to export the locator file from the solved motion, so we can tune  & improve quality. 

# Change
Adds a thin pybind over momentum::saveLocators so pymomentum callers can export the .locator file.

Reviewed By: cstollmeta

Differential Revision: D101213958


