### PR TITLE
Fix Eigen quaternion pybind11 type caster: broken load and cast (#1330)

### DIFF
--- a/pymomentum/python_utility/eigen_quaternion.h
+++ b/pymomentum/python_utility/eigen_quaternion.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
 #include <Eigen/Geometry>
@@ -40,29 +41,29 @@ struct type_caster<Eigen::Quaternion<Scalar>> {
   /// Standard pybind11 type caster interface
   PYBIND11_TYPE_CASTER(Type, const_name("numpy.ndarray[4]"));
 
-  /// Python -> C++ conversion: delegate to Vector4 caster
-  bool load(handle src, bool convert) {
-    // Use the existing pybind11 Vector4 type caster
-    type_caster<Vector4> vec_caster;
-    if (!vec_caster.load(src, convert)) {
+  /// Python -> C++ conversion: read [x, y, z, w] from numpy array
+  bool load(handle src, bool /*convert*/) {
+    auto array =
+        pybind11::array_t<Scalar, pybind11::array::c_style | pybind11::array::forcecast>::ensure(
+            src);
+    if (!array || array.size() != 4) {
       return false;
     }
-
-    // Extract the Vector4 and construct quaternion
-    // Vector4 is [x, y, z, w], Quaternion constructor is (w, x, y, z)
-    const Vector4& coeffs = vec_caster;
-    value = Type(coeffs(3), coeffs(0), coeffs(1), coeffs(2));
-
+    const Scalar* data = array.data();
+    // Array is [x, y, z, w], Quaternion ctor is (w, x, y, z)
+    value = Type(data[3], data[0], data[1], data[2]);
     return true;
   }
 
-  /// C++ -> Python conversion: delegate to Vector4 caster
-  static handle cast(const Type& src, return_value_policy policy, handle parent) {
-    // Get coefficients as Vector4 [x, y, z, w]
-    Vector4 coeffs = src.coeffs();
-
-    // Use the existing pybind11 Vector4 type caster
-    return type_caster<Vector4>::cast(coeffs, policy, parent);
+  /// C++ -> Python conversion: return [x, y, z, w] numpy array
+  static handle cast(const Type& src, return_value_policy /*policy*/, handle /*parent*/) {
+    auto result = pybind11::array_t<Scalar>(4);
+    auto* buf = result.mutable_data();
+    buf[0] = src.x();
+    buf[1] = src.y();
+    buf[2] = src.z();
+    buf[3] = src.w();
+    return result.release();
   }
 
   /// Support for const pointer return

--- a/pymomentum/test/test_sdf_collider.py
+++ b/pymomentum/test/test_sdf_collider.py
@@ -68,6 +68,27 @@ class TestSDFCollider(unittest.TestCase):
             collider.translation, np.array([0.5, 0.5, 0.5], dtype=np.float32)
         )
 
+    def test_rotation_round_trip(self) -> None:
+        """Test that rotation kwarg is stored and returned correctly."""
+        from pymomentum import geometry
+
+        # 90-degree rotation around Z: quat [x, y, z, w]
+        s = float(np.sin(np.pi / 4))
+        c = float(np.cos(np.pi / 4))
+        rot_quat = np.array([0.0, 0.0, s, c], dtype=np.float32)
+
+        collider = geometry.SDFCollider(rotation=rot_quat)
+        stored = np.asarray(collider.rotation)
+        np.testing.assert_allclose(stored, rot_quat, atol=1e-6)
+
+    def test_default_rotation_is_identity(self) -> None:
+        """Test that default rotation is identity quaternion [0, 0, 0, 1]."""
+        from pymomentum import geometry
+
+        collider = geometry.SDFCollider()
+        identity = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+        np.testing.assert_allclose(np.asarray(collider.rotation), identity, atol=1e-6)
+
     def test_repr(self) -> None:
         """Test SDFCollider __repr__."""
         from pymomentum import geometry


### PR DESCRIPTION
Summary:

The custom `type_caster<Eigen::Quaternion<Scalar>>` in `eigen_quaternion.h` had broken `load` (Python→C++) and `cast` (C++→Python) methods. Both delegated to the pybind11 `Vector4` type caster via implicit conversion, which produced dangling references and garbage values.

The `load` method extracted a `const Vector4&` from the intermediate caster, but pybind11's Eigen matrix caster stores data as a `Ref` or `Map` that doesn't support this implicit conversion pattern. The `cast` method had a similar issue delegating `Vector4` output through `type_caster<Vector4>::cast()`.

Fixed both methods to operate directly on numpy arrays via `pybind11::array_t`, avoiding all intermediate caster delegation. This is simpler, more robust, and handles type coercion via the `forcecast` flag.

Added rotation round-trip tests in `test_sdf_collider.py` to prevent regression. Also fixed minor pyre type annotations in `test_sdf_collision.py`.

Reviewed By: cstollmeta

Differential Revision: D101391980


