### PR TITLE
Remove dead AVX-related declarations after AVX error functions removed

### DIFF
--- a/momentum/character_solver_simd/simd_helpers.h
+++ b/momentum/character_solver_simd/simd_helpers.h
@@ -12,10 +12,6 @@
 
 #include <Eigen/Core>
 
-#ifdef MOMENTUM_ENABLE_AVX
-#include <immintrin.h>
-#endif
-
 #ifndef __vectorcall
 #define __vectorcall
 #endif
@@ -51,25 +47,5 @@ __vectorcall DRJIT_INLINE void jacobian_jointParams_to_modelParams(
             parameterTransform_.transform.valuePtr()[index] * jacobian_jointParams);
   }
 }
-
-#ifdef MOMENTUM_ENABLE_AVX
-
-/// Horizontal sum of 8 floats in an AVX-256 register, accumulating in double precision.
-///
-/// The conversion to double prevents the catastrophic cancellation that can occur when summing
-/// many small squared residuals at single precision.
-inline double __vectorcall sum8(const __m256 x) {
-  const __m128 high = _mm256_extractf128_ps(x, 1);
-  const __m128 low = _mm256_castps256_ps128(x);
-  const __m256d val = _mm256_add_pd(_mm256_cvtps_pd(high), _mm256_cvtps_pd(low));
-  const __m128d valupper = _mm256_extractf128_pd(val, 1);
-  const __m128d vallower = _mm256_castpd256_pd128(val);
-  _mm256_zeroupper();
-  const __m128d valval = _mm_add_pd(valupper, vallower);
-  const __m128d res = _mm_add_pd(_mm_permute_pd(valval, 1), valval);
-  return _mm_cvtsd_f64(res);
-}
-
-#endif // MOMENTUM_ENABLE_AVX
 
 } // namespace momentum

--- a/momentum/simd/simd.h
+++ b/momentum/simd/simd.h
@@ -38,12 +38,6 @@
 
 namespace momentum {
 
-/// Number of floats in an AVX-256 register.
-inline constexpr size_t kAvxPacketSize = 8;
-
-/// Byte alignment required for AVX-256 loads/stores.
-inline constexpr size_t kAvxAlignment = kAvxPacketSize * sizeof(float);
-
 /// Number of floats in the platform's default SIMD register (chosen by DrJit).
 inline constexpr size_t kSimdPacketSize = drjit::DefaultSize;
 

--- a/momentum/test/character_solver_simd/simd_aim_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_aim_error_function_test.cpp
@@ -31,15 +31,7 @@ TEST(Momentum_ErrorFunctions, SimdAimDistFunctionIsSame) {
 
   SimdAimConstraints cl_simd(&skeleton);
   const std::initializer_list<size_t> constraintCounts = {
-      0ul,
-      1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kSimdPacketSize - 1,
-      kSimdPacketSize,
-      kSimdPacketSize + 1,
-      100ul};
+      0ul, 1ul, kSimdPacketSize - 1, kSimdPacketSize, kSimdPacketSize + 1, 100ul};
 
   for (size_t nConstraints : constraintCounts) {
     if (verbose) {

--- a/momentum/test/character_solver_simd/simd_distance_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_distance_error_function_test.cpp
@@ -23,7 +23,7 @@
 using namespace momentum;
 
 // Verify SIMD distance error function matches the scalar reference at multiple constraint counts
-// that exercise both partial and full SIMD/AVX packets.
+// that exercise both partial and full SIMD packets.
 TEST(Momentum_ErrorFunctions, SimdDistanceFunctionIsSame) {
   const bool verbose = false;
 
@@ -33,15 +33,7 @@ TEST(Momentum_ErrorFunctions, SimdDistanceFunctionIsSame) {
 
   SimdDistanceConstraints cl_simd(&skeleton);
   const std::initializer_list<size_t> constraintCounts = {
-      0ul,
-      1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kSimdPacketSize - 1,
-      kSimdPacketSize,
-      kSimdPacketSize + 1,
-      100ul};
+      0ul, 1ul, kSimdPacketSize - 1, kSimdPacketSize, kSimdPacketSize + 1, 100ul};
 
   for (size_t nConstraints : constraintCounts) {
     if (verbose) {

--- a/momentum/test/character_solver_simd/simd_fixed_axis_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_fixed_axis_error_function_test.cpp
@@ -31,15 +31,7 @@ TEST(Momentum_ErrorFunctions, SimdFixedAxisFunctionIsSame) {
 
   SimdFixedAxisConstraints cl_simd(&skeleton);
   const std::initializer_list<size_t> constraintCounts = {
-      0ul,
-      1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kSimdPacketSize - 1,
-      kSimdPacketSize,
-      kSimdPacketSize + 1,
-      100ul};
+      0ul, 1ul, kSimdPacketSize - 1, kSimdPacketSize, kSimdPacketSize + 1, 100ul};
 
   for (size_t nConstraints : constraintCounts) {
     if (verbose) {

--- a/momentum/test/character_solver_simd/simd_normal_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_normal_error_function_test.cpp
@@ -36,10 +36,6 @@ TEST(Momentum_ErrorFunctions, SimdNormalFunctionIsSame) {
   const std::initializer_list<size_t> constraints = {
       0ul,
       1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kAvxPacketSize * 2,
       kSimdPacketSize - 1,
       kSimdPacketSize,
       kSimdPacketSize + 1,

--- a/momentum/test/character_solver_simd/simd_orientation_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_orientation_error_function_test.cpp
@@ -31,15 +31,7 @@ TEST(Momentum_ErrorFunctions, SimdOrientationFunctionIsSame) {
 
   SimdOrientationConstraints cl_simd(&skeleton);
   const std::initializer_list<size_t> constraintCounts = {
-      0ul,
-      1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kSimdPacketSize - 1,
-      kSimdPacketSize,
-      kSimdPacketSize + 1,
-      100ul};
+      0ul, 1ul, kSimdPacketSize - 1, kSimdPacketSize, kSimdPacketSize + 1, 100ul};
 
   for (size_t nConstraints : constraintCounts) {
     if (verbose) {

--- a/momentum/test/character_solver_simd/simd_plane_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_plane_error_function_test.cpp
@@ -39,10 +39,6 @@ void runSimdPlaneEquivalenceSweep(bool above) {
   const std::initializer_list<size_t> constraints = {
       0ul,
       1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kAvxPacketSize * 2,
       kSimdPacketSize - 1,
       kSimdPacketSize,
       kSimdPacketSize + 1,

--- a/momentum/test/character_solver_simd/simd_position_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_position_error_function_test.cpp
@@ -36,10 +36,6 @@ TEST(Momentum_ErrorFunctions, SimdPositionFunctionIsSame) {
   const std::initializer_list<size_t> constraints = {
       0ul,
       1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kAvxPacketSize * 2,
       kSimdPacketSize - 1,
       kSimdPacketSize,
       kSimdPacketSize + 1,

--- a/momentum/test/character_solver_simd/simd_projection_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_projection_error_function_test.cpp
@@ -31,15 +31,7 @@ TEST(Momentum_ErrorFunctions, SimdProjectionFunctionIsSame) {
 
   SimdProjectionConstraints cl_simd(&skeleton);
   const std::initializer_list<size_t> constraintCounts = {
-      0ul,
-      1ul,
-      kAvxPacketSize - 1,
-      kAvxPacketSize,
-      kAvxPacketSize + 1,
-      kSimdPacketSize - 1,
-      kSimdPacketSize,
-      kSimdPacketSize + 1,
-      100ul};
+      0ul, 1ul, kSimdPacketSize - 1, kSimdPacketSize, kSimdPacketSize + 1, 100ul};
 
   for (size_t nConstraints : constraintCounts) {
     if (verbose) {


### PR DESCRIPTION
Summary:
After D101391338 deleted the hand-rolled AVX error functions (`SimdNormalErrorFunctionAVX`, `SimdPlaneErrorFunctionAVX`, `SimdPositionErrorFunctionAVX`), several AVX-only declarations and references were left behind unused. Remove them.

- `momentum/simd/simd.h`: drop `kAvxPacketSize` and `kAvxAlignment`. Their only consumers (the hand-unrolled AVX error functions) are gone, and `kSimdPacketSize`/`kSimdAlignment` already cover the platform-default SIMD path used by every remaining error function.
- `momentum/character_solver_simd/simd_helpers.h`: drop the `MOMENTUM_ENABLE_AVX`-gated `sum8` AVX-256 horizontal-sum helper and its `<immintrin.h>` include. `sum8` was only called from the removed AVX error functions; nothing in the new DrJit-based SIMD impls uses it.
- `momentum/test/character_solver_simd/*_test.cpp` (8 files): the boundary-case sweeps included `kAvxPacketSize`-relative sizes (7, 8, 9, 16) alongside `kSimdPacketSize`-relative sizes. Drop the AVX-relative entries; on x86 with AVX2 they are duplicates of the kSimdPacketSize entries, and on SSE/NEON (kSimdPacketSize=4) the kSimdPacketSize sweep already covers the sub-/at-/over-packet boundaries we care about.

Not removed (intentional):
- `momentum/simd/simd.h` `Silvochka` and `kSimdPacketSize` comments still mention AVX2 — they correctly describe DrJit's platform behavior (8-wide on x86 with AVX2, 4-wide on SSE/NEON).
- `momentum/solver/solver_function.h` `kJacobianRowAlignment` comment still mentions AVX — the 32-byte alignment is still for AVX-256 loads.

Differential Revision: D102449383


