### PR TITLE
Fix GitHub Pages deploy: use v4 token parameter name

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -102,6 +102,6 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # releases/v4
       with:
-          ACCESS_TOKEN: ${{ secrets.BYPASS_TOKEN }}
+          token: ${{ secrets.BYPASS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: momentum/website/build


### PR DESCRIPTION
Summary:
The publish_website workflow uses JamesIves/github-pages-deploy-action
v4 (pinned by commit hash), but passes the secret via ACCESS_TOKEN
which is the v3 parameter name. In v4, the parameter was renamed to
"token". This caused the BYPASS_TOKEN PAT to be silently ignored,
falling back to the default github.token with read-only permissions,
breaking deploys to gh-pages.

Fix: Rename ACCESS_TOKEN to token to match the v4 API.

Reviewed By: cstollmeta

Differential Revision: D101189428
