### PR TITLE
Add half-plane (above) flag to SimdPlaneErrorFunction for parity

### DIFF
--- a/momentum/character_solver_simd/simd_plane_error_function.cpp
+++ b/momentum/character_solver_simd/simd_plane_error_function.cpp
@@ -103,13 +103,17 @@ void SimdPlaneConstraints::clearConstraints() {
 SimdPlaneErrorFunction::SimdPlaneErrorFunction(
     const Skeleton& skel,
     const ParameterTransform& pt,
+    bool above,
     uint32_t maxThreads)
-    : SkeletonErrorFunction(skel, pt), maxThreads_(maxThreads) {
+    : SkeletonErrorFunction(skel, pt), above_(above), maxThreads_(maxThreads) {
   constraints_ = nullptr;
 }
 
-SimdPlaneErrorFunction::SimdPlaneErrorFunction(const Character& character, uint32_t maxThreads)
-    : SimdPlaneErrorFunction(character.skeleton, character.parameterTransform, maxThreads) {
+SimdPlaneErrorFunction::SimdPlaneErrorFunction(
+    const Character& character,
+    bool above,
+    uint32_t maxThreads)
+    : SimdPlaneErrorFunction(character.skeleton, character.parameterTransform, above, maxThreads) {
   // Do nothing
 }
 
@@ -152,10 +156,15 @@ double SimdPlaneErrorFunction::getError(
       const auto target = drjit::load<FloatP>(&constraints_->targets[constraintOffsetIndex]);
       const FloatP dist = dot(pos_world, normal_world) - target;
 
-      // Calculate error as squared distance: err = constraintWeight * dist * dist
+      // For half-plane (above_=true), mask out constraints whose point lies above the plane
+      // (dist > 0); only points at-or-below the plane contribute.
+      const FloatP mask =
+          above_ ? drjit::select(dist > 0.0f, FloatP(0.0f), FloatP(1.0f)) : FloatP(1.0f);
+
+      // Calculate error as squared distance: err = constraintWeight * dist * dist * mask
       const auto constraintWeight =
           drjit::load<FloatP>(&constraints_->weights[constraintOffsetIndex]);
-      error += constraintWeight * drjit::square(dist);
+      error += constraintWeight * drjit::square(dist) * mask;
     }
   }
 
@@ -215,14 +224,20 @@ double SimdPlaneErrorFunction::getGradient(
           const auto target = drjit::load<FloatP>(&constraints_->targets[constraintOffsetIndex]);
           const FloatP dist = dot(pos_world, normal_world) - target;
 
-          // Calculate error as squared distance: err = constraintWeight * dist * dist
+          // For half-plane (above_=true), mask out constraints whose point lies above the plane
+          // (dist > 0); only points at-or-below the plane contribute.
+          const FloatP mask =
+              above_ ? drjit::select(dist > 0.0f, FloatP(0.0f), FloatP(1.0f)) : FloatP(1.0f);
+
+          // Calculate error as squared distance: err = constraintWeight * dist * dist * mask
           const auto constraintWeight =
               drjit::load<FloatP>(&constraints_->weights[constraintOffsetIndex]);
-          jointError += constraintWeight * drjit::square(dist);
+          jointError += constraintWeight * drjit::square(dist) * mask;
 
           // Pre-calculate values for the gradient: wgt = 2.0 * kPlaneWeight * constraintWeight *
-          // dist
-          const FloatP wgt = 2.0f * kPlaneWeight * constraintWeight * dist;
+          // dist * mask. Multiplying by mask zeroes the gradient contribution when the half-plane
+          // constraint is inactive (point above the plane).
+          const FloatP wgt = 2.0f * kPlaneWeight * constraintWeight * dist * mask;
 
           // Loop over all joints the constraint is attached to and calculate gradient
           size_t jointIndex = jointId;
@@ -368,13 +383,20 @@ double SimdPlaneErrorFunction::getJacobian(
           const auto target = drjit::load<FloatP>(&constraints_->targets[constraintOffsetIndex]);
           const FloatP dist = dot(pos_world, normal_world) - target;
 
-          // Calculate error as squared distance: err = constraintWeight * dist * dist
+          // For half-plane (above_=true), mask out constraints whose point lies above the plane
+          // (dist > 0); only points at-or-below the plane contribute.
+          const FloatP mask =
+              above_ ? drjit::select(dist > 0.0f, FloatP(0.0f), FloatP(1.0f)) : FloatP(1.0f);
+
+          // Calculate error as squared distance: err = constraintWeight * dist * dist * mask
           const auto constraintWeight =
               drjit::load<FloatP>(&constraints_->weights[constraintOffsetIndex]);
-          jointError += constraintWeight * drjit::square(dist);
+          jointError += constraintWeight * drjit::square(dist) * mask;
 
           // Calculate square-root of weight: wgt = sqrt(kPlaneWeight * weight * constraintWeight)
-          const FloatP wgt = drjit::sqrt(kPlaneWeight * weight_ * constraintWeight);
+          // and apply the half-plane mask so both the residual (dist * wgt) and the Jacobian rows
+          // (geometric_d * wgt) are zeroed for inactive half-plane constraints.
+          const FloatP wgt = drjit::sqrt(kPlaneWeight * weight_ * constraintWeight) * mask;
 
           // Calculate residual: res = wgt * dist
           drjit::store(residual.segment(jacobianOffsetCur, kSimdPacketSize).data(), dist * wgt);

--- a/momentum/character_solver_simd/simd_plane_error_function.h
+++ b/momentum/character_solver_simd/simd_plane_error_function.h
@@ -69,11 +69,18 @@ struct SimdPlaneConstraints final {
 /// This function is recommended for use only when dealing with a large number of constraints. For a
 /// smaller number of constraints, consider using the generic PlaneErrorFunction.
 ///
+/// When `above` is true (half-plane mode), constraints contribute zero error/gradient/Jacobian
+/// whenever the constrained point lies above the plane (signed distance > 0). This matches the
+/// scalar `PlaneErrorFunctionT` half-plane semantics.
+///
 /// @warning Due to the multi-threaded evaluation of the error/gradient, the functions are
 /// non-deterministic. This might lead to numerical inconsistencies, resulting in slightly different
 /// outcomes on multiple calls with the same data.
 class SimdPlaneErrorFunction : public SkeletonErrorFunction {
  public:
+  /// @param above If true, this is a half-plane (inequality) constraint: only points at-or-below
+  /// the plane (signed distance <= 0) contribute. If false (default), this is a point-on-plane
+  /// (equality) constraint and all constraints contribute.
   /// @param maxThreads An optional parameter that specifies the maximum number of threads to be
   /// used with dispenso::parallel_for. If this parameter is set to zero, the function will run in
   /// serial mode, i.e., it will not use any additional threads. By default, the value is set to the
@@ -81,14 +88,19 @@ class SimdPlaneErrorFunction : public SkeletonErrorFunction {
   explicit SimdPlaneErrorFunction(
       const Skeleton& skel,
       const ParameterTransform& pt,
+      bool above = false,
       uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
+  /// @param above If true, this is a half-plane (inequality) constraint: only points at-or-below
+  /// the plane (signed distance <= 0) contribute. If false (default), this is a point-on-plane
+  /// (equality) constraint and all constraints contribute.
   /// @param maxThreads An optional parameter that specifies the maximum number of threads to be
   /// used with dispenso::parallel_for. If this parameter is set to zero, the function will run in
   /// serial mode, i.e., it will not use any additional threads. By default, the value is set to the
   /// maximum allowable size of a uint32_t, which is also the default for dispenso.
   explicit SimdPlaneErrorFunction(
       const Character& character,
+      bool above = false,
       uint32_t maxThreads = std::numeric_limits<uint32_t>::max());
 
   [[nodiscard]] double getError(
@@ -122,6 +134,10 @@ class SimdPlaneErrorFunction : public SkeletonErrorFunction {
 
   // constraints to use
   const SimdPlaneConstraints* constraints_;
+
+  /// True for an inequality "above the plane" constraint; false for an equality "on the plane"
+  /// constraint. Mirrors `PlaneErrorFunctionT::halfPlane_` semantics.
+  bool above_;
 
   uint32_t maxThreads_;
 };

--- a/momentum/test/character_solver_simd/simd_plane_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_plane_error_function_test.cpp
@@ -23,9 +23,14 @@
 
 using namespace momentum;
 
-// TODO: Test for double once we have SIMD implementation for double
-TEST(Momentum_ErrorFunctions, SimdPlaneFunctionIsSame) {
-  // create skeleton and reference values
+namespace {
+
+// Compares SimdPlaneErrorFunction against the scalar PlaneErrorFunction across
+// the full constraint-count sweep. Parameterized over the half-plane flag so the same
+// sweep covers both equality (point-on-plane) and inequality (point-above-plane)
+// formulations and verifies the half-plane mask zeroes-out above-the-plane constraints
+// identically to the scalar reference.
+void runSimdPlaneEquivalenceSweep(bool above) {
   const Character character = createTestCharacter();
   const Skeleton& skeleton = character.skeleton;
   const ParameterTransform& transform = character.parameterTransform;
@@ -47,13 +52,15 @@ TEST(Momentum_ErrorFunctions, SimdPlaneFunctionIsSame) {
     const auto parameters = uniform<VectorXf>(transform.numAllModelParameters(), -0.5, 0.5);
 
     std::vector<PlaneData> cl;
-    PlaneErrorFunction errorFunction(skeleton, transform);
+    PlaneErrorFunction errorFunction(skeleton, transform, above);
     errorFunction.setWeight(PlaneErrorFunction::kLegacyWeight);
     for (size_t iCons = 0; iCons < nConstraints; ++iCons) {
+      // Sample d in a range that straddles the joint origin so a healthy mix of
+      // active/inactive constraints exists in half-plane mode.
       cl.emplace_back(
           uniform<Vector3f>(0, 1),
           uniform<Vector3f>(0, 1).normalized(),
-          uniform<float>(0, 1),
+          uniform<float>(-1, 1),
           2,
           uniform<float>(0, 1));
     }
@@ -63,7 +70,7 @@ TEST(Momentum_ErrorFunctions, SimdPlaneFunctionIsSame) {
     for (const auto& c : cl) {
       cl_simd.addConstraint(c.parent, c.offset, c.normal, c.d, c.weight);
     }
-    SimdPlaneErrorFunction errorFunction_simd(skeleton, transform);
+    SimdPlaneErrorFunction errorFunction_simd(skeleton, transform, above);
     errorFunction_simd.setConstraints(&cl_simd);
 
     // TODO: the result difference between SimdPlaneError and PlaneError is larger than that with
@@ -72,4 +79,15 @@ TEST(Momentum_ErrorFunctions, SimdPlaneFunctionIsSame) {
         float, errorFunction, errorFunction_simd, skeleton, transform, parameters, 0.1f, 5e-1f);
     timeJacobian(character, errorFunction_simd, parameters, "SimdPlaneErrorFunction");
   }
+}
+
+} // namespace
+
+// TODO: Test for double once we have SIMD implementation for double
+TEST(Momentum_ErrorFunctions, SimdPlaneFunctionIsSame) {
+  runSimdPlaneEquivalenceSweep(/*above=*/false);
+}
+
+TEST(Momentum_ErrorFunctions, SimdPlaneFunctionHalfPlaneIsSame) {
+  runSimdPlaneEquivalenceSweep(/*above=*/true);
 }


### PR DESCRIPTION
Summary:
This diff adds an `above` constructor parameter that mirrors
`PlaneErrorFunctionT::halfPlane_`. When `above_=true`, a per-packet DrJit mask
`drjit::select(dist > 0, 0, 1)` is computed and multiplied through the error,
gradient, and Jacobian contributions. Constraints whose constrained point lies
above the plane (signed distance > 0) thus contribute zero error/gradient and
zero Jacobian rows, matching the scalar half-plane semantics. The default
`above=false` preserves the existing point-on-plane behaviour for current
callers.

The benchmark in `benchmark/character_solver_simd/simd_constraints_benchmark.cpp`
previously passed `static_cast<uint32_t>(state.range(0))` as the third
positional argument to `SimdPlaneErrorFunction(skel, pt, maxThreads)`. Because
the new `above` parameter sits before `maxThreads`, the call is updated to pass
`above=false` explicitly.

The existing equivalence test is refactored into a parameterized helper run
twice — once with `above=false` and once with `above=true` — so the half-plane
mask is verified to produce numerically-identical error/gradient/Jacobian
values to the scalar `PlaneErrorFunction(above=true)` reference across the full
constraint-count sweep (0, 1, packet boundaries up to 100). The constraint
plane offset is sampled in `[-1, 1]` (was `[0, 1]`) so a healthy mix of
active and inactive half-plane constraints exists in each test iteration.

Differential Revision: D101694946


