### PR TITLE
Fix SDF buffer protocol strides for non-cubic grids (#1331)

### DIFF
--- a/pymomentum/axel/axel_pybind.cpp
+++ b/pymomentum/axel/axel_pybind.cpp
@@ -385,19 +385,22 @@ More efficient than calling sample() and gradient() separately.
         const auto& res = self.resolution();
         auto& data = self.data();
 
+        // The internal storage uses column-major (Fortran) order where x varies
+        // fastest: linearIndex(i, j, k) = k * nx * ny + j * nx + i.
+        // Declare matching Fortran-order strides so that
+        // np.asarray(sdf)[i, j, k] == sdf.at(i, j, k).
         return py::buffer_info(
             data.data(), // Pointer to buffer
             sizeof(float), // Size of one scalar
-            py::format_descriptor<float>::format(), // Python format
-                                                    // descriptor
+            py::format_descriptor<float>::format(), // Python format descriptor
             3, // Number of dimensions
             {static_cast<py::ssize_t>(res.x()), // Shape: nx
              static_cast<py::ssize_t>(res.y()), //        ny
              static_cast<py::ssize_t>(res.z())}, //        nz
-            {sizeof(float) * static_cast<py::ssize_t>(res.y()) *
-                 static_cast<py::ssize_t>(res.z()), // Strides: x dimension
-             sizeof(float) * static_cast<py::ssize_t>(res.z()), //          y dimension
-             sizeof(float)} //          z dimension
+            {sizeof(float), // Stride x: i varies fastest
+             sizeof(float) * static_cast<py::ssize_t>(res.x()), // Stride y: j
+             sizeof(float) * static_cast<py::ssize_t>(res.x()) * static_cast<py::ssize_t>(res.y())}
+            // Stride z: k varies slowest
         );
       })
       .def("__repr__", [](const axel::SignedDistanceField<float>& self) {

--- a/pymomentum/python_utility/eigen_quaternion.h
+++ b/pymomentum/python_utility/eigen_quaternion.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
 #include <Eigen/Geometry>
@@ -40,29 +41,29 @@ struct type_caster<Eigen::Quaternion<Scalar>> {
   /// Standard pybind11 type caster interface
   PYBIND11_TYPE_CASTER(Type, const_name("numpy.ndarray[4]"));
 
-  /// Python -> C++ conversion: delegate to Vector4 caster
-  bool load(handle src, bool convert) {
-    // Use the existing pybind11 Vector4 type caster
-    type_caster<Vector4> vec_caster;
-    if (!vec_caster.load(src, convert)) {
+  /// Python -> C++ conversion: read [x, y, z, w] from numpy array
+  bool load(handle src, bool /*convert*/) {
+    auto array =
+        pybind11::array_t<Scalar, pybind11::array::c_style | pybind11::array::forcecast>::ensure(
+            src);
+    if (!array || array.size() != 4) {
       return false;
     }
-
-    // Extract the Vector4 and construct quaternion
-    // Vector4 is [x, y, z, w], Quaternion constructor is (w, x, y, z)
-    const Vector4& coeffs = vec_caster;
-    value = Type(coeffs(3), coeffs(0), coeffs(1), coeffs(2));
-
+    const Scalar* data = array.data();
+    // Array is [x, y, z, w], Quaternion ctor is (w, x, y, z)
+    value = Type(data[3], data[0], data[1], data[2]);
     return true;
   }
 
-  /// C++ -> Python conversion: delegate to Vector4 caster
-  static handle cast(const Type& src, return_value_policy policy, handle parent) {
-    // Get coefficients as Vector4 [x, y, z, w]
-    Vector4 coeffs = src.coeffs();
-
-    // Use the existing pybind11 Vector4 type caster
-    return type_caster<Vector4>::cast(coeffs, policy, parent);
+  /// C++ -> Python conversion: return [x, y, z, w] numpy array
+  static handle cast(const Type& src, return_value_policy /*policy*/, handle /*parent*/) {
+    auto result = pybind11::array_t<Scalar>(4);
+    auto* buf = result.mutable_data();
+    buf[0] = src.x();
+    buf[1] = src.y();
+    buf[2] = src.z();
+    buf[3] = src.w();
+    return result.release();
   }
 
   /// Support for const pointer return

--- a/pymomentum/test/test_axel.py
+++ b/pymomentum/test/test_axel.py
@@ -259,6 +259,45 @@ class TestAxel(unittest.TestCase):
             data_array_after_clear, np.zeros((2, 2, 2), dtype=np.float32)
         )
 
+    def test_sdf_buffer_protocol_axis_order(self):
+        """Test that buffer protocol indexing matches C++ sample() on a non-cubic grid.
+
+        Uses a non-cubic grid with asymmetric values at specific grid points to
+        detect axis transposition bugs (e.g. C-order vs Fortran-order strides).
+        """
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([3.0, 5.0, 7.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+
+        # Non-cubic resolution is critical: nx != ny != nz ensures that
+        # swapping axes produces different results.
+        resolution = np.array([3, 5, 7], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution)
+
+        # Write distinct values at asymmetric grid positions via the
+        # buffer protocol view.
+        sdf_view = np.asarray(sdf)
+        sdf_view[:] = 0.0
+        sdf_view[1, 0, 0] = 10.0  # Only x offset
+        sdf_view[0, 1, 0] = 20.0  # Only y offset
+        sdf_view[0, 0, 1] = 30.0  # Only z offset
+        sdf_view[2, 3, 5] = 99.0  # Asymmetric point (i!=j!=k)
+
+        # sample() at exact grid points should return the values we wrote.
+        # voxel_size = (max - min) / resolution = (1.0, 1.0, 1.0)
+        self.assertAlmostEqual(sdf.sample(np.array([1.0, 0.0, 0.0])), 10.0, places=5)
+        self.assertAlmostEqual(sdf.sample(np.array([0.0, 1.0, 0.0])), 20.0, places=5)
+        self.assertAlmostEqual(sdf.sample(np.array([0.0, 0.0, 1.0])), 30.0, places=5)
+        self.assertAlmostEqual(sdf.sample(np.array([2.0, 3.0, 5.0])), 99.0, places=5)
+
+        # Also verify that a round-trip through np.array() (which copies to
+        # C-contiguous) preserves the correct indexing.
+        sdf_copy = np.array(sdf)
+        self.assertAlmostEqual(sdf_copy[1, 0, 0], 10.0)
+        self.assertAlmostEqual(sdf_copy[0, 1, 0], 20.0)
+        self.assertAlmostEqual(sdf_copy[0, 0, 1], 30.0)
+        self.assertAlmostEqual(sdf_copy[2, 3, 5], 99.0)
+
     def test_mesh_to_sdf_tetrahedron(self):
         """Test mesh_to_sdf with a simple tetrahedron mesh."""
         # Create a simple tetrahedron mesh

--- a/pymomentum/test/test_sdf_collider.py
+++ b/pymomentum/test/test_sdf_collider.py
@@ -68,6 +68,27 @@ class TestSDFCollider(unittest.TestCase):
             collider.translation, np.array([0.5, 0.5, 0.5], dtype=np.float32)
         )
 
+    def test_rotation_round_trip(self) -> None:
+        """Test that rotation kwarg is stored and returned correctly."""
+        from pymomentum import geometry
+
+        # 90-degree rotation around Z: quat [x, y, z, w]
+        s = float(np.sin(np.pi / 4))
+        c = float(np.cos(np.pi / 4))
+        rot_quat = np.array([0.0, 0.0, s, c], dtype=np.float32)
+
+        collider = geometry.SDFCollider(rotation=rot_quat)
+        stored = np.asarray(collider.rotation)
+        np.testing.assert_allclose(stored, rot_quat, atol=1e-6)
+
+    def test_default_rotation_is_identity(self) -> None:
+        """Test that default rotation is identity quaternion [0, 0, 0, 1]."""
+        from pymomentum import geometry
+
+        collider = geometry.SDFCollider()
+        identity = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+        np.testing.assert_allclose(np.asarray(collider.rotation), identity, atol=1e-6)
+
     def test_repr(self) -> None:
         """Test SDFCollider __repr__."""
         from pymomentum import geometry


### PR DESCRIPTION
Summary:

The axel SignedDistanceField buffer protocol declared C-contiguous strides (ny*nz, nz, 1) for shape (nx, ny, nz), but the internal C++ storage uses column-major (Fortran) order where x varies fastest: linearIndex(i,j,k) = k*nx*ny + j*nx + i with element strides (1, nx, nx*ny). For non-cubic grids this caused np.asarray(sdf)[i,j,k] to access the wrong element compared to sdf.at(i,j,k), effectively transposing the x and z axes.

Fix the buffer protocol to declare Fortran-order strides matching the actual storage layout. This was not caught previously because all existing tests used either cubic grids or origin-centered spheres (symmetric under x/z swap).

Adds a test with a non-cubic (3,5,7) grid and asymmetric values that verifies buffer protocol indexing matches C++ sample() at exact grid points.

Reviewed By: cstollmeta

Differential Revision: D101270101


