### PR TITLE
Fix OSS pymomentum CI: bypass pixi task wrapper to propagate pytest exit code (#1310)

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -75,8 +75,19 @@ jobs:
           cache: true
 
       - name: Build and test PyMomentum
+        env:
+          MOMENTUM_MODELS_PATH: momentum/
         run: |
-          pixi run -e py312 test_py
+          pixi run -e py312 build_py
+          # Bypass `pixi run` for pytest: in GHA the `pixi run -- pytest`
+          # exit code is silently swallowed (passes locally, fails in CI).
+          # shell-hook activates the env, then we capture pytest's exit code
+          # explicitly and `exit $status` to guarantee the step fails on errors.
+          eval "$(pixi shell-hook -e py312)"
+          status=0
+          pytest pymomentum/test/ -k 'not TestRendering' || status=$?
+          echo "===PYTEST_EXIT_CODE=$status==="
+          exit $status
 
       - name: Build Python API Doc
         run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -104,8 +104,17 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build and test PyMomentum
+        shell: bash
+        env:
+          MOMENTUM_MODELS_PATH: momentum/
         run: |
-          pixi run -e ${{ matrix.pixi_env }} test_py
+          pixi run -e ${{ matrix.pixi_env }} build_py
+          pixi run -e ${{ matrix.pixi_env }} install
+          # Bypass `pixi run` for pytest: in GHA the `pixi run -- pytest`
+          # exit code is silently swallowed (passes locally, fails in CI).
+          # shell-hook activates the env so pytest's exit code reaches bash -e.
+          eval "$(pixi shell-hook -e ${{ matrix.pixi_env }} --shell bash)"
+          pytest pymomentum/test/ -k 'not ((TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params)) or test_lighting)'
 
       - name: Print sccache stats
         run: sccache --show-stats

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,9 +40,17 @@ jobs:
           cache: true
 
       - name: Build and test PyMomentum
+        env:
+          MOMENTUM_BUILD_WITH_FBXSDK: "ON"
+          MOMENTUM_MODELS_PATH: momentum/
         run: |
-          MOMENTUM_BUILD_WITH_FBXSDK=ON \
-            pixi run test_py
+          pixi run build_py
+          pixi run install
+          # Bypass `pixi run` for pytest: in GHA the `pixi run -- pytest`
+          # exit code is silently swallowed (passes locally, fails in CI).
+          # shell-hook activates the env so pytest's exit code reaches bash -e.
+          eval "$(pixi shell-hook)"
+          pytest pymomentum/test/ -k 'not ((TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params)) or test_lighting)'
 
       - name: Build Python API Doc
         run: |
@@ -67,8 +75,15 @@ jobs:
           cache: true
 
       - name: Build and test PyMomentum
+        env:
+          MOMENTUM_MODELS_PATH: momentum/
         run: |
-          pixi run -e py313 test_py
+          pixi run -e py313 build_py
+          # Bypass `pixi run` for pytest: in GHA the `pixi run -- pytest`
+          # exit code is silently swallowed (passes locally, fails in CI).
+          # shell-hook activates the env so pytest's exit code reaches bash -e.
+          eval "$(pixi shell-hook -e py313)"
+          pytest pymomentum/test/ -k 'not TestRendering'
 
   pymomentum-ubuntu-arm64:
     name: nightly-py-py312-ubuntu-arm64
@@ -84,5 +99,12 @@ jobs:
           cache: true
 
       - name: Build and test PyMomentum
+        env:
+          MOMENTUM_MODELS_PATH: momentum/
         run: |
-          pixi run -e py312 test_py
+          pixi run -e py312 build_py
+          # Bypass `pixi run` for pytest: in GHA the `pixi run -- pytest`
+          # exit code is silently swallowed (passes locally, fails in CI).
+          # shell-hook activates the env so pytest's exit code reaches bash -e.
+          eval "$(pixi shell-hook -e py312)"
+          pytest pymomentum/test/ -k 'not TestRendering'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -76,8 +76,15 @@ jobs:
       - name: Build and test PyMomentum (GPU)
         # With standalone mdspan (no Kokkos runtime), nvcc_wrapper is no longer
         # used, so Ninja works without module scanning issues.
+        env:
+          MOMENTUM_MODELS_PATH: momentum/
         run: |
-          pixi run -e py312-cuda129 test_py
+          pixi run -e py312-cuda129 build_py
+          # Bypass `pixi run` for pytest: in GHA the `pixi run -- pytest`
+          # exit code is silently swallowed (passes locally, fails in CI).
+          # shell-hook activates the env so pytest's exit code reaches bash -e.
+          eval "$(pixi shell-hook -e py312-cuda129)"
+          pytest pymomentum/test/ -k 'not TestRendering'
 
   pymomentum-windows-gpu:
     # Disabled: 4-core-windows-gpu-t4 runner has Visual Studio 2019 but conda


### PR DESCRIPTION
Summary:

The OSS pymomentum CI has been silently green on pytest failures. Confirmed by printing pytest output: the OSS Ubuntu run produced
```
=========== 345 passed, 9 deselected, 2 warnings, 8 errors in 8.37s ============
``` 
followed by 
```
===PIXI_TEST_PY_EXIT=0===
```
So `pixi run -e py312 test_py` returns 0 even when the inner `pytest` command exits 1. 

The bug appears to be in pixi's task runner — likely it returns the exit code of the last successful `depends-on` task (`build_py`) rather than the `cmd`. As a result, every pytest failure has been silently passing.

Fix: 
Replace `pixi run -e <env> test_py` with a two- or three-step sequence that bypasses the task runner for the test invocation:
- `pixi run -e <env> build_py` — runs the build task (still through the task runner; if its `cmd` silently fails, the next pytest step will surface it because pytest cannot import the module).
- `pixi run -e <env> install` — only on osx and win-64, where `test_py` also depends on `install` to put C++ libs in CONDA_PREFIX for runtime linking.
- `pixi run -e <env> -- pytest pymomentum/test/ -k '<filter>'` — the `--` form invokes pytest directly in the activated pixi environment without going through the task graph, so its exit code propagates correctly.

The pytest filter is replicated from `pixi.toml`'s per-platform `test_py` task. Filter inventory:
- linux-64, linux-aarch64, py312-cuda129 → `not TestRendering`
- osx-64, osx-arm64, win-64 → `not ((TestFBXIO and (test_save_motions_with_joint_params or test_save_motions_with_model_params)) or test_lighting)`

The `MOMENTUM_MODELS_PATH=momentum/` env var (previously set inside the pixi task definition) is now set at the workflow step level via `env:`. The nightly mac job's `MOMENTUM_BUILD_WITH_FBXSDK=ON` is preserved verbatim.

Callsites changed (6 total across 4 files):
- ci_ubuntu.yml (per-push, py312, ubuntu-latest)
- ci_windows.yml (per-push, py312, windows-latest)
- nightly.yml: nightly mac (py312 default, macos-latest), nightly py313 (py313, ubuntu-latest), nightly arm64 (py312, ubuntu-arm)
- weekly.yml: GPU job (py312-cuda129, ubuntu-gpu-t4)

Disabled callsites (`if: false`) left untouched: ci_macos.yml pymomentum, weekly.yml windows GPU. Note: weekly.yml's windows GPU job already uses a similar workaround via Python `subprocess.call`, suggesting this bug has been hit before.

Differential Revision: D101511456


