### PR TITLE
Fix URDF negative-axis parameter limits and docs

### DIFF
--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -92,15 +92,17 @@ template <typename S>
 
 /// Returns the principal axis index (0=X, 1=Y, 2=Z) and sign (+1/-1) for a URDF axis vector.
 ///
-/// URDF joints specify an arbitrary axis direction, but Momentum's joint parameters are
-/// defined along fixed principal axes (tx/ty/tz, rx/ry/rz). Rather than aligning the URDF
-/// axis to Momentum's X axis via preRotation (which would create a rotated internal frame
-/// that differs from the URDF link frame), we map the DOF directly to the matching principal
-/// axis. This preserves frame compatibility with URDF visual meshes and animation data.
+/// The imported Momentum node represents the child link carrying its incoming URDF joint. Since
+/// the local frame is kept equal to the URDF child link frame, we do not spend preRotation on
+/// aligning arbitrary URDF axes to a canonical axis. Instead, we only accept URDF axes already
+/// aligned with a principal axis and map the DOF onto the matching Momentum parameter.
 ///
-/// For negative axes (e.g., (0,0,-1)), the sign is -1 and the parameter transform coefficient
-/// is negated, so that a positive URDF joint angle still corresponds to rotation around the
-/// positive axis direction.
+/// For negative axes (e.g., (0,0,-1)), the sign tracks how the URDF scalar joint coordinate maps
+/// into the preserved child-link frame's local principal-axis parameter. The imported model
+/// parameter itself stays equal to the URDF joint scalar, so limits remain in the same coordinate.
+/// This also means the exposed model parameter is not always numerically equal to the local
+/// positive-axis rx/ry/rz slot used by Momentum FK; for a negative axis, the local slot receives
+/// the negated value through the parameter transform.
 ///
 /// @return A pair of (axis index, sign): axis index 0=X, 1=Y, 2=Z; sign is +1 or -1.
 /// @throws If the axis is not aligned with a principal axis (e.g., (0.707, 0, 0.707)).
@@ -218,6 +220,8 @@ bool loadUrdfSkeletonRecursive(
       urdfLink->name);
 
   Joint joint;
+  // The imported Momentum node is identified by the child link. It stores the incoming URDF
+  // joint that moves that link, rather than creating a separate "joint frame" node.
   joint.name = urdfLink->name;
   joint.parent = parentJointId;
 
@@ -229,11 +233,16 @@ bool loadUrdfSkeletonRecursive(
   // Parse Parameter transform
   //---------------------------
   //
-  // URDF joints specify an arbitrary axis direction for their DOF. Instead of aligning that
-  // axis to Momentum's X axis via preRotation (which would create a rotated internal frame),
-  // we map the DOF directly to the corresponding principal axis parameter (rx/ry/rz for
-  // revolute, tx/ty/tz for prismatic). This preserves the URDF link frame as the joint's
-  // local frame, making visual meshes and animation data directly compatible.
+  // URDF expresses motion on a joint between links, but attached data is authored in the child
+  // link frame. Our imported Momentum node therefore keeps the child link frame as its local
+  // frame and stores the incoming URDF joint's DOF on that node. We do not introduce a separate
+  // internal axis-alignment frame.
+  //
+  // As a result, we map the URDF DOF directly to the corresponding principal-axis parameter
+  // (rx/ry/rz for revolute, tx/ty/tz for prismatic) inside the preserved link frame. For
+  // negative URDF axes, the parameter transform carries a negative coefficient into the local
+  // principal axis so the imported model parameter remains the URDF joint scalar coordinate
+  // rather than the local positive-axis rotation used internally by Momentum FK.
 
   if (urdfJoint != nullptr) {
     // Check if this joint mimics another joint. Mimic joints don't create their own model
@@ -311,7 +320,7 @@ bool loadUrdfSkeletonRecursive(
       case urdf::Joint::PLANAR: {
         // The axis defines the plane normal. DOFs are translation along the two in-plane
         // axes and rotation around the normal.
-        const auto [normalIdx, sign] = getPrincipalAxis(urdfJoint->axis);
+        const int normalIdx = getPrincipalAxis(urdfJoint->axis).first;
         const int planeAxis0 = (normalIdx + 1) % 3;
         const int planeAxis1 = (normalIdx + 2) % 3;
         const auto& jn = urdfJoint->name;
@@ -325,7 +334,7 @@ bool loadUrdfSkeletonRecursive(
             jointParamsBaseIndex + planeAxis1, modelParamsBaseIndex + 1, 1.0f);
         data.parameterTransform.name.push_back(fmt::format("{}_{}", jn, kRotationNames[normalIdx]));
         data.triplets.emplace_back(
-            jointParamsBaseIndex + 3 + normalIdx, modelParamsBaseIndex + 2, sign);
+            jointParamsBaseIndex + 3 + normalIdx, modelParamsBaseIndex + 2, 1.0f);
         data.totalDoFs += 3;
         break;
       }
@@ -345,34 +354,21 @@ bool loadUrdfSkeletonRecursive(
       auto urdfJointLimits = urdfJoint->limits;
       switch (urdfJoint->type) {
         case urdf::Joint::REVOLUTE: {
-          const auto [axisIdx, sign] = getPrincipalAxis(urdfJoint->axis);
           ParameterLimit jointLimits;
           jointLimits.type = MinMax;
           jointLimits.data.minMax.parameterIndex = modelParamsBaseIndex;
-          if (sign > 0) {
-            jointLimits.data.minMax.limits[0] = urdfJointLimits->lower; // rad
-            jointLimits.data.minMax.limits[1] = urdfJointLimits->upper;
-          } else {
-            // Negative axis: model param = -urdf_angle, so limits are negated and swapped
-            jointLimits.data.minMax.limits[0] = -urdfJointLimits->upper;
-            jointLimits.data.minMax.limits[1] = -urdfJointLimits->lower;
-          }
+          jointLimits.data.minMax.limits[0] = urdfJointLimits->lower; // rad
+          jointLimits.data.minMax.limits[1] = urdfJointLimits->upper;
           jointLimits.weight = 1.0f;
           data.limits.push_back(jointLimits);
           break;
         }
         case urdf::Joint::PRISMATIC: {
-          const auto [axisIdx, sign] = getPrincipalAxis(urdfJoint->axis);
           ParameterLimit jointLimits;
           jointLimits.type = MinMax;
           jointLimits.data.minMax.parameterIndex = modelParamsBaseIndex;
-          if (sign > 0) {
-            jointLimits.data.minMax.limits[0] = toCm<float>(urdfJointLimits->lower);
-            jointLimits.data.minMax.limits[1] = toCm<float>(urdfJointLimits->upper);
-          } else {
-            jointLimits.data.minMax.limits[0] = -toCm<float>(urdfJointLimits->upper);
-            jointLimits.data.minMax.limits[1] = -toCm<float>(urdfJointLimits->lower);
-          }
+          jointLimits.data.minMax.limits[0] = toCm<float>(urdfJointLimits->lower);
+          jointLimits.data.minMax.limits[1] = toCm<float>(urdfJointLimits->upper);
           jointLimits.weight = 1.0f;
           data.limits.push_back(jointLimits);
           break;
@@ -388,11 +384,12 @@ bool loadUrdfSkeletonRecursive(
   // Set Joint Offset
   //
   // The preRotation is simply the URDF joint origin rotation — the transform from the parent
-  // link frame to the child link frame at bind pose. No axis alignment is applied because DOFs
-  // are mapped directly to the corresponding principal axis parameter (rx/ry/rz).
+  // link frame to the child link frame at bind pose. No extra axis-alignment rotation is baked
+  // in, because the imported Momentum node is meant to coincide with the URDF child link frame.
   //
-  // This means the Momentum joint frame coincides with the URDF link frame, which makes visual
-  // meshes and animation data directly compatible without any frame correction.
+  // If we axis-aligned the local frame here, every quantity authored in the child link frame
+  // (visuals, collisions, inertials, descendant joint origins, external animation data) would
+  // need an additional frame conversion.
   if (urdfJoint != nullptr) {
     const urdf::Pose& urdfPose = urdfJoint->parent_to_joint_origin_transform;
     joint.preRotation = toMomentumQuaternion<float>(urdfPose.rotation);

--- a/momentum/io/urdf/urdf_io.h
+++ b/momentum/io/urdf/urdf_io.h
@@ -20,41 +20,46 @@ namespace momentum {
 ///
 /// ## URDF-to-Momentum Frame Convention
 ///
-/// URDF and Momentum have different conventions for representing joint degrees of freedom.
-/// This loader maps between them as follows:
+/// URDF and Momentum organize skeletons differently, so this loader has to choose what a
+/// Momentum "joint" node means.
 ///
 /// **URDF convention:**
-/// - Each joint specifies an arbitrary `axis` direction (e.g., `<axis xyz="0 0 1"/>`)
-///   that defines the direction of rotation (revolute) or translation (prismatic).
-/// - The axis is just a direction vector — it does NOT define the local coordinate system.
-/// - The link frame is defined solely by the joint's `<origin>` transform (xyz + rpy).
-/// - Visual meshes are positioned relative to the link frame.
+/// - A URDF `joint` connects a parent link to a child link.
+/// - The joint contributes the parent-to-child bind-pose transform (`<origin>`) and the
+///   motion axis (`<axis>`).
+/// - Data attached to the child link — visuals, collisions, inertials, and descendant joint
+///   origins — is authored in the child link frame.
 ///
 /// **Momentum convention:**
-/// - Joint DOFs are applied along fixed local axes: `rx`/`ry`/`rz` for rotation,
-///   `tx`/`ty`/`tz` for translation.
-/// - `preRotation` defines the parent-to-child frame rotation at bind pose.
+/// - Each skeleton node stores a local frame (`preRotation` + translation offset) plus
+///   parameters on fixed local principal axes: `rx`/`ry`/`rz`, `tx`/`ty`/`tz`.
 ///
-/// **How this loader bridges the two:**
-/// - DOFs are mapped to the **natural principal axis** matching the URDF axis direction.
-///   For example, a revolute joint with axis `(0,0,1)` maps to `rz`, not `rx`.
-/// - `preRotation` is set to the URDF joint origin rotation **only** — no axis alignment
-///   rotation is baked in. This means the Momentum joint frame coincides with the URDF
-///   link frame.
-/// - Visual meshes can be transformed using the joint world transform directly, with no
-///   frame correction needed.
+/// **Loader choice: child-link-centric import**
+/// - The imported Momentum node corresponds to the URDF child link and carries that link's
+///   incoming URDF joint.
+/// - `preRotation` is set to the URDF joint origin rotation only, so the imported local frame
+///   stays equal to the URDF child link frame.
+/// - This keeps child-link-authored data directly compatible with the imported skeleton.
 ///
-/// **Why this matters for animation:**
-/// - URDF has no official animation format. Motion data typically comes from BVH or other
-///   formats that express rotations in the joint's local frame.
-/// - Because we preserve the URDF link frame (no axis remapping), animation data can be
-///   applied directly to the corresponding `rx`/`ry`/`rz` parameter without any frame
-///   conversion.
-/// - If axis alignment were baked into `preRotation`, external animation data would need
-///   to account for the internal frame rotation, which no external tool would know to do.
+/// **Consequence for DOF mapping:**
+/// - DOFs are mapped onto the matching Momentum principal axis inside the preserved link frame.
+///   For example, a revolute joint with axis `(0,0,1)` maps to `rz`.
+/// - The exposed model parameter preserves the URDF joint scalar coordinate. If the URDF axis
+///   points along `-X`, `-Y`, or `-Z`, the parameter transform therefore carries a `-1`
+///   coefficient into the corresponding local Momentum principal axis.
+/// - In other words, under this link-preserving convention the exposed model parameter is not
+///   always numerically equal to the local positive-axis `rx`/`ry`/`rz` entry used by Momentum
+///   FK. For negative-axis joints, a positive model parameter produces a negative local
+///   principal-axis rotation.
+/// - Because the model parameter stays in URDF joint coordinates, revolute and prismatic limits
+///   and mimic relations remain in the same coordinate as the imported model parameter.
+/// - We do not bake an extra axis-alignment rotation into `preRotation`. Doing so would make
+///   the imported local frame differ from the URDF child link frame, and every child-link-
+///   authored quantity would need frame conversion.
 ///
 /// **Limitation:** Only principal axes (±X, ±Y, ±Z) are supported. Non-principal axes
-/// (e.g., `(0.707, 0, 0.707)`) will throw an error.
+/// (e.g., `(0.707, 0, 0.707)`) would require an additional axis-alignment frame or a more
+/// general joint representation, so the loader rejects them.
 ///
 /// **Units:** URDF uses meters; Momentum uses centimeters. All positions are converted
 /// automatically.

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -603,6 +603,76 @@ TEST(IoUrdfTest, MimicJoint) {
   EXPECT_FLOAT_EQ(pt.transform.coeff(2 * kParametersPerJoint + 5, 0), 2.0f);
 }
 
+TEST(IoUrdfTest, NegativeAxisUsesSignedUrdfModelParameter) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="negative_axis_robot">
+      <link name="base_link"/>
+      <link name="child_link"/>
+      <joint name="joint1" type="revolute">
+        <parent link="base_link"/>
+        <child link="child_link"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <axis xyz="0 -1 0"/>
+        <limit lower="-0.25" upper="1.0" effort="100" velocity="1"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_EQ(character.skeleton.joints.size(), 2);
+  ASSERT_EQ(character.parameterTransform.name.size(), 1);
+  ASSERT_EQ(character.parameterLimits.size(), 1);
+
+  constexpr Eigen::Index kChildRyIndex = 1 * kParametersPerJoint + RY;
+  EXPECT_FLOAT_EQ(character.parameterTransform.transform.coeff(kChildRyIndex, 0), -1.0f);
+  EXPECT_FLOAT_EQ(character.parameterLimits[0].data.minMax.limits[0], -0.25f);
+  EXPECT_FLOAT_EQ(character.parameterLimits[0].data.minMax.limits[1], 1.0f);
+
+  const ModelParameters modelParams(Eigen::VectorXf::Constant(1, 0.5f));
+  const JointParameters jointParams = character.parameterTransform.apply(modelParams);
+  EXPECT_FLOAT_EQ(jointParams[kChildRyIndex], -0.5f);
+}
+
+TEST(IoUrdfTest, NegativeAxisMimicUsesSignedUrdfModelParameter) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="negative_axis_mimic_robot">
+      <link name="base_link"/>
+      <link name="link1"/>
+      <link name="link2"/>
+      <joint name="joint1" type="revolute">
+        <parent link="base_link"/>
+        <child link="link1"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <axis xyz="0 -1 0"/>
+        <limit lower="-0.5" upper="1.2" effort="100" velocity="1"/>
+      </joint>
+      <joint name="joint2" type="revolute">
+        <parent link="base_link"/>
+        <child link="link2"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <axis xyz="0 -1 0"/>
+        <limit lower="-3.14" upper="3.14" effort="100" velocity="1"/>
+        <mimic joint="joint1" multiplier="2" offset="0.1"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_EQ(character.parameterTransform.name.size(), 1);
+
+  constexpr Eigen::Index kJoint1RyIndex = 1 * kParametersPerJoint + RY;
+  constexpr Eigen::Index kJoint2RyIndex = 2 * kParametersPerJoint + RY;
+  EXPECT_FLOAT_EQ(character.parameterTransform.transform.coeff(kJoint1RyIndex, 0), -1.0f);
+  EXPECT_FLOAT_EQ(character.parameterTransform.transform.coeff(kJoint2RyIndex, 0), -2.0f);
+  EXPECT_FLOAT_EQ(character.parameterTransform.offsets[kJoint2RyIndex], -0.1f);
+}
+
 TEST(IoUrdfTest, MaterialColors) {
   const std::string urdfContent = R"(
     <?xml version="1.0"?>


### PR DESCRIPTION
Summary:
There is a bug where joint limits for negative rotation axis are incorrectly flipped. Turns out it's a confusion of link vs joint in urdf. For convenience in handling the mesh objects, we choose "link" as a node / "joint" in momentum. As a result, we can only support joints that are axis aligned, and model parameters may have a negative coefficient if the joint axis is negative in the link space. In any case, the joint limits is still 1:1 corresponding to model parameter limits, even when model parameters have a negative sign. This was the bug fixed in this diff. A test case is added to ensure negative axis has correct joint limits.

Documentations are updated to explain this design and its consequence more clearly to future readers.

Differential Revision: D102415272


