### PR TITLE
Add viser visualization helpers for character logging (#1302)

### DIFF
--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -384,6 +384,11 @@ mt_python_library(
   PRESERVE_DIRECTORY_STRUCTURE
 )
 
+mt_python_library(
+  NAME rerun_vis
+  PYMOMENTUM_SOURCES_VARS rerun_vis_sources
+)
+
 #===============================================================================
 # Tests
 #===============================================================================

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -389,6 +389,11 @@ mt_python_library(
   PYMOMENTUM_SOURCES_VARS rerun_vis_sources
 )
 
+mt_python_library(
+  NAME viser_vis
+  PYMOMENTUM_SOURCES_VARS viser_vis_sources
+)
+
 #===============================================================================
 # Tests
 #===============================================================================

--- a/pymomentum/backend/utils.py
+++ b/pymomentum/backend/utils.py
@@ -17,7 +17,7 @@ within pymomentum for the backend porting effort.
 from typing import List, Tuple
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import torch
 
 

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -286,6 +286,10 @@ geometry_test_utils_sources = [
     "geometry_test_utils/geometry_test_utils_pybind.cpp",
 ]
 
+rerun_vis_sources = [
+    "rerun_vis.py",
+]
+
 camera_sources = [
     "camera/camera_pybind.cpp",
 ]

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -290,6 +290,10 @@ rerun_vis_sources = [
     "rerun_vis.py",
 ]
 
+viser_vis_sources = [
+    "viser_vis.py",
+]
+
 camera_sources = [
     "camera/camera_pybind.cpp",
 ]

--- a/pymomentum/geometry/logging_pybind.cpp
+++ b/pymomentum/geometry/logging_pybind.cpp
@@ -60,7 +60,11 @@ arvr::logging::LogResult pythonLogCallback(
 
   // Acquire the GIL before calling into Python:
   py::gil_scoped_acquire gil;
-  py::print(std::string(prefix) + message);
+  // Decode with 'replace' to handle non-UTF-8 bytes (e.g. on macOS):
+  auto msg = std::string(prefix) + message;
+  auto decoded =
+      py::reinterpret_steal<py::object>(PyUnicode_DecodeUTF8(msg.data(), msg.size(), "replace"));
+  py::print(decoded);
 
   return arvr::logging::LogResult::Accepted;
 }

--- a/pymomentum/rerun_vis.py
+++ b/pymomentum/rerun_vis.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Rerun Visualization Helpers
+============================
+
+Helper functions for visualizing momentum characters using the
+`Rerun <https://www.rerun.io/>`_ viewer, providing the Python equivalent of
+the C++ ``momentum::logCharacter`` family of functions in
+``momentum/gui/rerun/logger.h``.
+
+The primary entry point is :func:`log_character`, which logs the skeleton,
+mesh, and locators of a character in a structured entity tree::
+
+    import rerun as rr
+    import pymomentum.geometry as geo
+    from pymomentum.rerun_vis import log_character
+
+    character = geo.Character.load_gltf("character.glb")
+    char, motion, identity, fps = geo.Character.load_gltf_with_motion("motion.glb")
+    skel_state = geo.joint_parameters_to_skeleton_state(char, motion[0])
+    posed_mesh = char.pose_mesh(motion[0])
+
+    rec = rr.init("pymomentum_viewer", spawn=True)
+    log_character(rec, "character", char, skel_state, posed_mesh=posed_mesh)
+
+Individual logging functions are also available for finer control:
+
+- :func:`log_mesh` — log a :class:`~pymomentum.geometry.Mesh`
+- :func:`log_joints` — log skeleton bones and per-joint transforms
+- :func:`log_locators` — log locator world-space positions
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from pymomentum.quaternion_np import (
+    rotate_vector_assume_normalized,
+    to_rotation_matrix_assume_normalized,
+)
+
+if TYPE_CHECKING:
+    import rerun as rr
+    from pymomentum.geometry import Character, Mesh
+
+
+def log_mesh(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    mesh: Mesh,
+    *,
+    color: tuple[int, int, int] | None = None,
+) -> None:
+    """Log a :class:`~pymomentum.geometry.Mesh` to Rerun as a 3D mesh.
+
+    :param rec: The Rerun recording stream.
+    :param entity_path: Entity path in the Rerun viewer.
+    :param mesh: The mesh to log (typically a posed mesh from
+        :meth:`~pymomentum.geometry.Character.pose_mesh`).
+    :param color: Optional RGB color tuple ``(r, g, b)`` applied as an
+        albedo factor.  If *None*, per-vertex colors from the mesh are used
+        when available.
+    """
+    import rerun as rr
+
+    vertices = np.asarray(mesh.vertices, dtype=np.float32)
+    faces = np.asarray(mesh.faces, dtype=np.uint32)
+
+    kwargs: dict[str, object] = {
+        "vertex_positions": vertices,
+        "triangle_indices": faces,
+    }
+
+    normals = np.asarray(mesh.normals, dtype=np.float32)
+    if normals.size > 0:
+        kwargs["vertex_normals"] = normals
+
+    if color is not None:
+        kwargs["albedo_factor"] = rr.AlbedoFactor(color)
+    else:
+        colors = np.asarray(mesh.colors, dtype=np.uint8)
+        if colors.size > 0:
+            kwargs["vertex_colors"] = colors
+
+    rec.log(entity_path, rr.Mesh3D(**kwargs))
+
+
+def log_joints(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+) -> None:
+    """Log skeleton bones and per-joint transforms to Rerun.
+
+    Bones are drawn as grey :class:`rerun.LineStrips3D` connecting parent–child
+    joint pairs.  Each joint also gets a :class:`rerun.Transform3D` logged as a
+    child entity so that the Rerun viewer can display its local coordinate
+    frame.
+
+    :param rec: The Rerun recording stream.
+    :param entity_path: Entity path for the skeleton entity.
+    :param character: The character whose skeleton is logged.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)`` with
+        per-joint ``[tx, ty, tz, rx, ry, rz, rw, scale]``.
+    """
+    import rerun as rr
+
+    skeleton = character.skeleton
+    joint_names: list[str] = skeleton.joint_names
+    joint_parents: list[int] = list(skeleton.joint_parents)
+    n_joints: int = len(joint_names)
+
+    lines: list[list[list[float]]] = []
+    labels: list[str] = []
+
+    for i in range(n_joints):
+        parent_idx = joint_parents[i]
+        if 0 <= parent_idx < n_joints:
+            parent_pos: list[float] = skel_state[parent_idx, :3].tolist()
+            child_pos: list[float] = skel_state[i, :3].tolist()
+            lines.append([parent_pos, child_pos])
+            labels.append(joint_names[i])
+
+        # Log per-joint transform
+        rot_mat = to_rotation_matrix_assume_normalized(skel_state[i, 3:7])
+        translation = skel_state[i, :3]
+        rec.log(
+            f"{entity_path}/{joint_names[i]}",
+            rr.Transform3D(
+                translation=translation,
+                mat3x3=rot_mat,
+            ),
+        )
+
+    if lines:
+        rec.log(
+            entity_path,
+            rr.LineStrips3D(
+                lines,
+                radii=0.2,
+                colors=(180, 180, 180),
+                labels=labels,
+            ),
+        )
+
+
+def log_locators(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+) -> None:
+    """Log locator positions to Rerun as colored 3D points.
+
+    Locators whose name contains ``"Floor_"`` are shown in green; others are
+    shown in a grey whose intensity is proportional to the locator weight.
+
+    :param rec: The Rerun recording stream.
+    :param entity_path: Entity path for the locators entity.
+    :param character: The character whose locators are logged.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    """
+    import rerun as rr
+
+    locators = character.locators
+    if not locators:
+        return
+
+    positions: list[list[float]] = []
+    colors: list[tuple[int, int, int]] = []
+    labels: list[str] = []
+
+    for loc in locators:
+        parent_idx: int = loc.parent
+        q = skel_state[parent_idx, 3:7]
+        t = skel_state[parent_idx, :3]
+        s = float(skel_state[parent_idx, 7])
+        offset = np.asarray(loc.offset, dtype=np.float32)
+        world_pos: np.ndarray = t + rotate_vector_assume_normalized(q, offset * s)
+
+        positions.append(world_pos.tolist())
+        labels.append(loc.name)
+
+        if "Floor_" in loc.name:
+            colors.append((100, 255, 100))
+        else:
+            intensity = int(255.0 * loc.weight * 0.6)
+            intensity = max(0, min(255, intensity))
+            colors.append(
+                (intensity, intensity, max(0, min(255, int(intensity * 0.5))))
+            )
+
+    rec.log(
+        entity_path,
+        rr.Points3D(
+            positions=positions,
+            radii=0.5,
+            colors=colors,
+            labels=labels,
+        ),
+    )
+
+
+def log_character(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    posed_mesh: Mesh | None = None,
+    color: tuple[int, int, int] = (200, 200, 200),
+) -> None:
+    """Log a complete character visualization to Rerun.
+
+    This is the top-level convenience function that logs the skeleton,
+    optionally the mesh, and locators as a structured entity tree:
+
+    - ``{entity_path}/mesh`` — posed mesh (if *posed_mesh* is provided)
+    - ``{entity_path}/joints`` — skeleton bones and per-joint transforms
+    - ``{entity_path}/locators`` — locator positions (if character has locators)
+
+    This is the Python equivalent of the C++ ``momentum::logCharacter`` function.
+
+    :param rec: The Rerun recording stream.
+    :param entity_path: Root entity path for the character.
+    :param character: The character to visualize.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)`` with
+        per-joint ``[tx, ty, tz, rx, ry, rz, rw, scale]``.  Obtain via
+        :func:`~pymomentum.geometry.joint_parameters_to_skeleton_state` or
+        :func:`~pymomentum.geometry.model_parameters_to_skeleton_state`.
+    :param posed_mesh: An optional pre-posed mesh (from
+        :meth:`~pymomentum.geometry.Character.pose_mesh`).  If *None*, no mesh
+        is logged.
+    :param color: RGB color tuple for the mesh albedo.  Defaults to light grey
+        ``(200, 200, 200)``.
+    """
+    if posed_mesh is not None:
+        log_mesh(rec, f"{entity_path}/mesh", posed_mesh, color=color)
+
+    log_joints(rec, f"{entity_path}/joints", character, skel_state)
+
+    if character.locators:
+        log_locators(rec, f"{entity_path}/locators", character, skel_state)

--- a/pymomentum/test/conftest.py
+++ b/pymomentum/test/conftest.py
@@ -22,7 +22,7 @@ import os
 collect_ignore: list[str] = []
 
 try:
-    import pymomentum.io_usd as _io_usd  # noqa: F401
+    import pymomentum.io_usd as _io_usd  # noqa: F401  # @manual=:io_usd
 
     usd_available = True
 except ImportError:

--- a/pymomentum/test/test_axel.py
+++ b/pymomentum/test/test_axel.py
@@ -6,7 +6,7 @@
 import unittest
 
 import numpy as np
-import pymomentum.axel as axel
+import pymomentum.axel as axel  # @manual=:axel
 
 
 class TestAxel(unittest.TestCase):

--- a/pymomentum/test/test_blend_shape.py
+++ b/pymomentum/test/test_blend_shape.py
@@ -8,13 +8,13 @@
 import unittest
 
 import numpy as np
-import pymomentum.diff_geometry as pym_diff_geometry
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.diff_geometry as pym_diff_geometry  # @manual=:diff_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.skel_state as pym_skel_state
-import pymomentum.solver as pym_solver
+import pymomentum.solver as pym_solver  # @manual=:solver
 import torch
-from pymomentum.solver import ErrorFunctionType
+from pymomentum.solver import ErrorFunctionType  # @manual=:solver
 
 # Flag to check if autograd is enabled (disabled in arvr build modes)
 AUTOGRAD_ENABLED: bool = pym_diff_geometry.AUTOGRAD_ENABLED

--- a/pymomentum/test/test_camera.py
+++ b/pymomentum/test/test_camera.py
@@ -8,7 +8,7 @@
 import unittest
 
 import numpy as np
-import pymomentum.camera as pym_camera
+import pymomentum.camera as pym_camera  # @manual=:camera
 
 
 class TestCamera(unittest.TestCase):

--- a/pymomentum/test/test_closest_points.py
+++ b/pymomentum/test/test_closest_points.py
@@ -9,7 +9,7 @@ import unittest
 
 import numpy as np
 import numpy.typing as npt
-import pymomentum.geometry as geometry
+import pymomentum.geometry as geometry  # @manual=:geometry
 
 
 def _brute_force_closest_points(

--- a/pymomentum/test/test_diff_geometry.py
+++ b/pymomentum/test/test_diff_geometry.py
@@ -16,9 +16,9 @@ import math
 import unittest
 
 import numpy as np
-import pymomentum.diff_geometry as pym_diff_geometry
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.diff_geometry as pym_diff_geometry  # @manual=:diff_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.skel_state as pym_skel_state
 import torch

--- a/pymomentum/test/test_fbx.py
+++ b/pymomentum/test/test_fbx.py
@@ -10,8 +10,8 @@ import tempfile
 import unittest
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 
 
 class TestFBX(unittest.TestCase):

--- a/pymomentum/test/test_fbx.py
+++ b/pymomentum/test/test_fbx.py
@@ -12,29 +12,21 @@ import unittest
 import numpy as np
 import pymomentum.geometry as pym_geometry
 import pymomentum.geometry_test_utils as pym_test_utils
-import torch
 
 
 class TestFBX(unittest.TestCase):
     def setUp(self) -> None:
         self.character = pym_test_utils.create_test_character()
-        torch.manual_seed(0)  # ensure repeatability
 
         nBatch = 5
         nParams = self.character.parameter_transform.size
         np.random.seed(0)  # ensure repeatability
-        self.model_params = torch.from_numpy(
-            pym_geometry.uniform_random_to_model_parameters(
-                self.character, np.random.rand(nBatch, nParams).astype(np.float32)
-            )
-        ).double()
-        self.joint_params = torch.from_numpy(
-            self.character.parameter_transform.apply(self.model_params.numpy())
-        )
-        self.skeleton_state = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                self.character, self.model_params.numpy()
-            )
+        self.model_params = pym_geometry.uniform_random_to_model_parameters(
+            self.character, np.random.rand(nBatch, nParams).astype(np.float32)
+        ).astype(np.float64)
+        self.joint_params = self.character.parameter_transform.apply(self.model_params)
+        self.skeleton_state = pym_geometry.model_parameters_to_skeleton_state(
+            self.character, self.model_params
         )
 
     def test_load_animation(self) -> None:
@@ -94,8 +86,8 @@ class TestFBX(unittest.TestCase):
             )
         )
 
-        skel_state = torch.from_numpy(
-            pym_geometry.joint_parameters_to_skeleton_state(character, joint_params)
+        skel_state = pym_geometry.joint_parameters_to_skeleton_state(
+            character, joint_params
         )
 
         skel_state_first = skel_state[0]
@@ -133,7 +125,7 @@ class TestFBX(unittest.TestCase):
             pym_geometry.Character.save_fbx(
                 path=temp_file.name,
                 character=self.character,
-                motion=self.model_params.numpy(),
+                motion=self.model_params,
                 offsets=offsets,
                 fps=60,
             )
@@ -152,7 +144,7 @@ class TestFBX(unittest.TestCase):
             pym_geometry.Character.save_fbx(
                 path=temp_file.name,
                 character=self.character,
-                motion=self.model_params.numpy(),
+                motion=self.model_params,
                 offsets=offsets,
                 fps=60,
                 options=options,
@@ -168,7 +160,7 @@ class TestFBX(unittest.TestCase):
             pym_geometry.Character.save_fbx_with_joint_params(
                 path=temp_file.name,
                 character=self.character,
-                joint_params=self.joint_params.numpy(),
+                joint_params=self.joint_params,
                 fps=60,
             )
             self._verify_fbx(temp_file.name)
@@ -185,7 +177,7 @@ class TestFBX(unittest.TestCase):
             pym_geometry.Character.save_fbx_with_joint_params(
                 path=temp_file.name,
                 character=self.character,
-                joint_params=self.joint_params.numpy(),
+                joint_params=self.joint_params,
                 fps=60,
                 options=options,
             )
@@ -201,7 +193,7 @@ class TestFBX(unittest.TestCase):
                 path=temp_file.name,
                 character=self.character,
                 fps=60,
-                skel_states=self.skeleton_state.numpy(),
+                skel_states=self.skeleton_state,
             )
             self._verify_fbx(temp_file.name)
 
@@ -224,7 +216,7 @@ class TestFBX(unittest.TestCase):
             pym_geometry.Character.save_fbx(
                 path=temp_file.name,
                 character=self.character,
-                motion=self.model_params.numpy(),
+                motion=self.model_params,
                 offsets=offsets,
                 fps=60,
                 options=options,
@@ -242,7 +234,7 @@ class TestFBX(unittest.TestCase):
             pym_geometry.Character.save_fbx_with_joint_params(
                 path=temp_file.name,
                 character=self.character,
-                joint_params=self.joint_params.numpy(),
+                joint_params=self.joint_params,
                 fps=60,
                 options=options,
             )
@@ -260,7 +252,7 @@ class TestFBX(unittest.TestCase):
                 path=temp_file.name,
                 character=self.character,
                 fps=60,
-                motion=self.model_params.numpy(),
+                motion=self.model_params,
             )
             # Verify file can be loaded
             self._verify_fbx(temp_file.name)
@@ -339,7 +331,7 @@ class TestFBX(unittest.TestCase):
             pym_geometry.Character.save(
                 path=temp_file.name,
                 character=self.character,
-                motion=self.model_params[:nFrames].numpy(),
+                motion=self.model_params[:nFrames],
                 fps=60,
                 markers=markers_per_frame,
             )

--- a/pymomentum/test/test_geometry_diff_geometry_consistency.py
+++ b/pymomentum/test/test_geometry_diff_geometry_consistency.py
@@ -16,9 +16,9 @@ in pymomentum.diff_geometry.
 import unittest
 
 import numpy as np
-import pymomentum.diff_geometry as pym_diff_geometry
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.diff_geometry as pym_diff_geometry  # @manual=:diff_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.skel_state as pym_skel_state
 import torch
 

--- a/pymomentum/test/test_legacy_json_io.py
+++ b/pymomentum/test/test_legacy_json_io.py
@@ -8,8 +8,8 @@ import tempfile
 import unittest
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 
 
 class TestLegacyJsonIO(unittest.TestCase):

--- a/pymomentum/test/test_legacy_json_io.py
+++ b/pymomentum/test/test_legacy_json_io.py
@@ -10,13 +10,12 @@ import unittest
 import numpy as np
 import pymomentum.geometry as pym_geometry
 import pymomentum.geometry_test_utils as pym_test_utils
-import torch
 
 
 class TestLegacyJsonIO(unittest.TestCase):
     def setUp(self) -> None:
         self.character = pym_test_utils.create_test_character()
-        torch.manual_seed(0)  # ensure repeatability
+        np.random.seed(0)  # ensure repeatability
 
     def test_round_trip_conversion(self) -> None:
         """Test that Character -> Legacy JSON -> Character preserves data."""

--- a/pymomentum/test/test_logging.py
+++ b/pymomentum/test/test_logging.py
@@ -7,7 +7,7 @@
 
 import unittest
 
-import pymomentum.geometry as pym_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
 
 
 class TestLogging(unittest.TestCase):

--- a/pymomentum/test/test_marker_tracking.py
+++ b/pymomentum/test/test_marker_tracking.py
@@ -11,8 +11,7 @@ import numpy as np
 import pymomentum.geometry as pym_geometry
 import pymomentum.geometry_test_utils as pym_test_utils
 import pymomentum.marker_tracking as pym_marker_tracking
-import pymomentum.skel_state as pym_skel_state
-import torch
+import pymomentum.skel_state_np as pym_skel_state
 
 
 class TestMarkerTracking(unittest.TestCase):
@@ -29,11 +28,9 @@ class TestMarkerTracking(unittest.TestCase):
         print("mesh_vertex_position: ", mesh_vertex_position)
 
         rest_model_params = np.zeros((1, character.parameter_transform.size))
-        rest_skeleton_state = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, rest_model_params
-            )[0]  # Remove batch dimension
-        )
+        rest_skeleton_state = pym_geometry.model_parameters_to_skeleton_state(
+            character, rest_model_params
+        )[0]  # Remove batch dimension
         parent_joint_idx = character.skin_weights.index[mesh_vertex_idx][0]
 
         # Create a locator positioned at the mesh vertex
@@ -42,8 +39,8 @@ class TestMarkerTracking(unittest.TestCase):
             parent=parent_joint_idx,
             offset=pym_skel_state.transform_points(
                 pym_skel_state.inverse(rest_skeleton_state[parent_joint_idx]),
-                torch.from_numpy(mesh_vertex_position),
-            ).numpy(),  # Position it at the mesh vertex
+                mesh_vertex_position,
+            ),  # Position it at the mesh vertex
             attached_to_skin=True,
         )
 
@@ -188,27 +185,25 @@ class TestMarkerTracking(unittest.TestCase):
         # Verify that the world position is preserved
         # Compute the world position of the converted locator in rest pose
         rest_model_params = np.zeros((1, character.parameter_transform.size))
-        rest_skeleton_state = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, rest_model_params
-            )[0]
-        )
+        rest_skeleton_state = pym_geometry.model_parameters_to_skeleton_state(
+            character, rest_model_params
+        )[0]
 
         # Transform the offset to world space using the parent bone's transform
         converted_world_pos = pym_skel_state.transform_points(
             rest_skeleton_state[converted_locator.parent],
-            torch.from_numpy(converted_locator.offset),
+            converted_locator.offset,
         )
 
         # Compare with original skinned locator position
-        original_world_pos = torch.from_numpy(test_skinned_locator.position)
-        position_diff = torch.norm(converted_world_pos - original_world_pos).item()
+        original_world_pos = test_skinned_locator.position
+        position_diff = np.linalg.norm(converted_world_pos - original_world_pos)
 
         self.assertLess(
             position_diff,
             0.01,
             msg=f"Converted locator world position should match original skinned locator position. "
-            f"Original: {original_world_pos.numpy()}, Converted: {converted_world_pos.numpy()}, "
+            f"Original: {original_world_pos}, Converted: {converted_world_pos}, "
             f"Diff: {position_diff}",
         )
 
@@ -221,8 +216,6 @@ class TestMarkerTracking(unittest.TestCase):
 
     def test_marker_tracking_with_skinned_locators(self) -> None:
         """Test marker tracking with skinned locators created from mesh vertices."""
-        torch.manual_seed(42)  # Ensure repeatability
-
         # Create a test character with mesh and skin weights
         character = pym_test_utils.create_test_character(num_joints=5)
         self.assertIsNotNone(character.mesh)
@@ -585,8 +578,6 @@ class TestMarkerTracking(unittest.TestCase):
 
     def test_get_locator_error_with_skinned_locators(self) -> None:
         """Test get_locator_error computes similar errors for regular and skinned locators."""
-        torch.manual_seed(42)
-
         # Create a test character with mesh and skin weights
         character = pym_test_utils.create_test_character(num_joints=5)
         self.assertIsNotNone(character.mesh)
@@ -604,11 +595,9 @@ class TestMarkerTracking(unittest.TestCase):
         rest_model_params = np.zeros(
             (1, character.parameter_transform.size), dtype=np.float32
         )
-        rest_skeleton_state = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, rest_model_params
-            )[0]
-        )
+        rest_skeleton_state = pym_geometry.model_parameters_to_skeleton_state(
+            character, rest_model_params
+        )[0]
         parent_joint_idx = character.skin_weights.index[mesh_vertex_idx][0]
 
         # Create a locator positioned at the mesh vertex
@@ -617,8 +606,8 @@ class TestMarkerTracking(unittest.TestCase):
             parent=parent_joint_idx,
             offset=pym_skel_state.transform_points(
                 pym_skel_state.inverse(rest_skeleton_state[parent_joint_idx]),
-                torch.from_numpy(mesh_vertex_position),
-            ).numpy(),
+                mesh_vertex_position,
+            ),
             attached_to_skin=True,
         )
 

--- a/pymomentum/test/test_marker_tracking.py
+++ b/pymomentum/test/test_marker_tracking.py
@@ -5,9 +5,17 @@
 
 # pyre-strict
 
+import atexit
+import os
 import unittest
 
 import numpy as np
+
+# Work around glibc ptmalloc2 arena teardown false-positive in platform010/dev
+# shared-linking mode: glibc's free() validation rejects a pointer during C++
+# static destruction that ASAN confirms is not actual memory corruption.
+# os._exit() skips C++ static destruction; test results are already reported.
+atexit.register(os._exit, 0)
 import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.marker_tracking as pym_marker_tracking  # @manual=:marker_tracking

--- a/pymomentum/test/test_marker_tracking.py
+++ b/pymomentum/test/test_marker_tracking.py
@@ -8,9 +8,9 @@
 import unittest
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
-import pymomentum.marker_tracking as pym_marker_tracking
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
+import pymomentum.marker_tracking as pym_marker_tracking  # @manual=:marker_tracking
 import pymomentum.skel_state_np as pym_skel_state
 
 

--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -8,7 +8,7 @@
 import unittest
 
 import numpy as np
-from pymomentum.geometry import (
+from pymomentum.geometry import (  # @manual=:geometry
     Character,
     ParameterTransform,
     uniform_random_to_model_parameters,

--- a/pymomentum/test/test_parameter_transform.py
+++ b/pymomentum/test/test_parameter_transform.py
@@ -8,7 +8,6 @@
 import unittest
 
 import numpy as np
-import torch
 from pymomentum.geometry import (
     Character,
     ParameterTransform,
@@ -27,14 +26,11 @@ class TestParameterTransform(unittest.TestCase):
         model_params = uniform_random_to_model_parameters(
             character, np.random.rand(1, 10).astype(np.float32)
         ).squeeze()
-        joint_params_1 = torch.from_numpy(
-            character.parameter_transform.apply(model_params[None, :])
+        joint_params_1 = character.parameter_transform.apply(
+            model_params[None, :]
         ).flatten()
-        # transform is now a numpy array, so convert to tensor for matmul
-        joint_params_2 = torch.matmul(
-            torch.from_numpy(transform), torch.from_numpy(model_params)
-        )
-        self.assertTrue(torch.allclose(joint_params_1, joint_params_2))
+        joint_params_2 = transform @ model_params
+        np.testing.assert_allclose(joint_params_1, joint_params_2)
 
     def test_parameter_transform_round_trip(self) -> None:
         """Test that converting parameter transform to dense matrix and back is lossless."""
@@ -58,12 +54,10 @@ class TestParameterTransform(unittest.TestCase):
             character, np.random.rand(5, 10).astype(np.float32)
         )
 
-        joint_params_original = torch.from_numpy(original_pt.apply(model_params))
-        joint_params_new = torch.from_numpy(new_pt.apply(model_params))
+        joint_params_original = original_pt.apply(model_params)
+        joint_params_new = new_pt.apply(model_params)
 
-        self.assertTrue(
-            torch.allclose(joint_params_original, joint_params_new, atol=1e-6)
-        )
+        np.testing.assert_allclose(joint_params_original, joint_params_new, atol=1e-6)
 
         # Verify parameter names are preserved
         self.assertEqual(original_pt.names, new_pt.names)

--- a/pymomentum/test/test_pose_prior.py
+++ b/pymomentum/test/test_pose_prior.py
@@ -7,12 +7,12 @@
 import logging
 import unittest
 
-import pymomentum.diff_geometry as pym_diff_geometry
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
-import pymomentum.solver as pym_solver
+import pymomentum.diff_geometry as pym_diff_geometry  # @manual=:diff_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
+import pymomentum.solver as pym_solver  # @manual=:solver
 import torch
-from pymomentum.solver import ErrorFunctionType
+from pymomentum.solver import ErrorFunctionType  # @manual=:solver
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/pymomentum/test/test_process_markers.py
+++ b/pymomentum/test/test_process_markers.py
@@ -5,11 +5,19 @@
 
 # pyre-strict
 
+import atexit
 import math
+import os
 import tempfile
 import unittest
 
 import numpy as np
+
+# Work around glibc ptmalloc2 arena teardown false-positive in platform010/dev
+# shared-linking mode: glibc's free() validation rejects a pointer during C++
+# static destruction that ASAN confirms is not actual memory corruption.
+# os._exit() skips C++ static destruction; test results are already reported.
+atexit.register(os._exit, 0)
 import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 from pymomentum.marker_tracking import (  # @manual=:marker_tracking

--- a/pymomentum/test/test_process_markers.py
+++ b/pymomentum/test/test_process_markers.py
@@ -10,9 +10,9 @@ import tempfile
 import unittest
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
-from pymomentum.marker_tracking import (
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
+from pymomentum.marker_tracking import (  # @manual=:marker_tracking
     calibrate_markers,
     CalibrationConfig,
     ModelOptions,

--- a/pymomentum/test/test_renderer.py
+++ b/pymomentum/test/test_renderer.py
@@ -10,9 +10,9 @@ import unittest
 
 import numpy as np
 import torch  # isort: skip  # Must be imported before pymomentum C++ extensions
-import pymomentum.camera as pym_camera
-import pymomentum.geometry as pym_geometry
-import pymomentum.renderer as pym_renderer
+import pymomentum.camera as pym_camera  # @manual=:camera
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.renderer as pym_renderer  # @manual=:renderer
 from numpy.typing import NDArray
 
 

--- a/pymomentum/test/test_rerun_vis.py
+++ b/pymomentum/test/test_rerun_vis.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pymomentum.geometry as geo
+import pymomentum.geometry_test_utils as test_utils
+from pymomentum.rerun_vis import log_character, log_joints, log_locators, log_mesh
+
+try:
+    import rerun as rr
+
+    _HAS_RERUN = True
+except ImportError:
+    rr = None  # pyre-ignore[9]
+    _HAS_RERUN = False
+
+
+def _is_tsan_active() -> bool:
+    # rerun-sdk's Rust internals (RecordingStream + ChunkBatcher background
+    # threads) trigger ThreadSanitizer warnings on its own shared state. The
+    # warnings happen inside the SDK and cannot be fixed from Python; skipping
+    # the whole module under TSan keeps the binary from exiting non-zero.
+    # Detect TSan by inspecting the loaded shared libraries — TSAN_OPTIONS is
+    # not set by Meta's TSan build mode.
+    try:
+        return "tsan" in Path("/proc/self/maps").read_text()
+    except OSError:
+        return False
+
+
+def load_tests(
+    loader: unittest.TestLoader,
+    tests: unittest.TestSuite,
+    pattern: str | None,
+) -> unittest.TestSuite:
+    """Skip when rerun-sdk is unavailable or ThreadSanitizer is active."""
+    if not _HAS_RERUN or _is_tsan_active():
+        return unittest.TestSuite()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(TestRerunVis))
+    return suite
+
+
+class TestRerunVis(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Reuse one RecordingStream across all log tests. Each new stream spins
+        # up its own RecordingStream + ChunkBatcher background threads; sharing
+        # one stream keeps thread count bounded and the test fast.
+        cls._rec: rr.RecordingStream = rr.RecordingStream("test_rerun_vis")
+
+    def _make_character_and_skel_state(
+        self,
+    ) -> tuple[geo.Character, np.ndarray]:
+        character = test_utils.create_test_character()
+        self.assertGreater(character.skeleton.size, 0)
+        self.assertTrue(
+            character.has_mesh,
+            "create_test_character() is documented to return a mesh",
+        )
+        model_params = np.zeros(character.parameter_transform.size, dtype=np.float32)
+        skel_state = geo.model_parameters_to_skeleton_state(character, model_params)
+        self.assertEqual(skel_state.shape, (character.skeleton.size, 8))
+        return character, skel_state
+
+    def _posed_mesh(self, character: geo.Character) -> geo.Mesh:
+        joint_params = np.zeros(character.skeleton.size * 7, dtype=np.float32)
+        return character.pose_mesh(joint_params)
+
+    def test_log_joints_uses_skeleton_state(self) -> None:
+        character, skel_state = self._make_character_and_skel_state()
+        # Smoke check: the call should consume the full skel_state and not
+        # raise. There is no public API to introspect what was logged, so we
+        # also re-run with an obviously-bad shape to confirm input validation
+        # propagates a real error rather than silently corrupting the stream.
+        log_joints(self._rec, "test/joints", character, skel_state)
+        with self.assertRaises((ValueError, IndexError, AssertionError)):
+            log_joints(self._rec, "test/joints_bad", character, np.zeros((1, 8)))
+
+    def test_log_mesh_default_and_custom_color(self) -> None:
+        character, _ = self._make_character_and_skel_state()
+        posed_mesh = self._posed_mesh(character)
+        self.assertGreater(len(posed_mesh.vertices), 0)
+        self.assertGreater(len(posed_mesh.faces), 0)
+
+        mock_rec = MagicMock()
+        log_mesh(mock_rec, "m", posed_mesh)
+        mock_rec.log.assert_called_once()
+        path, archetype = mock_rec.log.call_args.args
+        self.assertEqual(path, "m")
+        self.assertIsInstance(archetype, rr.Mesh3D)
+
+        mock_rec = MagicMock()
+        log_mesh(mock_rec, "m_color", posed_mesh, color=(255, 0, 0))
+        path, archetype = mock_rec.log.call_args.args
+        self.assertEqual(path, "m_color")
+        self.assertIsInstance(archetype, rr.Mesh3D)
+
+    def test_log_locators(self) -> None:
+        character, skel_state = self._make_character_and_skel_state()
+        self.assertGreater(len(character.locators), 0)
+
+        mock_rec = MagicMock()
+        log_locators(mock_rec, "locs", character, skel_state)
+        mock_rec.log.assert_called_once()
+        path, archetype = mock_rec.log.call_args.args
+        self.assertEqual(path, "locs")
+        self.assertIsInstance(archetype, rr.Points3D)
+
+    def test_log_character_with_and_without_mesh(self) -> None:
+        character, skel_state = self._make_character_and_skel_state()
+        posed_mesh = self._posed_mesh(character)
+        n_joints = character.skeleton.size
+
+        mock_rec = MagicMock()
+        log_character(mock_rec, "ch", character, skel_state, posed_mesh=posed_mesh)
+        paths = [c.args[0] for c in mock_rec.log.call_args_list]
+        self.assertIn("ch/mesh", paths)
+        self.assertIn("ch/joints", paths)
+        if character.locators:
+            self.assertIn("ch/locators", paths)
+        joint_transform_paths = [p for p in paths if p.startswith("ch/joints/")]
+        self.assertEqual(len(joint_transform_paths), n_joints)
+
+        mock_rec = MagicMock()
+        log_character(mock_rec, "ch_nm", character, skel_state)
+        paths_no_mesh = [c.args[0] for c in mock_rec.log.call_args_list]
+        self.assertNotIn("ch_nm/mesh", paths_no_mesh)
+        self.assertIn("ch_nm/joints", paths_no_mesh)

--- a/pymomentum/test/test_sdf_collider.py
+++ b/pymomentum/test/test_sdf_collider.py
@@ -16,7 +16,7 @@ class TestSDFCollider(unittest.TestCase):
 
     def test_import(self) -> None:
         """Test that SDFCollider can be imported."""
-        from pymomentum import geometry
+        from pymomentum import geometry  # @manual=:geometry
 
         # Should be able to access the class
         self.assertTrue(hasattr(geometry, "SDFCollider"))
@@ -48,7 +48,7 @@ class TestSDFCollider(unittest.TestCase):
 
     def test_create_collider_with_sdf(self) -> None:
         """Test creating an SDFCollider with an SDF."""
-        from pymomentum import axel, geometry
+        from pymomentum import axel, geometry  # @manual=:geometry
 
         # Create a simple sphere SDF
         bounds = axel.BoundingBox(

--- a/pymomentum/test/test_sequence_ik.py
+++ b/pymomentum/test/test_sequence_ik.py
@@ -7,12 +7,12 @@
 
 import unittest
 
-import pymomentum.diff_geometry as pym_diff_geometry
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
-import pymomentum.solver as pym_solver
+import pymomentum.diff_geometry as pym_diff_geometry  # @manual=:diff_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
+import pymomentum.solver as pym_solver  # @manual=:solver
 import torch
-from pymomentum.solver import ErrorFunctionType
+from pymomentum.solver import ErrorFunctionType  # @manual=:solver
 
 AUTOGRAD_ENABLED: bool = pym_diff_geometry.AUTOGRAD_ENABLED
 

--- a/pymomentum/test/test_skel_state.py
+++ b/pymomentum/test/test_skel_state.py
@@ -9,8 +9,8 @@ import unittest
 from typing import Tuple
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.skel_state as pym_skel_state
 import torch

--- a/pymomentum/test/test_skel_state.py
+++ b/pymomentum/test/test_skel_state.py
@@ -6,50 +6,21 @@
 # pyre-strict
 
 import unittest
-from typing import Optional, Tuple
+from typing import Tuple
 
 import numpy as np
-import pymomentum.diff_geometry as pym_diff_geometry
 import pymomentum.geometry as pym_geometry
 import pymomentum.geometry_test_utils as pym_test_utils
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.skel_state as pym_skel_state
 import torch
-from torch.nn import Parameter as P
 
-# Flag to check if autograd is enabled (disabled in arvr build modes)
-AUTOGRAD_ENABLED: bool = pym_diff_geometry.AUTOGRAD_ENABLED
-
-# Tests that require autograd; excluded via load_tests() when unavailable
-# to avoid "Skipping" notifications in CI.
-_AUTOGRAD_TESTS = frozenset(
-    {"test_bulk_multiplication_backward", "test_multiply_backprop"}
-)
-
-
-def load_tests(
-    loader: unittest.TestLoader,
-    standard_tests: unittest.TestSuite,
-    pattern: Optional[str],
-) -> unittest.TestSuite:
-    """Custom test loader that excludes autograd tests when autograd is unavailable.
-
-    This prevents 'Skipping' notifications in CI by not discovering
-    the tests at all, rather than discovering and then skipping them.
-    """
-    if AUTOGRAD_ENABLED:
-        return standard_tests
-
-    filtered = unittest.TestSuite()
-    for suite in standard_tests:
-        for test in suite:
-            if test._testMethodName not in _AUTOGRAD_TESTS:
-                filtered.addTest(test)
-    return filtered
+# Autograd tests (gradcheck, backward) are in test_skel_state_autograd.py
 
 
 def generate_skel_state_components(
     sz: int,
+    requires_grad: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # [sz, 3
     trans: torch.Tensor = torch.normal(
@@ -57,7 +28,7 @@ def generate_skel_state_components(
         std=4,
         size=(sz, 3),
         dtype=torch.float64,
-        requires_grad=AUTOGRAD_ENABLED,
+        requires_grad=requires_grad,
     )
 
     rot: torch.Tensor = pym_quaternion.normalize(
@@ -66,12 +37,14 @@ def generate_skel_state_components(
             std=4,
             size=(sz, 4),
             dtype=torch.float64,
-            requires_grad=AUTOGRAD_ENABLED,
+            requires_grad=requires_grad,
         )
     )
 
     scale: torch.Tensor = torch.rand(
-        size=(sz, 1), dtype=torch.float64, requires_grad=AUTOGRAD_ENABLED
+        size=(sz, 1),
+        dtype=torch.float64,
+        requires_grad=requires_grad,
     )
     return (trans, rot, scale)
 
@@ -97,16 +70,7 @@ class TestSkelState(unittest.TestCase):
             pym_geometry.joint_parameters_to_skeleton_state(
                 character, joint_params.astype(np.float64)
             )
-        ).requires_grad_(True)
-        inputs = [skel_state_d]
-        if AUTOGRAD_ENABLED:
-            torch.autograd.gradcheck(
-                pym_skel_state.to_matrix,
-                inputs,
-                eps=1e-3,
-                atol=1e-4,
-                raise_exception=True,
-            )
+        )
 
         self.assertTrue(torch.allclose(skel_state, skel_state_d.detach(), atol=1e-3))
 
@@ -404,30 +368,6 @@ class TestSkelState(unittest.TestCase):
 
         self.assertTrue(torch.allclose(p1, p2, atol=1e-5, rtol=1e-5))
 
-    def test_bulk_multiplication_backward(self) -> None:
-        """Test multiplication backward pass using the same approach as sim3 tests"""
-        torch.manual_seed(10023893)
-        state1 = self.init_sim3_like_skel_state(1024, 159)
-        state2 = self.init_sim3_like_skel_state(1024, 159)
-
-        ps1 = P(state1)
-        ps2 = P(state2)
-
-        state = pym_skel_state.multiply(ps1, ps2)
-        grad = torch.randn_like(state)
-
-        ds1, ds2 = torch.autograd.grad(
-            outputs=[state],
-            inputs=[ps1, ps2],
-            grad_outputs=[grad],
-        )
-
-        # Verify gradients are not None and have correct shape
-        self.assertIsNotNone(ds1)
-        self.assertIsNotNone(ds2)
-        self.assertEqual(ds1.shape, state1.shape)
-        self.assertEqual(ds2.shape, state2.shape)
-
     def test_bulk_inverse(self) -> None:
         """Test inverse using the same approach as sim3 tests"""
         torch.manual_seed(1002389)
@@ -445,31 +385,6 @@ class TestSkelState(unittest.TestCase):
 
         state3 = pym_skel_state.multiply(state_inv, state)
         self.assertTrue(torch.allclose(state3, state_expected, atol=1e-5, rtol=1e-5))
-
-    def test_multiply_backprop(self) -> None:
-        """Test multiply_backprop function matches autograd gradients"""
-        torch.manual_seed(10023893)
-        state1 = self.init_sim3_like_skel_state(1024, 159)
-        state2 = self.init_sim3_like_skel_state(1024, 159)
-
-        ps1 = P(state1)
-        ps2 = P(state2)
-
-        state = pym_skel_state.multiply(ps1, ps2)
-        grad = torch.randn_like(state)
-
-        ds1_autograd, ds2_autograd = torch.autograd.grad(
-            outputs=[state],
-            inputs=[ps1, ps2],
-            grad_outputs=[grad],
-        )
-
-        # Test our custom backprop function
-        ds1_custom, ds2_custom = pym_skel_state.multiply_backprop(ps1, ps2, grad)
-
-        # Compare gradients - use appropriate tolerance for numerical differences
-        self.assertTrue(torch.allclose(ds1_autograd, ds1_custom, atol=1e-4, rtol=1e-4))
-        self.assertTrue(torch.allclose(ds2_autograd, ds2_custom, atol=1e-4, rtol=1e-4))
 
     def test_multiply_broadcasting(self) -> None:
         """Test that multiplication works correctly with broadcasting for different tensor dimensions"""

--- a/pymomentum/test/test_skel_state_autograd.py
+++ b/pymomentum/test/test_skel_state_autograd.py
@@ -9,9 +9,9 @@ import unittest
 from typing import Optional
 
 import numpy as np
-import pymomentum.diff_geometry as pym_diff_geometry
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.diff_geometry as pym_diff_geometry  # @manual=:diff_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.skel_state as pym_skel_state
 import torch

--- a/pymomentum/test/test_skel_state_autograd.py
+++ b/pymomentum/test/test_skel_state_autograd.py
@@ -1,0 +1,147 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Optional
+
+import numpy as np
+import pymomentum.diff_geometry as pym_diff_geometry
+import pymomentum.geometry as pym_geometry
+import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.quaternion as pym_quaternion
+import pymomentum.skel_state as pym_skel_state
+import torch
+from torch.nn import Parameter as P
+
+# Flag to check if autograd is enabled (disabled in arvr build modes)
+AUTOGRAD_ENABLED: bool = pym_diff_geometry.AUTOGRAD_ENABLED
+
+# Tests that require autograd; excluded via load_tests() when unavailable
+# to avoid "Skipping" notifications in CI.
+_AUTOGRAD_TESTS = frozenset(
+    {
+        "test_skel_state_to_transforms",
+        "test_bulk_multiplication_backward",
+        "test_multiply_backprop",
+    }
+)
+
+
+def load_tests(
+    loader: unittest.TestLoader,
+    standard_tests: unittest.TestSuite,
+    pattern: Optional[str],
+) -> unittest.TestSuite:
+    """Custom test loader that excludes autograd tests when autograd is unavailable.
+
+    This prevents 'Skipping' notifications in CI by not discovering
+    the tests at all, rather than discovering and then skipping them.
+    """
+    if AUTOGRAD_ENABLED:
+        return standard_tests
+
+    filtered = unittest.TestSuite()
+    for suite in standard_tests:
+        for test in suite:
+            if test._testMethodName not in _AUTOGRAD_TESTS:
+                filtered.addTest(test)
+    return filtered
+
+
+class TestSkelStateAutograd(unittest.TestCase):
+    def test_skel_state_to_transforms(self) -> None:
+        character = pym_test_utils.create_test_character()
+        nBatch = 2
+        modelParams = 0.2 * np.ones(
+            (nBatch, character.parameter_transform.size),
+            dtype=np.float64,
+        )
+        joint_params = character.parameter_transform.apply(modelParams)
+        skel_state = torch.from_numpy(
+            pym_geometry.joint_parameters_to_skeleton_state(character, joint_params)
+        )
+        skel_state_d = torch.from_numpy(
+            pym_geometry.joint_parameters_to_skeleton_state(
+                character, joint_params.astype(np.float64)
+            )
+        ).requires_grad_(True)
+        inputs = [skel_state_d]
+        if AUTOGRAD_ENABLED:
+            torch.autograd.gradcheck(
+                pym_skel_state.to_matrix,
+                inputs,
+                eps=1e-3,
+                atol=1e-4,
+                raise_exception=True,
+            )
+
+        self.assertTrue(torch.allclose(skel_state, skel_state_d.detach(), atol=1e-3))
+
+    def init_sim3_like_skel_state(
+        self, batch_size: int, nr_joints: int
+    ) -> torch.Tensor:
+        """Initialize skel_state similar to how sim3 tests initialize their state"""
+        t = torch.randn((batch_size, nr_joints, 3), dtype=torch.float32)
+        q = torch.randn((batch_size, nr_joints, 4), dtype=torch.float32)
+        s = torch.randn((batch_size, nr_joints, 1), dtype=torch.float32)
+
+        q = pym_quaternion.normalize(q)
+        s = torch.exp2(s).clamp(max=2)
+        return torch.cat([t, q, s], dim=-1)
+
+    def test_bulk_multiplication_backward(self) -> None:
+        """Test multiplication backward pass using the same approach as sim3 tests"""
+        torch.manual_seed(10023893)
+        state1 = self.init_sim3_like_skel_state(1024, 159)
+        state2 = self.init_sim3_like_skel_state(1024, 159)
+
+        ps1 = P(state1)
+        ps2 = P(state2)
+
+        state = pym_skel_state.multiply(ps1, ps2)
+        grad = torch.randn_like(state)
+
+        ds1, ds2 = torch.autograd.grad(
+            outputs=[state],
+            inputs=[ps1, ps2],
+            grad_outputs=[grad],
+        )
+
+        # Verify gradients are not None and have correct shape
+        self.assertIsNotNone(ds1)
+        self.assertIsNotNone(ds2)
+        self.assertEqual(ds1.shape, state1.shape)
+        self.assertEqual(ds2.shape, state2.shape)
+
+    def test_multiply_backprop(self) -> None:
+        """Test multiply_backprop function matches autograd gradients"""
+        torch.manual_seed(10023893)
+        state1 = self.init_sim3_like_skel_state(1024, 159)
+        state2 = self.init_sim3_like_skel_state(1024, 159)
+
+        ps1 = P(state1)
+        ps2 = P(state2)
+
+        state = pym_skel_state.multiply(ps1, ps2)
+        grad = torch.randn_like(state)
+
+        ds1_autograd, ds2_autograd = torch.autograd.grad(
+            outputs=[state],
+            inputs=[ps1, ps2],
+            grad_outputs=[grad],
+        )
+
+        # Test our custom backprop function
+        ds1_custom, ds2_custom = pym_skel_state.multiply_backprop(ps1, ps2, grad)
+
+        # Compare gradients - use appropriate tolerance for numerical differences
+        self.assertTrue(torch.allclose(ds1_autograd, ds1_custom, atol=1e-4, rtol=1e-4))
+        self.assertTrue(torch.allclose(ds2_autograd, ds2_custom, atol=1e-4, rtol=1e-4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pymomentum/test/test_skel_state_np.py
+++ b/pymomentum/test/test_skel_state_np.py
@@ -8,8 +8,8 @@
 import unittest
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.quaternion_np as pym_quaternion
 import pymomentum.skel_state_np as pym_skel_state
 

--- a/pymomentum/test/test_skeleton.py
+++ b/pymomentum/test/test_skeleton.py
@@ -7,8 +7,10 @@
 
 import unittest
 
-from pymomentum.geometry import Character
-from pymomentum.geometry_test_utils import create_test_character
+from pymomentum.geometry import Character  # @manual=:geometry
+from pymomentum.geometry_test_utils import (  # @manual=:geometry_test_utils
+    create_test_character,
+)
 
 
 class TestSkeleton(unittest.TestCase):

--- a/pymomentum/test/test_solver.py
+++ b/pymomentum/test/test_solver.py
@@ -9,13 +9,13 @@ import unittest
 from multiprocessing.dummy import Pool
 
 import numpy as np
-import pymomentum.diff_geometry as pym_diff_geometry
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.diff_geometry as pym_diff_geometry  # @manual=:diff_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.skel_state as pym_skel_state
-import pymomentum.solver as pym_solver
+import pymomentum.solver as pym_solver  # @manual=:solver
 import torch
-from pymomentum.solver import ErrorFunctionType
+from pymomentum.solver import ErrorFunctionType  # @manual=:solver
 
 # Flag to check if autograd is enabled (disabled in arvr build modes)
 AUTOGRAD_ENABLED: bool = pym_solver.AUTOGRAD_ENABLED

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -11,10 +11,9 @@ import numpy as np
 import numpy.typing as npt
 import pymomentum.geometry as pym_geometry
 import pymomentum.geometry_test_utils as pym_test_utils
-import pymomentum.quaternion as pym_quaternion
-import pymomentum.skel_state as pym_skel_state
+import pymomentum.quaternion_np as pym_quaternion
+import pymomentum.skel_state_np as pym_skel_state
 import pymomentum.solver2 as pym_solver2
-import torch
 
 
 def _normalize_vec(vec: npt.NDArray) -> npt.NDArray:
@@ -33,14 +32,12 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(42)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
-        model_params_target = torch.rand_like(model_params_init)
-        skel_state_target = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_target.numpy()
-            )
+        model_params_target = (0.5 * np.random.rand(n_params)).astype(np.float32)
+        skel_state_target = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_target
         )
 
         pos_error = pym_solver2.PositionErrorFunction(character)
@@ -63,24 +60,22 @@ class TestSolver(unittest.TestCase):
         self.assertTrue(len(pos_error.constraints) == 0)
 
         pos_error.add_constraints(
-            parent=np.arange(n_joints), target=skel_state_target[:, :3].numpy()
+            parent=np.arange(n_joints), target=skel_state_target[:, :3]
         )
         solver_function = pym_solver2.SkeletonSolverFunction(character, [pos_error])
 
         solver_options = pym_solver2.GaussNewtonSolverOptions()
-        solver_options.max_iterations = 100
+        solver_options.max_iterations = 200
         solver_options.regularization = 1e-5
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        model_params_final = solver.solve(model_params_init)
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         self.assertTrue(
-            torch.allclose(
-                skel_state_final[:, :3], skel_state_target[:, :3], rtol=1e-5, atol=1e-5
+            np.allclose(
+                skel_state_final[:, :3], skel_state_target[:, :3], rtol=1e-4, atol=1e-4
             )
         )
 
@@ -89,7 +84,7 @@ class TestSolver(unittest.TestCase):
 
         # make sure it's deterministic:
         per_iter_errors_prev = solver.per_iteration_errors
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
         assert solver.per_iteration_errors == per_iter_errors_prev
 
         # delete constraints and ensure they're empty
@@ -132,10 +127,10 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
-        random_positions = torch.rand(n_joints, 3, dtype=torch.float32)
+        random_positions = np.random.rand(n_joints, 3).astype(np.float32)
 
         pos_error = pym_solver2.PositionErrorFunction(character)
 
@@ -143,14 +138,14 @@ class TestSolver(unittest.TestCase):
             pos_error.add_constraint(
                 parent=i_joint,
                 weight=1.0,
-                target=random_positions[i_joint, :3].numpy(),
+                target=random_positions[i_joint, :3],
             )
 
-        error = pos_error.get_error(model_params_init.numpy())
+        error = pos_error.get_error(model_params_init)
         self.assertTrue(error > 0.0)
 
         # Test get_gradient
-        grad = pos_error.get_gradient(model_params_init.numpy())
+        grad = pos_error.get_gradient(model_params_init)
         eps = 1e-3
         for i_param in range(n_params):
             mp_plus = np.copy(model_params_init)
@@ -161,31 +156,31 @@ class TestSolver(unittest.TestCase):
             )
 
         # Test get_jacobian
-        res, jac = pos_error.get_jacobian(model_params_init.numpy())
+        res, jac = pos_error.get_jacobian(model_params_init)
         grad_jac = 2.0 * np.matmul(np.transpose(jac), res)
         self.assertTrue(np.allclose(grad_jac, grad, rtol=1e-5, atol=1e-5))
 
         # Combine two error functions in a SkeletonSolverFunction:
         model_params_error = pym_solver2.ModelParametersErrorFunction(character)
         model_params_error.set_target_parameters(
-            torch.rand(n_params, dtype=torch.float32).numpy()
+            np.random.rand(n_params).astype(np.float32)
         )
         skel_solver_function = pym_solver2.SkeletonSolverFunction(character)
         skel_solver_function.add_error_function(model_params_error)
         skel_solver_function.add_error_function(pos_error)
-        error_combined = skel_solver_function.get_error(model_params_init.numpy())
+        error_combined = skel_solver_function.get_error(model_params_init)
         self.assertAlmostEqual(
             error_combined,
-            model_params_error.get_error(model_params_init.numpy())
-            + pos_error.get_error(model_params_init.numpy()),
+            model_params_error.get_error(model_params_init)
+            + pos_error.get_error(model_params_init),
             delta=1e-4,
         )
 
         self.assertTrue(
             np.allclose(
-                skel_solver_function.get_gradient(model_params_init.numpy()),
-                model_params_error.get_gradient(model_params_init.numpy())
-                + pos_error.get_gradient(model_params_init.numpy()),
+                skel_solver_function.get_gradient(model_params_init),
+                model_params_error.get_gradient(model_params_init)
+                + pos_error.get_gradient(model_params_init),
                 rtol=1e-4,
                 atol=1e-4,
             )
@@ -200,19 +195,17 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Set target model parameters
-        model_params_target = torch.rand_like(model_params_init)
+        model_params_target = np.random.rand(n_params).astype(np.float32)
 
         # Create ModelParametersErrorFunction
         model_params_error = pym_solver2.ModelParametersErrorFunction(character)
 
         # Set target parameters in the error function
-        model_params_error.set_target_parameters(
-            model_params_target.numpy(), np.ones(n_params)
-        )
+        model_params_error.set_target_parameters(model_params_target, np.ones(n_params))
 
         # Create solver function with the model parameters error
         solver_function = pym_solver2.SkeletonSolverFunction(character)
@@ -225,12 +218,12 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Assert that the solved model parameters are close to the target
         self.assertTrue(
-            torch.allclose(
-                torch.from_numpy(model_params_final),
+            np.allclose(
+                model_params_final,
                 model_params_target,
                 rtol=1e-5,
                 atol=1e-5,
@@ -248,11 +241,11 @@ class TestSolver(unittest.TestCase):
         n_frames = 5
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros((n_frames, n_params), dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros((n_frames, n_params), dtype=np.float32)
 
         # Set target model parameters for each frame
-        model_params_target = torch.rand((n_frames, n_params), dtype=torch.float32)
+        model_params_target = np.random.rand(n_frames, n_params).astype(np.float32)
 
         # Create SequenceSolverFunction
         solver_function = pym_solver2.SequenceSolverFunction(character, n_frames)
@@ -261,7 +254,7 @@ class TestSolver(unittest.TestCase):
         for i_frame in range(n_frames):
             model_params_error = pym_solver2.ModelParametersErrorFunction(character)
             model_params_error.set_target_parameters(
-                model_params_target[i_frame].numpy(), np.ones(n_params)
+                model_params_target[i_frame], np.ones(n_params)
             )
             solver_function.add_error_function(i_frame, model_params_error)
 
@@ -272,14 +265,14 @@ class TestSolver(unittest.TestCase):
 
         # Solve the sequence
         model_params_final = pym_solver2.solve_sequence(
-            solver_function, model_params_init.numpy(), solver_options
+            solver_function, model_params_init, solver_options
         )
 
         # Assert that the solved model parameters are close to the target for each frame
         for i_frame in range(n_frames):
             self.assertTrue(
-                torch.allclose(
-                    torch.from_numpy(model_params_final[i_frame]),
+                np.allclose(
+                    model_params_final[i_frame],
                     model_params_target[i_frame],
                     rtol=1e-5,
                     atol=1e-5,
@@ -297,11 +290,11 @@ class TestSolver(unittest.TestCase):
         n_frames = 5
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros((n_frames, n_params), dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros((n_frames, n_params), dtype=np.float32)
 
         # Set target model parameters for the first frame
-        model_params_target_first_frame = torch.rand(n_params, dtype=torch.float32)
+        model_params_target_first_frame = np.random.rand(n_params).astype(np.float32)
 
         # Create SequenceSolverFunction
         solver_function = pym_solver2.SequenceSolverFunction(character, n_frames)
@@ -309,7 +302,7 @@ class TestSolver(unittest.TestCase):
         # Add ModelParametersErrorFunction for the first frame
         model_params_error = pym_solver2.ModelParametersErrorFunction(character)
         model_params_error.set_target_parameters(
-            model_params_target_first_frame.numpy(), np.ones(n_params)
+            model_params_target_first_frame, np.ones(n_params)
         )
         solver_function.add_error_function(0, model_params_error)
 
@@ -329,13 +322,13 @@ class TestSolver(unittest.TestCase):
 
         # Solve the sequence
         model_params_final = pym_solver2.solve_sequence(
-            solver_function, model_params_init.numpy(), solver_options
+            solver_function, model_params_init, solver_options
         )
 
         # Assert that the solved model parameters for the first frame are close to the target
         self.assertTrue(
-            torch.allclose(
-                torch.from_numpy(model_params_final[0]),
+            np.allclose(
+                model_params_final[0],
                 model_params_target_first_frame,
                 rtol=1e-5,
                 atol=1e-5,
@@ -345,9 +338,9 @@ class TestSolver(unittest.TestCase):
         # Assert smoothness across frames by checking small differences between consecutive frames
         for i_frame in range(1, n_frames):
             self.assertTrue(
-                torch.allclose(
-                    torch.from_numpy(model_params_final[i_frame]),
-                    torch.from_numpy(model_params_final[i_frame - 1]),
+                np.allclose(
+                    model_params_final[i_frame],
+                    model_params_final[i_frame - 1],
                     rtol=1e-2,
                     atol=1e-2,
                 )
@@ -362,24 +355,22 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Generate a random set of model parameters as the target
-        model_params_target = torch.rand_like(model_params_init)
+        model_params_target = np.random.rand(n_params).astype(np.float32)
 
         # Convert target model parameters to a target skeleton state
-        skel_state_target = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_target.numpy()
-            )
+        skel_state_target = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_target
         )
 
         # Create StateErrorFunction
         state_error_function = pym_solver2.StateErrorFunction(character)
 
         # Set the target skeleton state in the error function
-        state_error_function.set_target_state(skel_state_target.numpy())
+        state_error_function.set_target_state(skel_state_target)
 
         # Create solver function with the state error
         solver_function = pym_solver2.SkeletonSolverFunction(
@@ -393,18 +384,16 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Assert that the solved skeleton state is close to the target
         self.assertTrue(
-            torch.allclose(
+            np.allclose(
                 pym_skel_state.to_matrix(skel_state_final),
                 pym_skel_state.to_matrix(skel_state_target),
                 rtol=1e-3,
@@ -421,19 +410,17 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Set target model parameters
-        model_params_target = torch.rand_like(model_params_init)
+        model_params_target = np.random.rand(n_params).astype(np.float32)
 
         # Create ModelParametersErrorFunction
         model_params_error = pym_solver2.ModelParametersErrorFunction(character)
 
         # Set target parameters in the error function
-        model_params_error.set_target_parameters(
-            model_params_target.numpy(), np.ones(n_params)
-        )
+        model_params_error.set_target_parameters(model_params_target, np.ones(n_params))
 
         # Create solver function with the model parameters error
         solver_function = pym_solver2.SkeletonSolverFunction(
@@ -456,13 +443,13 @@ class TestSolver(unittest.TestCase):
         solver.set_enabled_parameters(active_parameters)
 
         # Solve with active parameters
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Verify that only active parameters have changed
         self.assertTrue(
             np.allclose(
                 model_params_final[: n_params // 2],
-                model_params_target[: n_params // 2].numpy(),
+                model_params_target[: n_params // 2],
                 rtol=1e-5,
                 atol=1e-5,
             )
@@ -470,7 +457,7 @@ class TestSolver(unittest.TestCase):
         self.assertTrue(
             np.allclose(
                 model_params_final[n_params // 2 :],
-                model_params_init[n_params // 2 :].numpy(),
+                model_params_init[n_params // 2 :],
                 rtol=1e-5,
                 atol=1e-5,
             )
@@ -478,7 +465,7 @@ class TestSolver(unittest.TestCase):
 
     def test_point_triangle_error_function(self) -> None:
         """Test PointTriangleVertexErrorFunction to ensure a point is close to the target triangle."""
-        torch.manual_seed(0)
+        np.random.seed(0)
 
         # Create a test character
         character = pym_test_utils.create_test_character(num_joints=4)
@@ -514,8 +501,8 @@ class TestSolver(unittest.TestCase):
         solver_options.do_line_search = True
 
         # Create and run the solver
-        model_params_init = torch.randn(
-            character.parameter_transform.size, dtype=torch.float32
+        model_params_init = np.random.randn(character.parameter_transform.size).astype(
+            np.float32
         )
         solver = pym_solver2.GaussNewtonSolverQR(solver_function, solver_options)
         enabled_params = ~(
@@ -523,21 +510,19 @@ class TestSolver(unittest.TestCase):
             | character.parameter_transform.rigid_parameters
         )
         solver.set_enabled_parameters(enabled_params)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert final model parameters to skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final position of the point
-        final_mesh = character.skin_points(skel_state_final.numpy())
-        final_point_position = torch.from_numpy(final_mesh[point_index, :3])
+        final_mesh = character.skin_points(skel_state_final)
+        final_point_position = final_mesh[point_index, :3]
 
         # Compute the target position of the point on the triangle
-        triangle_vertices = torch.from_numpy(final_mesh[triangle_indices, :3])
+        triangle_vertices = final_mesh[triangle_indices, :3]
         final_target_position = (
             triangle_bary_coords[0] * triangle_vertices[0]
             + triangle_bary_coords[1] * triangle_vertices[1]
@@ -546,7 +531,7 @@ class TestSolver(unittest.TestCase):
 
         # Assert that the final point position is close to the target position
         self.assertTrue(
-            torch.allclose(
+            np.allclose(
                 final_point_position, final_target_position, rtol=1e-1, atol=1e-1
             )
         )
@@ -564,19 +549,19 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
+        np.random.seed(0)
 
         n_modes = 2
 
         # Generate a random set of model parameters as the target
-        model_params_target = torch.rand(n_modes, n_params, dtype=torch.float32)
+        model_params_target = np.random.rand(n_modes, n_params).astype(np.float32)
 
         n_pca = 2
         pose_prior_model = pym_geometry.Mppca(
-            pi=torch.ones(n_modes).numpy(),
-            mu=model_params_target.numpy(),
-            W=torch.rand(n_modes, n_pca, n_params).numpy(),
-            sigma=torch.ones(n_modes).numpy(),
+            pi=np.ones(n_modes, dtype=np.float32),
+            mu=model_params_target,
+            W=np.random.rand(n_modes, n_pca, n_params).astype(np.float32),
+            sigma=np.ones(n_modes, dtype=np.float32),
             names=character.parameter_transform.names,
         )
 
@@ -598,13 +583,13 @@ class TestSolver(unittest.TestCase):
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
         # Should converge to the closest mode:
         for i_mode in range(n_modes):
-            model_params_init = model_params_target[i_mode] + 0.1 * torch.randn_like(
-                model_params_target[i_mode]
-            )
-            model_params_final = solver.solve(model_params_init.numpy())
+            model_params_init = model_params_target[i_mode] + 0.1 * np.random.randn(
+                n_params
+            ).astype(np.float32)
+            model_params_final = solver.solve(model_params_init)
             self.assertTrue(
-                torch.allclose(
-                    torch.from_numpy(model_params_final),
+                np.allclose(
+                    model_params_final,
                     model_params_target[i_mode],
                     rtol=1e-5,
                     atol=1e-5,
@@ -620,9 +605,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
         np.random.seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         def _normalize_vec(vec: npt.NDArray) -> npt.NDArray:
             return vec / np.linalg.norm(vec)
@@ -655,26 +639,24 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final position and direction of the local ray
         final_point = pym_skel_state.transform_points(
             skel_state_final[parent_idx],
-            torch.from_numpy(local_point),
+            local_point,
         )
         final_dir = pym_quaternion.rotate_vector(
-            skel_state_final[parent_idx, 3:7], torch.from_numpy(local_dir)
+            skel_state_final[parent_idx, 3:7], local_dir
         )
 
         # Compute the direction to the global target
-        target_dir = _normalize_vec(global_target - final_point.numpy())
+        target_dir = _normalize_vec(global_target - final_point)
 
         # Assert that the final direction is close to the target direction
         self.assertTrue(np.allclose(final_dir, target_dir, rtol=1e-3, atol=1e-3))
@@ -692,9 +674,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
         np.random.seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Define local and global axes
         local_axis = _normalize_vec(np.random.randn(3).astype(np.float32))
@@ -731,18 +712,16 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final local axis in global space
         final_global_axis = pym_quaternion.rotate_vector(
-            skel_state_final[parent_idx, 3:7], torch.from_numpy(local_axis)
+            skel_state_final[parent_idx, 3:7], local_axis
         )
 
         # Assert that the final local axis is close to the global axis
@@ -763,8 +742,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Define local point, local normal, and global target point
         local_point = np.array([0.5, 0.0, 0.0], dtype=np.float32)
@@ -796,32 +775,29 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final position and normal in global space
         final_point = pym_skel_state.transform_points(
             skel_state_final[parent_idx],
-            torch.from_numpy(local_point),
+            local_point,
         )
         final_normal = pym_quaternion.rotate_vector(
-            skel_state_final[parent_idx, 3:7], torch.from_numpy(local_normal)
+            skel_state_final[parent_idx, 3:7], local_normal
         )
 
         # Calculate the signed distance from the global point to the plane
         # defined by the final point and normal
-        global_point_tensor = torch.from_numpy(global_point)
-        point_to_plane_vector = global_point_tensor - final_point
-        signed_distance = torch.dot(point_to_plane_vector, final_normal)
+        point_to_plane_vector = global_point - final_point
+        signed_distance = np.dot(point_to_plane_vector, final_normal)
 
         # Assert that the signed distance is close to zero
-        self.assertAlmostEqual(signed_distance.item(), 0.0, delta=1e-3)
+        self.assertAlmostEqual(float(signed_distance), 0.0, delta=1e-3)
 
         # delete constraints and ensure they're empty
         normal_error_function.clear_constraints()
@@ -836,8 +812,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Define origin point, target distance, and offset
         origin = np.array([0.0, 0.0, 0.0], dtype=np.float32)  # Origin in world space
@@ -869,24 +845,21 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final position of the point in global space
         final_point = pym_skel_state.transform_points(
             skel_state_final[parent_idx],
-            torch.from_numpy(offset),
+            offset,
         )
 
         # Calculate the distance from the origin to the final point
-        origin_tensor = torch.from_numpy(origin)
-        actual_distance = torch.norm(final_point - origin_tensor).item()
+        actual_distance = float(np.linalg.norm(final_point - origin))
 
         # Assert that the actual distance is close to the target distance
         self.assertAlmostEqual(actual_distance, target_distance, delta=1e-3)
@@ -922,18 +895,21 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
         np.random.seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Define offset and target quaternions
         axis1 = _normalize_vec(np.random.randn(3).astype(np.float32))
         angle1 = np.random.uniform(0, np.pi)
-        offset_quat = pym_quaternion.from_axis_angle(torch.from_numpy(axis1 * angle1))
+        offset_quat = pym_quaternion.from_axis_angle(
+            (axis1 * angle1).astype(np.float32)
+        )
 
         axis2 = _normalize_vec(np.random.randn(3).astype(np.float32))
         angle2 = np.random.uniform(0, np.pi)
-        target_quat = pym_quaternion.from_axis_angle(torch.from_numpy(axis2 * angle2))
+        target_quat = pym_quaternion.from_axis_angle(
+            (axis2 * angle2).astype(np.float32)
+        )
 
         # Create OrientationErrorFunction
         orientation_error_function = pym_solver2.OrientationErrorFunction(character)
@@ -941,8 +917,8 @@ class TestSolver(unittest.TestCase):
         # Add orientation constraint
         parent_idx: int = character.skeleton.size - 1
         orientation_error_function.add_constraint(
-            offset=offset_quat.numpy(),
-            target=target_quat.numpy(),
+            offset=offset_quat,
+            target=target_quat,
             parent=parent_idx,
             weight=1.0,
         )
@@ -959,13 +935,11 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final orientation
@@ -980,7 +954,7 @@ class TestSolver(unittest.TestCase):
         # Assert that the final orientation is close to the expected orientation
         # We need to check both q and -q since they represent the same rotation
         self.assertTrue(
-            torch.allclose(
+            np.allclose(
                 pym_quaternion.to_rotation_matrix(final_orientation),
                 pym_quaternion.to_rotation_matrix(expected_orientation),
                 rtol=1e-3,
@@ -1001,8 +975,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Define plane parameters
         offset = np.array([0.0, 0.0, 0.0], dtype=np.float32)  # Point in local space
@@ -1034,23 +1008,21 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final position of the point in global space
         final_point = pym_skel_state.transform_points(
             skel_state_final[parent_idx],
-            torch.from_numpy(offset),
+            offset,
         )
 
         # Calculate the signed distance to the plane
-        distance = final_point[1].item() - d  # y - d
+        distance = float(final_point[1]) - d  # y - d
 
         # Assert that the point is on the plane (distance close to zero)
         self.assertAlmostEqual(distance, 0.0, delta=1e-3)
@@ -1073,27 +1045,25 @@ class TestSolver(unittest.TestCase):
         )
 
         # Create and run the solver with initial parameters that put the point below the plane
-        model_params_below = model_params_init.clone()
+        model_params_below = model_params_init.copy()
         model_params_below[0] = -2.0  # Move the point below the plane
 
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_below.numpy())
+        model_params_final = solver.solve(model_params_below)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final position of the point in global space
         final_point = pym_skel_state.transform_points(
             skel_state_final[parent_idx],
-            torch.from_numpy(offset),
+            offset,
         )
 
         # Calculate the signed distance to the plane
-        distance = final_point[1].item() - d  # y - d
+        distance = float(final_point[1]) - d  # y - d
 
         # Assert that the point is above or on the plane (distance >= 0)
         self.assertGreaterEqual(distance, -1e-3)
@@ -1111,8 +1081,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Define projection parameters
         # Simple perspective projection matrix (3x4)
@@ -1158,20 +1128,18 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final position of the point in global space
         final_point = pym_skel_state.transform_points(
             skel_state_final[parent_idx],
-            torch.from_numpy(offset),
-        ).numpy()
+            offset,
+        )
 
         # Apply the projection matrix to get the projected 2D point
         # First create homogeneous coordinates by adding 1 as the 4th component
@@ -1315,8 +1283,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Define projection parameters
         # Simple perspective projection matrix (3x4)
@@ -1361,17 +1329,15 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert the solved model parameters to a skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute the final mesh
-        final_mesh = character.skin_points(skel_state_final.numpy())
+        final_mesh = character.skin_points(skel_state_final)
 
         # Get the final position of the vertex
         final_vertex_position = final_mesh[vertex_index, :3]
@@ -1410,15 +1376,14 @@ class TestSolver(unittest.TestCase):
         n_frames = 2  # VertexSequenceErrorFunction works with 2 frames
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
         np.random.seed(0)
 
         # Initialize model parameters for both frames
-        model_params_init = torch.zeros((n_frames, n_params), dtype=torch.float32)
+        model_params_init = np.zeros((n_frames, n_params), dtype=np.float32)
 
         # Set up different poses for the two frames to create motion
-        model_params_frame0 = torch.zeros(n_params, dtype=torch.float32)
-        model_params_frame1 = torch.zeros(n_params, dtype=torch.float32)
+        model_params_frame0 = np.zeros(n_params, dtype=np.float32)
+        model_params_frame1 = np.zeros(n_params, dtype=np.float32)
 
         # Create some motion by changing translation parameters
         model_params_frame1[0] = 1.0  # Move in x direction
@@ -1479,42 +1444,36 @@ class TestSolver(unittest.TestCase):
 
         # Solve the sequence
         model_params_final = pym_solver2.solve_sequence(
-            solver_function, model_params_init.numpy(), solver_options
+            solver_function, model_params_init, solver_options
         )
 
         # Convert final model parameters to skeleton states
-        skel_state_frame0 = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final[0]
-            )
+        skel_state_frame0 = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final[0]
         )
-        skel_state_frame1 = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final[1]
-            )
+        skel_state_frame1 = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final[1]
         )
 
         # Compute final meshes for both frames
-        mesh_frame0 = character.skin_points(skel_state_frame0.numpy())
-        mesh_frame1 = character.skin_points(skel_state_frame1.numpy())
+        mesh_frame0 = character.skin_points(skel_state_frame0)
+        mesh_frame1 = character.skin_points(skel_state_frame1)
 
         # Verify that vertex velocities match target velocities
         for i, vertex_idx in enumerate(vertex_indices):
             # Compute actual velocity (difference between frames)
-            actual_velocity = torch.from_numpy(
-                mesh_frame1[vertex_idx, :3] - mesh_frame0[vertex_idx, :3]
-            )
+            actual_velocity = mesh_frame1[vertex_idx, :3] - mesh_frame0[vertex_idx, :3]
             expected_velocity = target_velocities[i]
 
             # Assert that actual velocity is close to target velocity
             self.assertTrue(
-                torch.allclose(
+                np.allclose(
                     actual_velocity,
-                    torch.from_numpy(expected_velocity),
+                    expected_velocity,
                     rtol=1e-3,  # Allow some tolerance due to optimization
                     atol=1e-3,
                 ),
-                f"Vertex {vertex_idx}: actual velocity {actual_velocity.numpy()} "
+                f"Vertex {vertex_idx}: actual velocity {actual_velocity} "
                 f"does not match target {expected_velocity}",
             )
 
@@ -1532,24 +1491,20 @@ class TestSolver(unittest.TestCase):
 
         # Solve again with zero velocity constraints
         model_params_final_zero = pym_solver2.solve_sequence(
-            solver_function, model_params_init.numpy(), solver_options
+            solver_function, model_params_init, solver_options
         )
 
         # Convert to skeleton states
-        skel_state_frame0_zero = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final_zero[0]
-            )
+        skel_state_frame0_zero = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final_zero[0]
         )
-        skel_state_frame1_zero = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final_zero[1]
-            )
+        skel_state_frame1_zero = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final_zero[1]
         )
 
         # Compute meshes
-        mesh_frame0_zero = character.skin_points(skel_state_frame0_zero.numpy())
-        mesh_frame1_zero = character.skin_points(skel_state_frame1_zero.numpy())
+        mesh_frame0_zero = character.skin_points(skel_state_frame0_zero)
+        mesh_frame1_zero = character.skin_points(skel_state_frame1_zero)
 
         # Verify that constrained vertices have minimal motion
         for vertex_idx in [0, 1]:
@@ -1584,11 +1539,10 @@ class TestSolver(unittest.TestCase):
         n_frames = 3  # AccelerationSequenceErrorFunction requires 3 frames
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
         np.random.seed(0)
 
         # Initialize model parameters for three frames
-        model_params_init = torch.zeros((n_frames, n_params), dtype=torch.float32)
+        model_params_init = np.zeros((n_frames, n_params), dtype=np.float32)
 
         # Create AccelerationSequenceErrorFunction
         # Test basic construction
@@ -1637,13 +1591,13 @@ class TestSolver(unittest.TestCase):
         # Anchor first and last frames
         first_frame_pos_error = pym_solver2.ModelParametersErrorFunction(character)
         first_frame_pos_error.set_target_parameters(
-            model_params_init[0].numpy(), np.ones(n_params)
+            model_params_init[0], np.ones(n_params)
         )
         solver_function.add_error_function(0, first_frame_pos_error)
 
         last_frame_pos_error = pym_solver2.ModelParametersErrorFunction(character)
         last_frame_pos_error.set_target_parameters(
-            model_params_init[2].numpy(), np.ones(n_params)
+            model_params_init[2], np.ones(n_params)
         )
         solver_function.add_error_function(2, last_frame_pos_error)
 
@@ -1660,7 +1614,7 @@ class TestSolver(unittest.TestCase):
         solver_options.regularization = 1e-5
 
         model_params_final = pym_solver2.solve_sequence(
-            solver_function, model_params_init.numpy(), solver_options
+            solver_function, model_params_init, solver_options
         )
 
         # Convert to skeleton states and verify accelerations match zero target
@@ -1713,12 +1667,10 @@ class TestSolver(unittest.TestCase):
         p2_analytical = p0 + v0 * 2.0 + 0.5 * target_accel * 2.0**2
 
         # Set up initial model parameters with these positions
-        model_params_init_ballistic = torch.zeros(
-            (n_frames, n_params), dtype=torch.float32
-        )
-        model_params_init_ballistic[0, :3] = torch.from_numpy(p0)
-        model_params_init_ballistic[1, :3] = torch.from_numpy(p1_analytical)
-        model_params_init_ballistic[2, :3] = torch.from_numpy(p2_analytical)
+        model_params_init_ballistic = np.zeros((n_frames, n_params), dtype=np.float32)
+        model_params_init_ballistic[0, :3] = p0
+        model_params_init_ballistic[1, :3] = p1_analytical
+        model_params_init_ballistic[2, :3] = p2_analytical
 
         # Create a new solver
         solver_function_ballistic = pym_solver2.SequenceSolverFunction(
@@ -1728,7 +1680,7 @@ class TestSolver(unittest.TestCase):
         # Anchor first frame strongly
         first_frame_error = pym_solver2.ModelParametersErrorFunction(character)
         first_frame_error.set_target_parameters(
-            model_params_init_ballistic[0].numpy(), np.ones(n_params) * 10.0
+            model_params_init_ballistic[0], np.ones(n_params) * 10.0
         )
         solver_function_ballistic.add_error_function(0, first_frame_error)
 
@@ -1741,13 +1693,13 @@ class TestSolver(unittest.TestCase):
         solver_function_ballistic.add_sequence_error_function(0, accel_error_gravity)
 
         # Start from a perturbed initial guess
-        model_params_init_perturbed = model_params_init_ballistic.clone()
+        model_params_init_perturbed = model_params_init_ballistic.copy()
         model_params_init_perturbed[1, 1] += 0.3  # Perturb y position of frame 1
         model_params_init_perturbed[2, 1] += 0.5  # Perturb y position of frame 2
 
         model_params_final_ballistic = pym_solver2.solve_sequence(
             solver_function_ballistic,
-            model_params_init_perturbed.numpy(),
+            model_params_init_perturbed,
             solver_options,
         )
 
@@ -1786,11 +1738,10 @@ class TestSolver(unittest.TestCase):
         n_frames = 4  # JerkSequenceErrorFunction requires 4 frames
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
         np.random.seed(0)
 
         # Initialize model parameters for four frames
-        model_params_init = torch.zeros((n_frames, n_params), dtype=torch.float32)
+        model_params_init = np.zeros((n_frames, n_params), dtype=np.float32)
 
         # Create JerkSequenceErrorFunction
         # Test basic construction
@@ -1837,20 +1788,20 @@ class TestSolver(unittest.TestCase):
         # Compute analytical positions for t=0, 1, 2, 3
         for t in range(n_frames):
             pos = p0 + v0 * float(t) + 0.5 * accel * float(t) ** 2
-            model_params_init[t, :3] = torch.from_numpy(pos)
+            model_params_init[t, :3] = pos
 
         solver_function = pym_solver2.SequenceSolverFunction(character, n_frames)
 
         # Anchor first and last frames
         first_frame_pos_error = pym_solver2.ModelParametersErrorFunction(character)
         first_frame_pos_error.set_target_parameters(
-            model_params_init[0].numpy(), np.ones(n_params)
+            model_params_init[0], np.ones(n_params)
         )
         solver_function.add_error_function(0, first_frame_pos_error)
 
         last_frame_pos_error = pym_solver2.ModelParametersErrorFunction(character)
         last_frame_pos_error.set_target_parameters(
-            model_params_init[3].numpy(), np.ones(n_params)
+            model_params_init[3], np.ones(n_params)
         )
         solver_function.add_error_function(3, last_frame_pos_error)
 
@@ -1867,15 +1818,13 @@ class TestSolver(unittest.TestCase):
         solver_options.regularization = 1e-5
 
         model_params_final = pym_solver2.solve_sequence(
-            solver_function, model_params_init.numpy(), solver_options
+            solver_function, model_params_init, solver_options
         )
 
         # Convert to skeleton states and verify jerk matches zero target
         skel_states = [
-            torch.from_numpy(
-                pym_geometry.model_parameters_to_skeleton_state(
-                    character, model_params_final[i]
-                )
+            pym_geometry.model_parameters_to_skeleton_state(
+                character, model_params_final[i]
             )
             for i in range(n_frames)
         ]
@@ -1892,13 +1841,13 @@ class TestSolver(unittest.TestCase):
 
             # Assert that measured jerk matches target
             self.assertTrue(
-                torch.allclose(
+                np.allclose(
                     jerk,
-                    torch.from_numpy(target),
+                    target,
                     rtol=0.1,
                     atol=0.1,
                 ),
-                f"Joint {joint_idx}: jerk {jerk.numpy()} does not match target {target}",
+                f"Joint {joint_idx}: jerk {jerk} does not match target {target}",
             )
 
     def test_vertex_vertex_distance_constraint(self) -> None:
@@ -1910,8 +1859,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Choose two vertices to constrain - use vertices that are initially far apart
         vertex_index1 = 0
@@ -1920,12 +1869,10 @@ class TestSolver(unittest.TestCase):
         weight = 1.0
 
         # Get initial positions of the vertices
-        skel_state_init = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_init.numpy()
-            )
+        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_init
         )
-        initial_mesh = character.skin_points(skel_state_init.numpy())
+        initial_mesh = character.skin_points(skel_state_init)
         initial_pos1 = initial_mesh[vertex_index1, :3]
         initial_pos2 = initial_mesh[vertex_index2, :3]
         initial_distance = np.linalg.norm(initial_pos2 - initial_pos1)
@@ -1967,17 +1914,15 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert final model parameters to skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute final mesh and vertex positions
-        final_mesh = character.skin_points(skel_state_final.numpy())
+        final_mesh = character.skin_points(skel_state_final)
         final_pos1 = final_mesh[vertex_index1, :3]
         final_pos2 = final_mesh[vertex_index2, :3]
         final_distance = np.linalg.norm(final_pos2 - final_pos1)
@@ -2052,8 +1997,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Choose two joints to constrain - use joints that are initially far apart
         joint_index1 = 0
@@ -2064,20 +2009,18 @@ class TestSolver(unittest.TestCase):
         weight = 1.0
 
         # Get initial positions of the points
-        skel_state_init = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_init.numpy()
-            )
+        skel_state_init = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_init
         )
         initial_point1 = pym_skel_state.transform_points(
             skel_state_init[joint_index1],
-            torch.from_numpy(offset1),
+            offset1,
         )
         initial_point2 = pym_skel_state.transform_points(
             skel_state_init[joint_index2],
-            torch.from_numpy(offset2),
+            offset2,
         )
-        initial_distance = torch.norm(initial_point2 - initial_point1).item()
+        initial_distance = float(np.linalg.norm(initial_point2 - initial_point1))
 
         # Create JointToJointDistanceErrorFunction
         joint_distance_error = pym_solver2.JointToJointDistanceErrorFunction(character)
@@ -2118,25 +2061,23 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert final model parameters to skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute final positions of the points
         final_point1 = pym_skel_state.transform_points(
             skel_state_final[joint_index1],
-            torch.from_numpy(offset1),
+            offset1,
         )
         final_point2 = pym_skel_state.transform_points(
             skel_state_final[joint_index2],
-            torch.from_numpy(offset2),
+            offset2,
         )
-        final_distance = torch.norm(final_point2 - final_point1).item()
+        final_distance = float(np.linalg.norm(final_point2 - final_point1))
 
         # Assert that the final distance is close to the target distance
         self.assertAlmostEqual(
@@ -2280,8 +2221,8 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
-        model_params_init = torch.zeros(n_params, dtype=torch.float32)
+        np.random.seed(0)
+        model_params_init = np.zeros(n_params, dtype=np.float32)
 
         # Choose two joints to constrain
         source_joint = character.skeleton.size - 1  # Last joint
@@ -2334,23 +2275,21 @@ class TestSolver(unittest.TestCase):
 
         # Create and run the solver
         solver = pym_solver2.GaussNewtonSolver(solver_function, solver_options)
-        model_params_final = solver.solve(model_params_init.numpy())
+        model_params_final = solver.solve(model_params_init)
 
         # Convert final model parameters to skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Compute final positions of the points
         source_point_world = pym_skel_state.transform_points(
             skel_state_final[source_joint],
-            torch.from_numpy(source_offset),
+            source_offset,
         )
         reference_point_world = pym_skel_state.transform_points(
             skel_state_final[reference_joint],
-            torch.from_numpy(reference_offset),
+            reference_offset,
         )
 
         # Transform source point into reference frame
@@ -2365,13 +2304,13 @@ class TestSolver(unittest.TestCase):
 
         # Assert that the source position in reference frame is close to the target
         self.assertTrue(
-            torch.allclose(
+            np.allclose(
                 source_in_ref_frame,
-                torch.from_numpy(target_position),
+                target_position,
                 rtol=1e-2,
                 atol=1e-2,
             ),
-            msg=f"Source position in ref frame {source_in_ref_frame.numpy()} does not match target {target_position}",
+            msg=f"Source position in ref frame {source_in_ref_frame} does not match target {target_position}",
         )
 
         # Test multiple constraints using add_constraints
@@ -2439,7 +2378,7 @@ class TestSolver(unittest.TestCase):
         n_params = character.parameter_transform.size
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(42)
+        np.random.seed(42)
 
         # Choose two joints to constrain
         source_joint = character.skeleton.size - 1  # Last joint
@@ -2491,10 +2430,8 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init)
 
         # Convert final model parameters to skeleton state
-        skel_state_final = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state_final = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
 
         # Get the orientations of source and reference joints
@@ -2507,11 +2444,10 @@ class TestSolver(unittest.TestCase):
 
         # The relative orientation should be close to the target
         # Account for quaternion double cover (q and -q represent same rotation)
-        target_tensor = torch.from_numpy(target_quat)
-        dot = torch.abs(torch.dot(relative_quat, target_tensor))
+        dot = abs(float(np.dot(relative_quat, target_quat)))
         self.assertTrue(
             dot > 0.98,
-            msg=f"Relative orientation {relative_quat.numpy()} does not match target {target_quat}, dot={dot.item():.4f}",
+            msg=f"Relative orientation {relative_quat} does not match target {target_quat}, dot={dot:.4f}",
         )
 
         # Test multiple constraints using add_constraints
@@ -2595,12 +2531,10 @@ class TestSolver(unittest.TestCase):
         model_params_final = solver.solve(model_params_init)
 
         # Compute actual height from optimized parameters
-        skel_state = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final
-            )
+        skel_state = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final
         )
-        mesh_vertices = character.skin_points(skel_state.numpy())
+        mesh_vertices = character.skin_points(skel_state)
 
         # Compute height by projecting all vertices onto the up direction
         up_direction = np.array([0.0, 1.0, 0.0])
@@ -2630,12 +2564,10 @@ class TestSolver(unittest.TestCase):
         model_params_final_2 = solver.solve(model_params_init)
 
         # Compute actual height from optimized parameters
-        skel_state_2 = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(
-                character, model_params_final_2
-            )
+        skel_state_2 = pym_geometry.model_parameters_to_skeleton_state(
+            character, model_params_final_2
         )
-        mesh_vertices_2 = character.skin_points(skel_state_2.numpy())
+        mesh_vertices_2 = character.skin_points(skel_state_2)
 
         # Compute height
         projections_2 = mesh_vertices_2 @ up_direction
@@ -2733,11 +2665,10 @@ class TestSolver(unittest.TestCase):
         n_frames = 2  # VelocityMagnitudeSequenceErrorFunction requires 2 frames
 
         # Ensure repeatability in the rng:
-        torch.manual_seed(0)
         np.random.seed(0)
 
         # Initialize model parameters for two frames
-        model_params_init = torch.zeros((n_frames, n_params), dtype=torch.float32)
+        model_params_init = np.zeros((n_frames, n_params), dtype=np.float32)
 
         # ========================================
         # Test basic construction
@@ -2790,9 +2721,7 @@ class TestSolver(unittest.TestCase):
 
         # Anchor first frame
         first_frame_error = pym_solver2.ModelParametersErrorFunction(character)
-        first_frame_error.set_target_parameters(
-            model_params_init[0].numpy(), np.ones(n_params)
-        )
+        first_frame_error.set_target_parameters(model_params_init[0], np.ones(n_params))
         solver_function.add_error_function(0, first_frame_error)
 
         # Add velocity magnitude error with zero target (stationary constraint)
@@ -2808,7 +2737,7 @@ class TestSolver(unittest.TestCase):
         solver_options.regularization = 1e-5
 
         model_params_final = pym_solver2.solve_sequence(
-            solver_function, model_params_init.numpy(), solver_options
+            solver_function, model_params_init, solver_options
         )
 
         # Convert to skeleton states and verify velocity magnitudes are close to zero
@@ -2861,11 +2790,11 @@ class TestSolver(unittest.TestCase):
         solver_function2.add_sequence_error_function(0, vel_mag_error_target)
 
         # Start from a configuration with some movement
-        model_params_init2 = torch.zeros((n_frames, n_params), dtype=torch.float32)
+        model_params_init2 = np.zeros((n_frames, n_params), dtype=np.float32)
         model_params_init2[1, 0] = 1.0  # Initial guess with movement in x
 
         model_params_final2 = pym_solver2.solve_sequence(
-            solver_function2, model_params_init2.numpy(), solver_options
+            solver_function2, model_params_init2, solver_options
         )
 
         # Convert to skeleton states and verify velocity magnitudes match target

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -9,11 +9,11 @@ import unittest
 
 import numpy as np
 import numpy.typing as npt
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.quaternion_np as pym_quaternion
 import pymomentum.skel_state_np as pym_skel_state
-import pymomentum.solver2 as pym_solver2
+import pymomentum.solver2 as pym_solver2  # @manual=:solver2
 
 
 def _normalize_vec(vec: npt.NDArray) -> npt.NDArray:

--- a/pymomentum/test/test_texture_classification.py
+++ b/pymomentum/test/test_texture_classification.py
@@ -8,7 +8,7 @@
 import unittest
 
 import numpy as np
-import pymomentum.geometry as pym
+import pymomentum.geometry as pym  # @manual=:geometry
 
 
 def _make_quad_mesh() -> pym.Mesh:

--- a/pymomentum/test/test_usd.py
+++ b/pymomentum/test/test_usd.py
@@ -13,8 +13,7 @@ import numpy as np
 import pymomentum.geometry as pym_geometry
 import pymomentum.geometry_test_utils as pym_test_utils
 import pymomentum.io_usd as pym_io_usd
-import pymomentum.skel_state as pym_skel_state
-import torch
+import pymomentum.skel_state_np as pym_skel_state
 
 
 def load_tests(
@@ -238,8 +237,8 @@ class TestUsd(unittest.TestCase):
         model_params = np.random.random(
             (frames, len(ref.parameter_transform.names))
         ).astype(np.float32)
-        skeleton_states = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(ref, model_params)
+        skeleton_states = pym_geometry.model_parameters_to_skeleton_state(
+            ref, model_params
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -248,7 +247,7 @@ class TestUsd(unittest.TestCase):
                 path=path,
                 character=ref,
                 fps=120,
-                skel_states=skeleton_states.numpy(),
+                skel_states=skeleton_states,
             )
 
             char, skel_states_read, timestamps = (
@@ -257,9 +256,9 @@ class TestUsd(unittest.TestCase):
 
             self.assertEqual(char.skeleton.size, ref.skeleton.size)
             self.assertEqual(skel_states_read.shape, skeleton_states.shape)
-            torch.testing.assert_allclose(
+            np.testing.assert_allclose(
                 pym_skel_state.to_matrix(skeleton_states),
-                pym_skel_state.to_matrix(torch.from_numpy(skel_states_read)),
+                pym_skel_state.to_matrix(skel_states_read),
                 rtol=1e-3,
                 atol=1e-3,
             )
@@ -272,8 +271,8 @@ class TestUsd(unittest.TestCase):
         model_params = np.random.random(
             (frames, len(ref.parameter_transform.names))
         ).astype(np.float32)
-        skeleton_states = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(ref, model_params)
+        skeleton_states = pym_geometry.model_parameters_to_skeleton_state(
+            ref, model_params
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -282,7 +281,7 @@ class TestUsd(unittest.TestCase):
                 path=path,
                 character=ref,
                 fps=60,
-                skel_states=skeleton_states.numpy(),
+                skel_states=skeleton_states,
             )
 
             with open(path, "rb") as f:
@@ -294,9 +293,9 @@ class TestUsd(unittest.TestCase):
 
             self.assertEqual(char.skeleton.size, ref.skeleton.size)
             self.assertEqual(skel_states_read.shape, skeleton_states.shape)
-            torch.testing.assert_allclose(
+            np.testing.assert_allclose(
                 pym_skel_state.to_matrix(skeleton_states),
-                pym_skel_state.to_matrix(torch.from_numpy(skel_states_read)),
+                pym_skel_state.to_matrix(skel_states_read),
                 rtol=1e-3,
                 atol=1e-3,
             )
@@ -370,13 +369,13 @@ class TestUsd(unittest.TestCase):
             # joint params from USD TRS (quaternion->Euler + log2 scale round-trip),
             # introducing small numerical differences vs the model-parameter path.
             for i in range(n_frames):
-                skel_state_from_motion = torch.from_numpy(
+                skel_state_from_motion = (
                     pym_geometry.model_parameters_to_skeleton_state(char1, motion1[i])
                 )
                 self.assertTrue(
                     np.allclose(
                         pym_skel_state.to_matrix(skel_state_from_motion),
-                        pym_skel_state.to_matrix(torch.from_numpy(skel_states[i])),
+                        pym_skel_state.to_matrix(skel_states[i]),
                         atol=1e-3,
                         rtol=1e-3,
                     ),
@@ -534,8 +533,8 @@ class TestUsd(unittest.TestCase):
         model_params = np.random.random(
             (frames, len(ref.parameter_transform.names))
         ).astype(np.float32)
-        skeleton_states = torch.from_numpy(
-            pym_geometry.model_parameters_to_skeleton_state(ref, model_params)
+        skeleton_states = pym_geometry.model_parameters_to_skeleton_state(
+            ref, model_params
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -544,7 +543,7 @@ class TestUsd(unittest.TestCase):
                 path=path,
                 character=ref,
                 fps=60,
-                skel_states=skeleton_states.numpy(),
+                skel_states=skeleton_states,
             )
             self.assertTrue(os.path.exists(path))
 

--- a/pymomentum/test/test_usd.py
+++ b/pymomentum/test/test_usd.py
@@ -10,9 +10,9 @@ import unittest
 from typing import Optional
 
 import numpy as np
-import pymomentum.geometry as pym_geometry
-import pymomentum.geometry_test_utils as pym_test_utils
-import pymomentum.io_usd as pym_io_usd
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
+import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
+import pymomentum.io_usd as pym_io_usd  # @manual=:io_usd
 import pymomentum.skel_state_np as pym_skel_state
 
 

--- a/pymomentum/test/test_usd.py
+++ b/pymomentum/test/test_usd.py
@@ -10,10 +10,19 @@ import unittest
 from typing import Optional
 
 import numpy as np
-import pymomentum.geometry as pym_geometry  # @manual=:geometry
-import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
-import pymomentum.io_usd as pym_io_usd  # @manual=:io_usd
-import pymomentum.skel_state_np as pym_skel_state
+
+try:
+    import pymomentum.io_usd as pym_io_usd  # @manual=:io_usd
+
+    _io_usd_available = pym_io_usd.is_usd_available()
+except ImportError:
+    pym_io_usd = None  # type: ignore[assignment]
+    _io_usd_available = False
+
+if _io_usd_available:
+    import pymomentum.geometry as pym_geometry  # @manual=:geometry
+    import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
+    import pymomentum.skel_state_np as pym_skel_state
 
 
 def load_tests(
@@ -26,10 +35,10 @@ def load_tests(
 
     This prevents 'Skipping' notifications in CI by not discovering
     the tests at all, rather than discovering and then skipping them.
-    Works with uses_legacy_listing = True (static listing handles
-    this correctly by finding 0 tests when load_tests returns empty).
+    Works with supports_static_listing = False so the runner calls
+    load_tests() to discover tests instead of static analysis.
     """
-    if not pym_io_usd.is_usd_available():
+    if not _io_usd_available:
         return unittest.TestSuite()
     return standard_tests
 

--- a/pymomentum/test/test_viser_vis.py
+++ b/pymomentum/test/test_viser_vis.py
@@ -1,0 +1,227 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import numpy as np
+import pymomentum.geometry as geo
+import pymomentum.geometry_test_utils as test_utils
+
+try:
+    import viser
+
+    _HAS_VISER = True
+except ImportError:
+    viser = None  # pyre-ignore[9]
+    _HAS_VISER = False
+
+if _HAS_VISER:
+    from pymomentum.viser_vis import (
+        _normalize_param_limit,
+        _xyzw_to_wxyz,
+        add_character,
+        add_character_param_sliders,
+        add_joints,
+        add_log_panel,
+        add_mesh,
+        add_wireframe_toggle,
+        CharacterHandles,
+        remove_character,
+        update_character,
+        update_joints,
+        update_mesh,
+    )
+
+
+def load_tests(
+    loader: unittest.TestLoader,
+    tests: unittest.TestSuite,
+    pattern: str | None,
+) -> unittest.TestSuite:
+    """Skip all tests when viser is not installed."""
+    if not _HAS_VISER:
+        return unittest.TestSuite()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(TestViserVis))
+    return suite
+
+
+class TestViserVis(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Ephemeral port; the server runs locally only for handle creation.
+        cls.server: viser.ViserServer = viser.ViserServer(host="127.0.0.1", port=0)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.stop()
+
+    def _make_character_and_skel_state(
+        self,
+    ) -> tuple[geo.Character, np.ndarray]:
+        character = test_utils.create_test_character()
+        self.assertGreater(character.skeleton.size, 0)
+        self.assertTrue(
+            character.has_mesh,
+            "create_test_character() is documented to return a mesh",
+        )
+        model_params = np.zeros(character.parameter_transform.size, dtype=np.float32)
+        skel_state = geo.model_parameters_to_skeleton_state(character, model_params)
+        self.assertEqual(skel_state.shape, (character.skeleton.size, 8))
+        return character, skel_state
+
+    def _posed_mesh(self, character: geo.Character) -> geo.Mesh:
+        joint_params = np.zeros(character.skeleton.size * 7, dtype=np.float32)
+        return character.pose_mesh(joint_params)
+
+    def test_add_and_update_joints(self) -> None:
+        character, skel_state = self._make_character_and_skel_state()
+        handles, bones_handle = add_joints(
+            self.server, "test_joints", character, skel_state
+        )
+        self.assertEqual(set(handles.keys()), set(character.skeleton.joint_names))
+        # The test character has parent-child joints, so a bone handle exists.
+        self.assertIsNotNone(bones_handle)
+
+        # Move every joint by +1 cm along x; positions in handles should follow.
+        moved = skel_state.copy()
+        moved[:, 0] += 1.0
+        update_joints(handles, bones_handle, character, moved, scale=1.0)
+        for i, name in enumerate(character.skeleton.joint_names):
+            np.testing.assert_allclose(
+                np.asarray(handles[name].position),
+                moved[i, :3],
+                atol=1e-5,
+            )
+
+        for h in handles.values():
+            h.remove()
+        bones_handle.remove()
+
+    def test_add_and_update_mesh(self) -> None:
+        character, _ = self._make_character_and_skel_state()
+        posed_mesh = self._posed_mesh(character)
+        self.assertGreater(len(posed_mesh.vertices), 0)
+        solid_handle, wireframe_handle = add_mesh(self.server, "test_mesh", posed_mesh)
+
+        # update_mesh should propagate new vertices through both handles.
+        scale = 2.0
+        update_mesh(solid_handle, wireframe_handle, posed_mesh, scale=scale)
+        expected = np.asarray(posed_mesh.vertices, dtype=np.float32) * scale
+        np.testing.assert_allclose(np.asarray(solid_handle.vertices), expected)
+        np.testing.assert_allclose(np.asarray(wireframe_handle.vertices), expected)
+
+        solid_handle.remove()
+        wireframe_handle.remove()
+
+    def test_add_character_with_and_without_mesh(self) -> None:
+        character, skel_state = self._make_character_and_skel_state()
+        posed_mesh = self._posed_mesh(character)
+
+        # With mesh: handle bag should include both mesh and wireframe handles.
+        full = add_character(
+            self.server, "test_char_full", character, skel_state, posed_mesh=posed_mesh
+        )
+        self.assertIsInstance(full, CharacterHandles)
+        self.assertEqual(len(full.joint_frames), character.skeleton.size)
+        self.assertIsNotNone(full.mesh_handle)
+        self.assertIsNotNone(full.wireframe_handle)
+        # update_character should run without raising; verify the joint
+        # positions follow the new skel state.
+        moved = skel_state.copy()
+        moved[:, 0] += 0.5
+        update_character(self.server, full, character, moved, posed_mesh=posed_mesh)
+        for i, name in enumerate(character.skeleton.joint_names):
+            np.testing.assert_allclose(
+                np.asarray(full.joint_frames[name].position),
+                moved[i, :3] * 0.01,  # default CM_TO_M scale
+                atol=1e-5,
+            )
+        remove_character(full)
+        self.assertEqual(len(full.joint_frames), 0)
+        self.assertIsNone(full.mesh_handle)
+
+        # Without mesh: mesh/wireframe handles should be None.
+        no_mesh = add_character(self.server, "test_char_nm", character, skel_state)
+        self.assertIsNone(no_mesh.mesh_handle)
+        self.assertIsNone(no_mesh.wireframe_handle)
+        self.assertGreater(len(no_mesh.joint_frames), 0)
+        remove_character(no_mesh)
+
+    def test_xyzw_to_wxyz(self) -> None:
+        # xyzw [0.1, 0.2, 0.3, 0.9] -> wxyz [0.9, 0.1, 0.2, 0.3]
+        q_xyzw = np.array([0.1, 0.2, 0.3, 0.9])
+        np.testing.assert_allclose(
+            _xyzw_to_wxyz(q_xyzw), [0.9, 0.1, 0.2, 0.3], atol=1e-6
+        )
+
+    def test_normalize_param_limit(self) -> None:
+        # Bounded limits pass through unchanged.
+        self.assertEqual(_normalize_param_limit("foo", -1.5, 1.5), (-1.5, 1.5))
+        # Translation params get clamped to ±200 cm.
+        self.assertEqual(
+            _normalize_param_limit("root_tx", -1e35, 1e35), (-200.0, 200.0)
+        )
+        # Rotation params get clamped to ±π.
+        import math
+
+        lo, hi = _normalize_param_limit("hip_rx", -1e35, 1e35)
+        self.assertAlmostEqual(lo, -math.pi)
+        self.assertAlmostEqual(hi, math.pi)
+
+    def test_add_character_param_sliders(self) -> None:
+        character, _ = self._make_character_and_skel_state()
+        n_params = character.parameter_transform.size
+        events: list[object] = []
+
+        def _cb(evt: object) -> None:
+            events.append(evt)
+
+        sliders = add_character_param_sliders(self.server, character, on_change=_cb)
+        self.assertEqual(len(sliders), n_params)
+        # Verify the callback is wired by mutating one slider's value (which
+        # triggers on_update synchronously in viser).
+        sliders[0].value = sliders[0].min
+        self.assertGreater(len(events), 0)
+        for s in sliders:
+            s.remove()
+
+    def test_add_wireframe_toggle(self) -> None:
+        character, skel_state = self._make_character_and_skel_state()
+        posed_mesh = self._posed_mesh(character)
+        handles = add_character(
+            self.server, "test_wf", character, skel_state, posed_mesh=posed_mesh
+        )
+        self.assertIsNotNone(handles.mesh_handle)
+        self.assertIsNotNone(handles.wireframe_handle)
+
+        # Default initial_value=False: solid visible, wireframe hidden.
+        cb = add_wireframe_toggle(self.server, handles)
+        self.assertTrue(handles.mesh_handle.visible)
+        self.assertFalse(handles.wireframe_handle.visible)
+
+        # Flip the checkbox; visibility should swap.
+        cb.value = True
+        self.assertFalse(handles.mesh_handle.visible)
+        self.assertTrue(handles.wireframe_handle.visible)
+
+        cb.remove()
+        remove_character(handles)
+
+    def test_add_log_panel(self) -> None:
+        panel = add_log_panel(self.server, echo_to_stdout=False)
+        panel.log("hello")
+        panel.log("uh oh", level="error")
+        # The panel renders into an HTML handle; assert the HTML content
+        # picked up both messages and the error icon.
+        # pyre-ignore[16]: _handle is set in __init__
+        content = panel._handle.content
+        self.assertIn("hello", content)
+        self.assertIn("uh oh", content)
+        self.assertIn("🔴", content)
+        # pyre-ignore[16]
+        panel._handle.remove()

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -7,7 +7,7 @@
 
 from typing import Tuple
 
-import pymomentum.geometry as pym_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.skel_state as pym_skel_state
 import pymomentum.trs as pym_trs

--- a/pymomentum/torch/parameter_limits.py
+++ b/pymomentum/torch/parameter_limits.py
@@ -5,7 +5,7 @@
 
 from typing import Any, List, Optional
 
-import pymomentum.geometry as pym_geometry
+import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import pymomentum.skel_state as pym_skel_state
 import torch
 

--- a/pymomentum/viser_vis.py
+++ b/pymomentum/viser_vis.py
@@ -1,0 +1,574 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Viser Visualization Helpers
+============================
+
+Helper functions for visualizing momentum characters in a
+`viser <https://viser.studio/>`_ web viewer, providing a live interactive
+3D scene with per-frame updates.
+
+Unlike the Rerun helpers (:mod:`pymomentum.rerun_vis`), viser is a
+**live server** — you add geometry once and then update transforms each
+frame.  The typical usage pattern is::
+
+    import viser
+    import pymomentum.geometry as geo
+    from pymomentum.viser_vis import add_character, update_character
+
+    server = viser.ViserServer(host="::", port=8080)
+    character = geo.Character.load_urdf("robot.urdf")
+    skel_state = geo.joint_parameters_to_skeleton_state(character, joint_params)
+
+    handles = add_character(server, "character", character, skel_state)
+
+    # In your simulation loop:
+    for frame in frames:
+        new_skel_state = geo.joint_parameters_to_skeleton_state(character, params)
+        update_character(server, handles, character, new_skel_state)
+
+Individual functions are also available:
+
+- :func:`add_mesh` / :func:`update_mesh` — manage a :class:`~pymomentum.geometry.Mesh`
+- :func:`add_joints` / :func:`update_joints` — manage skeleton joint frames
+- :func:`add_character` / :func:`update_character` / :func:`remove_character` —
+  manage a complete character
+
+GUI widget helpers (optional, for apps building interactive viewers):
+
+- :func:`add_character_param_sliders` — one slider per model parameter
+- :func:`add_wireframe_toggle` — checkbox that toggles a character's mesh/wireframe
+- :func:`add_log_panel` — scrollable HTML log strip (returns a :class:`LogPanel`)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Callable, TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import viser
+    from pymomentum.geometry import Character, Mesh
+
+
+@dataclass
+class CharacterHandles:
+    """Opaque handle bag returned by :func:`add_character`.
+
+    Pass this to :func:`update_character` or :func:`remove_character`.
+    """
+
+    entity_path: str = ""
+    joint_frames: dict[str, Any] = field(default_factory=dict)
+    bones_handle: Any | None = None
+    mesh_handle: Any | None = None
+    wireframe_handle: Any | None = None
+
+
+#: Default scale factor to convert momentum units (cm) to meters for viser.
+CM_TO_M: float = 0.01
+
+
+def _xyzw_to_wxyz(q: np.ndarray) -> np.ndarray:
+    """Convert quaternion from ``[x, y, z, w]`` (pymomentum) to ``[w, x, y, z]`` (viser)."""
+    return np.array([q[3], q[0], q[1], q[2]], dtype=np.float64)
+
+
+def add_mesh(
+    server: viser.ViserServer,
+    entity_path: str,
+    mesh: Mesh,
+    *,
+    color: tuple[int, int, int] = (200, 200, 200),
+    scale: float = CM_TO_M,
+) -> tuple[Any, Any]:
+    """Add a :class:`~pymomentum.geometry.Mesh` to the viser scene.
+
+    Creates both a solid mesh and a hidden wireframe mesh for toggling.
+
+    :param server: The viser server instance.
+    :param entity_path: Scene-graph path for the mesh node.
+    :param mesh: The mesh to add (typically from
+        :meth:`~pymomentum.geometry.Character.pose_mesh`).
+    :param color: RGB color tuple ``(r, g, b)`` in 0–255.
+    :param scale: Unit conversion factor applied to vertex positions.
+        Defaults to :data:`CM_TO_M` (0.01) to convert momentum's cm to meters.
+    :return: A tuple of (solid_handle, wireframe_handle).
+    """
+    vertices = np.asarray(mesh.vertices, dtype=np.float32) * scale
+    faces = np.asarray(mesh.faces, dtype=np.int32)
+    solid = server.scene.add_mesh_simple(
+        entity_path,
+        vertices=vertices,
+        faces=faces,
+        color=color,
+    )
+    wireframe = server.scene.add_mesh_simple(
+        f"{entity_path}_wireframe",
+        vertices=vertices,
+        faces=faces,
+        color=(80, 80, 80),
+        wireframe=True,
+        visible=False,
+    )
+    return solid, wireframe
+
+
+def add_floor(
+    server: viser.ViserServer,
+    entity_path: str = "/ground",
+    *,
+    height: float = 0.0,
+    up: str = "z",
+    width: float = 20.0,
+    cell_size: float = 0.5,
+    shadow_opacity: float = 0.3,
+    plane_opacity: float = 0.5,
+) -> Any:
+    """Add a ground plane grid with shadow receiving to the viser scene.
+
+    :param server: The viser server instance.
+    :param entity_path: Scene-graph path for the grid node.
+    :param height: Position along the up axis for the ground plane.
+    :param up: The up axis — ``"y"`` for Y-up (glTF/FBX convention) or
+        ``"z"`` for Z-up (URDF/robotics convention).
+    :param width: Width and depth of the grid (in scene units).
+    :param cell_size: Size of each grid cell.
+    :param shadow_opacity: Shadow darkness (0 = none, 1 = black).
+    :param plane_opacity: Ground plane opacity (0 = transparent, 1 = opaque).
+    :return: A viser grid handle.
+    """
+    if up == "z":
+        plane = "xy"
+        position = (0.0, 0.0, height)
+    else:
+        plane = "xz"
+        position = (0.0, height, 0.0)
+
+    return server.scene.add_grid(
+        entity_path,
+        width=width,
+        height=width,
+        plane=plane,
+        cell_size=cell_size,
+        section_size=cell_size * 4,
+        position=position,
+        shadow_opacity=shadow_opacity,
+        plane_color=(255, 255, 255),
+        plane_opacity=plane_opacity,
+    )
+
+
+def update_mesh(
+    mesh_handle: Any,
+    wireframe_handle: Any | None,
+    mesh: Mesh,
+    *,
+    scale: float = CM_TO_M,
+) -> None:
+    """Update vertex positions of existing mesh handles.
+
+    :param mesh_handle: The solid mesh handle from :func:`add_mesh`.
+    :param wireframe_handle: The wireframe handle from :func:`add_mesh`.
+    :param mesh: The new posed mesh.
+    :param scale: Unit conversion factor.  Defaults to :data:`CM_TO_M`.
+    """
+    vertices = np.asarray(mesh.vertices, dtype=np.float32) * scale
+    mesh_handle.vertices = vertices
+    if wireframe_handle is not None:
+        wireframe_handle.vertices = vertices
+
+
+def _build_bone_segments(
+    character: Character,
+    skel_state: np.ndarray,
+    scale: float = 1.0,
+) -> np.ndarray | None:
+    """Build an (N, 2, 3) array of bone line segments from parent-child joints."""
+    joint_parents: list[int] = list(character.skeleton.joint_parents)
+    n_joints = len(joint_parents)
+    segments: list[list[np.ndarray]] = []
+    for i in range(n_joints):
+        parent_idx = joint_parents[i]
+        if 0 <= parent_idx < n_joints:
+            segments.append([skel_state[parent_idx, :3], skel_state[i, :3]])
+    if not segments:
+        return None
+    return np.array(segments, dtype=np.float32) * scale
+
+
+def add_joints(
+    server: viser.ViserServer,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    scale: float = CM_TO_M,
+    axes_length: float = 0.05,
+    axes_radius: float = 0.002,
+    bone_line_width: float = 4.0,
+    bone_color: tuple[int, int, int] = (180, 180, 180),
+) -> tuple[dict[str, Any], Any | None]:
+    """Add per-joint coordinate frames and bone lines to the viser scene.
+
+    Each joint is rendered as a small set of RGB axes at its world-space
+    position and orientation.  Parent-child joints are connected by grey
+    line segments.
+
+    :param server: The viser server instance.
+    :param entity_path: Base scene-graph path; joints are added as children.
+    :param character: The character whose skeleton is visualized.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)`` with
+        per-joint ``[tx, ty, tz, rx, ry, rz, rw, scale]``.
+    :param axes_length: Length of the axis indicators (in scene units).
+    :param axes_radius: Radius of the axis indicators.
+    :param bone_line_width: Width of the bone line segments.
+    :param bone_color: RGB color tuple for the bone lines.
+    :return: A tuple of (joint_handle_dict, bones_handle_or_None).
+    """
+    skeleton = character.skeleton
+    joint_names: list[str] = skeleton.joint_names
+    n_joints: int = len(joint_names)
+    handles: dict[str, Any] = {}
+
+    for i in range(n_joints):
+        name = joint_names[i]
+        pos = skel_state[i, :3].astype(np.float64) * scale
+        wxyz = _xyzw_to_wxyz(skel_state[i, 3:7])
+        handle = server.scene.add_frame(
+            f"{entity_path}/{name}",
+            position=pos,
+            wxyz=wxyz,
+            axes_length=axes_length,
+            axes_radius=axes_radius,
+        )
+        handles[name] = handle
+
+    # Add bone line segments connecting parent-child joints
+    bones_handle = None
+    segments = _build_bone_segments(character, skel_state, scale=scale)
+    if segments is not None:
+        bones_handle = server.scene.add_line_segments(
+            f"{entity_path}/bones",
+            points=segments,
+            colors=np.array(bone_color, dtype=np.uint8),
+            line_width=bone_line_width,
+        )
+
+    return handles, bones_handle
+
+
+def update_joints(
+    handles: dict[str, Any],
+    bones_handle: Any | None,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    scale: float = CM_TO_M,
+) -> None:
+    """Update joint frame positions, orientations, and bone lines.
+
+    :param handles: The joint handle dict returned by :func:`add_joints`.
+    :param bones_handle: The bones handle returned by :func:`add_joints`.
+    :param character: The character whose skeleton is being updated.
+    :param skel_state: New skeleton state array of shape ``(n_joints, 8)``.
+    :param scale: Unit conversion factor.  Defaults to :data:`CM_TO_M`.
+    """
+    joint_names: list[str] = character.skeleton.joint_names
+    for i, name in enumerate(joint_names):
+        handle = handles.get(name)
+        if handle is None:
+            continue
+        handle.position = skel_state[i, :3].astype(np.float64) * scale
+        handle.wxyz = _xyzw_to_wxyz(skel_state[i, 3:7])
+
+    if bones_handle is not None:
+        segments = _build_bone_segments(character, skel_state, scale=scale)
+        if segments is not None:
+            bones_handle.points = segments
+
+
+def add_character(
+    server: viser.ViserServer,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    posed_mesh: Mesh | None = None,
+    color: tuple[int, int, int] = (200, 200, 200),
+    scale: float = CM_TO_M,
+    axes_length: float = 0.05,
+    axes_radius: float = 0.002,
+) -> CharacterHandles:
+    """Add a complete character visualization to the viser scene.
+
+    Creates joint frames and optionally a mesh, returning handles for
+    subsequent updates via :func:`update_character`.
+
+    - ``{entity_path}/joints/{name}`` — per-joint coordinate frames
+    - ``{entity_path}/mesh`` — posed mesh (if *posed_mesh* is provided)
+
+    :param server: The viser server instance.
+    :param entity_path: Root scene-graph path for the character.
+    :param character: The character to visualize.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    :param posed_mesh: An optional pre-posed mesh.  If *None*, no mesh
+        is added.
+    :param color: RGB color tuple for the mesh.
+    :param axes_length: Length of joint axis indicators.
+    :param axes_radius: Radius of joint axis indicators.
+    :return: A :class:`CharacterHandles` for use with :func:`update_character`.
+    """
+    handles = CharacterHandles(entity_path=entity_path)
+
+    handles.joint_frames, handles.bones_handle = add_joints(
+        server,
+        f"{entity_path}/joints",
+        character,
+        skel_state,
+        scale=scale,
+        axes_length=axes_length,
+        axes_radius=axes_radius,
+    )
+
+    if posed_mesh is not None:
+        handles.mesh_handle, handles.wireframe_handle = add_mesh(
+            server, f"{entity_path}/mesh", posed_mesh, color=color, scale=scale
+        )
+
+    return handles
+
+
+def update_character(
+    server: viser.ViserServer,
+    handles: CharacterHandles,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    posed_mesh: Mesh | None = None,
+    scale: float = CM_TO_M,
+) -> None:
+    """Update all character transforms in a single atomic batch.
+
+    Wraps updates in ``server.atomic()`` to avoid partial-frame rendering
+    artifacts, following the pattern used in ``rl_robot``'s viser renderer.
+
+    :param server: The viser server instance.
+    :param handles: The handles returned by :func:`add_character`.
+    :param character: The character being updated.
+    :param skel_state: New skeleton state array of shape ``(n_joints, 8)``.
+    :param posed_mesh: If provided, updates mesh vertex positions.
+    :param scale: Unit conversion factor.  Defaults to :data:`CM_TO_M`.
+    """
+    with server.atomic():
+        update_joints(
+            handles.joint_frames,
+            handles.bones_handle,
+            character,
+            skel_state,
+            scale=scale,
+        )
+
+        if posed_mesh is not None and handles.mesh_handle is not None:
+            update_mesh(
+                handles.mesh_handle, handles.wireframe_handle, posed_mesh, scale=scale
+            )
+
+        server.flush()
+
+
+def remove_character(
+    handles: CharacterHandles,
+    server: viser.ViserServer | None = None,
+) -> None:
+    """Remove all character scene nodes from the viser scene.
+
+    :param handles: The handles returned by :func:`add_character`.
+    :param server: If provided, removes the entire scene subtree by name
+        (cleans up parent nodes from viser's scene tree).
+    """
+    if server is not None and handles.entity_path:
+        server.scene.remove_by_name(handles.entity_path)
+    else:
+        for handle in handles.joint_frames.values():
+            handle.remove()
+        if handles.bones_handle is not None:
+            handles.bones_handle.remove()
+        if handles.mesh_handle is not None:
+            handles.mesh_handle.remove()
+        if handles.wireframe_handle is not None:
+            handles.wireframe_handle.remove()
+
+    handles.joint_frames.clear()
+    handles.bones_handle = None
+    handles.mesh_handle = None
+    handles.wireframe_handle = None
+
+
+# =============================================================================
+# Optional GUI widget helpers
+# =============================================================================
+
+
+def _normalize_param_limit(name: str, lo: float, hi: float) -> tuple[float, float]:
+    """Clamp unbounded model-parameter limits to viewer-friendly slider ranges.
+
+    Translation parameters (``_tx``/``_ty``/``_tz`` in the name) are clamped to
+    ±200 cm; everything else is clamped to ±π radians.
+    """
+    if lo > -1e30 and hi < 1e30:
+        return lo, hi
+    if "_tx" in name or "_ty" in name or "_tz" in name:
+        return max(lo, -200.0), min(hi, 200.0)
+    return max(lo, -math.pi), min(hi, math.pi)
+
+
+def add_character_param_sliders(
+    server: viser.ViserServer,
+    character: Character,
+    *,
+    on_change: Callable[[Any], None] | None = None,
+    initial_values: np.ndarray | None = None,
+) -> list[Any]:
+    """Build one slider per model parameter of *character*.
+
+    Unbounded parameter limits are clamped via :func:`_normalize_param_limit` so
+    the sliders stay usable. The caller reads slider values from the returned
+    list (e.g. ``np.array([s.value for s in sliders])``) and converts them back
+    into model parameters.
+
+    :param server: The viser server instance.
+    :param character: The character whose model parameters drive the sliders.
+    :param on_change: Optional callback wired to every slider's
+        ``on_update`` event. The callback receives a single positional argument
+        (the viser event object), which it can ignore.
+    :param initial_values: Optional length-``n_params`` array of initial slider
+        values. Each value is clamped to its slider's range. If *None*, all
+        sliders start at 0 (or the closest in-range value).
+    :return: The list of slider handles, in parameter-index order.
+    """
+    param_names: list[str] = character.parameter_transform.names
+    min_limits, max_limits = character.model_parameter_limits
+    n_params = character.parameter_transform.size
+    sliders: list[Any] = []
+    for i in range(n_params):
+        lo, hi = _normalize_param_limit(
+            param_names[i], float(min_limits[i]), float(max_limits[i])
+        )
+        initial = 0.0 if initial_values is None else float(initial_values[i])
+        slider = server.gui.add_slider(
+            param_names[i],
+            min=lo,
+            max=hi,
+            step=(hi - lo) / 200.0,
+            initial_value=max(lo, min(hi, initial)),
+        )
+        if on_change is not None:
+            slider.on_update(on_change)
+        sliders.append(slider)
+    return sliders
+
+
+def add_wireframe_toggle(
+    server: viser.ViserServer,
+    handles: CharacterHandles,
+    *,
+    label: str = "Wireframe",
+    initial_value: bool = False,
+) -> Any:
+    """Add a checkbox that toggles between solid and wireframe for *handles*.
+
+    :func:`add_mesh` (and therefore :func:`add_character`) creates both a solid
+    and a wireframe handle; this widget flips their ``.visible`` flags so only
+    one is shown at a time. Sets initial visibility on both handles to match
+    *initial_value*.
+
+    :param server: The viser server instance.
+    :param handles: The character handles whose mesh/wireframe to toggle.
+    :param label: Checkbox label shown in the GUI.
+    :param initial_value: ``True`` shows the wireframe initially, ``False``
+        shows the solid mesh.
+    :return: The viser checkbox handle.
+    """
+    cb = server.gui.add_checkbox(label, initial_value=initial_value)
+    if handles.mesh_handle is not None:
+        handles.mesh_handle.visible = not initial_value
+    if handles.wireframe_handle is not None:
+        handles.wireframe_handle.visible = initial_value
+
+    @cb.on_update
+    def _(_: object) -> None:
+        if handles.mesh_handle is not None:
+            handles.mesh_handle.visible = not cb.value
+        if handles.wireframe_handle is not None:
+            handles.wireframe_handle.visible = cb.value
+
+    return cb
+
+
+class LogPanel:
+    """Scrollable HTML log strip created by :func:`add_log_panel`.
+
+    Call :meth:`log` to append a line. The panel keeps the last ``max_lines``
+    entries and auto-scrolls to the latest.
+    """
+
+    def __init__(
+        self,
+        html_handle: Any,
+        *,
+        height_px: int = 80,
+        max_lines: int = 50,
+        echo_to_stdout: bool = True,
+    ) -> None:
+        self._handle: Any = html_handle
+        self._height_px: int = height_px
+        self._max_lines: int = max_lines
+        self._echo: bool = echo_to_stdout
+        self._lines: list[str] = []
+
+    def log(self, msg: str, level: str = "info") -> None:
+        """Append a log line. *level* is one of ``"info"``, ``"warning"``, ``"error"``."""
+        icon = {"error": "🔴", "warning": "🟡"}.get(level, "🟢")
+        self._lines.append(f"{icon} {msg}")
+        body = "<br>".join(self._lines[-self._max_lines :])
+        self._handle.content = (
+            f'<div style="height:{self._height_px}px; overflow-y:auto; '
+            f"font-size:12px; padding:4px; background:#f8f8f8; "
+            f'border-radius:4px; border:1px solid #ddd;">{body}</div>'
+        )
+        if self._echo:
+            print(f"  [{level.upper()}] {msg}")
+
+
+def add_log_panel(
+    server: viser.ViserServer,
+    *,
+    height_px: int = 80,
+    max_lines: int = 50,
+    echo_to_stdout: bool = True,
+) -> LogPanel:
+    """Add a scrollable HTML log strip to the GUI and return its controller.
+
+    :param server: The viser server instance.
+    :param height_px: Fixed height of the log strip.
+    :param max_lines: Maximum number of lines retained on screen.
+    :param echo_to_stdout: If ``True`` (default), each ``log()`` call also
+        prints to ``stdout`` for terminal visibility.
+    :return: A :class:`LogPanel` whose ``.log(msg, level)`` method appends lines.
+    """
+    handle = server.gui.add_html("")
+    return LogPanel(
+        handle,
+        height_px=height_px,
+        max_lines=max_lines,
+        echo_to_stdout=echo_to_stdout,
+    )


### PR DESCRIPTION
Summary:

Add a pure Python module (`pymomentum.viser_vis`) that provides helper functions for visualizing momentum characters in a viser web viewer. This complements the existing `pymomentum.rerun_vis` module with a live-server alternative.

Unlike rerun (fire-and-forget recording), viser is a live server — you add geometry once and update transforms each frame. The API reflects this:
- `add_character()` → creates scene nodes, returns `CharacterHandles`
- `update_character()` → updates positions/orientations in an atomic batch
- `remove_character()` → cleans up scene nodes

Key design decisions:
- Uses wxyz quaternion format (viser convention), with automatic conversion from pymomentum's xyzw skel_state format
- Wraps updates in `server.atomic()` + `server.flush()` for flicker-free rendering, matching the rl_robot pattern
- `add_joints()` renders per-joint coordinate frames via `server.scene.add_frame()`
- `add_mesh()` uses `server.scene.add_mesh_simple()` with live vertex updates via handle property; pairs each mesh with a hidden wireframe handle so a wireframe toggle can flip between them without rebuilding geometry

Optional GUI widget helpers (for apps building interactive viewers on top of `viser_vis`):
- `add_character_param_sliders(server, character, *, on_change)` → builds one slider per model parameter, clamping unbounded limits to viewer-friendly ranges (±200 cm for translation params, ±π for rotation params)
- `add_wireframe_toggle(server, handles)` → checkbox that flips `mesh_handle.visible`/`wireframe_handle.visible` on a `CharacterHandles`, closing the loop on the wireframe handle that `add_mesh` already creates
- `add_log_panel(server)` → returns a `LogPanel` whose `.log(msg, level)` appends to a scrollable HTML strip in the GUI; supports info/warning/error levels with color-coded icons and stdout echo

These are opt-in — none of the core `add_*`/`update_*` functions depend on them.

Differential Revision: D100736502
