### PR TITLE
Remove 2 diagnostics in momentum:math_test_fast_math (#1309)

### DIFF
--- a/momentum/test/math/utility_test.cpp
+++ b/momentum/test/math/utility_test.cpp
@@ -25,19 +25,20 @@ TYPED_TEST_SUITE(UtilityTest, Types);
 TYPED_TEST(UtilityTest, IsNanNoOpt) {
   using T = typename TestFixture::Type;
 
+  const auto normalValue = static_cast<T>(42.0);
+  EXPECT_FALSE(std::isnan(normalValue));
+  EXPECT_FALSE(IsNanNoOpt(normalValue));
+
+#if !__FINITE_MATH_ONLY__
   const T nanValue = std::numeric_limits<T>::quiet_NaN();
   const T infValue = std::numeric_limits<T>::infinity();
-  const auto normalValue = static_cast<T>(42.0);
 
-#ifndef MOMENTUM_TEST_FAST_MATH
   EXPECT_TRUE(std::isnan(nanValue));
-#endif
   EXPECT_FALSE(std::isnan(infValue));
-  EXPECT_FALSE(std::isnan(normalValue));
 
   EXPECT_TRUE(IsNanNoOpt(nanValue));
   EXPECT_FALSE(IsNanNoOpt(infValue));
-  EXPECT_FALSE(IsNanNoOpt(normalValue));
+#endif
 }
 
 TYPED_TEST(UtilityTest, AllParams) {


### PR DESCRIPTION
Summary:

The `math_test_fast_math` target compiles with `-ffinite-math-only`, which makes uses of `std::numeric_limits<T>::infinity()` and `std::numeric_limits<T>::quiet_NaN()` undefined behavior. The `IsNanNoOpt` test was creating NaN and infinity values unconditionally, triggering `-Wnan-infinity-disabled` errors.

Guard the NaN and infinity value creation and their associated assertions with `#if !__FINITE_MATH_ONLY__`, so they are only compiled when the compiler allows non-finite math. The normal-value assertions remain unconditional.

Differential Revision: D101388680


