### PR TITLE
Unify fast-math test guards and restore IsNanNoOpt coverage

### DIFF
--- a/momentum/test/math/random_test.cpp
+++ b/momentum/test/math/random_test.cpp
@@ -117,7 +117,7 @@ void testUniformDynamicMatrixScalarBounds(int rows, int cols, Scalar min, Scalar
       << "type: " << typeid(T).name() << "\nrand: " << rand.transpose() << "\nmin: " << min
       << "\nmax: " << max;
   if constexpr (std::is_floating_point_v<Scalar>) {
-#if defined(MOMENTUM_TEST_FAST_MATH)
+#if __FINITE_MATH_ONLY__
     EXPECT_TRUE((rand.array() <= max).all())
         << "type: " << typeid(T).name() << "\nrand: " << rand.transpose() << "\nmin: " << min
         << "\nmax: " << max;
@@ -141,7 +141,7 @@ void testUniformDynamicVectorScalarBounds(int size, Scalar min, Scalar max) {
       << "type: " << typeid(T).name() << "\nrand: " << rand.transpose() << "\nmin: " << min
       << "\nmax: " << max;
   if constexpr (std::is_floating_point_v<Scalar>) {
-#if defined(MOMENTUM_TEST_FAST_MATH)
+#if __FINITE_MATH_ONLY__
     EXPECT_TRUE((rand.array() <= max).all())
         << "type: " << typeid(T).name() << "\nrand: " << rand.transpose() << "\nmin: " << min
         << "\nmax: " << max;

--- a/momentum/test/math/utility_test.cpp
+++ b/momentum/test/math/utility_test.cpp
@@ -11,6 +11,9 @@
 
 #include <gtest/gtest.h>
 
+#include <bit>
+#include <cstdint>
+
 using namespace momentum;
 
 using Types = testing::Types<float, double>;
@@ -29,15 +32,28 @@ TYPED_TEST(UtilityTest, IsNanNoOpt) {
   EXPECT_FALSE(std::isnan(normalValue));
   EXPECT_FALSE(IsNanNoOpt(normalValue));
 
-#if !__FINITE_MATH_ONLY__
-  const T nanValue = std::numeric_limits<T>::quiet_NaN();
-  const T infValue = std::numeric_limits<T>::infinity();
-
-  EXPECT_TRUE(std::isnan(nanValue));
-  EXPECT_FALSE(std::isnan(infValue));
+  // Construct NaN/Inf via bit-cast to avoid -Wnan-infinity-disabled under
+  // -ffinite-math-only. IsNanNoOpt's whole purpose is to detect NaN even when
+  // fast-math elides std::isnan, so its assertions must run unconditionally —
+  // otherwise the function's no-opt contract is untested in the fast-math build.
+  T nanValue;
+  T infValue;
+  if constexpr (std::is_same_v<T, float>) {
+    nanValue = std::bit_cast<float>(std::uint32_t{0x7fc00000});
+    infValue = std::bit_cast<float>(std::uint32_t{0x7f800000});
+  } else {
+    static_assert(std::is_same_v<T, double>);
+    nanValue = std::bit_cast<double>(std::uint64_t{0x7ff8000000000000});
+    infValue = std::bit_cast<double>(std::uint64_t{0x7ff0000000000000});
+  }
 
   EXPECT_TRUE(IsNanNoOpt(nanValue));
   EXPECT_FALSE(IsNanNoOpt(infValue));
+
+#if !__FINITE_MATH_ONLY__
+  // std::isnan is unreliable under -ffinite-math-only.
+  EXPECT_TRUE(std::isnan(nanValue));
+  EXPECT_FALSE(std::isnan(infValue));
 #endif
 }
 


### PR DESCRIPTION
Summary:
**1. Single idiom for fast-math conditionals.**

D101388680 switched `utility_test.cpp` from the project-defined `MOMENTUM_TEST_FAST_MATH` macro to the compiler-defined `__FINITE_MATH_ONLY__`. That left the codebase with two idioms — `random_test.cpp` still keyed off `MOMENTUM_TEST_FAST_MATH`, which was set by `-DMOMENTUM_TEST_FAST_MATH` only on the `math_test_fast_math` BUCK target.

`__FINITE_MATH_ONLY__` is the more direct check: it is auto-defined by GCC/Clang whenever `-ffinite-math-only` is in effect, which is the actual condition that makes `std::numeric_limits<T>::quiet_NaN()` and `infinity()` undefined behavior and triggers `-Wnan-infinity-disabled`. It also works in any build (BUCK or CMake) without needing to mirror a `-D` define.

**2. Restore IsNanNoOpt coverage under fast-math in `utility_test.cpp`.**

`IsNanNoOpt` exists specifically to detect NaN even when `-ffinite-math-only` causes the compiler to elide `std::isnan`. D101388680 silently dropped the `EXPECT_TRUE(IsNanNoOpt(nanValue))` and `EXPECT_FALSE(IsNanNoOpt(infValue))` assertions under fast-math because the values couldn't be constructed via `std::numeric_limits<T>::quiet_NaN()` / `infinity()` without triggering `-Wnan-infinity-disabled`. That left the function's no-opt contract unverified in exactly the build mode it's designed for.

Reviewed By: drodriguez

Differential Revision: D101502945


