### PR TITLE
Fix pytest exit code masking by atexit handler in test files

### DIFF
--- a/pymomentum/test/test_marker_tracking.py
+++ b/pymomentum/test/test_marker_tracking.py
@@ -5,17 +5,15 @@
 
 # pyre-strict
 
-import atexit
-import os
 import unittest
 
 import numpy as np
 
-# Work around glibc ptmalloc2 arena teardown false-positive in platform010/dev
-# shared-linking mode: glibc's free() validation rejects a pointer during C++
-# static destruction that ASAN confirms is not actual memory corruption.
-# os._exit() skips C++ static destruction; test results are already reported.
-atexit.register(os._exit, 0)
+# Note: an atexit.register(os._exit, 0) workaround previously lived here to
+# suppress a glibc ptmalloc2 false-positive specific to the platform010/dev
+# shared-linking mode. It was removed because (a) pymomentum builds use
+# @fbcode//mode/opt rather than platform010/dev, and (b) the workaround
+# silently masked pytest's non-zero exit codes on the OSS GitHub CI path.
 import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.marker_tracking as pym_marker_tracking  # @manual=:marker_tracking

--- a/pymomentum/test/test_process_markers.py
+++ b/pymomentum/test/test_process_markers.py
@@ -5,19 +5,17 @@
 
 # pyre-strict
 
-import atexit
 import math
-import os
 import tempfile
 import unittest
 
 import numpy as np
 
-# Work around glibc ptmalloc2 arena teardown false-positive in platform010/dev
-# shared-linking mode: glibc's free() validation rejects a pointer during C++
-# static destruction that ASAN confirms is not actual memory corruption.
-# os._exit() skips C++ static destruction; test results are already reported.
-atexit.register(os._exit, 0)
+# Note: an atexit.register(os._exit, 0) workaround previously lived here to
+# suppress a glibc ptmalloc2 false-positive specific to the platform010/dev
+# shared-linking mode. It was removed because (a) pymomentum builds use
+# @fbcode//mode/opt rather than platform010/dev, and (b) the workaround
+# silently masked pytest's non-zero exit codes on the OSS GitHub CI path.
 import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 from pymomentum.marker_tracking import (  # @manual=:marker_tracking


### PR DESCRIPTION
Summary:
Three test files (`test/test_marker_tracking.py`, `test/test_process_markers.py`, `test/test_marker_tracking_metrics.py`) registered `atexit.register(os._exit, 0)` at module scope. This installs `os._exit(0)` as a Python shutdown handler, which unconditionally forces exit code 0 during process termination. When pytest calls `sys.exit(1)` after detecting test failures, Python's shutdown sequence runs the atexit handler, which calls `os._exit(0)` and terminates with code 0 — overriding pytest's failure exit code.

The result is that failing tests in any of these three modules report success on CI, hiding regressions.

This change:
- Removes `atexit.register(os._exit, 0)` and the now-unused `import atexit` / `import os` from all three files.
- Leaves a short comment in each file recording the historical context, so the workaround is not silently re-added later. If the underlying false-positive recurs, the right fix is to address the false-positive directly, not to mask exit codes.

Differential Revision: D101551752


