### PR TITLE
Fix GitHub Pages deploy permissions in publish_website workflow

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -25,6 +25,8 @@ concurrency:
 jobs:
   build_docs_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     # 0) Check out the repository
@@ -102,6 +104,6 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # releases/v4
       with:
-          token: ${{ secrets.BYPASS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: momentum/website/build


### PR DESCRIPTION
Summary:
The website publish workflow was using a custom `BYPASS_TOKEN` secret to push
to the `gh-pages` branch, which was causing deploy failures (it may have expired, and it's tie to a particular user).

Switch to the standard `GITHUB_TOKEN` and grant the `build_docs_job` the
`contents: write` permission needed for the push. The top-level workflow
retains `contents: read` (least privilege); only the deploy job is granted
write access.

The deploy step is already gated on `push` events to `refs/heads/main`, so
pull requests (including from forks, where `GITHUB_TOKEN` is read-only
regardless) are unaffected.

Differential Revision: D101738364


