### PR TITLE
Add bytes-based marker loaders

### DIFF
--- a/momentum/io/common/stream_utils.cpp
+++ b/momentum/io/common/stream_utils.cpp
@@ -30,6 +30,47 @@ std::streamsize spanstreambuf::xsputn(
   MT_THROW("spanstreambuf is not writable.");
 }
 
+spanstreambuf::pos_type
+spanstreambuf::seekoff(off_type off, std::ios_base::seekdir way, std::ios_base::openmode which) {
+  if ((which & std::ios_base::in) == 0) {
+    return {off_type(-1)};
+  }
+  char* const beg = eback();
+  char* const cur = gptr();
+  char* const end = egptr();
+  if (beg == nullptr) {
+    // Empty buffer -- only seeking to position 0 is valid.
+    return (off == 0) ? pos_type(0) : pos_type(off_type(-1));
+  }
+  off_type base = 0;
+  // libstdc++ adds the implementation-detail sentinel `_S_ios_seekdir_end` to
+  // the seekdir enum; the `default:` branch handles it (and any future
+  // additions) safely.
+  switch (way) { // NOLINT(clang-diagnostic-switch-enum)
+    case std::ios_base::beg:
+      base = 0;
+      break;
+    case std::ios_base::cur:
+      base = cur - beg;
+      break;
+    case std::ios_base::end:
+      base = end - beg;
+      break;
+    default:
+      return {off_type(-1)};
+  }
+  const off_type target = base + off;
+  if (target < 0 || target > (end - beg)) {
+    return {off_type(-1)};
+  }
+  setg(beg, beg + target, end);
+  return {target};
+}
+
+spanstreambuf::pos_type spanstreambuf::seekpos(pos_type pos, std::ios_base::openmode which) {
+  return seekoff(off_type(pos), std::ios_base::beg, which);
+}
+
 ispanstream::ispanstream(std::span<const std::byte> buffer) : std::istream(&sbuf_), sbuf_(buffer) {
   // Empty
 }

--- a/momentum/io/common/stream_utils.h
+++ b/momentum/io/common/stream_utils.h
@@ -40,6 +40,16 @@ struct spanstreambuf : std::streambuf {
   /// @param n The number of characters to write.
   /// @return The number of characters successfully written.
   std::streamsize xsputn(const char_type* s, std::streamsize n) override;
+
+  /// Seek to an offset relative to ``way`` (begin/cur/end). Required for callers that
+  /// need random access (e.g., binary parsers like ezc3d that use seekg/tellg).
+  pos_type seekoff(
+      off_type off,
+      std::ios_base::seekdir way,
+      std::ios_base::openmode which = std::ios_base::in) override;
+
+  /// Seek to an absolute position from the start of the buffer.
+  pos_type seekpos(pos_type pos, std::ios_base::openmode which = std::ios_base::in) override;
 };
 
 /// istream that takes a span of const bytes as input.

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -1053,6 +1053,10 @@ MarkerSequence loadFbxMarkerSequence(const filesystem::path& filename, bool stri
   return loadOpenFbxMarkerSequence(filename, stripNamespaces);
 }
 
+MarkerSequence loadFbxMarkerSequence(std::span<const std::byte> inputSpan, bool stripNamespaces) {
+  return loadOpenFbxMarkerSequence(inputSpan, stripNamespaces);
+}
+
 #ifdef MOMENTUM_WITH_FBX_SDK
 
 void saveFbx(

--- a/momentum/io/fbx/fbx_io.h
+++ b/momentum/io/fbx/fbx_io.h
@@ -158,4 +158,16 @@ MatrixXf loadFbxBlendShapeWeights(const filesystem::path& filename);
 ///         markers or animations are found.
 MarkerSequence loadFbxMarkerSequence(const filesystem::path& filename, bool stripNamespaces = true);
 
+/// Loads a MarkerSequence from an in-memory FBX byte buffer.
+///
+/// Same semantics as the filename overload. Uses OpenFBX, which natively accepts a byte
+/// buffer, so this is true zero-copy.
+///
+/// @param[in] inputSpan Buffer holding the FBX file contents.
+/// @param stripNamespaces Removes namespace from joints when true. True by default.
+/// @return A MarkerSequence object containing the marker animation data.
+MarkerSequence loadFbxMarkerSequence(
+    std::span<const std::byte> inputSpan,
+    bool stripNamespaces = true);
+
 } // namespace momentum

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -1444,10 +1444,12 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbxCharacterWithMoti
       stripNamespaces);
 }
 
-MarkerSequence loadOpenFbxMarkerSequence(const filesystem::path& filename, bool stripNamespaces) {
-  auto buffer = readFileToBuffer(filename);
-  MT_THROW_IF(buffer.size() > INT32_MAX, "File too large for OpenFBX.");
-  auto fbxCharDataRaw = gsl::make_span(buffer);
+MarkerSequence loadOpenFbxMarkerSequence(
+    std::span<const std::byte> inputData,
+    bool stripNamespaces) {
+  auto fbxCharDataRaw = cast_span<const unsigned char>(inputData);
+  const size_t length = fbxCharDataRaw.size();
+  MT_THROW_IF(length > INT32_MAX, "File too large for OpenFBX.");
 
   auto ofbx_deleter = [](ofbx::IScene* s) { s->destroy(); };
   // We don't currently use blend shapes for anything and they can be very
@@ -1457,7 +1459,7 @@ MarkerSequence loadOpenFbxMarkerSequence(const filesystem::path& filename, bool 
       ofbx::LoadFlags::IGNORE_BLEND_SHAPES;
 
   std::unique_ptr<ofbx::IScene, decltype(ofbx_deleter)> scene(
-      ofbx::load(fbxCharDataRaw.data(), static_cast<int32_t>(buffer.size()), (ofbx::u16)loadFlags),
+      ofbx::load(fbxCharDataRaw.data(), static_cast<int32_t>(length), (ofbx::u16)loadFlags),
       ofbx_deleter);
   MT_THROW_IF(!scene, "Error reading FBX scene data. Error: {}", ofbx::getError());
   MT_THROW_IF(!scene->getRoot(), "FBX scene has no root node. Error: {}", ofbx::getError());
@@ -1473,6 +1475,11 @@ MarkerSequence loadOpenFbxMarkerSequence(const filesystem::path& filename, bool 
   }
 
   return parseMarkerSequence(scene.get(), scene->getRoot(), scene->getSceneFrameRate());
+}
+
+MarkerSequence loadOpenFbxMarkerSequence(const filesystem::path& filename, bool stripNamespaces) {
+  auto buffer = readFileToBuffer(filename);
+  return loadOpenFbxMarkerSequence(gsl::as_bytes(gsl::make_span(buffer)), stripNamespaces);
 }
 
 } // namespace momentum

--- a/momentum/io/fbx/openfbx_loader.h
+++ b/momentum/io/fbx/openfbx_loader.h
@@ -59,4 +59,17 @@ MarkerSequence loadOpenFbxMarkerSequence(
     const filesystem::path& filename,
     bool stripNamespaces = true);
 
+/// Load a MarkerSequence from an in-memory FBX byte buffer.
+///
+/// Same semantics as the filename overload but parses the FBX scene from a buffer instead of
+/// reading from disk. OpenFBX accepts a raw byte pointer + length, so this is true zero-copy.
+///
+/// @param[in] inputData Buffer holding the FBX file contents.
+/// @param[in] stripNamespaces Removes namespace from joints when true. True by default.
+/// @return A MarkerSequence object containing the marker animation data, or an empty sequence
+///         if no markers or animations are found.
+MarkerSequence loadOpenFbxMarkerSequence(
+    std::span<const std::byte> inputData,
+    bool stripNamespaces = true);
+
 } // namespace momentum

--- a/momentum/io/gltf/gltf_io.cpp
+++ b/momentum/io/gltf/gltf_io.cpp
@@ -395,10 +395,11 @@ fx::gltf::Document makeCharacterDocument(
   return fileBuilder.getDocument();
 }
 
-MarkerSequence loadMarkerSequence(const filesystem::path& filename) {
+namespace {
+
+MarkerSequence loadMarkerSequenceFromModel(fx::gltf::Document model) {
   MarkerSequence result;
 
-  fx::gltf::Document model = loadModel(filename);
   if (model.animations.empty()) {
     return result;
   }
@@ -417,7 +418,10 @@ MarkerSequence loadMarkerSequence(const filesystem::path& filename) {
     }
 
     // get the node for the channel
-    const auto& node = model.nodes[channel.target.node];
+    if (channel.target.node < 0 || static_cast<size_t>(channel.target.node) >= model.nodes.size()) {
+      continue;
+    }
+    const auto& node = model.nodes.at(channel.target.node);
 
     // ignore skins and cameras; don't ignore meshes because a marker node may have a mesh for viz
     if (node.skin >= 0 || node.camera >= 0) {
@@ -468,6 +472,16 @@ MarkerSequence loadMarkerSequence(const filesystem::path& filename) {
   }
 
   return result;
+}
+
+} // namespace
+
+MarkerSequence loadMarkerSequence(const filesystem::path& filename) {
+  return loadMarkerSequenceFromModel(loadModel(filename));
+}
+
+MarkerSequence loadMarkerSequence(std::span<const std::byte> byteSpan) {
+  return loadMarkerSequenceFromModel(loadModel(byteSpan));
 }
 
 void saveGltfCharacter(

--- a/momentum/io/gltf/gltf_io.h
+++ b/momentum/io/gltf/gltf_io.h
@@ -169,6 +169,16 @@ std::tuple<MatrixXf, JointParameters, float> loadMotionOnCharacter(
 /// @return A MarkerSequence object containing the loaded motion capture marker data.
 MarkerSequence loadMarkerSequence(const filesystem::path& filename);
 
+/// Load a marker sequence from an in-memory glTF byte buffer.
+///
+/// Same semantics as the filename overload but reads the glTF document from a buffer instead
+/// of a file path. Useful when the glTF data is already in memory (e.g., fetched from blob
+/// storage) and you want to avoid spilling it to disk.
+///
+/// @param[in] byteSpan Buffer holding the glTF (.glb) file contents.
+/// @return A MarkerSequence object containing the loaded motion capture marker data.
+MarkerSequence loadMarkerSequence(std::span<const std::byte> byteSpan);
+
 /// Create a glTF document from a character.
 ///
 /// This function creates a glTF document containing the character data and optionally motion,

--- a/momentum/io/marker/c3d_io.cpp
+++ b/momentum/io/marker/c3d_io.cpp
@@ -9,10 +9,12 @@
 
 #include "momentum/character/marker.h"
 #include "momentum/common/log.h"
+#include "momentum/io/common/stream_utils.h"
 #include "momentum/io/marker/conversions.h"
 
 #include <ezc3d/ezc3d_all.h>
 
+#include <optional>
 #include <set>
 #include <unordered_map>
 
@@ -69,173 +71,248 @@ bool isMarkerValid(const std::string_view label, std::span<const std::string> va
 
 } // namespace
 
+namespace {
+
+// Returns the validated unit string from the c3d POINT group, or std::nullopt on error.
+std::optional<std::string> getValidatedUnit(const ezc3d::ParametersNS::GroupNS::Group& pointGroup) {
+  constexpr auto kUnitStr = "UNITS";
+  const auto& unit = pointGroup.parameter(kUnitStr).valuesAsString();
+  if (unit.size() != 1) {
+    MT_LOGE("{}: Invalid c3d file: no unit information found!", __func__);
+    return std::nullopt;
+  }
+  const auto& unitStr = unit[0];
+  if (unitStr != "mm" && unitStr != "m" && unitStr != "cm" && unitStr != "dm") {
+    MT_LOGE("{}: Unknown unit string '{}' found in the file.", __func__, unitStr);
+    return std::nullopt;
+  }
+  MT_LOGW_IF(
+      unitStr != "mm",
+      "{}: Unit '{}' is not mm. Translating a C3D file that contains 3D point data stored in any units other than millimeters is extremely complex and any mistakes will render the file invalid.",
+      __func__,
+      unitStr);
+  return unitStr;
+}
+
+// Load all point labels from POINT.LABELS plus the LABEL2/LABEL3/... overflow sections.
+// The c3d format limits LABELS to 255 entries per section.
+// Returns an empty vector if the total label count is inconsistent with the header.
+std::vector<std::string> loadPointLabels(
+    const ezc3d::ParametersNS::GroupNS::Group& pointGroup,
+    size_t kPointsPerFrame) {
+  constexpr auto kLabelStr = "LABELS";
+  constexpr auto kNumLabelsPerSection = 255;
+  constexpr size_t kAdditionSectionStartIndex = 2;
+
+  auto pointLabels = pointGroup.parameter(kLabelStr).valuesAsString();
+  const size_t numOfExtraSections = kPointsPerFrame / kNumLabelsPerSection;
+  pointLabels.reserve(kPointsPerFrame);
+  for (size_t sectionId = kAdditionSectionStartIndex;
+       sectionId < kAdditionSectionStartIndex + numOfExtraSections;
+       sectionId++) {
+    const auto labelStr = kLabelStr + std::to_string(sectionId);
+    const auto& additionalPointLabels = pointGroup.parameter(labelStr).valuesAsString();
+    pointLabels.insert(
+        pointLabels.end(), additionalPointLabels.begin(), additionalPointLabels.end());
+  }
+  if (pointLabels.size() < kPointsPerFrame) {
+    MT_LOGE("{}: Number of point labels loaded isn't consistent with the header! ", __func__);
+    return {};
+  }
+  pointLabels.resize(kPointsPerFrame);
+  return pointLabels;
+}
+
+// Group point indices by their parsed subject name.
+// A Subject is a collection of points that should be grouped together to represent an object.
+std::unordered_map<std::string, std::vector<size_t>> groupPointsBySubject(
+    std::span<const std::string> pointLabels) {
+  std::unordered_map<std::string, std::vector<size_t>> subjectNameMap;
+  subjectNameMap.reserve(pointLabels.size());
+  for (size_t iLabel = 0; iLabel < pointLabels.size(); ++iLabel) {
+    subjectNameMap[findSubjectName(pointLabels[iLabel])].push_back(iLabel);
+  }
+  return subjectNameMap;
+}
+
+// Initialize per-actor MarkerSequence/template-actor arrays and return the mapping from
+// each c3d point index to (actorId, markerId). Indices not mapped to any marker stay (-1, -1).
+// Resizes ``resultAnim`` and ``templateActors`` to ``subjectNameMap.size()``.
+std::vector<std::pair<int, int>> buildSubjectStructures(
+    const std::unordered_map<std::string, std::vector<size_t>>& subjectNameMap,
+    std::span<const std::string> pointLabels,
+    std::span<const std::string> validMarkerNames,
+    float fps,
+    std::vector<MarkerSequence>& resultAnim,
+    std::vector<std::vector<Marker>>& templateActors) {
+  resultAnim.assign(subjectNameMap.size(), {});
+  templateActors.assign(subjectNameMap.size(), {});
+  std::vector<std::pair<int, int>> markerMap(pointLabels.size(), {-1, -1});
+  size_t actorId = 0;
+  for (const auto& [subjectName, pointIndices] : subjectNameMap) {
+    int markerCount = 0;
+    // ``actorId`` is bounded by ``subjectNameMap.size()``, which we just used
+    // to size both vectors above; the analyzer cannot trace this through the
+    // range-based for loop counter.
+    auto& actorSequence = resultAnim.at(actorId);
+    actorSequence.fps = fps;
+    actorSequence.name = subjectName;
+    auto& templateActor = templateActors.at(actorId);
+    for (const auto kPointIdx : pointIndices) {
+      if (kPointIdx >= pointLabels.size()) {
+        continue;
+      }
+      auto pointLabel = pointLabels[kPointIdx];
+      if (!subjectName.empty()) {
+        pointLabel = pointLabel.substr(subjectName.size() + 1);
+      }
+      if (!isMarkerValid(pointLabel, validMarkerNames)) {
+        continue;
+      }
+      // ``kPointIdx`` is checked above against ``pointLabels.size()``, which
+      // also sizes ``markerMap``.
+      markerMap.at(kPointIdx) = {static_cast<int>(actorId), markerCount};
+      Marker marker;
+      marker.name = pointLabel;
+      marker.occluded = true;
+      templateActor.push_back(marker);
+      ++markerCount;
+    }
+    ++actorId;
+  }
+  return markerMap;
+}
+
+// Reset all template markers to occluded, then update them from one frame's c3d points.
+// Returns true if any marker was visible (residual >= 0, non-NaN, non-zero) in this frame.
+bool updateFrameMarkers(
+    const ezc3d::DataNS::Frame& frameData,
+    std::span<const std::pair<int, int>> markerMap,
+    UpVector up,
+    const std::string& unitStr,
+    std::vector<std::vector<Marker>>& templateActors) {
+  for (auto& templateActor : templateActors) {
+    for (auto& marker : templateActor) {
+      marker.occluded = true;
+    }
+  }
+
+  bool hasVisible = false;
+  const auto& framePoints = frameData.points().points();
+  for (size_t pointId = 0; pointId < markerMap.size(); ++pointId) {
+    const auto [kActorId, kMarkerId] = markerMap[pointId];
+    if (kActorId == -1 || kMarkerId == -1) {
+      continue;
+    }
+    const auto& pointData = framePoints[pointId];
+    Vector3d pos{pointData.x(), pointData.y(), pointData.z()};
+    if (std::isnan(pos[0]) || std::isnan(pos[1]) || std::isnan(pos[2])) {
+      continue;
+    }
+    if (pos == Eigen::Vector3d::Zero()) {
+      continue;
+    }
+    // residual < 0 indicates that the data is invalid;
+    // residual == 0 indicates that the data is generated.
+    if (pointData.residual() < 0) {
+      continue;
+    }
+    // ``kActorId`` / ``kMarkerId`` come from ``markerMap`` populated by
+    // ``buildSubjectStructures`` and are guaranteed to address the matching
+    // ``templateActors`` entry; bounds-checked accessors guard against any
+    // future divergence.
+    if (static_cast<size_t>(kActorId) >= templateActors.size() ||
+        static_cast<size_t>(kMarkerId) >= templateActors.at(kActorId).size()) {
+      continue;
+    }
+    auto& marker = templateActors.at(kActorId).at(kMarkerId);
+    marker.occluded = false;
+    marker.pos = toMomentumVector3(pos, up, unitStr);
+    hasVisible = true;
+  }
+  return hasVisible;
+}
+
+// Shared parsing logic, agnostic to whether the c3d came from a file path or an istream.
 std::vector<MarkerSequence>
-loadC3d(const std::string& filename, UpVector up, std::span<const std::string> validMarkerNames) {
-  std::vector<MarkerSequence> resultAnim;
-  float fps = 0.0f;
-
-  bool hasAnim = false;
-
+loadC3dFromObject(ezc3d::c3d& c3dFile, UpVector up, std::span<const std::string> validMarkerNames) {
   try {
-    // Load animation Info from the header
-    ezc3d::c3d c3dFile(filename);
     const auto& header = c3dFile.header();
-    const auto kPointsPerFrame = header.nb3dPoints();
+    const size_t kPointsPerFrame = header.nb3dPoints();
     const auto kFrameCount = header.nbFrames();
-    fps = header.frameRate();
+    const float fps = header.frameRate();
     MT_LOGD("{}: Found {} frames", __func__, kFrameCount);
     MT_LOGD("{}: Frame rate {}", __func__, fps);
 
-    // Load Point Labels from Parameter Section
     constexpr auto kPointGroupStr = "POINT";
-    constexpr auto kLabelStr = "LABELS";
-    const auto& parameters = c3dFile.parameters();
-    const auto& pointGroup = parameters.group(kPointGroupStr);
+    const auto& pointGroup = c3dFile.parameters().group(kPointGroupStr);
 
-    // Load Unit
-    constexpr auto kUnitStr = "UNITS";
-    const auto& unit = pointGroup.parameter(kUnitStr).valuesAsString();
-    if (unit.size() != 1) {
-      MT_LOGE("{}: Invalid c3d file: no unit information found!", __func__);
+    const auto unitStr = getValidatedUnit(pointGroup);
+    if (!unitStr.has_value()) {
       return {};
     }
 
-    const auto& unitStr = unit[0];
-    if (unitStr != "mm" && unitStr != "m" && unitStr != "cm" && unitStr != "dm") {
-      MT_LOGE("{}: Unknown unit string '{}' found in the file.", __func__, unitStr);
+    const auto pointLabels = loadPointLabels(pointGroup, kPointsPerFrame);
+    if (pointLabels.empty()) {
       return {};
     }
-    MT_LOGW_IF(
-        unitStr != "mm",
-        "{}: Unit '{}' is not mm. Translating a C3D file that contains 3D point data stored in any units other than millimeters is extremely complex and any mistakes will render the file invalid.",
-        __func__,
-        unitStr);
 
-    // Point:Labels section can store max 255 labels. For the other labels, find them in section
-    // LABEL2, LABEL3.. Each additional section can contain max 255 labels. The file may contain
-    // more labels than kPointsPerFrame since some points may be invalid.
-    constexpr auto kNumLabelsPerSection = 255;
-    auto pointLabels = pointGroup.parameter(kLabelStr).valuesAsString();
-    size_t numOfExtraSections = kPointsPerFrame / kNumLabelsPerSection;
+    const auto subjectNameMap = groupPointsBySubject(pointLabels);
+    const size_t kNumOfSubjects = subjectNameMap.size();
+    std::vector<MarkerSequence> resultAnim(kNumOfSubjects);
+    std::vector<std::vector<Marker>> templateActors(kNumOfSubjects);
+    const auto markerMap = buildSubjectStructures(
+        subjectNameMap, pointLabels, validMarkerNames, fps, resultAnim, templateActors);
 
-    constexpr size_t kAdditionSectionStartIndex = 2;
-    pointLabels.reserve(kPointsPerFrame);
-    for (size_t sectionId = kAdditionSectionStartIndex;
-         sectionId < kAdditionSectionStartIndex + numOfExtraSections;
-         sectionId++) {
-      const auto labelStr = kLabelStr + std::to_string(sectionId);
-      const auto& additionalPointLabels = pointGroup.parameter(labelStr).valuesAsString();
-      pointLabels.insert(
-          pointLabels.end(), additionalPointLabels.begin(), additionalPointLabels.end());
-    }
-
-    if (pointLabels.size() < kPointsPerFrame) {
-      MT_LOGE("{}: Number of point labels loaded isn't consistent with the header! ", __func__);
-      return {};
-    }
-    // Only the first kPointsPerFrame points need to be loaded
-    pointLabels.resize(kPointsPerFrame);
-
-    // Go through the labels to find all the subjects and their markers.
-    // A Subject is a collection of points that should be grouped together to represent an object.
-    std::unordered_map<std::string, std::vector<size_t>> subjectNameMap;
-    subjectNameMap.reserve(kPointsPerFrame);
-    for (size_t iLabel = 0; iLabel < kPointsPerFrame; ++iLabel) {
-      const std::string& name = pointLabels[iLabel];
-      const std::string subjectName = findSubjectName(name);
-      subjectNameMap[subjectName].push_back(iLabel);
-    }
-
-    // Set up a look up table for each point on which actor it belongs to
-    const auto kNumOfSubjects = subjectNameMap.size();
-    std::vector<std::pair<int, int>> markerMap(kPointsPerFrame, {-1, -1});
-    resultAnim = std::vector<MarkerSequence>(kNumOfSubjects);
-    auto templateActors = std::vector<std::vector<Marker>>(kNumOfSubjects);
-    auto actorId = 0;
-    for (const auto& namePointsPair : subjectNameMap) {
-      const auto& subjectName = namePointsPair.first;
-      auto markerCount = 0;
-      auto& actorSequence = resultAnim[actorId];
-      actorSequence.fps = fps;
-      auto& templateActor = templateActors[actorId];
-      actorSequence.name = subjectName;
-      for (const auto kPointIdx : namePointsPair.second) {
-        auto pointLabel = pointLabels[kPointIdx];
-        if (!subjectName.empty()) {
-          pointLabel = pointLabel.substr(subjectName.size() + 1);
-        }
-
-        if (isMarkerValid(pointLabel, validMarkerNames)) {
-          markerMap[kPointIdx] = std::make_pair(actorId, markerCount);
-
-          Marker marker;
-          marker.name = pointLabel;
-          marker.occluded = true;
-          templateActor.push_back(marker);
-          markerCount++;
-        }
-      }
-      actorId++;
-    }
-
-    // Go through each frame to save the data
+    bool hasAnim = false;
     const auto& frames = c3dFile.data().frames();
-    for (int frameId = 0; frameId < kFrameCount; frameId++) {
-      // Set all markers to be occluded
-      for (auto& templateActor : templateActors) {
-        for (auto& marker : templateActor) {
-          marker.occluded = true;
-        }
-      }
-      const auto& frameData = frames[frameId];
-      const auto& framePoints = frameData.points().points();
-      for (int pointId = 0; pointId < kPointsPerFrame; ++pointId) {
-        const auto& markerMapEntry = markerMap[pointId];
-        const auto kActorId = markerMapEntry.first;
-        const auto kMarkerId = markerMapEntry.second;
-        // not a marker of interest
-        if ((kActorId == -1) || (kMarkerId == -1)) {
-          continue;
-        }
-
-        auto& marker = templateActors[kActorId][kMarkerId];
-        const auto& pointData = framePoints[pointId];
-        Vector3d pos{pointData.x(), pointData.y(), pointData.z()};
-        if (std::isnan(pos[0]) || std::isnan(pos[1]) || std::isnan(pos[2])) {
-          continue;
-        }
-        if (pos == Eigen::Vector3d::Zero()) {
-          continue;
-        }
-        pos = toMomentumVector3(pos, up, unitStr);
-
-        const auto& residual = pointData.residual();
-        // residual < 0 indicates that the data is invalid
-        // residual == 0 indicates that the data is generated. Can see if the want to keep the =
-        // here or not
-        if (residual >= 0) {
-          marker.occluded = false;
-          marker.pos = pos;
-          hasAnim = true;
-        }
-      }
-      for (actorId = 0; actorId < templateActors.size(); actorId++) {
+    for (int frameId = 0; frameId < kFrameCount; ++frameId) {
+      hasAnim |= updateFrameMarkers(frames[frameId], markerMap, up, *unitStr, templateActors);
+      for (size_t actorId = 0; actorId < templateActors.size(); ++actorId) {
         resultAnim[actorId].frames.push_back(templateActors[actorId]);
       }
     }
+
+    if (!hasAnim) {
+      return {};
+    }
+    return resultAnim;
   } catch (std::exception& e) {
-    MT_LOGE("{}: Exception: {}", e.what(), __func__);
+    MT_LOGE("{}: Exception: {}", __func__, e.what());
     return {};
   } catch (...) {
     MT_LOGE("{}: Unknown c3d reading error", __func__);
     return {};
   }
-
-  if (!hasAnim) {
-    resultAnim.clear();
-  }
-
-  return resultAnim;
 }
+
+} // namespace
+
+std::vector<MarkerSequence>
+loadC3d(const std::string& filename, UpVector up, std::span<const std::string> validMarkerNames) {
+  try {
+    ezc3d::c3d c3dFile(filename);
+    return loadC3dFromObject(c3dFile, up, validMarkerNames);
+  } catch (const std::exception& e) {
+    MT_LOGE("{}: failed to open {}: {}", __func__, filename, e.what());
+    return {};
+  }
+}
+
+#ifdef MOMENTUM_WITH_EZC3D_ISTREAM
+std::vector<MarkerSequence> loadC3d(
+    std::span<const std::byte> bytes,
+    UpVector up,
+    std::span<const std::string> validMarkerNames) {
+  try {
+    ispanstream stream(bytes);
+    ezc3d::c3d c3dFile(static_cast<std::istream&>(stream));
+    return loadC3dFromObject(c3dFile, up, validMarkerNames);
+  } catch (const std::exception& e) {
+    MT_LOGE("{}: failed to read c3d from buffer ({} bytes): {}", __func__, bytes.size(), e.what());
+    return {};
+  }
+}
+#endif
 
 } // namespace momentum

--- a/momentum/io/marker/c3d_io.h
+++ b/momentum/io/marker/c3d_io.h
@@ -10,6 +10,8 @@
 #include <momentum/character/marker.h>
 #include <momentum/io/marker/coordinate_system.h>
 
+#include <span>
+
 namespace momentum {
 
 /// Loads all the subjects from a C3D file into a vector of MarkerSequences.
@@ -26,5 +28,20 @@ namespace momentum {
     const std::string& filename,
     UpVector up = UpVector::Y,
     std::span<const std::string> validMarkerNames = {});
+
+#ifdef MOMENTUM_WITH_EZC3D_ISTREAM
+/// Loads all the subjects from an in-memory C3D byte buffer into a vector of MarkerSequences.
+///
+/// Same semantics as the filename overload, but reads from a buffer instead of a file.
+///
+/// @param[in] bytes Buffer holding the C3D file contents.
+/// @param[in] up (Optional) The up-vector convention of the input data.
+/// @param[in] validMarkerNames (Optional) Marker-name allowlist.
+/// @return std::vector<MarkerSequence> A vector containing the marker sequences from the buffer.
+[[nodiscard]] std::vector<MarkerSequence> loadC3d(
+    std::span<const std::byte> bytes,
+    UpVector up = UpVector::Y,
+    std::span<const std::string> validMarkerNames = {});
+#endif
 
 } // namespace momentum

--- a/momentum/io/marker/marker_io.cpp
+++ b/momentum/io/marker/marker_io.cpp
@@ -66,6 +66,51 @@ std::optional<MarkerSequence> loadMarkersForMainSubject(
   }
 }
 
+std::vector<MarkerSequence> loadMarkers(
+    std::span<const std::byte> bytes,
+    const std::string& format,
+    UpVector up,
+    std::span<const std::string> validMarkerNames) {
+  try {
+    if (format == ".trc") {
+      return {loadTrc(bytes, up)};
+    } else if (format == ".glb") {
+      return {loadMarkerSequence(bytes)};
+    } else if (format == ".fbx") {
+      return {loadFbxMarkerSequence(bytes)};
+    } else if (format == ".c3d") {
+#ifdef MOMENTUM_WITH_EZC3D_ISTREAM
+      return loadC3d(bytes, up, validMarkerNames);
+#else
+      // ezc3d does not support reading from a stream; load c3d files by path instead.
+      MT_LOGE("{}: in-memory c3d loading is not supported", __func__);
+      return {};
+#endif
+    } else {
+      MT_LOGE("{}: Unknown marker format '{}' for {}-byte buffer", __func__, format, bytes.size());
+      return {};
+    }
+  } catch (...) {
+    MT_LOGE("{}: Unknown error reading {} buffer", __func__, format);
+    return {};
+  }
+}
+
+std::optional<MarkerSequence> loadMarkersForMainSubject(
+    std::span<const std::byte> bytes,
+    const std::string& format,
+    UpVector up,
+    std::span<const std::string> validMarkerNames) {
+  const std::vector<MarkerSequence> markerSequences =
+      loadMarkers(bytes, format, up, validMarkerNames);
+  const int subjectID = findMainSubjectIndex(markerSequences);
+  if (subjectID < 0) {
+    return {};
+  } else {
+    return {markerSequences.at(subjectID)};
+  }
+}
+
 int findMainSubjectIndex(std::span<const MarkerSequence> markerSequences) {
   if (markerSequences.empty()) {
     return -1;

--- a/momentum/io/marker/marker_io.h
+++ b/momentum/io/marker/marker_io.h
@@ -11,6 +11,8 @@
 #include <momentum/io/marker/coordinate_system.h>
 
 #include <optional>
+#include <span>
+#include <string>
 #include <vector>
 
 namespace momentum {
@@ -52,5 +54,38 @@ namespace momentum {
 /// returned.
 /// @note This function is exposed mainly for unit tests.
 [[nodiscard]] int findMainSubjectIndex(std::span<const MarkerSequence> markerSequences);
+
+/// Loads all actor sequences from an in-memory marker file buffer (c3d, trc, glb, fbx).
+///
+/// Same semantics as the filename overload, but takes a byte buffer plus an explicit format
+/// hint (since bytes don't carry an extension). All four formats use a true-bytes path with no
+/// temporary file: c3d via the patched ezc3d istream constructor, trc via std::istringstream,
+/// glb via fx::gltf's byte-span loader, and fbx via OpenFBX's native buffer API.
+///
+/// @param[in] bytes Marker file contents.
+/// @param[in] format File extension including the leading dot (".c3d", ".trc", ".glb", ".fbx").
+/// @param[in] up (Optional) Up-vector convention of the input data.
+/// @param[in] validMarkerNames (Optional) Marker-name allowlist (c3d only).
+/// @return Vector of MarkerSequences. Empty on unknown format or read error.
+[[nodiscard]] std::vector<MarkerSequence> loadMarkers(
+    std::span<const std::byte> bytes,
+    const std::string& format,
+    UpVector up = UpVector::Y,
+    std::span<const std::string> validMarkerNames = {});
+
+/// Loads the main subject's marker data from an in-memory marker file buffer.
+///
+/// Convenience wrapper around the buffer-based loadMarkers + findMainSubjectIndex.
+///
+/// @param[in] bytes Marker file contents.
+/// @param[in] format File extension including the leading dot (".c3d", ".trc", ".glb", ".fbx").
+/// @param[in] up (Optional) Up-vector convention of the input data.
+/// @param[in] validMarkerNames (Optional) Marker-name allowlist (c3d only).
+/// @return The main subject's sequence, or empty optional if no main subject is found.
+[[nodiscard]] std::optional<MarkerSequence> loadMarkersForMainSubject(
+    std::span<const std::byte> bytes,
+    const std::string& format,
+    UpVector up = UpVector::Y,
+    std::span<const std::string> validMarkerNames = {});
 
 } // namespace momentum

--- a/momentum/io/marker/trc_io.cpp
+++ b/momentum/io/marker/trc_io.cpp
@@ -16,31 +16,26 @@
 
 namespace momentum {
 
-MarkerSequence loadTrc(const std::string& filename, UpVector up) {
+MarkerSequence loadTrc(std::istream& stream, UpVector up) {
   MarkerSequence res;
   res.fps = 0.f;
-
-  std::ifstream infile(filename);
-  if (!infile.is_open()) {
-    return res;
-  }
 
   std::string line;
 
   // parse header
-  GetLineCrossPlatform(infile, line);
+  GetLineCrossPlatform(stream, line);
   if (line.find("PathFileType\t4\t(X/Y/Z)") == std::string::npos) {
     return res;
   }
 
-  GetLineCrossPlatform(infile, line);
+  GetLineCrossPlatform(stream, line);
   if (line.find(
           "DataRate\tCameraRate\tNumFrames\tNumMarkers\tUnits\tOrigDataRate\tOrigDataStartFrame\tOrigNumFrames") ==
       std::string::npos) {
     return res;
   }
 
-  GetLineCrossPlatform(infile, line);
+  GetLineCrossPlatform(stream, line);
   auto tokens = tokenize(line, " \t\r\n");
   if (tokens.size() != 8) {
     return res;
@@ -51,7 +46,7 @@ MarkerSequence loadTrc(const std::string& filename, UpVector up) {
   res.fps = static_cast<float>(frameRate);
 
   // get line with marker names and parse it
-  GetLineCrossPlatform(infile, line);
+  GetLineCrossPlatform(stream, line);
   tokens = tokenize(line, " \t\r\n");
   if (tokens.size() != numMarkers + 2) {
     res.fps = 0.0f;
@@ -63,9 +58,9 @@ MarkerSequence loadTrc(const std::string& filename, UpVector up) {
   }
 
   // ignore next line
-  GetLineCrossPlatform(infile, line);
+  GetLineCrossPlatform(stream, line);
 
-  while (GetLineCrossPlatform(infile, line)) {
+  while (GetLineCrossPlatform(stream, line)) {
     tokens = tokenize(line, "\t", false);
     // check for right size
     if (tokens.size() != numMarkers * 3 + 2) {
@@ -97,6 +92,19 @@ MarkerSequence loadTrc(const std::string& filename, UpVector up) {
   }
 
   return res;
+}
+
+MarkerSequence loadTrc(const std::string& filename, UpVector up) {
+  std::ifstream infile(filename);
+  if (!infile.is_open()) {
+    return MarkerSequence{};
+  }
+  return loadTrc(static_cast<std::istream&>(infile), up);
+}
+
+MarkerSequence loadTrc(std::span<const std::byte> bytes, UpVector up) {
+  ispanstream stream(bytes);
+  return loadTrc(static_cast<std::istream&>(stream), up);
 }
 
 } // namespace momentum

--- a/momentum/io/marker/trc_io.h
+++ b/momentum/io/marker/trc_io.h
@@ -10,6 +10,9 @@
 #include <momentum/character/marker.h>
 #include <momentum/io/marker/coordinate_system.h>
 
+#include <istream>
+#include <span>
+
 namespace momentum {
 
 /// Loads marker data from a TRC file into a MarkerSequence.
@@ -23,5 +26,24 @@ namespace momentum {
 /// UpVector::Y).
 /// @return MarkerSequence A MarkerSequence containing the marker data from the TRC file.
 [[nodiscard]] MarkerSequence loadTrc(const std::string& filename, UpVector up = UpVector::Y);
+
+/// Loads marker data from a TRC input stream into a MarkerSequence.
+///
+/// Same as the filename overload but reads from any std::istream (e.g., a file, a memory-backed
+/// stream, etc.). The caller owns the stream and is responsible for opening it in text mode.
+///
+/// @param[in,out] stream Open input stream positioned at the start of the TRC content.
+/// @param[in] up (Optional) The up-vector convention of the input marker file.
+/// @return MarkerSequence A MarkerSequence containing the marker data from the stream.
+[[nodiscard]] MarkerSequence loadTrc(std::istream& stream, UpVector up = UpVector::Y);
+
+/// Loads marker data from an in-memory TRC byte buffer into a MarkerSequence.
+///
+/// Wraps the buffer in an ispanstream and forwards to the istream overload, so no copy is made.
+///
+/// @param[in] bytes Buffer holding the TRC file contents.
+/// @param[in] up (Optional) The up-vector convention of the input marker file.
+/// @return MarkerSequence A MarkerSequence containing the marker data from the buffer.
+[[nodiscard]] MarkerSequence loadTrc(std::span<const std::byte> bytes, UpVector up = UpVector::Y);
 
 } // namespace momentum

--- a/momentum/test/io/io_marker_test.cpp
+++ b/momentum/test/io/io_marker_test.cpp
@@ -11,6 +11,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <cstring>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -22,6 +25,37 @@ std::string getMarkerFile() {
   auto envVar = GetEnvVar("TEST_RESOURCES_PATH");
   const auto markerFilePath = filesystem::path(envVar.value()) / "markers.c3d";
   return markerFilePath.string();
+}
+
+std::vector<std::byte> readFileBytes(const std::string& path) {
+  std::ifstream f(path, std::ios::binary);
+  std::istreambuf_iterator<char> begin(f);
+  std::istreambuf_iterator<char> end;
+  std::vector<char> chars(begin, end);
+  std::vector<std::byte> bytes(chars.size());
+  std::memcpy(bytes.data(), chars.data(), chars.size());
+  return bytes;
+}
+
+void expectSequencesEqual(
+    const std::vector<MarkerSequence>& a,
+    const std::vector<MarkerSequence>& b) {
+  ASSERT_EQ(a.size(), b.size());
+  for (size_t i = 0; i < a.size(); ++i) {
+    EXPECT_EQ(a[i].name, b[i].name);
+    EXPECT_FLOAT_EQ(a[i].fps, b[i].fps);
+    ASSERT_EQ(a[i].frames.size(), b[i].frames.size());
+    for (size_t f = 0; f < a[i].frames.size(); ++f) {
+      ASSERT_EQ(a[i].frames[f].size(), b[i].frames[f].size());
+      for (size_t m = 0; m < a[i].frames[f].size(); ++m) {
+        EXPECT_EQ(a[i].frames[f][m].name, b[i].frames[f][m].name);
+        EXPECT_EQ(a[i].frames[f][m].occluded, b[i].frames[f][m].occluded);
+        if (!a[i].frames[f][m].occluded) {
+          EXPECT_TRUE(a[i].frames[f][m].pos.isApprox(b[i].frames[f][m].pos));
+        }
+      }
+    }
+  }
 }
 
 TEST(MarkerIOTest, testLoadMarkers) {
@@ -83,6 +117,47 @@ TEST(MarkerIOTest, testLoadMarkersForMainSubject) {
 TEST(MarkerIOTest, testLoadMarkersEmpty) {
   const auto actorSequences = loadMarkers("");
   EXPECT_EQ(actorSequences.size(), 0);
+}
+
+// The c3d bytes path is gated on MOMENTUM_WITH_EZC3D_ISTREAM (only defined when
+// the io_marker library is built against our patched ezc3d). In OSS builds the
+// overload is a documented no-op, so file-vs-bytes equivalence tests are skipped.
+#ifdef MOMENTUM_WITH_EZC3D_ISTREAM
+TEST(MarkerIOTest, testLoadMarkersFromBytesC3d) {
+  const std::string markerFile = getMarkerFile();
+  const auto bytes = readFileBytes(markerFile);
+  ASSERT_FALSE(bytes.empty()) << "fixture markers.c3d not found at " << markerFile;
+
+  const auto fromFile = loadMarkers(markerFile);
+  const auto fromBytes = loadMarkers(bytes, ".c3d");
+  expectSequencesEqual(fromFile, fromBytes);
+}
+
+TEST(MarkerIOTest, testLoadMarkersForMainSubjectFromBytes) {
+  const std::string markerFile = getMarkerFile();
+  const auto bytes = readFileBytes(markerFile);
+  ASSERT_FALSE(bytes.empty());
+
+  const auto fromFile = loadMarkersForMainSubject(markerFile);
+  const auto fromBytes = loadMarkersForMainSubject(bytes, ".c3d");
+  ASSERT_TRUE(fromFile.has_value());
+  ASSERT_TRUE(fromBytes.has_value());
+  EXPECT_EQ(fromFile->frames.size(), fromBytes->frames.size());
+  EXPECT_EQ(fromFile->frames[0].size(), fromBytes->frames[0].size());
+}
+#endif
+
+TEST(MarkerIOTest, testLoadMarkersFromBytesUnknownFormat) {
+  const std::vector<std::byte> bytes(16, std::byte{0});
+  const auto sequences = loadMarkers(bytes, ".xyz");
+  EXPECT_EQ(sequences.size(), 0);
+}
+
+TEST(MarkerIOTest, testLoadMarkersFromBytesEmpty) {
+  const std::vector<std::byte> bytes;
+  // empty buffer for any format -> graceful empty return, no crash
+  EXPECT_EQ(loadMarkers(bytes, ".c3d").size(), 0);
+  EXPECT_EQ(loadMarkers(bytes, ".trc").size(), 1); // trc returns one empty sequence
 }
 
 } // namespace

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -794,6 +794,26 @@ you will likely want to retarget the parameters using the :meth:`mapParameters` 
       py::arg("main_subject_only") = true,
       py::arg("up") = mm::UpVector::Y);
 
+  m.def(
+      "load_markers_from_bytes",
+      &loadMarkersFromBytes,
+      R"(Load 3d mocap marker data from an in-memory byte buffer.
+
+Same semantics as load_markers, but takes the file contents as bytes plus an explicit
+format hint (since bytes don't carry an extension). Useful for loading from cloud
+storage without spilling to disk.
+
+:param bytes: The marker file contents.
+:param format: File extension including the leading dot (".c3d", ".trc", ".glb", ".fbx").
+:param main_subject_only: True to load only one subject's data.
+:param up: The up vector to use for the coordinate system, default to Y.
+:return: an array of MarkerSequence, one per subject in the file.
+      )",
+      py::arg("bytes"),
+      py::arg("format"),
+      py::arg("main_subject_only") = true,
+      py::arg("up") = mm::UpVector::Y);
+
   // mapModelParameters(motionData, sourceCharacter, targetCharacter)
   // Note: This overload is registered FIRST to ensure proper overload resolution.
   // When called with (array, Character, Character), pybind11 will match this first.

--- a/pymomentum/geometry/momentum_io.cpp
+++ b/pymomentum/geometry/momentum_io.cpp
@@ -417,6 +417,27 @@ std::vector<momentum::MarkerSequence> loadMarkersFromFile(
   }
 }
 
+std::vector<momentum::MarkerSequence> loadMarkersFromBytes(
+    const pybind11::bytes& bytes,
+    const std::string& format,
+    const bool mainSubjectOnly,
+    const momentum::UpVector up) {
+  // pybind11::bytes -> std::string_view -> span<const std::byte> (no copy).
+  const std::string_view view = static_cast<std::string_view>(bytes);
+  const std::span<const std::byte> byteSpan(
+      reinterpret_cast<const std::byte*>(view.data()), view.size());
+  if (mainSubjectOnly) {
+    const auto markerSequence = momentum::loadMarkersForMainSubject(byteSpan, format, up);
+    if (markerSequence.has_value()) {
+      return {markerSequence.value()};
+    } else {
+      return {};
+    }
+  } else {
+    return momentum::loadMarkers(byteSpan, format, up);
+  }
+}
+
 bool isFbxsdkAvailable() {
 #ifdef MOMENTUM_WITH_FBX_SDK
   return true;

--- a/pymomentum/geometry/momentum_io.h
+++ b/pymomentum/geometry/momentum_io.h
@@ -129,6 +129,12 @@ std::vector<momentum::MarkerSequence> loadMarkersFromFile(
     bool mainSubjectOnly = true,
     momentum::UpVector up = momentum::UpVector::Y);
 
+std::vector<momentum::MarkerSequence> loadMarkersFromBytes(
+    const pybind11::bytes& bytes,
+    const std::string& format,
+    bool mainSubjectOnly = true,
+    momentum::UpVector up = momentum::UpVector::Y);
+
 /// Utility function to convert pybind11::array_t<float> to SkeletonState vector
 /// This is shared between saveGLTFCharacterToFileFromSkelStates and
 /// GltfBuilder::addSkeletonStates


### PR DESCRIPTION
Summary: Add an in-memory byte-buffer path for loading markers. glb and fbx already support byte stream; trc is easy to add; ezc3d doesn't support byte-buffer interface currently and has to be special cased.

Differential Revision: D101576320


