### PR TITLE
Fix uninitialized ReprojectionResult crash in skinned locator triangle constraints (#1334)

### DIFF
--- a/momentum/character_solver/skinned_locator_triangle_error_function.cpp
+++ b/momentum/character_solver/skinned_locator_triangle_error_function.cpp
@@ -16,6 +16,7 @@
 #include "momentum/character/skeleton_state.h"
 #include "momentum/character/skin_weights.h"
 #include "momentum/common/checks.h"
+#include "momentum/common/log.h"
 #include "momentum/common/profile.h"
 #include "momentum/math/mesh.h"
 
@@ -95,9 +96,10 @@ namespace {
 // Helper struct for reprojection result
 template <typename T>
 struct ReprojectionResult {
-  Eigen::Vector3i triangleIndices;
-  Eigen::Vector3<T> baryCoords;
-  Eigen::Vector3<T> closestPoint;
+  Eigen::Vector3i triangleIndices = Eigen::Vector3i::Constant(-1);
+  Eigen::Vector3<T> baryCoords = Eigen::Vector3<T>::Zero();
+  Eigen::Vector3<T> closestPoint = Eigen::Vector3<T>::Zero();
+  bool valid = false;
 };
 
 // Find the closest candidate triangle and compute reprojection
@@ -135,6 +137,7 @@ ReprojectionResult<T> findClosestCandidateTriangle(
       result.triangleIndices = candidate.vertexIndices;
       result.baryCoords = bary;
       result.closestPoint = targetPoint;
+      result.valid = true;
     }
   }
 
@@ -154,6 +157,16 @@ SkinnedLocatorTriangleConstraintT<T> getEffectiveConstraint(
   // Find closest candidate triangle
   ReprojectionResult<T> reproj =
       findClosestCandidateTriangle(mesh, locatorPos, constr.candidateTriangles, constr.depth);
+
+  // If reprojection failed (e.g., NaN vertices → all candidates skipped), fall back to original
+  if (!reproj.valid) {
+    MT_LOGI(
+        "SkinnedLocatorTriangle: reprojection failed for locatorIndex {} "
+        "({} candidates, all had NaN/Inf distances). Using original constraint.",
+        constr.locatorIndex,
+        constr.candidateTriangles.size());
+    return constr;
+  }
 
   // Create effective constraint with reprojected triangle
   SkinnedLocatorTriangleConstraintT<T> effective;


### PR DESCRIPTION
Summary:

Initialize ReprojectionResult fields to prevent undefined behavior when
findClosestCandidateTriangle fails to select any candidate (e.g., NaN
mesh vertices cause all distance comparisons to fail). Fall back to the
original constraint when reprojection fails instead of using garbage
vertex indices.

Reviewed By: cstollmeta

Differential Revision: D101050237
