### PR TITLE
Add missing stream state checks after string reads and fix redundant expression

### DIFF
--- a/momentum/io/motion/mmo_io.cpp
+++ b/momentum/io/motion/mmo_io.cpp
@@ -294,7 +294,7 @@ std::tuple<MatrixXf, VectorXf, std::vector<std::string>, std::vector<std::string
   }
 
   // Guard against integer overflow in size calculations
-  if (nJoints != 0 && nJoints > std::numeric_limits<size_t>::max() / kParametersPerJoint) {
+  if (nJoints > std::numeric_limits<size_t>::max() / kParametersPerJoint) {
     MT_LOGW("{}: Integer overflow in scale size for file {}", __func__, filename);
     return result;
   }
@@ -315,6 +315,10 @@ std::tuple<MatrixXf, VectorXf, std::vector<std::string>, std::vector<std::string
     std::string name;
     name.resize(count);
     fs.read((char*)name.data(), count);
+    if (!fs.good()) {
+      MT_LOGW("{}: Failed to read parameter name data from file {}", __func__, filename);
+      return result;
+    }
     parameterNames.push_back(name);
   }
 
@@ -330,6 +334,10 @@ std::tuple<MatrixXf, VectorXf, std::vector<std::string>, std::vector<std::string
     std::string name;
     name.resize(count);
     fs.read((char*)name.data(), count);
+    if (!fs.good()) {
+      MT_LOGW("{}: Failed to read joint name data from file {}", __func__, filename);
+      return result;
+    }
     jointNames.push_back(name);
   }
 

--- a/momentum/io/shape/pose_shape_io.cpp
+++ b/momentum/io/shape/pose_shape_io.cpp
@@ -79,6 +79,10 @@ PoseShape loadPoseShape(const std::string& filename, const Character& character)
   std::string base;
   base.resize(count);
   data.read((char*)base.data(), count);
+  if (!data.good()) {
+    MT_LOGW("{}: Failed to read base joint name data from file {}", __func__, filename);
+    return result;
+  }
   result.baseJoint = character.skeleton.getJointIdByName(base);
   MT_CHECK(result.baseJoint != kInvalidIndex);
   MT_CHECK(
@@ -97,6 +101,10 @@ PoseShape loadPoseShape(const std::string& filename, const Character& character)
     }
     names[i].resize(count);
     data.read((char*)names[i].data(), count);
+    if (!data.good()) {
+      MT_LOGW("{}: Failed to read joint name data from file {}", __func__, filename);
+      return result;
+    }
   }
 
   // read mean shape

--- a/momentum/io/skeleton/mppca_io.cpp
+++ b/momentum/io/skeleton/mppca_io.cpp
@@ -82,6 +82,7 @@ std::shared_ptr<const Mppca> loadMppca(std::istream& inputStream) {
           "Error loading Mppca model: invalid name length.");
       result->names[i].resize(count);
       inputStream.read((char*)result->names[i].data(), count);
+      MT_THROW_IF(!inputStream.good(), "Error loading Mppca model: failed to read name data.");
     }
 
     // prepare data structures


### PR DESCRIPTION
Summary:
1. Fix misc-redundant-expression CLANGTIDY warning in mmo_io.cpp: removed redundant `nJoints != 0` check before overflow guard (the comparison `nJoints > X` already handles zero correctly for unsigned types).

2. Add missing `fs.good()` / `data.good()` / `inputStream.good()` checks after reading string content in all three parsers (mmo_io.cpp, pose_shape_io.cpp, mppca_io.cpp). Without these checks, a file truncated mid-string-read could produce partially uninitialized data that gets used before the next loop iteration detects the failure.

Differential Revision: D100931374


