### PR TITLE
Add msgpack serialization for SignedDistanceField (#1329)

### DIFF
--- a/axel/CMakeLists.txt
+++ b/axel/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(drjit CONFIG REQUIRED)
 find_package(Eigen3 3.4.0 CONFIG REQUIRED)
 find_package(Microsoft.GSL CONFIG REQUIRED)
 find_package(Dispenso CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
 
 #===============================================================================
 # Build axel
@@ -43,6 +44,7 @@ set(headers
   axel/MeshToSdf.h
   axel/Ray.h
   axel/SignedDistanceField.h
+  axel/SignedDistanceFieldIO.h
   axel/SimdKdTree.h
   axel/TriBvh.h
 )
@@ -56,6 +58,7 @@ set(sources
   axel/DualContouring.cpp
   axel/MeshToSdf.cpp
   axel/SignedDistanceField.cpp
+  axel/SignedDistanceFieldIO.cpp
   axel/SimdKdTree.cpp
   axel/TriBvh.cpp
 )
@@ -81,6 +84,7 @@ target_link_libraries(${target_name}
     Microsoft.GSL::GSL
     Dispenso::dispenso
     drjit
+    nlohmann_json::nlohmann_json
 )
 
 if(MSVC)

--- a/axel/axel-config.cmake.in
+++ b/axel/axel-config.cmake.in
@@ -11,6 +11,7 @@ find_dependency(drjit CONFIG)
 find_dependency(Eigen3 3.4.0 CONFIG)
 find_dependency(Microsoft.GSL CONFIG)
 find_dependency(Dispenso CONFIG)
+find_dependency(nlohmann_json CONFIG)
 
 if(@MOMENTUM_ENABLE_PROFILING@)
   find_dependency(Tracy CONFIG)

--- a/axel/axel/SignedDistanceField.cpp
+++ b/axel/axel/SignedDistanceField.cpp
@@ -274,6 +274,16 @@ void SignedDistanceField<ScalarType>::clear() {
 }
 
 template <typename ScalarType>
+const std::string& SignedDistanceField<ScalarType>::parentJoint() const {
+  return parentJoint_;
+}
+
+template <typename ScalarType>
+void SignedDistanceField<ScalarType>::setParentJoint(const std::string& name) {
+  parentJoint_ = name;
+}
+
+template <typename ScalarType>
 SignedDistanceField<ScalarType> SignedDistanceField<ScalarType>::createSphere(
     Scalar radius,
     const Eigen::Vector3<Index>& resolution,

--- a/axel/axel/SignedDistanceField.h
+++ b/axel/axel/SignedDistanceField.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <string>
 #include <vector>
 
 #include <Eigen/Core>
@@ -201,6 +202,21 @@ class SignedDistanceField {
   [[nodiscard]] std::vector<Scalar>& data();
 
   /**
+   * Get the optional parent joint name. Used by collision systems to associate
+   * this SDF with a skeleton joint for coordinate frame transforms.
+   *
+   * @return The parent joint name, or empty string if not set
+   */
+  [[nodiscard]] const std::string& parentJoint() const;
+
+  /**
+   * Set the parent joint name.
+   *
+   * @param name Skeleton joint name (e.g., "c_spine2" for chest)
+   */
+  void setParentJoint(const std::string& name);
+
+  /**
    * Fill the entire SDF with a constant value.
    *
    * @param value The value to fill with
@@ -251,6 +267,7 @@ class SignedDistanceField {
   Eigen::Vector3<Index> resolution_;
   Vector3 voxelSize_;
   std::vector<Scalar> data_;
+  std::string parentJoint_;
 };
 
 using SignedDistanceFieldf = SignedDistanceField<float>;

--- a/axel/axel/SignedDistanceFieldIO.cpp
+++ b/axel/axel/SignedDistanceFieldIO.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "axel/SignedDistanceFieldIO.h"
+
+#include <algorithm>
+#include <fstream>
+#include <stdexcept>
+
+#include <nlohmann/json.hpp>
+
+namespace axel {
+
+namespace {
+
+template <typename ScalarType>
+nlohmann::json sdfToJsonObject(const SignedDistanceField<ScalarType>& sdf) {
+  const auto& bounds = sdf.bounds();
+  const auto& res = sdf.resolution();
+  const auto& data = sdf.data();
+
+  nlohmann::json j;
+  j["bounds_min"] = {bounds.min().x(), bounds.min().y(), bounds.min().z()};
+  j["bounds_max"] = {bounds.max().x(), bounds.max().y(), bounds.max().z()};
+  j["resolution"] = {res.x(), res.y(), res.z()};
+
+  const auto* bytePtr = reinterpret_cast<const uint8_t*>(data.data());
+  const size_t byteCount = data.size() * sizeof(ScalarType);
+  j["data"] = nlohmann::json::binary({bytePtr, bytePtr + byteCount});
+
+  return j;
+}
+
+template <typename ScalarType>
+SignedDistanceField<ScalarType> jsonObjectToSdf(const nlohmann::json& j) {
+  const auto& boundsMin = j.at("bounds_min");
+  const auto& boundsMax = j.at("bounds_max");
+  const auto& res = j.at("resolution");
+
+  const BoundingBox<ScalarType> bounds(
+      Eigen::Vector3<ScalarType>(
+          boundsMin[0].get<ScalarType>(),
+          boundsMin[1].get<ScalarType>(),
+          boundsMin[2].get<ScalarType>()),
+      Eigen::Vector3<ScalarType>(
+          boundsMax[0].get<ScalarType>(),
+          boundsMax[1].get<ScalarType>(),
+          boundsMax[2].get<ScalarType>()));
+
+  const Eigen::Vector3<Index> resolution(
+      res[0].get<Index>(), res[1].get<Index>(), res[2].get<Index>());
+
+  const auto& bin = j.at("data").get_binary();
+  const size_t numElements = bin.size() / sizeof(ScalarType);
+  std::vector<ScalarType> data(numElements);
+  const auto* src = bin.data();
+  std::copy(src, src + numElements * sizeof(ScalarType), reinterpret_cast<uint8_t*>(data.data()));
+
+  return SignedDistanceField<ScalarType>(bounds, resolution, std::move(data));
+}
+
+void writeMsgpackToFile(const nlohmann::json& j, const std::string& path) {
+  std::ofstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open file for writing: " + path);
+  }
+  const auto bytes = nlohmann::json::to_msgpack(j);
+  file.write(
+      reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+  if (!file.good()) {
+    throw std::runtime_error("Failed to write msgpack data to: " + path);
+  }
+}
+
+nlohmann::json readMsgpackFromFile(const std::string& path) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open file for reading: " + path);
+  }
+  const auto size = file.tellg();
+  file.seekg(0, std::ios::beg);
+  std::vector<uint8_t> buffer(static_cast<size_t>(size));
+  file.read(reinterpret_cast<char*>(buffer.data()), size);
+  if (!file.good()) {
+    throw std::runtime_error("Failed to read msgpack data from: " + path);
+  }
+  return nlohmann::json::from_msgpack(buffer);
+}
+
+} // namespace
+
+template <typename ScalarType>
+void saveSdfToMsgpack(const SignedDistanceField<ScalarType>& sdf, const std::string& path) {
+  writeMsgpackToFile(sdfToJsonObject(sdf), path);
+}
+
+template <typename ScalarType>
+SignedDistanceField<ScalarType> loadSdfFromMsgpack(const std::string& path) {
+  return jsonObjectToSdf<ScalarType>(readMsgpackFromFile(path));
+}
+
+template <typename ScalarType>
+void saveSdfsToMsgpack(
+    const std::unordered_map<std::string, SignedDistanceField<ScalarType>>& sdfs,
+    const std::string& path) {
+  nlohmann::json j;
+  for (const auto& [name, sdf] : sdfs) {
+    nlohmann::json entry;
+    entry["sdf"] = sdfToJsonObject(sdf);
+    if (!sdf.parentJoint().empty()) {
+      entry["parent_joint"] = sdf.parentJoint();
+    }
+    j[name] = std::move(entry);
+  }
+  writeMsgpackToFile(j, path);
+}
+
+template <typename ScalarType>
+std::unordered_map<std::string, SignedDistanceField<ScalarType>> loadSdfsFromMsgpack(
+    const std::string& path) {
+  const auto j = readMsgpackFromFile(path);
+  std::unordered_map<std::string, SignedDistanceField<ScalarType>> result;
+  for (const auto& [name, entry] : j.items()) {
+    auto sdf = jsonObjectToSdf<ScalarType>(entry.at("sdf"));
+    if (entry.contains("parent_joint")) {
+      sdf.setParentJoint(entry.at("parent_joint").get<std::string>());
+    }
+    result.emplace(name, std::move(sdf));
+  }
+  return result;
+}
+
+template void saveSdfToMsgpack<float>(
+    const SignedDistanceField<float>& sdf,
+    const std::string& path);
+template void saveSdfToMsgpack<double>(
+    const SignedDistanceField<double>& sdf,
+    const std::string& path);
+
+template SignedDistanceField<float> loadSdfFromMsgpack<float>(const std::string& path);
+template SignedDistanceField<double> loadSdfFromMsgpack<double>(const std::string& path);
+
+template void saveSdfsToMsgpack<float>(
+    const std::unordered_map<std::string, SignedDistanceField<float>>& sdfs,
+    const std::string& path);
+template void saveSdfsToMsgpack<double>(
+    const std::unordered_map<std::string, SignedDistanceField<double>>& sdfs,
+    const std::string& path);
+
+template std::unordered_map<std::string, SignedDistanceField<float>> loadSdfsFromMsgpack<float>(
+    const std::string& path);
+template std::unordered_map<std::string, SignedDistanceField<double>> loadSdfsFromMsgpack<double>(
+    const std::string& path);
+
+} // namespace axel

--- a/axel/axel/SignedDistanceFieldIO.h
+++ b/axel/axel/SignedDistanceFieldIO.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "axel/SignedDistanceField.h"
+
+namespace axel {
+
+/// Save a signed distance field to a msgpack file.
+///
+/// @param sdf The signed distance field to save
+/// @param path Output file path
+template <typename ScalarType>
+void saveSdfToMsgpack(const SignedDistanceField<ScalarType>& sdf, const std::string& path);
+
+/// Load a signed distance field from a msgpack file.
+///
+/// @param path Input file path
+/// @return The loaded signed distance field
+/// @throws std::runtime_error if the file cannot be read or parsed
+template <typename ScalarType>
+SignedDistanceField<ScalarType> loadSdfFromMsgpack(const std::string& path);
+
+/// Save multiple named signed distance fields to a single msgpack file.
+/// Each entry is stored as {"sdf": {...}, "parent_joint": "..."} where
+/// parent_joint is serialized from each SDF's parentJoint() field (omitted if empty).
+///
+/// @param sdfs Map of name to SDF
+/// @param path Output file path
+template <typename ScalarType>
+void saveSdfsToMsgpack(
+    const std::unordered_map<std::string, SignedDistanceField<ScalarType>>& sdfs,
+    const std::string& path);
+
+/// Load multiple named signed distance fields from a single msgpack file.
+/// The parent_joint field (if present) is restored onto each SDF via setParentJoint().
+///
+/// @param path Input file path
+/// @return Map of name to SDF
+/// @throws std::runtime_error if the file cannot be read or parsed
+template <typename ScalarType>
+std::unordered_map<std::string, SignedDistanceField<ScalarType>> loadSdfsFromMsgpack(
+    const std::string& path);
+
+extern template void saveSdfToMsgpack<float>(
+    const SignedDistanceField<float>& sdf,
+    const std::string& path);
+extern template void saveSdfToMsgpack<double>(
+    const SignedDistanceField<double>& sdf,
+    const std::string& path);
+
+extern template SignedDistanceField<float> loadSdfFromMsgpack<float>(const std::string& path);
+extern template SignedDistanceField<double> loadSdfFromMsgpack<double>(const std::string& path);
+
+extern template void saveSdfsToMsgpack<float>(
+    const std::unordered_map<std::string, SignedDistanceField<float>>& sdfs,
+    const std::string& path);
+extern template void saveSdfsToMsgpack<double>(
+    const std::unordered_map<std::string, SignedDistanceField<double>>& sdfs,
+    const std::string& path);
+
+extern template std::unordered_map<std::string, SignedDistanceField<float>>
+loadSdfsFromMsgpack<float>(const std::string& path);
+extern template std::unordered_map<std::string, SignedDistanceField<double>>
+loadSdfsFromMsgpack<double>(const std::string& path);
+
+} // namespace axel

--- a/axel/axel/test/SignedDistanceFieldIOTest.cpp
+++ b/axel/axel/test/SignedDistanceFieldIOTest.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdio>
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+#include "axel/SignedDistanceFieldIO.h"
+
+namespace axel {
+
+namespace {
+
+std::string getTempFilePath(const std::string& suffix) {
+  return (std::filesystem::temp_directory_path() / ("sdf_io_test_" + suffix + ".msgpack")).string();
+}
+
+} // namespace
+
+TEST(SignedDistanceFieldIOTest, RoundtripFloat) {
+  const BoundingBoxf bounds(
+      Eigen::Vector3f(-1.0f, -2.0f, -3.0f), Eigen::Vector3f(4.0f, 5.0f, 6.0f));
+  const Eigen::Vector3<Index> resolution(3, 4, 5);
+
+  SignedDistanceFieldf sdf(bounds, resolution);
+  for (Index k = 0; k < resolution.z(); ++k) {
+    for (Index j = 0; j < resolution.y(); ++j) {
+      for (Index i = 0; i < resolution.x(); ++i) {
+        sdf.set(i, j, k, static_cast<float>(i * 100 + j * 10 + k) * 0.1f);
+      }
+    }
+  }
+
+  const auto path = getTempFilePath("float");
+  saveSdfToMsgpack(sdf, path);
+
+  const auto loaded = loadSdfFromMsgpack<float>(path);
+
+  EXPECT_EQ(loaded.resolution(), sdf.resolution());
+  EXPECT_NEAR(loaded.bounds().min().x(), sdf.bounds().min().x(), 1e-6f);
+  EXPECT_NEAR(loaded.bounds().min().y(), sdf.bounds().min().y(), 1e-6f);
+  EXPECT_NEAR(loaded.bounds().min().z(), sdf.bounds().min().z(), 1e-6f);
+  EXPECT_NEAR(loaded.bounds().max().x(), sdf.bounds().max().x(), 1e-6f);
+  EXPECT_NEAR(loaded.bounds().max().y(), sdf.bounds().max().y(), 1e-6f);
+  EXPECT_NEAR(loaded.bounds().max().z(), sdf.bounds().max().z(), 1e-6f);
+
+  ASSERT_EQ(loaded.data().size(), sdf.data().size());
+  for (size_t i = 0; i < sdf.data().size(); ++i) {
+    EXPECT_NEAR(loaded.data()[i], sdf.data()[i], 1e-6f) << "Mismatch at index " << i;
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST(SignedDistanceFieldIOTest, RoundtripDouble) {
+  const BoundingBoxd bounds(Eigen::Vector3d(0.0, 0.0, 0.0), Eigen::Vector3d(1.0, 1.0, 1.0));
+  const Eigen::Vector3<Index> resolution(2, 2, 2);
+  std::vector<double> data = {1.23456789, -2.87654321, 0.5, -0.5, 3.14, -3.14, 0.0, 1.0};
+
+  SignedDistanceFieldd sdf(bounds, resolution, std::move(data));
+
+  const auto path = getTempFilePath("double");
+  saveSdfToMsgpack(sdf, path);
+
+  const auto loaded = loadSdfFromMsgpack<double>(path);
+
+  EXPECT_EQ(loaded.resolution(), sdf.resolution());
+  ASSERT_EQ(loaded.data().size(), sdf.data().size());
+  for (size_t i = 0; i < sdf.data().size(); ++i) {
+    EXPECT_NEAR(loaded.data()[i], sdf.data()[i], 1e-12) << "Mismatch at index " << i;
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST(SignedDistanceFieldIOTest, SampleConsistencyAfterRoundtrip) {
+  auto sdf = SignedDistanceFieldf::createSphere(2.0f, Eigen::Vector3<Index>(8, 8, 8));
+
+  const auto path = getTempFilePath("sample");
+  saveSdfToMsgpack(sdf, path);
+  const auto loaded = loadSdfFromMsgpack<float>(path);
+
+  const std::vector<Eigen::Vector3f> testPositions = {
+      {0.0f, 0.0f, 0.0f},
+      {1.0f, 0.0f, 0.0f},
+      {0.5f, 0.5f, 0.5f},
+      {-1.0f, 0.5f, -0.3f},
+  };
+
+  for (const auto& pos : testPositions) {
+    EXPECT_NEAR(loaded.sample(pos), sdf.sample(pos), 1e-6f)
+        << "Sample mismatch at [" << pos.transpose() << "]";
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST(SignedDistanceFieldIOTest, RoundtripMultipleSdfs) {
+  const Eigen::Vector3<Index> res(3, 3, 3);
+
+  auto sphere1 = SignedDistanceFieldf::createSphere(1.0f, res);
+  auto sphere2 = SignedDistanceFieldf::createSphere(2.0f, res);
+  auto sphere3 = SignedDistanceFieldf::createSphere(0.5f, res);
+
+  std::unordered_map<std::string, SignedDistanceFieldf> sdfs;
+  sdfs.emplace("chest", std::move(sphere1));
+  sdfs.emplace("r_upperarm", std::move(sphere2));
+  sdfs.emplace("head", std::move(sphere3));
+
+  const auto path = getTempFilePath("multi");
+  saveSdfsToMsgpack(sdfs, path);
+
+  const auto loaded = loadSdfsFromMsgpack<float>(path);
+
+  ASSERT_EQ(loaded.size(), 3);
+  ASSERT_TRUE(loaded.count("chest"));
+  ASSERT_TRUE(loaded.count("r_upperarm"));
+  ASSERT_TRUE(loaded.count("head"));
+
+  for (const auto& [name, original] : sdfs) {
+    const auto& restored = loaded.at(name);
+    EXPECT_EQ(restored.resolution(), original.resolution());
+    ASSERT_EQ(restored.data().size(), original.data().size());
+    for (size_t i = 0; i < original.data().size(); ++i) {
+      EXPECT_NEAR(restored.data()[i], original.data()[i], 1e-6f)
+          << "Mismatch in '" << name << "' at index " << i;
+    }
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST(SignedDistanceFieldIOTest, RoundtripMultipleSdfsWithParentJoint) {
+  const Eigen::Vector3<Index> res(3, 3, 3);
+
+  std::unordered_map<std::string, SignedDistanceFieldf> sdfs;
+  auto chest = SignedDistanceFieldf::createSphere(1.0f, res);
+  chest.setParentJoint("c_spine2");
+  auto pelvis = SignedDistanceFieldf::createSphere(0.5f, res);
+  pelvis.setParentJoint("root");
+  auto head = SignedDistanceFieldf::createSphere(0.3f, res);
+  sdfs.emplace("chest", std::move(chest));
+  sdfs.emplace("pelvis", std::move(pelvis));
+  sdfs.emplace("head", std::move(head));
+
+  const auto path = getTempFilePath("parent_joint");
+  saveSdfsToMsgpack(sdfs, path);
+
+  const auto loaded = loadSdfsFromMsgpack<float>(path);
+
+  ASSERT_EQ(loaded.size(), 3);
+  EXPECT_EQ(loaded.at("chest").parentJoint(), "c_spine2");
+  EXPECT_EQ(loaded.at("pelvis").parentJoint(), "root");
+  EXPECT_EQ(loaded.at("head").parentJoint(), "");
+
+  for (const auto& [name, original] : sdfs) {
+    const auto& restored = loaded.at(name);
+    EXPECT_EQ(restored.resolution(), original.resolution());
+    ASSERT_EQ(restored.data().size(), original.data().size());
+  }
+
+  std::remove(path.c_str());
+}
+
+TEST(SignedDistanceFieldIOTest, LoadNonexistentFileThrows) {
+  EXPECT_THROW(loadSdfFromMsgpack<float>("/nonexistent/path/sdf.msgpack"), std::runtime_error);
+}
+
+} // namespace axel


### PR DESCRIPTION
Summary:

Add save/load functions for SignedDistanceField to/from msgpack files using nlohmann::json. Supports both single SDF and multiple named SDFs in one file.

The multi-SDF format stores each entry as `{name: {sdf: {bounds_min, bounds_max, resolution, data}, metadata: {...}}}` where metadata is an optional per-SDF dictionary of string key-value pairs. This enables consumers to attach arbitrary annotations (e.g., parent joint names for collision IK) to individual SDFs without changing the core SDF data structure.

Passing metadata keys that don't match any SDF name is an error (throws std::runtime_error).

API:
- `saveSdfToMsgpack` / `loadSdfFromMsgpack` — single SDF
- `saveSdfsToMsgpack` / `loadSdfsFromMsgpack` — multiple named SDFs with optional per-SDF metadata
- `SdfMetadata` type alias for `unordered_map<string, string>`

Reviewed By: cdtwigg, cstollmeta

Differential Revision: D101953561


