### PR TITLE
Move texture classification to C++ library and add SDF numpy constructor (#1338)

### DIFF
--- a/axel/axel/MeshToSdf.cpp
+++ b/axel/axel/MeshToSdf.cpp
@@ -116,19 +116,31 @@ void meshToSdfImpl(
   const ScalarType bandWidthWorld = config.narrowBandWidth * voxelSize.maxCoeff();
 
   // STEP 1: Initialize narrow band with exact triangle distances
-  std::cout << "Step 1: Narrow band initialization..." << std::endl;
+  if (config.verbose) {
+    std::cout << "Step 1: Narrow band initialization..." << std::endl;
+  }
   initializeNarrowBand(vertices, triangles, sdf, bandWidthWorld);
-  std::cout << "Narrow band initialized" << std::endl;
+  if (config.verbose) {
+    std::cout << "Narrow band initialized" << std::endl;
+  }
 
   // STEP 2: Fast marching propagation to fill entire grid
-  std::cout << "Step 2: Fast marching propagation..." << std::endl;
+  if (config.verbose) {
+    std::cout << "Step 2: Fast marching propagation..." << std::endl;
+  }
   fastMarchingPropagate(sdf);
-  std::cout << "Fast marching completed" << std::endl;
+  if (config.verbose) {
+    std::cout << "Fast marching completed" << std::endl;
+  }
 
   // STEP 3: Apply signs based on inside/outside determination
-  std::cout << "Step 3: Applying signs..." << std::endl;
+  if (config.verbose) {
+    std::cout << "Step 3: Applying signs..." << std::endl;
+  }
   applySignsToDistanceField(sdf, vertices, triangles);
-  std::cout << "Signs applied" << std::endl;
+  if (config.verbose) {
+    std::cout << "Signs applied" << std::endl;
+  }
 
   // Apply distance clamping if configured
   if (config.maxDistance > ScalarType{0}) {

--- a/axel/axel/MeshToSdf.h
+++ b/axel/axel/MeshToSdf.h
@@ -36,6 +36,9 @@ struct MeshToSdfConfig {
 
   /// Numerical tolerance for computations
   Scalar tolerance = std::numeric_limits<Scalar>::epsilon() * Scalar{1000};
+
+  /// Print progress messages to stdout
+  bool verbose = false;
 };
 
 /**

--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -213,6 +213,7 @@ character_public_headers = [
     "character/sdf_collision_geometry.h",
     "character/skinned_locator.h",
     "character/skin_weights.h",
+    "character/texture_classification.h",
 ]
 
 character_sources = [
@@ -229,6 +230,7 @@ character_sources = [
     "character/mesh_state.cpp",
     "character/pose_shape.cpp",
     "character/skin_weights.cpp",
+    "character/texture_classification.cpp",
 ]
 
 character_test_sources = [

--- a/momentum/character/texture_classification.cpp
+++ b/momentum/character/texture_classification.cpp
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/character/texture_classification.h"
+
+#include "momentum/common/exception.h"
+
+#include <momentum/character/character_utility.h>
+
+#include <algorithm>
+#include <cmath>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace momentum {
+
+namespace {
+
+struct BarycentricCoord {
+  float u;
+  float v;
+  float w;
+};
+
+std::vector<BarycentricCoord> getSamplePoints(int32_t numSamples) {
+  constexpr BarycentricCoord v0{1.0f, 0.0f, 0.0f};
+  constexpr BarycentricCoord v1{0.0f, 1.0f, 0.0f};
+  constexpr BarycentricCoord v2{0.0f, 0.0f, 1.0f};
+
+  constexpr float third = 1.0f / 3.0f;
+  constexpr BarycentricCoord centroid{third, third, third};
+
+  constexpr BarycentricCoord mid01{0.5f, 0.5f, 0.0f};
+  constexpr BarycentricCoord mid12{0.0f, 0.5f, 0.5f};
+  constexpr BarycentricCoord mid02{0.5f, 0.0f, 0.5f};
+
+  constexpr float quarter = 0.25f;
+  constexpr float threeQuarters = 0.75f;
+  constexpr BarycentricCoord int0{threeQuarters, quarter * 0.5f, quarter * 0.5f};
+  constexpr BarycentricCoord int1{quarter * 0.5f, threeQuarters, quarter * 0.5f};
+  constexpr BarycentricCoord int2{quarter * 0.5f, quarter * 0.5f, threeQuarters};
+
+  switch (numSamples) {
+    case 1:
+      return {centroid};
+    case 3:
+      return {v0, v1, v2};
+    case 4:
+      return {centroid, v0, v1, v2};
+    case 6:
+      return {v0, v1, v2, mid01, mid12, mid02};
+    case 7:
+      return {centroid, v0, v1, v2, mid01, mid12, mid02};
+    case 10:
+      return {centroid, v0, v1, v2, mid01, mid12, mid02, int0, int1, int2};
+  }
+  MT_THROW("Invalid num_samples value {}. Must be one of: 1, 3, 4, 6, 7, 10.", numSamples);
+}
+
+inline size_t packRgb(uint8_t r, uint8_t g, uint8_t b) {
+  return static_cast<size_t>(r) | (static_cast<size_t>(g) << 8) | (static_cast<size_t>(b) << 16);
+}
+
+std::unordered_map<size_t, int32_t> buildColorLookup(const RegionColorsView& colors) {
+  std::unordered_map<size_t, int32_t> lookup;
+  lookup.reserve(colors.nRegions);
+  for (int32_t i = 0; i < colors.nRegions; ++i) {
+    const uint8_t* ptr = colors.data + i * colors.stride0;
+    lookup[packRgb(ptr[0 * colors.stride1], ptr[1 * colors.stride1], ptr[2 * colors.stride1])] = i;
+  }
+  return lookup;
+}
+
+std::unordered_set<size_t> buildInsideColorSet(const RegionColorsView& colors) {
+  std::unordered_set<size_t> result;
+  result.reserve(colors.nRegions);
+  for (int32_t i = 0; i < colors.nRegions; ++i) {
+    const uint8_t* ptr = colors.data + i * colors.stride0;
+    result.insert(
+        packRgb(ptr[0 * colors.stride1], ptr[1 * colors.stride1], ptr[2 * colors.stride1]));
+  }
+  return result;
+}
+
+} // namespace
+
+std::vector<std::vector<int32_t>> classifyTrianglesByTexture(
+    const Mesh& mesh,
+    const TextureView& texture,
+    const RegionColorsView& regionColors,
+    float threshold,
+    int32_t numSamples) {
+  MT_THROW_IF(mesh.texcoords.empty(), "Mesh must have texture coordinates");
+  MT_THROW_IF(mesh.texcoord_faces.empty(), "Mesh must have texture coordinate faces");
+  MT_THROW_IF(threshold < 0.0f || threshold > 1.0f, "threshold must be in range [0, 1]");
+
+  const auto samplePoints = getSamplePoints(numSamples);
+  const auto nSamples = static_cast<int32_t>(samplePoints.size());
+  const auto colorLookup = buildColorLookup(regionColors);
+  const auto nTriangles = static_cast<int64_t>(mesh.faces.size());
+  const auto nRegions = regionColors.nRegions;
+
+  const int32_t minSamplesNeeded = (threshold == 0.0f)
+      ? 1
+      : static_cast<int32_t>(std::ceil(threshold * static_cast<float>(nSamples)));
+
+  std::vector<std::vector<int32_t>> regionTriangles(nRegions);
+  std::vector<int32_t> regionCounts(nRegions, 0);
+
+  for (int64_t triIdx = 0; triIdx < nTriangles; ++triIdx) {
+    std::fill(regionCounts.begin(), regionCounts.end(), 0);
+
+    const auto& texFace = mesh.texcoord_faces[triIdx];
+    const auto& uv0 = mesh.texcoords[texFace.x()];
+    const auto& uv1 = mesh.texcoords[texFace.y()];
+    const auto& uv2 = mesh.texcoords[texFace.z()];
+
+    for (const auto& bary : samplePoints) {
+      const float u = bary.u * uv0.x() + bary.v * uv1.x() + bary.w * uv2.x();
+      const float v = bary.u * uv0.y() + bary.v * uv1.y() + bary.w * uv2.y();
+
+      const auto col = std::clamp(
+          static_cast<int64_t>(std::lround(u * static_cast<float>(texture.width - 1))),
+          int64_t{0},
+          texture.width - 1);
+      const auto row = std::clamp(
+          static_cast<int64_t>(std::lround(v * static_cast<float>(texture.height - 1))),
+          int64_t{0},
+          texture.height - 1);
+
+      const auto* pixel = texture.data + row * texture.stride0 + col * texture.stride1;
+      const auto packedColor = packRgb(
+          pixel[0 * texture.stride2], pixel[1 * texture.stride2], pixel[2 * texture.stride2]);
+
+      auto it = colorLookup.find(packedColor);
+      if (it != colorLookup.end() && it->second >= 0 && it->second < nRegions) {
+        ++regionCounts[it->second];
+      }
+    }
+
+    for (int32_t regionIdx = 0; regionIdx < nRegions; ++regionIdx) {
+      if (regionCounts[regionIdx] >= minSamplesNeeded) {
+        regionTriangles[regionIdx].push_back(static_cast<int32_t>(triIdx));
+      }
+    }
+  }
+
+  return regionTriangles;
+}
+
+namespace {
+
+struct TextureSampler {
+  const TextureView& tex;
+  std::unordered_set<size_t> insideColors;
+
+  bool isInside(const Eigen::Vector2f& uv) const {
+    const auto col = std::clamp(
+        static_cast<int64_t>(std::lround(uv.x() * static_cast<float>(tex.width - 1))),
+        int64_t{0},
+        tex.width - 1);
+    const auto row = std::clamp(
+        static_cast<int64_t>(std::lround(uv.y() * static_cast<float>(tex.height - 1))),
+        int64_t{0},
+        tex.height - 1);
+    const auto* pixel = tex.data + row * tex.stride0 + col * tex.stride1;
+    return insideColors.count(
+               packRgb(pixel[0 * tex.stride2], pixel[1 * tex.stride2], pixel[2 * tex.stride2])) > 0;
+  }
+
+  float findCrossingT(const Eigen::Vector2f& uvA, const Eigen::Vector2f& uvB, int32_t numSteps)
+      const {
+    float lo = 0.0f, hi = 1.0f;
+    for (int32_t i = 0; i < numSteps; ++i) {
+      const float mid = 0.5f * (lo + hi);
+      const Eigen::Vector2f uvMid = (1.0f - mid) * uvA + mid * uvB;
+      if (isInside(uvMid)) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    return 0.5f * (lo + hi);
+  }
+};
+
+using Edge = std::pair<int, int>;
+
+Edge makeEdge(int v1, int v2) {
+  return v1 < v2 ? Edge{v1, v2} : Edge{v2, v1};
+}
+
+struct HashEdge {
+  std::size_t operator()(const Edge& e) const {
+    std::size_t h1 = std::hash<int>{}(e.first);
+    std::size_t h2 = std::hash<int>{}(e.second);
+    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+  }
+};
+
+struct GeomCacheEntry {
+  int vertexIndex;
+  float t;
+};
+
+float findEdgeCrossingT(
+    const TextureSampler& sampler,
+    const Eigen::Vector2f& uv0,
+    const Eigen::Vector2f& uv1,
+    int geomV0,
+    int geomV1,
+    bool v0IsInside,
+    const std::unordered_map<Edge, GeomCacheEntry, HashEdge>& geomCache,
+    int32_t numSteps) {
+  const auto edge = makeEdge(geomV0, geomV1);
+  auto it = geomCache.find(edge);
+  if (it != geomCache.end()) {
+    float tOriented = it->second.t;
+    return (geomV0 < geomV1) ? tOriented : (1.0f - tOriented);
+  }
+  if (v0IsInside) {
+    return sampler.findCrossingT(uv0, uv1, numSteps);
+  }
+  return 1.0f - sampler.findCrossingT(uv1, uv0, numSteps);
+}
+
+template <typename GetOrCreateGeomVertexFn, typename GetOrCreateTexVertexFn>
+void processMixedFace(
+    const Eigen::Vector3i& face,
+    const Eigen::Vector3i& texFace,
+    const std::array<bool, 3>& inside,
+    int nInside,
+    const std::vector<Eigen::Vector2f>& meshTexcoords,
+    const TextureSampler& sampler,
+    int32_t numBinarySearchSteps,
+    const std::unordered_map<Edge, GeomCacheEntry, HashEdge>& geomCache,
+    GetOrCreateGeomVertexFn& getOrCreateGeomVertex,
+    GetOrCreateTexVertexFn& getOrCreateTexVertex,
+    std::vector<Eigen::Vector3i>& newFaces,
+    std::vector<Eigen::Vector3i>& newTexcoordFaces) {
+  int solo = -1;
+  for (int k = 0; k < 3; ++k) {
+    if ((nInside == 1 && inside[k]) || (nInside == 2 && !inside[k])) {
+      solo = k;
+      break;
+    }
+  }
+
+  const int k0 = solo, k1 = (solo + 1) % 3, k2 = (solo + 2) % 3;
+  const int gV0 = face[k0], gV1 = face[k1], gV2 = face[k2];
+  const int tV0 = texFace[k0], tV1 = texFace[k1], tV2 = texFace[k2];
+
+  const bool v0IsInside = (nInside == 1);
+  const float t01 = findEdgeCrossingT(
+      sampler,
+      meshTexcoords[tV0],
+      meshTexcoords[tV1],
+      gV0,
+      gV1,
+      v0IsInside,
+      geomCache,
+      numBinarySearchSteps);
+  const float t02 = findEdgeCrossingT(
+      sampler,
+      meshTexcoords[tV0],
+      meshTexcoords[tV2],
+      gV0,
+      gV2,
+      v0IsInside,
+      geomCache,
+      numBinarySearchSteps);
+
+  const int gM01 = getOrCreateGeomVertex(gV0, gV1, t01);
+  const int gM02 = getOrCreateGeomVertex(gV0, gV2, t02);
+  const int tM01 = getOrCreateTexVertex(tV0, tV1, t01);
+  const int tM02 = getOrCreateTexVertex(tV0, tV2, t02);
+
+  if (nInside == 1) {
+    newFaces.emplace_back(gV0, gM01, gM02);
+    newTexcoordFaces.emplace_back(tV0, tM01, tM02);
+  } else {
+    newFaces.emplace_back(gV1, gV2, gM01);
+    newTexcoordFaces.emplace_back(tV1, tV2, tM01);
+    newFaces.emplace_back(gV2, gM02, gM01);
+    newTexcoordFaces.emplace_back(tV2, tM02, tM01);
+  }
+}
+
+} // namespace
+
+Mesh splitMeshByTextureRegion(
+    const Mesh& mesh,
+    const TextureView& texture,
+    const RegionColorsView& regionColors,
+    int32_t numBinarySearchSteps) {
+  MT_THROW_IF(mesh.texcoords.empty(), "Mesh must have texture coordinates");
+  MT_THROW_IF(mesh.texcoord_faces.empty(), "Mesh must have texture coordinate faces");
+  MT_THROW_IF(
+      mesh.faces.size() != mesh.texcoord_faces.size(),
+      "faces and texcoord_faces must have the same size");
+
+  TextureSampler sampler{texture, buildInsideColorSet(regionColors)};
+
+  const auto nTexVerts = static_cast<int>(mesh.texcoords.size());
+  std::vector<bool> texVertInside(nTexVerts);
+  for (int i = 0; i < nTexVerts; ++i) {
+    texVertInside[i] = sampler.isInside(mesh.texcoords[i]);
+  }
+
+  auto vertices = mesh.vertices;
+  auto normals = mesh.normals;
+  auto colors = mesh.colors;
+  auto confidence = mesh.confidence;
+  auto texcoords = mesh.texcoords;
+
+  std::vector<Eigen::Vector3i> newFaces;
+  std::vector<Eigen::Vector3i> newTexcoordFaces;
+  newFaces.reserve(mesh.faces.size());
+  newTexcoordFaces.reserve(mesh.faces.size());
+
+  std::unordered_map<Edge, GeomCacheEntry, HashEdge> geomCache;
+  std::unordered_map<Edge, int, HashEdge> texCache;
+
+  const bool hasNormals = !normals.empty();
+  const bool hasColors = !colors.empty();
+  const bool hasConfidence = !confidence.empty();
+
+  auto getOrCreateGeomVertex = [&](int geomA, int geomB, float t) -> int {
+    const auto edge = makeEdge(geomA, geomB);
+    auto it = geomCache.find(edge);
+    if (it != geomCache.end()) {
+      return it->second.vertexIndex;
+    }
+    float tOriented = (geomA < geomB) ? t : (1.0f - t);
+    const int newIdx = static_cast<int>(vertices.size());
+    vertices.emplace_back(
+        (1.0f - tOriented) * vertices[edge.first] + tOriented * vertices[edge.second]);
+    if (hasNormals) {
+      Eigen::Vector3f n =
+          ((1.0f - tOriented) * normals[edge.first] + tOriented * normals[edge.second])
+              .normalized();
+      normals.emplace_back(n);
+    }
+    if (hasColors) {
+      Eigen::Vector3f cf = (1.0f - tOriented) * colors[edge.first].cast<float>() +
+          tOriented * colors[edge.second].cast<float>();
+      colors.emplace_back(
+          static_cast<uint8_t>(std::clamp(cf.x(), 0.0f, 255.0f)),
+          static_cast<uint8_t>(std::clamp(cf.y(), 0.0f, 255.0f)),
+          static_cast<uint8_t>(std::clamp(cf.z(), 0.0f, 255.0f)));
+    }
+    if (hasConfidence) {
+      confidence.emplace_back(
+          (1.0f - tOriented) * confidence[edge.first] + tOriented * confidence[edge.second]);
+    }
+    geomCache[edge] = {newIdx, tOriented};
+    return newIdx;
+  };
+
+  auto getOrCreateTexVertex = [&](int texA, int texB, float t) -> int {
+    const auto edge = makeEdge(texA, texB);
+    auto it = texCache.find(edge);
+    if (it != texCache.end()) {
+      return it->second;
+    }
+    float tOriented = (texA < texB) ? t : (1.0f - t);
+    const int newIdx = static_cast<int>(texcoords.size());
+    texcoords.emplace_back(
+        (1.0f - tOriented) * texcoords[edge.first] + tOriented * texcoords[edge.second]);
+    texCache[edge] = newIdx;
+    return newIdx;
+  };
+
+  for (size_t fi = 0; fi < mesh.faces.size(); ++fi) {
+    const auto& face = mesh.faces[fi];
+    const auto& texFace = mesh.texcoord_faces[fi];
+
+    std::array<bool, 3> inside = {
+        texVertInside[texFace.x()], texVertInside[texFace.y()], texVertInside[texFace.z()]};
+    const int nInside =
+        static_cast<int>(inside[0]) + static_cast<int>(inside[1]) + static_cast<int>(inside[2]);
+
+    if (nInside == 3) {
+      newFaces.push_back(face);
+      newTexcoordFaces.push_back(texFace);
+    } else if (nInside > 0) {
+      processMixedFace(
+          face,
+          texFace,
+          inside,
+          nInside,
+          mesh.texcoords,
+          sampler,
+          numBinarySearchSteps,
+          geomCache,
+          getOrCreateGeomVertex,
+          getOrCreateTexVertex,
+          newFaces,
+          newTexcoordFaces);
+    }
+  }
+
+  Mesh result;
+  result.vertices = std::move(vertices);
+  result.normals = std::move(normals);
+  result.colors = std::move(colors);
+  result.confidence = std::move(confidence);
+  result.texcoords = std::move(texcoords);
+  result.faces = std::move(newFaces);
+  result.texcoord_faces = std::move(newTexcoordFaces);
+
+  if (result.faces.empty()) {
+    return Mesh{};
+  }
+
+  std::vector<bool> activeFaces(result.faces.size(), true);
+  return reduceMeshByFaces<float>(result, activeFaces);
+}
+
+} // namespace momentum

--- a/momentum/character/texture_classification.h
+++ b/momentum/character/texture_classification.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/math/mesh.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace momentum {
+
+/// View into a contiguous RGB texture image (non-owning).
+struct TextureView {
+  const uint8_t* data;
+  int64_t height;
+  int64_t width;
+  int64_t stride0; ///< Row stride in bytes
+  int64_t stride1; ///< Column stride in bytes
+  int64_t stride2; ///< Channel stride in bytes
+};
+
+/// View into a contiguous array of RGB region colors (non-owning).
+struct RegionColorsView {
+  const uint8_t* data;
+  int32_t nRegions;
+  int64_t stride0; ///< Stride between regions in bytes
+  int64_t stride1; ///< Stride between channels in bytes
+};
+
+/// Classify mesh triangles into regions based on texture colors.
+///
+/// For each triangle, samples the texture at barycentric coordinates within the
+/// triangle, matches the sampled color against the provided region colors, and
+/// assigns the triangle to any matching regions.
+///
+/// @param mesh The mesh with texcoords and texcoord_faces.
+/// @param texture RGB texture image data.
+/// @param regionColors RGB colors defining each region.
+/// @param threshold Fraction of samples that must match for a triangle to be
+///     assigned to a region. 0.0 means at least one sample must match.
+/// @param numSamples Number of barycentric sample points per triangle
+///     (1, 3, 4, 6, 7, or 10).
+/// @return Vector of sorted triangle index lists, one per region.
+std::vector<std::vector<int32_t>> classifyTrianglesByTexture(
+    const Mesh& mesh,
+    const TextureView& texture,
+    const RegionColorsView& regionColors,
+    float threshold = 0.0f,
+    int32_t numSamples = 3);
+
+/// Split mesh triangles along texture region boundaries.
+///
+/// For each face, classifies its texcoord vertices as inside or outside the
+/// specified region colors. Faces fully inside are kept, fully outside are
+/// discarded, and boundary faces are split by binary-searching for the crossing
+/// point along each edge in UV space.
+///
+/// @param mesh The mesh with vertices, faces, texcoords, and texcoord_faces.
+/// @param texture RGB texture image data.
+/// @param regionColors RGB colors defining the "inside" region.
+/// @param numBinarySearchSteps Number of binary search iterations for edge
+///     crossing precision (8 gives 1/256 sub-pixel accuracy).
+/// @return A new Mesh containing only the inside portion, with boundary
+///     triangles split along the texture region boundary.
+Mesh splitMeshByTextureRegion(
+    const Mesh& mesh,
+    const TextureView& texture,
+    const RegionColorsView& regionColors,
+    int32_t numBinarySearchSteps = 8);
+
+} // namespace momentum

--- a/pymomentum/axel/axel_pybind.cpp
+++ b/pymomentum/axel/axel_pybind.cpp
@@ -266,6 +266,43 @@ Available methods:
           py::arg("bounds"),
           py::arg("resolution"),
           py::arg("data"))
+      .def(
+          py::init([](const axel::BoundingBox<float>& bounds, const py::array_t<float>& data) {
+            auto info = data.request();
+            MT_THROW_IF(
+                info.ndim != 3,
+                "data must be a 3D array with shape (nx, ny, nz), got ndim={}",
+                info.ndim);
+            const auto nx = static_cast<axel::Index>(info.shape[0]);
+            const auto ny = static_cast<axel::Index>(info.shape[1]);
+            const auto nz = static_cast<axel::Index>(info.shape[2]);
+            const Eigen::Vector3<axel::Index> resolution(nx, ny, nz);
+
+            // Copy data respecting strides (handles both C and Fortran order)
+            std::vector<float> flatData(static_cast<size_t>(nx) * ny * nz);
+            const auto* src = static_cast<const float*>(info.ptr);
+            for (axel::Index k = 0; k < nz; ++k) {
+              for (axel::Index j = 0; j < ny; ++j) {
+                for (axel::Index i = 0; i < nx; ++i) {
+                  const auto srcIdx = i * (info.strides[0] / sizeof(float)) +
+                      j * (info.strides[1] / sizeof(float)) + k * (info.strides[2] / sizeof(float));
+                  // Internal storage: k * nx * ny + j * nx + i
+                  flatData[k * nx * ny + j * nx + i] = src[srcIdx];
+                }
+              }
+            }
+            return axel::SignedDistanceField<float>(bounds, resolution, std::move(flatData));
+          }),
+          R"(Create a signed distance field from a bounding box and a 3D numpy array.
+
+The array shape ``(nx, ny, nz)`` determines the grid resolution. Data is
+copied from the array into the SDF's internal storage, correctly handling
+both C-contiguous and Fortran-contiguous memory layouts.
+
+:param bounds: 3D bounding box defining the spatial extent of the SDF.
+:param data: 3D numpy array of shape (nx, ny, nz) with float32 distance values.)",
+          py::arg("bounds"),
+          py::arg("data"))
       .def_property_readonly(
           "bounds", &axel::SignedDistanceField<float>::bounds, "Get the bounding box of the SDF.")
       .def_property_readonly(

--- a/pymomentum/geometry/texture_classification.cpp
+++ b/pymomentum/geometry/texture_classification.cpp
@@ -7,124 +7,41 @@
 
 #include "pymomentum/geometry/texture_classification.h"
 
-#include <momentum/character/character_utility.h>
+#include <momentum/character/texture_classification.h>
 #include <momentum/common/exception.h>
-
-#include <dispenso/parallel_for.h>
-
-#include <algorithm>
-#include <array>
-#include <cstddef>
-#include <mutex>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace pymomentum {
 
 namespace {
 
-/// Barycentric coordinate for a sample point within a triangle.
-struct BarycentricCoord {
-  float u;
-  float v;
-  float w;
-
-  constexpr BarycentricCoord(float u_, float v_, float w_) : u(u_), v(v_), w(w_) {}
-};
-
-/// Get the barycentric sample points for a given num_samples value.
-std::vector<BarycentricCoord> getSamplePoints(int32_t numSamples) {
-  // Vertex coordinates
-  constexpr BarycentricCoord v0(1.0f, 0.0f, 0.0f);
-  constexpr BarycentricCoord v1(0.0f, 1.0f, 0.0f);
-  constexpr BarycentricCoord v2(0.0f, 0.0f, 1.0f);
-
-  // Centroid
-  constexpr float third = 1.0f / 3.0f;
-  constexpr BarycentricCoord centroid(third, third, third);
-
-  // Edge midpoints
-  constexpr BarycentricCoord mid01(0.5f, 0.5f, 0.0f);
-  constexpr BarycentricCoord mid12(0.0f, 0.5f, 0.5f);
-  constexpr BarycentricCoord mid02(0.5f, 0.0f, 0.5f);
-
-  // Interior points (at 1/4 from each vertex toward centroid)
-  constexpr float quarter = 0.25f;
-  constexpr float threeQuarters = 0.75f;
-  constexpr BarycentricCoord int0(threeQuarters, quarter * 0.5f, quarter * 0.5f);
-  constexpr BarycentricCoord int1(quarter * 0.5f, threeQuarters, quarter * 0.5f);
-  constexpr BarycentricCoord int2(quarter * 0.5f, quarter * 0.5f, threeQuarters);
-
-  switch (numSamples) {
-    case 1:
-      return {centroid};
-    case 3:
-      // Vertices only - backward compatible with Python implementation
-      return {v0, v1, v2};
-    case 4:
-      return {centroid, v0, v1, v2};
-    case 6:
-      return {v0, v1, v2, mid01, mid12, mid02};
-    case 7:
-      return {centroid, v0, v1, v2, mid01, mid12, mid02};
-    case 10:
-      return {centroid, v0, v1, v2, mid01, mid12, mid02, int0, int1, int2};
-    default:
-      MT_THROW("Invalid num_samples value {}. Must be one of: 1, 3, 4, 6, 7, 10.", numSamples);
-  }
-}
-
-/// Hash function for packing RGB into a single size_t value for fast lookup.
-inline size_t packRgb(uint8_t r, uint8_t g, uint8_t b) {
-  return static_cast<size_t>(r) | (static_cast<size_t>(g) << 8) | (static_cast<size_t>(b) << 16);
-}
-
-/// Build a lookup table from packed RGB to region index using the regionColors array.
-std::unordered_map<size_t, int32_t> buildColorLookup(
-    const uint8_t* regionColorsData,
-    py::ssize_t stride0,
-    py::ssize_t stride1,
-    int32_t nRegions) {
-  std::unordered_map<size_t, int32_t> lookup;
-  lookup.reserve(nRegions);
-
-  for (int32_t regionIdx = 0; regionIdx < nRegions; ++regionIdx) {
-    const uint8_t* colorPtr = regionColorsData + regionIdx * stride0;
-    const uint8_t r = colorPtr[0 * stride1];
-    const uint8_t g = colorPtr[1 * stride1];
-    const uint8_t b = colorPtr[2 * stride1];
-    lookup[packRgb(r, g, b)] = regionIdx;
-  }
-  return lookup;
-}
-
-/// Validated texture array information.
-struct TextureInfo {
-  const uint8_t* data;
-  py::ssize_t stride0;
-  py::ssize_t stride1;
-  py::ssize_t stride2;
-  py::ssize_t height;
-  py::ssize_t width;
-};
-
-/// Validate a texture numpy array and extract sampling info.
-TextureInfo validateTexture(const py::array_t<uint8_t>& texture) {
+/// Validate a texture numpy array and return a TextureView.
+momentum::TextureView validateTexture(const py::array_t<uint8_t>& texture) {
   py::buffer_info texInfo = texture.request();
   MT_THROW_IF(texInfo.ndim != 3, "texture must be a 3D array [height, width, 3]");
   MT_THROW_IF(texInfo.shape[2] != 3, "texture must have 3 channels (RGB)");
+  MT_THROW_IF(
+      texInfo.shape[0] <= 0 || texInfo.shape[1] <= 0, "texture dimensions must be positive");
 
-  const auto height = static_cast<py::ssize_t>(texInfo.shape[0]);
-  const auto width = static_cast<py::ssize_t>(texInfo.shape[1]);
-  MT_THROW_IF(height <= 0 || width <= 0, "texture dimensions must be positive");
-
-  return TextureInfo{
+  return momentum::TextureView{
       static_cast<const uint8_t*>(texInfo.ptr),
-      static_cast<py::ssize_t>(texInfo.strides[0]),
-      static_cast<py::ssize_t>(texInfo.strides[1]),
-      static_cast<py::ssize_t>(texInfo.strides[2]),
-      height,
-      width};
+      static_cast<int64_t>(texInfo.shape[0]),
+      static_cast<int64_t>(texInfo.shape[1]),
+      static_cast<int64_t>(texInfo.strides[0]),
+      static_cast<int64_t>(texInfo.strides[1]),
+      static_cast<int64_t>(texInfo.strides[2])};
+}
+
+/// Validate a region colors numpy array and return a RegionColorsView.
+momentum::RegionColorsView validateRegionColors(const py::array_t<uint8_t>& regionColors) {
+  py::buffer_info colorsInfo = regionColors.request();
+  MT_THROW_IF(colorsInfo.ndim != 2, "region_colors must be a 2D array [n_regions, 3]");
+  MT_THROW_IF(colorsInfo.shape[1] != 3, "region_colors must have 3 columns (RGB)");
+
+  return momentum::RegionColorsView{
+      static_cast<const uint8_t*>(colorsInfo.ptr),
+      static_cast<int32_t>(colorsInfo.shape[0]),
+      static_cast<int64_t>(colorsInfo.strides[0]),
+      static_cast<int64_t>(colorsInfo.strides[1])};
 }
 
 } // namespace
@@ -135,477 +52,26 @@ std::vector<std::vector<int32_t>> classifyTrianglesByTexture(
     const py::array_t<uint8_t>& regionColors,
     float threshold,
     int32_t numSamples) {
-  // Validate inputs
-  MT_THROW_IF(mesh.texcoords.empty(), "Mesh must have texture coordinates");
-  MT_THROW_IF(mesh.texcoord_faces.empty(), "Mesh must have texture coordinate faces");
-  MT_THROW_IF(threshold < 0.0f || threshold > 1.0f, "threshold must be in range [0, 1]");
+  const auto texView = validateTexture(texture);
+  const auto colorsView = validateRegionColors(regionColors);
 
-  // Validate texture array
-  const auto tex = validateTexture(texture);
-  const auto* textureData = tex.data;
-  const auto height = tex.height;
-  const auto width = tex.width;
-  const auto texStride0 = tex.stride0;
-  const auto texStride1 = tex.stride1;
-  const auto texStride2 = tex.stride2;
-
-  // Validate regionColors array
-  py::buffer_info colorsInfo = regionColors.request();
-  MT_THROW_IF(colorsInfo.ndim != 2, "region_colors must be a 2D array [n_regions, 3]");
-  MT_THROW_IF(colorsInfo.shape[1] != 3, "region_colors must have 3 columns (RGB)");
-
-  const auto nRegions = static_cast<int32_t>(colorsInfo.shape[0]);
-  MT_THROW_IF(nRegions == 0, "region_colors must not be empty");
-
-  const auto* regionColorsData = static_cast<const uint8_t*>(colorsInfo.ptr);
-  const auto colorsStride0 = static_cast<py::ssize_t>(colorsInfo.strides[0]);
-  const auto colorsStride1 = static_cast<py::ssize_t>(colorsInfo.strides[1]);
-
-  // Get sample points
-  const auto samplePoints = getSamplePoints(numSamples);
-  const auto nSamples = static_cast<int32_t>(samplePoints.size());
-
-  // Build fast color lookup from region colors array
-  const auto colorLookup =
-      buildColorLookup(regionColorsData, colorsStride0, colorsStride1, nRegions);
-
-  const auto nTriangles = static_cast<int64_t>(mesh.faces.size());
-
-  // Per-region triangle lists
-  std::vector<std::vector<int32_t>> regionTriangles(nRegions);
-
-  // Release GIL for parallel computation
+  std::vector<std::vector<int32_t>> result;
   {
     py::gil_scoped_release release;
-
-    // Use thread-local accumulation to avoid mutex contention
-    std::mutex mergeMutex;
-    dispenso::parallel_for(
-        dispenso::makeChunkedRange(
-            static_cast<int64_t>(0), nTriangles, dispenso::ParForChunking::kAuto),
-        [&](int64_t rangeBegin, int64_t rangeEnd) {
-          // Thread-local storage for region counts and per-region triangle lists
-          std::vector<int32_t> regionCounts(nRegions, 0);
-          std::vector<std::vector<int32_t>> localRegionTriangles(nRegions);
-
-          for (int64_t triIdx = rangeBegin; triIdx != rangeEnd; ++triIdx) {
-            // Reset counts
-            std::fill(regionCounts.begin(), regionCounts.end(), 0);
-
-            // Get texture coordinate indices for this triangle
-            const auto& texFace = mesh.texcoord_faces[triIdx];
-            const auto& uv0 = mesh.texcoords[texFace.x()];
-            const auto& uv1 = mesh.texcoords[texFace.y()];
-            const auto& uv2 = mesh.texcoords[texFace.z()];
-
-            // Sample at each barycentric coordinate
-            for (const auto& bary : samplePoints) {
-              // Interpolate UV coordinates
-              const float u = bary.u * uv0.x() + bary.v * uv1.x() + bary.w * uv2.x();
-              const float v = bary.u * uv0.y() + bary.v * uv1.y() + bary.w * uv2.y();
-
-              // Convert UV to pixel coordinates (matching Python implementation)
-              const std::ptrdiff_t col = std::clamp(
-                  static_cast<std::ptrdiff_t>(u * static_cast<float>(width - 1)),
-                  std::ptrdiff_t{0},
-                  width - 1);
-              const std::ptrdiff_t row = std::clamp(
-                  static_cast<std::ptrdiff_t>(v * static_cast<float>(height - 1)),
-                  std::ptrdiff_t{0},
-                  height - 1);
-
-              // Sample texture color
-              const auto* pixel = textureData + row * texStride0 + col * texStride1;
-              const uint8_t r = pixel[0 * texStride2];
-              const uint8_t g = pixel[1 * texStride2];
-              const uint8_t b = pixel[2 * texStride2];
-
-              // Look up region
-              const size_t packedColor = packRgb(r, g, b);
-              auto it = colorLookup.find(packedColor);
-              if (it != colorLookup.end()) {
-                const int32_t regionIdx = it->second;
-                if (regionIdx >= 0 && regionIdx < nRegions) {
-                  ++regionCounts[regionIdx];
-                }
-              }
-            }
-
-            // Determine which regions this triangle belongs to based on threshold
-            const int32_t minSamplesNeeded = (threshold == 0.0f)
-                ? 1
-                : static_cast<int32_t>(std::ceil(threshold * static_cast<float>(nSamples)));
-
-            for (int32_t regionIdx = 0; regionIdx < nRegions; ++regionIdx) {
-              if (regionCounts[regionIdx] >= minSamplesNeeded) {
-                localRegionTriangles[regionIdx].push_back(static_cast<int32_t>(triIdx));
-              }
-            }
-          }
-
-          // Merge thread-local results into shared vectors
-          std::lock_guard<std::mutex> lock(mergeMutex);
-          for (int32_t regionIdx = 0; regionIdx < nRegions; ++regionIdx) {
-            auto& dst = regionTriangles[regionIdx];
-            auto& src = localRegionTriangles[regionIdx];
-            dst.insert(dst.end(), src.begin(), src.end());
-          }
-        });
-  }
-
-  // Sort triangle lists for determinism
-  for (auto& triangles : regionTriangles) {
-    std::sort(triangles.begin(), triangles.end());
-  }
-
-  return regionTriangles;
-}
-
-namespace {
-
-// Canonical edge representation for caching split vertices.
-using Edge = std::pair<int, int>;
-
-Edge makeEdge(int v1, int v2) {
-  if (v1 > v2) {
-    std::swap(v1, v2);
-  }
-  return {v1, v2};
-}
-
-struct HashEdge {
-  std::size_t operator()(const Edge& e) const {
-    std::size_t h1 = std::hash<int>{}(e.first);
-    std::size_t h2 = std::hash<int>{}(e.second);
-    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
-  }
-};
-
-// Cached result from splitting a geometry edge.
-struct GeomCacheEntry {
-  int vertexIndex;
-  float t;
-};
-
-// Build a set of "inside" colors from the regionColors array.
-std::unordered_set<size_t> buildInsideColorSet(
-    const uint8_t* regionColorsData,
-    py::ssize_t stride0,
-    py::ssize_t stride1,
-    int32_t nColors) {
-  std::unordered_set<size_t> result;
-  result.reserve(nColors);
-  for (int32_t i = 0; i < nColors; ++i) {
-    const uint8_t* colorPtr = regionColorsData + i * stride0;
-    const uint8_t r = colorPtr[0 * stride1];
-    const uint8_t g = colorPtr[1 * stride1];
-    const uint8_t b = colorPtr[2 * stride1];
-    result.insert(packRgb(r, g, b));
+    result = momentum::classifyTrianglesByTexture(mesh, texView, colorsView, threshold, numSamples);
   }
   return result;
 }
-
-// Bundles texture data and inside-color set for sampling operations.
-struct TextureSampler {
-  TextureInfo tex;
-  std::unordered_set<size_t> insideColors;
-
-  // Sample texture at a UV coordinate and check if the color is "inside".
-  bool isInside(const Eigen::Vector2f& uv) const {
-    const float colF = uv.x() * static_cast<float>(tex.width - 1);
-    const auto col = std::clamp(static_cast<py::ssize_t>(colF), py::ssize_t{0}, tex.width - 1);
-    const float rowF = uv.y() * static_cast<float>(tex.height - 1);
-    const auto row = std::clamp(static_cast<py::ssize_t>(rowF), py::ssize_t{0}, tex.height - 1);
-
-    const auto* pixel = tex.data + row * tex.stride0 + col * tex.stride1;
-    const uint8_t r = pixel[0 * tex.stride2];
-    const uint8_t g = pixel[1 * tex.stride2];
-    const uint8_t b = pixel[2 * tex.stride2];
-
-    return insideColors.count(packRgb(r, g, b)) > 0;
-  }
-
-  // Binary search for the crossing point on an edge from inside vertex A to outside vertex B
-  // in UV space. Returns the parameter t such that the crossing is at A + t*(B - A).
-  float findCrossingT(const Eigen::Vector2f& uvA, const Eigen::Vector2f& uvB, int32_t numSteps)
-      const {
-    float lo = 0.0f;
-    float hi = 1.0f;
-    for (int32_t i = 0; i < numSteps; ++i) {
-      const float mid = 0.5f * (lo + hi);
-      const Eigen::Vector2f uvMid = (1.0f - mid) * uvA + mid * uvB;
-      if (isInside(uvMid)) {
-        lo = mid;
-      } else {
-        hi = mid;
-      }
-    }
-    return 0.5f * (lo + hi);
-  }
-};
-
-// Find the crossing t-value on the edge from V0 to V1, checking the geometry cache first.
-// Returns t in the V0->V1 direction. v0IsInside indicates whether V0 is inside the region.
-float findEdgeCrossingT(
-    const TextureSampler& sampler,
-    const Eigen::Vector2f& uv0,
-    const Eigen::Vector2f& uv1,
-    int geomV0,
-    int geomV1,
-    bool v0IsInside,
-    const std::unordered_map<Edge, GeomCacheEntry, HashEdge>& geomCache,
-    int32_t numSteps) {
-  // Check geometry cache for a previously computed t-value on this edge
-  const auto edge = makeEdge(geomV0, geomV1);
-  auto it = geomCache.find(edge);
-  if (it != geomCache.end()) {
-    // Convert cached t (in min->max direction) to V0->V1 direction
-    float tOriented = it->second.t;
-    return (geomV0 < geomV1) ? tOriented : (1.0f - tOriented);
-  }
-
-  // Binary search: always orient from inside to outside
-  if (v0IsInside) {
-    return sampler.findCrossingT(uv0, uv1, numSteps);
-  } else {
-    return 1.0f - sampler.findCrossingT(uv1, uv0, numSteps);
-  }
-}
-
-// Process a mixed face (1 or 2 vertices inside) by splitting it along the texture
-// region boundary. Appends the resulting inside triangle(s) to newFaces/newTexcoordFaces.
-template <typename GetOrCreateGeomVertexFn, typename GetOrCreateTexVertexFn>
-void processMixedFace(
-    const Eigen::Vector3i& face,
-    const Eigen::Vector3i& texFace,
-    const std::array<bool, 3>& inside,
-    int nInside,
-    const std::vector<Eigen::Vector2f>& meshTexcoords,
-    const TextureSampler& sampler,
-    int32_t numBinarySearchSteps,
-    const std::unordered_map<Edge, GeomCacheEntry, HashEdge>& geomCache,
-    GetOrCreateGeomVertexFn& getOrCreateGeomVertex,
-    GetOrCreateTexVertexFn& getOrCreateTexVertex,
-    std::vector<Eigen::Vector3i>& newFaces,
-    std::vector<Eigen::Vector3i>& newTexcoordFaces) {
-  // Find the solo vertex: for "1 in, 2 out" the lone inside vertex;
-  // for "2 in, 1 out" the lone outside vertex.
-  int solo = -1;
-  for (int k = 0; k < 3; ++k) {
-    if ((nInside == 1 && inside[k]) || (nInside == 2 && !inside[k])) {
-      solo = k;
-      break;
-    }
-  }
-
-  // The two edges that cross are (solo, (solo+1)%3) and (solo, (solo+2)%3)
-  const int k0 = solo;
-  const int k1 = (solo + 1) % 3;
-  const int k2 = (solo + 2) % 3;
-
-  const int gV0 = face[k0], gV1 = face[k1], gV2 = face[k2];
-  const int tV0 = texFace[k0], tV1 = texFace[k1], tV2 = texFace[k2];
-
-  // Find crossing points on the two edges from V0 to V1 and V0 to V2.
-  const bool v0IsInside = (nInside == 1);
-  const float t01 = findEdgeCrossingT(
-      sampler,
-      meshTexcoords[tV0],
-      meshTexcoords[tV1],
-      gV0,
-      gV1,
-      v0IsInside,
-      geomCache,
-      numBinarySearchSteps);
-  const float t02 = findEdgeCrossingT(
-      sampler,
-      meshTexcoords[tV0],
-      meshTexcoords[tV2],
-      gV0,
-      gV2,
-      v0IsInside,
-      geomCache,
-      numBinarySearchSteps);
-
-  // Create split vertices on edge V0-V1 and V0-V2
-  const int gM01 = getOrCreateGeomVertex(gV0, gV1, t01);
-  const int gM02 = getOrCreateGeomVertex(gV0, gV2, t02);
-  const int tM01 = getOrCreateTexVertex(tV0, tV1, t01);
-  const int tM02 = getOrCreateTexVertex(tV0, tV2, t02);
-
-  if (nInside == 1) {
-    // 1 inside (V0), 2 outside: emit 1 triangle (V0, M01, M02)
-    newFaces.emplace_back(gV0, gM01, gM02);
-    newTexcoordFaces.emplace_back(tV0, tM01, tM02);
-  } else {
-    // 2 inside (V1, V2), 1 outside (V0): emit 2 triangles forming the inside quad
-    newFaces.emplace_back(gV1, gV2, gM01);
-    newTexcoordFaces.emplace_back(tV1, tV2, tM01);
-    newFaces.emplace_back(gV2, gM02, gM01);
-    newTexcoordFaces.emplace_back(tV2, tM02, tM01);
-  }
-}
-
-} // namespace
 
 momentum::Mesh splitMeshByTextureRegion(
     const momentum::Mesh& mesh,
     const py::array_t<uint8_t>& texture,
     const py::array_t<uint8_t>& regionColors,
     int32_t numBinarySearchSteps) {
-  // Validate inputs
-  MT_THROW_IF(mesh.texcoords.empty(), "Mesh must have texture coordinates");
-  MT_THROW_IF(mesh.texcoord_faces.empty(), "Mesh must have texture coordinate faces");
-  MT_THROW_IF(
-      mesh.faces.size() != mesh.texcoord_faces.size(),
-      "faces and texcoord_faces must have the same size");
+  const auto texView = validateTexture(texture);
+  const auto colorsView = validateRegionColors(regionColors);
 
-  // Validate and build texture sampler
-  const auto tex = validateTexture(texture);
-
-  py::buffer_info colorsInfo = regionColors.request();
-  MT_THROW_IF(colorsInfo.ndim != 2, "region_colors must be a 2D array [n_colors, 3]");
-  MT_THROW_IF(colorsInfo.shape[1] != 3, "region_colors must have 3 columns (RGB)");
-
-  const auto nColors = static_cast<int32_t>(colorsInfo.shape[0]);
-  MT_THROW_IF(nColors == 0, "region_colors must not be empty");
-
-  const auto* regionColorsData = static_cast<const uint8_t*>(colorsInfo.ptr);
-  const auto colorsStride0 = static_cast<py::ssize_t>(colorsInfo.strides[0]);
-  const auto colorsStride1 = static_cast<py::ssize_t>(colorsInfo.strides[1]);
-
-  const TextureSampler sampler{
-      tex, buildInsideColorSet(regionColorsData, colorsStride0, colorsStride1, nColors)};
-
-  // Classify each texcoord vertex as inside or outside
-  const auto nTexVerts = static_cast<int>(mesh.texcoords.size());
-  std::vector<bool> texVertInside(nTexVerts);
-  for (int i = 0; i < nTexVerts; ++i) {
-    texVertInside[i] = sampler.isInside(mesh.texcoords[i]);
-  }
-
-  // Initialize output: start with copies of all original vertices and texcoords.
-  // We'll append new split vertices/texcoords for boundary edges.
-  auto vertices = mesh.vertices;
-  auto normals = mesh.normals;
-  auto colors = mesh.colors;
-  auto confidence = mesh.confidence;
-  auto texcoords = mesh.texcoords;
-
-  std::vector<Eigen::Vector3i> newFaces;
-  std::vector<Eigen::Vector3i> newTexcoordFaces;
-  newFaces.reserve(mesh.faces.size());
-  newTexcoordFaces.reserve(mesh.faces.size());
-
-  // Edge caches for vertex reuse
-  std::unordered_map<Edge, GeomCacheEntry, HashEdge> geomCache;
-  std::unordered_map<Edge, int, HashEdge> texCache;
-
-  const bool hasNormals = !normals.empty();
-  const bool hasColors = !colors.empty();
-  const bool hasConfidence = !confidence.empty();
-
-  // Helper: get or create a split vertex on a geometry edge
-  auto getOrCreateGeomVertex = [&](int geomA, int geomB, float t) -> int {
-    const auto edge = makeEdge(geomA, geomB);
-    auto it = geomCache.find(edge);
-    if (it != geomCache.end()) {
-      return it->second.vertexIndex;
-    }
-    // Ensure t is oriented: from min to max vertex index
-    float tOriented = (geomA < geomB) ? t : (1.0f - t);
-    const int newIdx = static_cast<int>(vertices.size());
-    vertices.emplace_back(
-        (1.0f - tOriented) * vertices[edge.first] + tOriented * vertices[edge.second]);
-    if (hasNormals) {
-      Eigen::Vector3f n =
-          (1.0f - tOriented) * normals[edge.first] + tOriented * normals[edge.second];
-      n.normalize();
-      normals.emplace_back(n);
-    }
-    if (hasColors) {
-      // Linearly interpolate colors (cast to float for interpolation)
-      Eigen::Vector3f cf = (1.0f - tOriented) * colors[edge.first].cast<float>() +
-          tOriented * colors[edge.second].cast<float>();
-      colors.emplace_back(
-          static_cast<uint8_t>(std::clamp(cf.x(), 0.0f, 255.0f)),
-          static_cast<uint8_t>(std::clamp(cf.y(), 0.0f, 255.0f)),
-          static_cast<uint8_t>(std::clamp(cf.z(), 0.0f, 255.0f)));
-    }
-    if (hasConfidence) {
-      confidence.emplace_back(
-          (1.0f - tOriented) * confidence[edge.first] + tOriented * confidence[edge.second]);
-    }
-    geomCache[edge] = {newIdx, tOriented};
-    return newIdx;
-  };
-
-  // Helper: get or create a split vertex on a texcoord edge
-  auto getOrCreateTexVertex = [&](int texA, int texB, float t) -> int {
-    const auto edge = makeEdge(texA, texB);
-    auto it = texCache.find(edge);
-    if (it != texCache.end()) {
-      return it->second;
-    }
-    float tOriented = (texA < texB) ? t : (1.0f - t);
-    const int newIdx = static_cast<int>(texcoords.size());
-    texcoords.emplace_back(
-        (1.0f - tOriented) * texcoords[edge.first] + tOriented * texcoords[edge.second]);
-    texCache[edge] = newIdx;
-    return newIdx;
-  };
-
-  for (size_t fi = 0; fi < mesh.faces.size(); ++fi) {
-    const auto& face = mesh.faces[fi];
-    const auto& texFace = mesh.texcoord_faces[fi];
-
-    // Classify: count how many texcoord vertices are inside
-    std::array<bool, 3> inside = {
-        texVertInside[texFace.x()], texVertInside[texFace.y()], texVertInside[texFace.z()]};
-    const int nInside =
-        static_cast<int>(inside[0]) + static_cast<int>(inside[1]) + static_cast<int>(inside[2]);
-
-    if (nInside == 3) {
-      // All inside: keep face unchanged
-      newFaces.push_back(face);
-      newTexcoordFaces.push_back(texFace);
-    } else if (nInside > 0) {
-      // Mixed face: split along the texture region boundary
-      processMixedFace(
-          face,
-          texFace,
-          inside,
-          nInside,
-          mesh.texcoords,
-          sampler,
-          numBinarySearchSteps,
-          geomCache,
-          getOrCreateGeomVertex,
-          getOrCreateTexVertex,
-          newFaces,
-          newTexcoordFaces);
-    }
-    // nInside == 0: all outside, discard
-  }
-
-  // Build the output mesh with all vertices/texcoords (including newly created ones)
-  momentum::Mesh result;
-  result.vertices = std::move(vertices);
-  result.normals = std::move(normals);
-  result.colors = std::move(colors);
-  result.confidence = std::move(confidence);
-  result.texcoords = std::move(texcoords);
-  result.faces = std::move(newFaces);
-  result.texcoord_faces = std::move(newTexcoordFaces);
-  // Lines are not preserved through triangle splitting
-
-  // Compact the mesh: remove unreferenced vertices and texcoords
-  if (result.faces.empty()) {
-    return momentum::Mesh{};
-  }
-
-  std::vector<bool> activeFaces(result.faces.size(), true);
-  return momentum::reduceMeshByFaces<float>(result, activeFaces);
+  return momentum::splitMeshByTextureRegion(mesh, texView, colorsView, numBinarySearchSteps);
 }
 
 } // namespace pymomentum


### PR DESCRIPTION
Summary:

Move the texture classification implementation (classifyTrianglesByTexture, splitMeshByTextureRegion) from the pymomentum pybind file into momentum/character as a proper C++ library. The Python bindings now wrap the C++ functions instead of implementing the logic inline.

Add verbose flag to axel MeshToSdf for progress logging.

Add SignedDistanceField constructor from bounds + 3D numpy array, handling both C and Fortran memory layouts.

Reviewed By: cstollmeta

Differential Revision: D102061428


