### PR TITLE
Add pure PyTorch SDF collision geometry for torch_character (#1337)

### DIFF
--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -248,6 +248,7 @@ marker_tracking_extensions_sources = [
 gpu_character_sources = [
     "torch/character.py",
     "torch/parameter_limits.py",
+    "torch/sdf_collision.py",
     "torch/utility.py",
 ]
 

--- a/pymomentum/test/test_sdf_collision.py
+++ b/pymomentum/test/test_sdf_collision.py
@@ -1,0 +1,424 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Tests for pure PyTorch SDF collision geometry (sdf_collision.py)."""
+
+import unittest
+
+import numpy as np
+import pymomentum.axel as axel
+import pymomentum.geometry as pym_geometry
+import pymomentum.geometry_test_utils as pym_test_utils
+import pymomentum.quaternion as pym_quaternion
+import pymomentum.torch.character as character
+import torch
+from pymomentum.torch.sdf_collision import (
+    evaluate_sdf,
+    SDFCollider,
+    SDFCollisionGeometry,
+)
+
+
+class TestSDFCollision(unittest.TestCase):
+    """Tests for evaluate_sdf, SDFCollider, and SDFCollisionGeometry."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _create_linear_sdf(
+        self, nx: int = 3, ny: int = 5, nz: int = 7
+    ) -> axel.SignedDistanceField:
+        """Non-cubic SDF with linear values f(i,j,k) = i + 2j + 3k.
+
+        Trilinear interpolation is exact for linear functions, so this
+        lets us verify correctness at arbitrary interior positions.
+        """
+        bounds = axel.BoundingBox(
+            np.array([0.0, 0.0, 0.0], dtype=np.float32),
+            np.array([float(nx), float(ny), float(nz)], dtype=np.float32),
+        )
+        sdf = axel.SignedDistanceField(bounds, np.array([nx, ny, nz], dtype=np.int32))
+        sdf_view = np.asarray(sdf)
+        for k in range(nz):
+            for j in range(ny):
+                for i in range(nx):
+                    sdf_view[i, j, k] = float(i) + 2.0 * j + 3.0 * k
+        return sdf
+
+    def _create_sphere_sdf(
+        self, nx: int = 5, ny: int = 7, nz: int = 3
+    ) -> axel.SignedDistanceField:
+        """Non-cubic sphere SDF centered at origin with radius 1."""
+        radius = 1.0
+        padding = 0.5
+        bounds = axel.BoundingBox(
+            np.array([-(radius + padding)] * 3, dtype=np.float32),
+            np.array([radius + padding] * 3, dtype=np.float32),
+        )
+        sdf = axel.SignedDistanceField(bounds, np.array([nx, ny, nz], dtype=np.int32))
+        sdf_view = np.asarray(sdf)
+        for k in range(nz):
+            for j in range(ny):
+                for i in range(nx):
+                    world = sdf.grid_to_world(
+                        np.array([float(i), float(j), float(k)], dtype=np.float32)
+                    )
+                    sdf_view[i, j, k] = float(np.linalg.norm(world)) - radius
+        return sdf
+
+    def _sdf_to_tensors(
+        self, sdf: axel.SignedDistanceField
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Convert a pymomentum SDF to (sdf_data, bounds_min, voxel_size).
+
+        Returns sdf_data in (nz, ny, nx) DHW order matching evaluate_sdf's
+        expected layout.
+        """
+        res = sdf.resolution
+        nx, ny, nz = int(res[0]), int(res[1]), int(res[2])
+        sdf_data = torch.tensor(
+            np.asarray(sdf).ravel(order="F"), dtype=torch.float32
+        ).reshape(nz, ny, nx)
+        bounds_min = torch.tensor(np.asarray(sdf.bounds.min), dtype=torch.float32)
+        voxel_size = torch.tensor(np.asarray(sdf.voxel_size), dtype=torch.float32)
+        return sdf_data, bounds_min, voxel_size
+
+    # ------------------------------------------------------------------
+    # Trilinear interpolation correctness
+    # ------------------------------------------------------------------
+
+    def test_trilinear_at_grid_points_non_cubic(self) -> None:
+        """Values at exact grid points match what was stored, on a non-cubic grid."""
+        sdf = self._create_linear_sdf(3, 5, 7)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+        nx, ny, nz = 3, 5, 7
+
+        for k in range(nz):
+            for j in range(ny):
+                for i in range(nx):
+                    world = sdf.grid_to_world(
+                        np.array([float(i), float(j), float(k)], dtype=np.float32)
+                    )
+                    point = torch.tensor(world).unsqueeze(0)
+                    result = evaluate_sdf(sdf_data, bounds_min, voxel_size, point)
+                    expected = float(i) + 2.0 * j + 3.0 * k
+                    self.assertAlmostEqual(
+                        result.item(),
+                        expected,
+                        places=4,
+                        msg=f"Mismatch at grid ({i},{j},{k})",
+                    )
+
+    def test_trilinear_exact_for_linear_function(self) -> None:
+        """Trilinear interpolation is exact for linear functions at arbitrary positions."""
+        sdf = self._create_linear_sdf(3, 5, 7)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+
+        torch.manual_seed(42)
+        grid_coords = torch.rand(50, 3) * torch.tensor([2.0, 4.0, 6.0])
+        world_points = grid_coords * voxel_size + bounds_min
+        results = evaluate_sdf(sdf_data, bounds_min, voxel_size, world_points)
+
+        expected = grid_coords[:, 0] + 2.0 * grid_coords[:, 1] + 3.0 * grid_coords[:, 2]
+        torch.testing.assert_close(results, expected, atol=1e-5, rtol=1e-5)
+
+    def test_evaluate_sdf_vs_cpp_non_cubic(self) -> None:
+        """evaluate_sdf matches C++ sdf.sample() on a non-cubic grid."""
+        sdf = self._create_sphere_sdf(5, 7, 3)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+
+        np.random.seed(42)
+        points_np = (np.random.rand(50, 3).astype(np.float32) - 0.5) * 4.0
+        cpp_values = sdf.sample(points_np)
+
+        torch_values = evaluate_sdf(
+            sdf_data, bounds_min, voxel_size, torch.tensor(points_np)
+        )
+        np.testing.assert_allclose(
+            torch_values.detach().numpy(), cpp_values, atol=1e-5, rtol=1e-5
+        )
+
+    def test_evaluate_sdf_out_of_bounds_vs_cpp(self) -> None:
+        """Out-of-bounds queries match C++ sample() (boundary value + offset distance)."""
+        sdf = self._create_sphere_sdf(5, 7, 3)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+
+        far_points = np.array(
+            [[10.0, 10.0, 10.0], [-5.0, 0.0, 0.0], [0.0, 0.0, 8.0]],
+            dtype=np.float32,
+        )
+        cpp_values = sdf.sample(far_points)
+        torch_values = evaluate_sdf(
+            sdf_data, bounds_min, voxel_size, torch.tensor(far_points)
+        )
+        np.testing.assert_allclose(
+            torch_values.detach().numpy(), cpp_values, atol=1e-5, rtol=1e-5
+        )
+
+    # ------------------------------------------------------------------
+    # Batching
+    # ------------------------------------------------------------------
+
+    def test_batch_shapes(self) -> None:
+        """Output shape matches input batch dimensions."""
+        sdf = self._create_sphere_sdf(5, 7, 3)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+
+        for shape in [(1, 3), (10, 3), (2, 5, 3), (2, 3, 4, 3)]:
+            points = torch.randn(shape)
+            result = evaluate_sdf(sdf_data, bounds_min, voxel_size, points)
+            self.assertEqual(result.shape, shape[:-1])
+
+    def test_batch_consistency(self) -> None:
+        """Batched evaluation produces the same results as unbatched loop."""
+        sdf = self._create_sphere_sdf(5, 7, 3)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+
+        torch.manual_seed(0)
+        points = torch.randn(2, 3, 4, 3)
+        batched = evaluate_sdf(sdf_data, bounds_min, voxel_size, points)
+
+        for b1 in range(2):
+            for b2 in range(3):
+                single = evaluate_sdf(sdf_data, bounds_min, voxel_size, points[b1, b2])
+                torch.testing.assert_close(batched[b1, b2], single)
+
+    # ------------------------------------------------------------------
+    # Gradients
+    # ------------------------------------------------------------------
+
+    def test_gradient_vs_cpp_interior(self) -> None:
+        """Autograd gradient matches C++ sdf.gradient() for interior points."""
+        sdf = self._create_sphere_sdf(5, 7, 3)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+
+        # Points strictly inside the grid (one voxel margin from boundary)
+        np.random.seed(42)
+        b_min = np.asarray(sdf.bounds.min)
+        margin = np.asarray(sdf.voxel_size) * 1.5
+        inner_min = b_min + margin
+        inner_max = np.asarray(sdf.bounds.max) - margin
+        points_np = (
+            np.random.rand(20, 3).astype(np.float32) * (inner_max - inner_min)
+            + inner_min
+        )
+
+        cpp_grad = sdf.gradient(points_np)
+
+        points = torch.tensor(points_np, requires_grad=True)
+        values = evaluate_sdf(sdf_data, bounds_min, voxel_size, points)
+        torch_grad = torch.autograd.grad(values.sum(), points)[0]
+
+        np.testing.assert_allclose(
+            torch_grad.detach().numpy(), cpp_grad, atol=1e-4, rtol=1e-4
+        )
+
+    def test_gradient_of_gradient(self) -> None:
+        """Second-order gradients are computable (cross-derivatives of trilinear blend)."""
+        sdf = self._create_sphere_sdf(5, 7, 3)
+        sdf_data, bounds_min, voxel_size = self._sdf_to_tensors(sdf)
+
+        points = torch.tensor([[0.1, 0.2, 0.3]], requires_grad=True)
+        values = evaluate_sdf(sdf_data, bounds_min, voxel_size, points)
+
+        grad1 = torch.autograd.grad(values.sum(), points, create_graph=True)[0]
+        grad2 = torch.autograd.grad(grad1.sum(), points)[0]
+
+        self.assertTrue(torch.isfinite(grad2).all())
+        # Cross-derivatives of trilinear blend are non-zero in general
+        self.assertTrue((grad2.abs() > 0).any())
+
+    # ------------------------------------------------------------------
+    # SDFCollider
+    # ------------------------------------------------------------------
+
+    def test_from_pymomentum_preserves_data(self) -> None:
+        """from_pymomentum produces correct SDF shape and metadata."""
+        sdf_pym = self._create_sphere_sdf(5, 7, 3)
+        collider_pym = pym_geometry.SDFCollider(
+            translation=np.array([0.5, -0.3, 0.1], dtype=np.float32),
+            parent=2,
+            sdf=sdf_pym,
+        )
+        collider = SDFCollider.from_pymomentum(collider_pym)
+
+        self.assertEqual(collider.sdf_data.shape, (3, 7, 5))  # (nz, ny, nx)
+        self.assertEqual(collider.parent_joint, 2)
+        np.testing.assert_allclose(
+            collider.bounds_min.numpy(), np.asarray(sdf_pym.bounds.min), atol=1e-6
+        )
+        np.testing.assert_allclose(
+            collider.voxel_size.numpy(), np.asarray(sdf_pym.voxel_size), atol=1e-6
+        )
+        np.testing.assert_allclose(
+            collider.local_translation.numpy(), [0.5, -0.3, 0.1], atol=1e-6
+        )
+
+    def test_collider_world_space(self) -> None:
+        """World-space SDFCollider (parent=-1) applies local transform correctly."""
+        sdf_pym = self._create_sphere_sdf(5, 7, 3)
+        collider_pym = pym_geometry.SDFCollider(
+            translation=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+            parent=-1,
+            sdf=sdf_pym,
+        )
+        collider = SDFCollider.from_pymomentum(collider_pym)
+
+        # World point [1,0,0] → SDF local point [0,0,0]
+        dummy_skel = torch.zeros(1, 1, 8)
+        points = torch.tensor([[1.0, 0.0, 0.0]])
+        result = collider.evaluate(dummy_skel, points)
+        expected = float(sdf_pym.sample(np.array([0.0, 0.0, 0.0])))
+        self.assertAlmostEqual(result.item(), expected, places=4)
+
+    def test_collider_joint_space(self) -> None:
+        """Joint-space SDFCollider composes joint and local transforms."""
+        sdf_pym = self._create_sphere_sdf(5, 7, 3)
+        char_pym = pym_test_utils.create_test_character()
+        skel = character.Skeleton(char_pym)
+
+        collider_pym = pym_geometry.SDFCollider(parent=0, sdf=sdf_pym)
+        collider = SDFCollider.from_pymomentum(collider_pym)
+
+        # Rest pose
+        n_joints = len(char_pym.skeleton.joint_names)
+        joint_params = torch.zeros(1, n_joints * 7)
+        skel_state = skel.forward(joint_params)
+
+        # Manually transform a world point using the joint transform
+        joint_t = skel_state[0, 0, 0:3]
+        joint_q = skel_state[0, 0, 3:7]
+        joint_R = pym_quaternion.to_rotation_matrix(joint_q.unsqueeze(0)).squeeze(0)
+
+        world_point = torch.tensor([[0.5, 0.3, -0.2]])
+        p_local = (world_point - joint_t) @ joint_R
+
+        expected = evaluate_sdf(
+            collider.sdf_data, collider.bounds_min, collider.voxel_size, p_local
+        )
+        # evaluate() broadcasts skel_state batch dim (1,) with points
+        actual = collider.evaluate(skel_state, world_point)
+        torch.testing.assert_close(actual.squeeze(0), expected)
+
+    # ------------------------------------------------------------------
+    # SDFCollisionGeometry
+    # ------------------------------------------------------------------
+
+    def test_evaluate_min_picks_smallest(self) -> None:
+        """evaluate_min returns the minimum distance across colliders."""
+        sdf_pym = self._create_sphere_sdf(5, 7, 3)
+        c1 = pym_geometry.SDFCollider(
+            translation=np.array([0.0, 0.0, 0.0], dtype=np.float32),
+            parent=-1,
+            sdf=sdf_pym,
+        )
+        c2 = pym_geometry.SDFCollider(
+            translation=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+            parent=-1,
+            sdf=sdf_pym,
+        )
+        geo = SDFCollisionGeometry.from_pymomentum([c1, c2])
+
+        dummy_skel = torch.zeros(1, 1, 8)
+        points = torch.tensor([[0.0, 0.0, 0.0]])
+
+        per_collider = geo.evaluate(dummy_skel, points)
+        self.assertEqual(len(per_collider), 2)
+
+        min_dist = geo.evaluate_min(dummy_skel, points)
+        expected_min = min(float(d.item()) for d in per_collider)
+        self.assertAlmostEqual(float(min_dist.item()), expected_min, places=5)
+
+    # ------------------------------------------------------------------
+    # Coverage gap: gradient through joint-space coordinate transform
+    # ------------------------------------------------------------------
+
+    def test_gradient_through_joint_transform(self) -> None:
+        """Gradients flow through the joint-space coordinate transform in evaluate()."""
+        sdf_pym = self._create_sphere_sdf(5, 7, 3)
+        char_pym = pym_test_utils.create_test_character()
+        skel = character.Skeleton(char_pym)
+
+        collider_pym = pym_geometry.SDFCollider(parent=0, sdf=sdf_pym)
+        collider = SDFCollider.from_pymomentum(collider_pym)
+
+        n_joints = len(char_pym.skeleton.joint_names)
+        joint_params = torch.zeros(1, n_joints * 7, requires_grad=True)
+        skel_state = skel.forward(joint_params)
+
+        points = torch.tensor([[0.3, 0.2, -0.1]])
+        dist = collider.evaluate(skel_state, points)
+        grad = torch.autograd.grad(dist.sum(), joint_params)[0]
+
+        self.assertTrue(torch.isfinite(grad).all())
+        self.assertTrue(
+            (grad.abs() > 0).any(),
+            "Gradient should be non-zero — joint params affect SDF distance",
+        )
+
+    # ------------------------------------------------------------------
+    # Coverage gap: non-identity local rotation
+    # ------------------------------------------------------------------
+
+    def test_from_pymomentum_with_rotation(self) -> None:
+        """from_pymomentum correctly converts a non-identity rotation quaternion."""
+        sdf_pym = self._create_linear_sdf(3, 5, 7)
+
+        # 90-degree rotation around Z axis: quat (x,y,z,w) = (0,0,sin45,cos45)
+        s = float(np.sin(np.pi / 4))
+        c = float(np.cos(np.pi / 4))
+        rot_quat = np.array([0.0, 0.0, s, c], dtype=np.float32)
+
+        collider_pym = pym_geometry.SDFCollider(
+            translation=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            rotation=rot_quat,  # pyre-ignore[6]: ndarray is valid for Optional[ndarray]
+            parent=-1,
+            sdf=sdf_pym,
+        )
+        collider = SDFCollider.from_pymomentum(collider_pym)
+        R = collider.local_rotation
+
+        # Rotation matrix should be orthogonal and non-identity
+        torch.testing.assert_close(R @ R.T, torch.eye(3), atol=1e-5, rtol=0.0)
+        self.assertFalse(torch.allclose(R, torch.eye(3), atol=1e-3))
+
+        # Point at translation maps to SDF origin
+        dummy_skel = torch.zeros(1, 1, 8)
+        dist = collider.evaluate(dummy_skel, torch.tensor([[1.0, 2.0, 3.0]]))
+        expected = float(sdf_pym.sample(np.zeros(3, dtype=np.float32)))
+        self.assertAlmostEqual(float(dist.item()), expected, places=4)
+
+    # ------------------------------------------------------------------
+    # Coverage gap: batched SDFCollider.evaluate()
+    # ------------------------------------------------------------------
+
+    def test_collider_batched_skel_state(self) -> None:
+        """SDFCollider.evaluate() handles batched skel_state and multiple points."""
+        sdf_pym = self._create_sphere_sdf(5, 7, 3)
+        char_pym = pym_test_utils.create_test_character()
+        skel = character.Skeleton(char_pym)
+
+        collider_pym = pym_geometry.SDFCollider(parent=0, sdf=sdf_pym)
+        collider = SDFCollider.from_pymomentum(collider_pym)
+
+        n_joints = len(char_pym.skeleton.joint_names)
+        batch_size = 3
+        n_points = 4
+
+        torch.manual_seed(123)
+        joint_params = torch.randn(batch_size, n_joints * 7) * 0.1
+        skel_state = skel.forward(joint_params)
+
+        points = torch.randn(n_points, 3) * 0.3
+
+        batched = collider.evaluate(skel_state, points)
+        self.assertEqual(batched.shape, (batch_size, n_points))
+
+        for b in range(batch_size):
+            single = collider.evaluate(skel_state[b : b + 1], points)
+            torch.testing.assert_close(batched[b], single.squeeze(0))

--- a/pymomentum/torch/sdf_collision.py
+++ b/pymomentum/torch/sdf_collision.py
@@ -1,0 +1,337 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Pure PyTorch SDF collision geometry for torch_character.
+
+Provides differentiable SDF evaluation matching the behavior of
+:class:`momentum.SDFColliderT`. All operations use pure PyTorch ops,
+enabling gradient computation through autograd including higher-order
+gradients (gradient-of-gradient).
+
+Typical usage::
+
+    import pymomentum.geometry as pym_geometry
+    from pymomentum.torch.sdf_collision import SDFCollider, SDFCollisionGeometry
+
+    # Create from pymomentum colliders
+    pym_colliders = [pym_geometry.SDFCollider(sdf=sdf, parent=joint_idx)]
+    collision_geo = SDFCollisionGeometry.from_pymomentum(pym_colliders)
+
+    # Evaluate: skel_state from Skeleton.forward(), points in world space
+    distances = collision_geo.evaluate(skel_state, world_points)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pymomentum.quaternion as pym_quaternion
+import torch
+
+
+def _trilinear_interpolate(
+    sdf_data: torch.Tensor,
+    grid_coords: torch.Tensor,
+) -> torch.Tensor:
+    """Trilinear interpolation of a 3D SDF grid in pure PyTorch.
+
+    Matches the interpolation in ``axel::SignedDistanceField::sample()``.
+    Grid coordinates must already be clamped to ``[0, res-1]``.
+
+    :param sdf_data: 3D SDF grid values, shape ``(nz, ny, nx)`` (DHW order).
+        ``sdf_data[k, j, i]`` is the signed distance at grid point
+        ``(i, j, k)``.  This layout matches ``F.grid_sample`` input
+        convention and avoids a permute when using it.
+    :param grid_coords: Clamped continuous grid coordinates, shape ``(..., 3)``
+        as ``(gx, gy, gz)`` where each component is in ``[0, res-1]``.
+    :return: Interpolated SDF values, shape ``(...)``.
+    """
+    nz, ny, nx = sdf_data.shape
+    gx = grid_coords[..., 0]
+    gy = grid_coords[..., 1]
+    gz = grid_coords[..., 2]
+
+    # Integer lower-corner indices (detach so floor doesn't affect gradient graph)
+    i0 = gx.detach().floor().long().clamp(0, nx - 1)
+    j0 = gy.detach().floor().long().clamp(0, ny - 1)
+    k0 = gz.detach().floor().long().clamp(0, nz - 1)
+
+    # Upper corner indices (clamped to grid bounds)
+    i1 = (i0 + 1).clamp(max=nx - 1)
+    j1 = (j0 + 1).clamp(max=ny - 1)
+    k1 = (k0 + 1).clamp(max=nz - 1)
+
+    # Fractional interpolation weights (differentiable w.r.t. grid_coords)
+    fx = gx - i0.to(gx.dtype)
+    fy = gy - j0.to(gy.dtype)
+    fz = gz - k0.to(gz.dtype)
+
+    # Gather 8 corner values — stored as (nz, ny, nx) so index [k, j, i]
+    c000 = sdf_data[k0, j0, i0]
+    c100 = sdf_data[k0, j0, i1]
+    c010 = sdf_data[k0, j1, i0]
+    c110 = sdf_data[k0, j1, i1]
+    c001 = sdf_data[k1, j0, i0]
+    c101 = sdf_data[k1, j0, i1]
+    c011 = sdf_data[k1, j1, i0]
+    c111 = sdf_data[k1, j1, i1]
+
+    # Blend along x, then y, then z (same order as C++ sample())
+    c00 = c000 * (1 - fx) + c100 * fx
+    c01 = c001 * (1 - fx) + c101 * fx
+    c10 = c010 * (1 - fx) + c110 * fx
+    c11 = c011 * (1 - fx) + c111 * fx
+
+    c0 = c00 * (1 - fy) + c10 * fy
+    c1 = c01 * (1 - fy) + c11 * fy
+
+    return c0 * (1 - fz) + c1 * fz
+
+
+def evaluate_sdf(
+    sdf_data: torch.Tensor,
+    bounds_min: torch.Tensor,
+    voxel_size: torch.Tensor,
+    points: torch.Tensor,
+) -> torch.Tensor:
+    """Evaluate SDF distances at query points in SDF local space.
+
+    Performs world-to-grid conversion, boundary clamping, trilinear
+    interpolation, and out-of-bounds distance computation, matching
+    ``axel::SignedDistanceField::sample()``.
+
+    All operations are differentiable via PyTorch autograd. For out-of-bounds
+    points, the Euclidean distance to the nearest grid boundary is added to
+    the interpolated boundary value, providing correct gradient behavior:
+
+    - Inside the grid: gradient comes from trilinear interpolation derivatives.
+    - Outside the grid: gradient points away from the boundary (increasing
+      distance).
+
+    :param sdf_data: 3D SDF grid values, shape ``(nz, ny, nx)`` (DHW order).
+    :param bounds_min: SDF bounding box minimum corner, shape ``(3,)``.
+    :param voxel_size: Size of each voxel in world units, shape ``(3,)``.
+    :param points: Query points in SDF local space, shape ``(..., 3)``.
+    :return: Signed distance values, shape ``(...)``.
+    """
+    nz, ny, nx = sdf_data.shape
+
+    # Convert world-space positions to continuous grid coordinates
+    grid_coords = (points - bounds_min) / voxel_size
+
+    # Clamp to valid grid range [0, res-1] for interpolation
+    gx_clamped = grid_coords[..., 0].clamp(0.0, nx - 1)
+    gy_clamped = grid_coords[..., 1].clamp(0.0, ny - 1)
+    gz_clamped = grid_coords[..., 2].clamp(0.0, nz - 1)
+    clamped = torch.stack([gx_clamped, gy_clamped, gz_clamped], dim=-1)
+
+    # Trilinear interpolation at clamped grid position
+    value = _trilinear_interpolate(sdf_data, clamped)
+
+    # For out-of-bounds points, add distance from query point to nearest
+    # grid boundary. Inside the grid this is exactly zero.
+    clamped_world = clamped * voxel_size + bounds_min
+    offset_dist = (points - clamped_world).norm(dim=-1)
+
+    return value + offset_dist
+
+
+class SDFCollider(torch.nn.Module):
+    """A signed distance field volume attached to a skeleton joint.
+
+    Mirrors :class:`momentum.SDFColliderT` with evaluation implemented
+    in pure PyTorch for full autograd differentiability.
+
+    The SDF data is stored as a 3D tensor in ``(nz, ny, nx)`` (DHW) order:
+    ``sdf_data[k, j, i]`` is the signed distance at grid point
+    ``(i, j, k)``.  This layout is compatible with ``F.grid_sample``.
+
+    :param sdf_data: 3D SDF grid values, shape ``(nz, ny, nx)`` (DHW order).
+    :param bounds_min: SDF bounding box minimum corner, shape ``(3,)``.
+    :param voxel_size: Voxel dimensions in world units, shape ``(3,)``.
+    :param local_translation: Translation offset from parent joint, shape ``(3,)``.
+    :param local_rotation: Rotation matrix relative to parent joint, shape ``(3, 3)``.
+    :param parent_joint: Parent joint index. Use ``-1`` for world-space SDFs.
+    """
+
+    parent_joint: int
+
+    def __init__(
+        self,
+        sdf_data: torch.Tensor,
+        bounds_min: torch.Tensor,
+        voxel_size: torch.Tensor,
+        local_translation: torch.Tensor,
+        local_rotation: torch.Tensor,
+        parent_joint: int = -1,
+    ) -> None:
+        super().__init__()
+        self.register_buffer("sdf_data", sdf_data)
+        self.register_buffer("bounds_min", bounds_min)
+        self.register_buffer("voxel_size", voxel_size)
+        self.register_buffer("local_translation", local_translation)
+        self.register_buffer("local_rotation", local_rotation)
+        self.parent_joint = parent_joint
+
+    @staticmethod
+    def from_pymomentum(
+        collider: object,
+        dtype: torch.dtype = torch.float32,
+    ) -> SDFCollider:
+        """Create an :class:`SDFCollider` from a :class:`pymomentum.geometry.SDFCollider`.
+
+        Converts the SDF grid data to a ``(nz, ny, nx)`` PyTorch tensor
+        (DHW order, ready for ``F.grid_sample``) and the collider's local
+        transform to a rotation matrix.
+
+        :param collider: A :class:`pymomentum.geometry.SDFCollider` instance.
+        :param dtype: Tensor dtype (default: ``torch.float32``).
+        :return: A new :class:`SDFCollider` module.
+        """
+        sdf = collider.sdf  # pyre-ignore[16]
+        res = sdf.resolution
+        nx, ny, nz = int(res[0]), int(res[1]), int(res[2])
+
+        # The buffer protocol exposes a Fortran-order (nx, ny, nz) view
+        # matching the C++ linearIndex(i,j,k) = k*nx*ny + j*nx + i storage.
+        # ravel(order='F') gives the flat data in memory order (x fastest).
+        # Reshaping to (nz, ny, nx) C-contiguous gives tensor[k,j,i] ==
+        # C++ at(i,j,k), which is the DHW layout for F.grid_sample.
+        sdf_data = torch.tensor(np.asarray(sdf).ravel(order="F"), dtype=dtype).reshape(
+            nz, ny, nx
+        )
+
+        bounds_min = torch.tensor(np.asarray(sdf.bounds.min), dtype=dtype)
+        voxel_size = torch.tensor(np.asarray(sdf.voxel_size), dtype=dtype)
+
+        local_translation = torch.tensor(
+            np.asarray(collider.translation),  # pyre-ignore[16]
+            dtype=dtype,
+        )
+        rotation_quat = torch.tensor(
+            np.asarray(collider.rotation),  # pyre-ignore[16]
+            dtype=dtype,
+        )
+        local_rotation: torch.Tensor = pym_quaternion.to_rotation_matrix(
+            rotation_quat.unsqueeze(0)
+        ).squeeze(0)
+
+        return SDFCollider(
+            sdf_data=sdf_data,
+            bounds_min=bounds_min,
+            voxel_size=voxel_size,
+            local_translation=local_translation,
+            local_rotation=local_rotation,
+            parent_joint=collider.parent,  # pyre-ignore[16]
+        )
+
+    def evaluate(
+        self,
+        skel_state: torch.Tensor,
+        points: torch.Tensor,
+    ) -> torch.Tensor:
+        """Evaluate SDF distances for world-space query points.
+
+        Transforms ``points`` from world space into the SDF's local coordinate
+        system using the joint transform from ``skel_state``, then evaluates
+        via trilinear interpolation.
+
+        :param skel_state: Global skeleton state from forward kinematics,
+            shape ``(..., n_joints, 8)`` with per-joint format
+            ``[tx, ty, tz, qx, qy, qz, qw, scale]``.
+            Ignored when ``parent_joint == -1`` (world-space SDF).
+        :param points: World-space query points, shape ``(..., n_points, 3)``.
+        :return: SDF distances at each query point, shape ``(..., n_points)``.
+        """
+        if self.parent_joint < 0:
+            # World-space SDF: local transform IS the world transform
+            R_world = self.local_rotation
+            t_world = self.local_translation
+        else:
+            # Joint-space SDF: compose joint transform with local transform
+            joint_t = skel_state[..., self.parent_joint, 0:3]
+            joint_q = skel_state[..., self.parent_joint, 3:7]
+            joint_R = pym_quaternion.to_rotation_matrix(joint_q)
+
+            # R_world = R_joint @ R_local
+            R_world = joint_R @ self.local_rotation
+            # t_world = R_joint @ t_local + t_joint
+            t_world = (
+                torch.einsum("...ij,j->...i", joint_R, self.local_translation) + joint_t
+            )
+
+        # Transform points to SDF local space:
+        #   p_local = R_world^T @ (p_world - t_world)
+        # In row-vector form: (p - t) @ R  (since p @ R == R^T @ p)
+        p_centered = points - t_world[..., None, :]
+        p_local = torch.einsum("...pi,...ij->...pj", p_centered, R_world)
+
+        return evaluate_sdf(
+            self.sdf_data,
+            self.bounds_min,
+            self.voxel_size,
+            p_local,
+        )
+
+
+class SDFCollisionGeometry(torch.nn.Module):
+    """Collection of SDF colliders for character collision detection.
+
+    Mirrors :class:`momentum.SDFCollisionGeometryT` — a list of
+    :class:`SDFCollider` modules attached to skeleton joints.
+
+    :param colliders: List of :class:`SDFCollider` modules.
+    """
+
+    def __init__(self, colliders: list[SDFCollider]) -> None:
+        super().__init__()
+        self.colliders: torch.nn.ModuleList = torch.nn.ModuleList(colliders)
+
+    @staticmethod
+    def from_pymomentum(
+        colliders: list[object],
+        dtype: torch.dtype = torch.float32,
+    ) -> SDFCollisionGeometry:
+        """Create from a list of :class:`pymomentum.geometry.SDFCollider` objects.
+
+        :param colliders: List of :class:`pymomentum.geometry.SDFCollider` instances.
+        :param dtype: Tensor dtype (default: ``torch.float32``).
+        :return: A new :class:`SDFCollisionGeometry` module.
+        """
+        return SDFCollisionGeometry(
+            [SDFCollider.from_pymomentum(c, dtype=dtype) for c in colliders]
+        )
+
+    def evaluate(
+        self,
+        skel_state: torch.Tensor,
+        points: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        """Evaluate all colliders and return per-collider SDF distances.
+
+        :param skel_state: Global skeleton state, shape ``(..., n_joints, 8)``.
+        :param points: World-space query points, shape ``(..., n_points, 3)``.
+        :return: List of distance tensors, one per collider, each shape
+            ``(..., n_points)``.
+        """
+        return [c.evaluate(skel_state, points) for c in self.colliders]
+
+    def evaluate_min(
+        self,
+        skel_state: torch.Tensor,
+        points: torch.Tensor,
+    ) -> torch.Tensor:
+        """Minimum SDF distance across all colliders for each point.
+
+        Useful for collision detection: negative values indicate penetration
+        into at least one collider.
+
+        :param skel_state: Global skeleton state, shape ``(..., n_joints, 8)``.
+        :param points: World-space query points, shape ``(..., n_points, 3)``.
+        :return: Minimum signed distance per point, shape ``(..., n_points)``.
+        """
+        distances = self.evaluate(skel_state, points)
+        return torch.stack(distances, dim=0).min(dim=0).values


### PR DESCRIPTION
Summary:

Adds sdf_collision.py implementing differentiable SDF evaluation in pure PyTorch, mirroring momentum::SDFColliderT. Includes trilinear interpolation with natural (nx, ny, nz) tensor indexing, out-of-bounds distance handling, and joint-space coordinate transforms via skeleton state.

Key classes:
- SDFCollider: single SDF volume attached to a joint, with from_pymomentum() factory
- SDFCollisionGeometry: collection of colliders with evaluate() and evaluate_min()
- evaluate_sdf(): standalone SDF evaluation with autograd support for grad-of-grad

All operations are pure PyTorch, enabling higher-order gradient computation through autograd.

Future work:
- Wire into Character class or provide integration example
- Consider switching C++ linearIndex to row-major order in a follow-up diff

Reviewed By: cstollmeta

Differential Revision: D101270099


