### PR TITLE
Comment audit: common/ (#1340)

### DIFF
--- a/momentum/common/aligned.h
+++ b/momentum/common/aligned.h
@@ -98,6 +98,10 @@ inline void aligned_free(void* ptr) {
 
 #endif
 
+/// Rounds `value` up to the nearest multiple of `alignment` (in bytes).
+///
+/// @pre `alignment` must be non-zero. Throws `std::invalid_argument` otherwise.
+/// @return The smallest multiple of `alignment` that is >= `value`.
 inline constexpr std::size_t roundUpToAlignment(std::size_t value, std::size_t alignment) {
   MT_THROW_IF_T(alignment == 0, std::invalid_argument, "Alignment must be non-zero");
   return ((value + alignment - 1) / alignment) * alignment;
@@ -106,7 +110,12 @@ inline constexpr std::size_t roundUpToAlignment(std::size_t value, std::size_t a
 /// Allocates a block of memory that can hold `n` elements of type `T` with the specified alignment.
 ///
 /// This function is intended to be used in the `AlignedAllocator::allocate()` method and throws
-/// exceptions as `std::allocator<T>::allocate` does.
+/// exceptions as `std::allocator<T>::allocate` does. The allocated size is rounded up to a multiple
+/// of `Alignment` so it satisfies the size requirements of `std::aligned_alloc` on platforms where
+/// it is used. The returned pointer must be released with `aligned_free`.
+///
+/// @throws std::bad_array_new_length if `n * sizeof(T)` would overflow.
+/// @throws std::bad_alloc if the underlying aligned allocation fails.
 template <typename T, std::size_t Alignment = alignof(T)>
 [[nodiscard]] T* alignedAlloc(std::size_t n) {
   MT_THROW_IF_T(std::numeric_limits<std::size_t>::max() / sizeof(T) < n, std::bad_array_new_length);
@@ -154,9 +163,7 @@ class AlignedAllocator {
   AlignedAllocator() noexcept = default;
 
   template <class U>
-  explicit AlignedAllocator(const AlignedAllocator<U, Alignment>& /*other*/) noexcept {
-    // Empty
-  }
+  explicit AlignedAllocator(const AlignedAllocator<U, Alignment>& /*other*/) noexcept {}
 
   /// Allocates a block of memory that can hold `n` elements of type `T`.
   ///
@@ -169,8 +176,8 @@ class AlignedAllocator {
   /// Deallocates a block of memory that was previously allocated by `allocate`.
   ///
   /// @param[in] ptr A pointer to the first byte of the memory block to deallocate.
-  /// @param size The size of the memory block to deallocate. This parameter is not used, but it is
-  /// included to maintain compatibility with `std::allocator`.
+  /// @param n The number of elements in the block. Unused; included to match the
+  /// `std::allocator` interface.
   void deallocate(T* ptr, std::size_t /*n*/) noexcept {
     aligned_free(ptr);
   }

--- a/momentum/common/checks.h
+++ b/momentum/common/checks.h
@@ -7,20 +7,41 @@
 
 #pragma once
 
+/// Runtime check macros with two interchangeable backends:
+/// - When @c MOMENTUM_WITH_XR_LOGGER is defined, failures are reported via the XR logger's
+///   @c XR_CHECK family (which typically logs and aborts).
+/// - Otherwise, failures throw a @c std::runtime_error via @c MT_THROW_IF.
+/// The trailing variadic arguments are an optional fmt-style message and its format arguments.
+
 #if defined(MOMENTUM_WITH_XR_LOGGER)
 
 #include <logging/Checks.h>
 
+/// Asserts that @p condition is true; on failure, reports the optional fmt-style message.
 #define MT_CHECK(condition, ...) XR_CHECK(condition, __VA_ARGS__)
+
+/// Asserts that @p val1 < @p val2; on failure, reports the optional fmt-style message
+/// along with both operand values.
 #define MT_CHECK_LT(val1, val2, ...) XR_CHECK_DETAIL_OP1(val1, val2, <, ##__VA_ARGS__)
+
+/// Asserts that @p ptr is not null; on failure, reports the optional fmt-style message.
 #define MT_CHECK_NOTNULL(ptr, ...) XR_CHECK(ptr != nullptr, ##__VA_ARGS__)
 
 #else
 
 #include <momentum/common/exception.h>
 
+/// Asserts that @p condition is true; on failure, throws @c std::runtime_error with the
+/// optional fmt-style message.
 #define MT_CHECK(condition, ...) MT_THROW_IF(!(condition), ##__VA_ARGS__)
+
+/// Asserts that @p val1 < @p val2; on failure, throws @c std::runtime_error with the
+/// optional fmt-style message. Note: unlike the XR logger backend, operand values are not
+/// auto-included in the message.
 #define MT_CHECK_LT(val1, val2, ...) MT_THROW_IF(!((val1) < (val2)), ##__VA_ARGS__)
+
+/// Asserts that @p ptr is not null; on failure, throws @c std::runtime_error with the
+/// optional fmt-style message.
 #define MT_CHECK_NOTNULL(ptr, ...) MT_THROW_IF((ptr) == nullptr, ##__VA_ARGS__)
 
 #endif

--- a/momentum/common/exception.h
+++ b/momentum/common/exception.h
@@ -39,6 +39,8 @@
 ///   MT_THROW_IF_T(x > y, std::out_of_range, "x ({}) is greater than y ({})", x, y);
 ///   MT_THROW_IF_T(x > y, std::bad_array_new_length); // No message
 /// @endcode
+// TODO: Wrap macro body in `do { ... } while (0)` to avoid dangling-else bugs when used
+// inside an `if`/`else` without braces.
 #define MT_THROW_IF_T(Condition, Exception, ...) \
   if (Condition) {                               \
     MT_THROW_T(Exception, ##__VA_ARGS__);        \
@@ -59,16 +61,15 @@ using DefaultException = std::runtime_error;
 
 #if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
 
-// Helper function template to throw with formatted message
 template <typename Exception = DefaultException, typename... Args>
 [[noreturn]] void throwImpl(fmt::format_string<Args...> format, Args&&... args) {
   throw Exception{fmt::format(format, std::forward<Args>(args)...)};
 }
 
-// Overload for throwing exceptions without a message.
-// Uses if-constexpr to handle both default-constructible exceptions (e.g.
-// std::bad_array_new_length) and exceptions that require a string argument (e.g.
-// std::runtime_error, std::logic_error).
+/// No-message overload. Selects a default-constructed exception when possible (e.g.
+/// `std::bad_array_new_length`); otherwise falls back to constructing from an empty string,
+/// which is required for exceptions like `std::runtime_error`/`std::logic_error` that have
+/// no default constructor.
 template <typename Exception>
 [[noreturn]] void throwImpl() {
   if constexpr (std::is_constructible_v<Exception>) {
@@ -80,8 +81,7 @@ template <typename Exception>
 
 #else
 
-// Fallback for platforms without exception support
-// Log the error message to stderr and abort.
+/// Fallback when exceptions are disabled: write the formatted message to stderr and abort.
 template <typename Exception = DefaultException, typename... Args>
 [[noreturn]] void throwImpl(fmt::format_string<Args...> format, Args&&... args) {
   std::fprintf(
@@ -89,7 +89,6 @@ template <typename Exception = DefaultException, typename... Args>
   std::abort();
 }
 
-// Overload for exceptions without a message.
 template <typename Exception>
 [[noreturn]] void throwImpl() {
   std::fputs("FATAL ERROR (no message)\n", stderr);

--- a/momentum/common/filesystem.h
+++ b/momentum/common/filesystem.h
@@ -7,6 +7,13 @@
 
 #pragma once
 
+/// Provides the ::filesystem alias used throughout Momentum.
+///
+/// When @c MOMENTUM_WITH_PORTABILITY is defined the alias resolves to the
+/// internal portability shim; otherwise it resolves to @c std::filesystem.
+/// Including this header (rather than @c <filesystem> directly) lets call
+/// sites work unchanged on platforms that lack a complete C++17 filesystem
+/// implementation.
 #if defined(MOMENTUM_WITH_PORTABILITY)
 
 #include <portability/Filesystem.h>

--- a/momentum/common/log.cpp
+++ b/momentum/common/log.cpp
@@ -68,8 +68,6 @@ LogLevel& spdlogLogLevel() {
 
 #else
 
-// Fallback: store the log level in a static variable when no logging backend
-// is available.
 LogLevel& fallbackLogLevel() {
   static LogLevel level = LogLevel::Info;
   return level;
@@ -130,10 +128,8 @@ void setLogLevel(const std::string& levelStr) {
 
 LogLevel getLogLevel() {
 #if defined(MOMENTUM_WITH_XR_LOGGER)
-  // Get the current log level from the XR logger
   int level = arvr::logging::getChannel(DEFAULT_LOG_CHANNEL).level();
 
-  // Convert from arvr::logging::Level to momentum::LogLevel
   switch (static_cast<arvr::logging::Level>(level)) {
     case arvr::logging::Level::Disabled:
       return LogLevel::Disabled;
@@ -148,7 +144,8 @@ LogLevel getLogLevel() {
     case arvr::logging::Level::Trace:
       return LogLevel::Trace;
     default:
-      // Default to Info level for unknown levels
+      // Unrecognized XR levels fall back to Info rather than throwing, since
+      // getLogLevel() must not fail.
       return LogLevel::Info;
   }
 #elif defined(MOMENTUM_WITH_SPDLOG)

--- a/momentum/common/log.h
+++ b/momentum/common/log.h
@@ -9,10 +9,10 @@
 
 #if defined(MOMENTUM_WITH_XR_LOGGER)
 
-// Allow DEFAULT_LOG_CHANNEL to be defined before including this file if you want to override the
-// default channel name. To set your own channel name (the order matters):
-//   #define DEFAULT_LOG_CHANNEL "my_custom_channel_name"
-//   #include <momentum/common/logging.h>
+/// To override the default log channel, define `DEFAULT_LOG_CHANNEL` before including this header
+/// (order matters):
+///   #define DEFAULT_LOG_CHANNEL "my_custom_channel_name"
+///   #include <momentum/common/log.h>
 #ifndef DEFAULT_LOG_CHANNEL
 #include <momentum/common/log_channel.h>
 #define DEFAULT_LOG_CHANNEL MOMENTUM_LOG_CHANNEL
@@ -20,29 +20,42 @@
 
 #include <logging/Log.h>
 
+/// @{
+/// Log a message at the corresponding severity (T=Trace, D=Debug, I=Info, W=Warning, E=Error).
+/// Uses fmt-style formatting via the underlying logger backend.
 #define MT_LOGT(...) XR_LOGT(__VA_ARGS__)
 #define MT_LOGD(...) XR_LOGD(__VA_ARGS__)
 #define MT_LOGI(...) XR_LOGI(__VA_ARGS__)
 #define MT_LOGW(...) XR_LOGW(__VA_ARGS__)
 #define MT_LOGE(...) XR_LOGE(__VA_ARGS__)
+/// @}
 
+/// @{
+/// Log only if `condition` evaluates to true at runtime.
 #define MT_LOGT_IF(condition, ...) XR_LOGT_IF(condition, __VA_ARGS__)
 #define MT_LOGD_IF(condition, ...) XR_LOGD_IF(condition, __VA_ARGS__)
 #define MT_LOGI_IF(condition, ...) XR_LOGI_IF(condition, __VA_ARGS__)
 #define MT_LOGW_IF(condition, ...) XR_LOGW_IF(condition, __VA_ARGS__)
 #define MT_LOGE_IF(condition, ...) XR_LOGE_IF(condition, __VA_ARGS__)
+/// @}
 
+/// @{
+/// Log at most once per process lifetime, regardless of how often the call site is reached.
 #define MT_LOGT_ONCE(...) XR_LOGT_ONCE(__VA_ARGS__)
 #define MT_LOGD_ONCE(...) XR_LOGD_ONCE(__VA_ARGS__)
 #define MT_LOGI_ONCE(...) XR_LOGI_ONCE(__VA_ARGS__)
 #define MT_LOGW_ONCE(...) XR_LOGW_ONCE(__VA_ARGS__)
 #define MT_LOGE_ONCE(...) XR_LOGE_ONCE(__VA_ARGS__)
+/// @}
 
+/// @{
+/// Log at most once per process lifetime, and only if `condition` is true on that first reach.
 #define MT_LOGT_ONCE_IF(condition, ...) XR_LOGT_ONCE_IF(condition, __VA_ARGS__)
 #define MT_LOGD_ONCE_IF(condition, ...) XR_LOGD_ONCE_IF(condition, __VA_ARGS__)
 #define MT_LOGI_ONCE_IF(condition, ...) XR_LOGI_ONCE_IF(condition, __VA_ARGS__)
 #define MT_LOGW_ONCE_IF(condition, ...) XR_LOGW_ONCE_IF(condition, __VA_ARGS__)
 #define MT_LOGE_ONCE_IF(condition, ...) XR_LOGE_ONCE_IF(condition, __VA_ARGS__)
+/// @}
 
 #elif defined(MOMENTUM_WITH_SPDLOG)
 
@@ -50,12 +63,22 @@
 
 #include <atomic>
 
+// TODO: The MT_LOG*_IF macros below expand to a bare `if (condition) { ... }`. When used inside an
+// unbraced `if`/`else` chain at the call site, this can change control flow (dangling-else) or
+// silently swallow a following `else`. Wrap in `do { ... } while (0)` for hygienic expansion.
+
+/// @{
+/// Log a message at the corresponding severity (T=Trace, D=Debug, I=Info, W=Warning, E=Error).
+/// Forwards to spdlog with fmt-style formatting.
 #define MT_LOGT(...) ::spdlog::trace(__VA_ARGS__)
 #define MT_LOGD(...) ::spdlog::debug(__VA_ARGS__)
 #define MT_LOGI(...) ::spdlog::info(__VA_ARGS__)
 #define MT_LOGW(...) ::spdlog::warn(__VA_ARGS__)
 #define MT_LOGE(...) ::spdlog::error(__VA_ARGS__)
+/// @}
 
+/// @{
+/// Log only if `condition` evaluates to true at runtime.
 #define MT_LOGT_IF(condition, ...) \
   if (condition) {                 \
     MT_LOGT(__VA_ARGS__);          \
@@ -76,9 +99,17 @@
   if (condition) {                 \
     MT_LOGE(__VA_ARGS__);          \
   }
+/// @}
 
-// This function is designed to limit the number of times an error is logged.
-// Please note that in a multi-threaded context, its behavior may not be guaranteed.
+// TODO: The leading underscore in `_MT_RUN_ONCE` puts the identifier in a name reserved by the
+// C++ standard at file scope (any identifier with a leading underscore in the global namespace).
+// Rename to e.g. `MT_RUN_ONCE_DETAIL` or `MT_DETAIL_RUN_ONCE`.
+
+/// Execute `runcode` at most once per process lifetime.
+///
+/// Implementation uses an atomic compare-exchange so concurrent first reaches are serialized;
+/// `runcode` runs exactly once even under contention. Subsequent calls become a single relaxed
+/// atomic load.
 #define _MT_RUN_ONCE(runcode)                                \
   {                                                          \
     static std::atomic<bool> codeRan(false);                 \
@@ -90,12 +121,20 @@
     }                                                        \
   }
 
+/// @{
+/// Log at most once per process lifetime, regardless of how often the call site is reached.
 #define MT_LOGT_ONCE(...) _MT_RUN_ONCE(MT_LOGT(__VA_ARGS__))
 #define MT_LOGD_ONCE(...) _MT_RUN_ONCE(MT_LOGD(__VA_ARGS__))
 #define MT_LOGI_ONCE(...) _MT_RUN_ONCE(MT_LOGI(__VA_ARGS__))
 #define MT_LOGW_ONCE(...) _MT_RUN_ONCE(MT_LOGW(__VA_ARGS__))
 #define MT_LOGE_ONCE(...) _MT_RUN_ONCE(MT_LOGE(__VA_ARGS__))
+/// @}
 
+/// @{
+/// Log at most once per process lifetime, gated by `condition`.
+///
+/// @note The "once" latch is set on the first reach where `condition` is true; reaches where the
+/// condition is false do not consume the latch.
 #define MT_LOGT_ONCE_IF(condition, ...) \
   if (condition) {                      \
     MT_LOGT_ONCE(__VA_ARGS__);          \
@@ -116,8 +155,12 @@
   if (condition) {                      \
     MT_LOGE_ONCE(__VA_ARGS__);          \
   }
+/// @}
 
 #else
+
+// Fallback: no logging backend is configured. All MT_LOG* macros expand to nothing, so call-site
+// arguments are not evaluated. Callers must not rely on side effects in log arguments.
 
 #define MT_LOGT(...)
 #define MT_LOGD(...)
@@ -152,7 +195,8 @@
 
 namespace momentum {
 
-/// Logging levels in descending order of verbosity
+/// Logging levels in ascending order of verbosity. `Disabled` suppresses all output; each
+/// successive level enables strictly more messages (Error < Warning < Info < Debug < Trace).
 enum class LogLevel {
   Disabled = 0,
   Error,
@@ -162,12 +206,25 @@ enum class LogLevel {
   Trace,
 };
 
+/// Returns the canonical mapping from human-readable level names ("Disabled", "Error",
+/// "Warning", "Info", "Debug", "Trace") to `LogLevel` values. Useful for building CLI argument
+/// parsers or config validators.
 [[nodiscard]] std::map<std::string, LogLevel> logLevelMap();
 
+/// Sets the global log threshold; messages below `level` are filtered out.
+///
+/// Forwards to the active backend (XR logger / spdlog). When no backend is compiled in, the value
+/// is recorded in a process-local fallback so that `getLogLevel` round-trips.
 void setLogLevel(LogLevel level);
 
+/// Parses `levelStr` (case-insensitive: "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "DISABLED")
+/// and forwards to `setLogLevel(LogLevel)`.
+///
+/// @throws std::invalid_argument if `levelStr` is not one of the recognized names.
 void setLogLevel(const std::string& levelStr);
 
+/// Returns the current global log threshold. Mirrors what was last set via `setLogLevel`; defaults
+/// to `LogLevel::Info` if never set.
 [[nodiscard]] LogLevel getLogLevel();
 
 } // namespace momentum

--- a/momentum/common/log_channel.h
+++ b/momentum/common/log_channel.h
@@ -9,9 +9,13 @@
 
 #if defined(MOMENTUM_WITH_XR_LOGGER)
 
-// The file to include in header files. Used as XR_LOGCI(MOMENTUM_LOG_CHANNEL, "message");
-
 #include <logging/Log.h>
+
+/// XR logger channel name used by all Momentum logging macros.
+///
+/// Pass this as the channel argument to XR_LOGC* macros, e.g.
+/// `XR_LOGCI(MOMENTUM_LOG_CHANNEL, "message")`. Only defined when
+/// `MOMENTUM_WITH_XR_LOGGER` is set at build time.
 #define MOMENTUM_LOG_CHANNEL "MOMENTUM"
 
 #endif

--- a/momentum/common/memory.h
+++ b/momentum/common/memory.h
@@ -9,7 +9,17 @@
 
 #include <memory>
 
-// Define smart pointers for a type
+/// Define the standard set of smart-pointer type aliases for type @p x.
+///
+/// Generates six aliases following the project naming convention:
+///   - `x##_p`        — `std::shared_ptr<x>`
+///   - `x##_u`        — `std::unique_ptr<x>`
+///   - `x##_w`        — `std::weak_ptr<x>`
+///   - `x##_const_p`  — `std::shared_ptr<const x>`
+///   - `x##_const_u`  — `std::unique_ptr<const x>`
+///   - `x##_const_w`  — `std::weak_ptr<const x>`
+///
+/// @pre @p x must be a previously declared (or forward-declared) type name.
 #ifndef MOMENTUM_DEFINE_POINTERS
 #define MOMENTUM_DEFINE_POINTERS(x)               \
   using x##_p = ::std::shared_ptr<x>;             \
@@ -20,14 +30,18 @@
   using x##_const_w = ::std::weak_ptr<const x>;
 #endif // MOMENTUM_DEFINE_POINTERS
 
-// Forward-declare a struct, define smart pointers
+/// Forward-declare struct @p x and define its smart-pointer aliases.
+///
+/// @see MOMENTUM_DEFINE_POINTERS for the generated alias names.
 #ifndef MOMENTUM_FWD_DECLARE_STRUCT
 #define MOMENTUM_FWD_DECLARE_STRUCT(x) \
   struct x;                            \
   MOMENTUM_DEFINE_POINTERS(x);
 #endif // MOMENTUM_FWD_DECLARE_STRUCT
 
-// Forward-declare a class, define smart pointers
+/// Forward-declare class @p x and define its smart-pointer aliases.
+///
+/// @see MOMENTUM_DEFINE_POINTERS for the generated alias names.
 #ifndef MOMENTUM_FWD_DECLARE_CLASS
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define MOMENTUM_FWD_DECLARE_CLASS(x) \
@@ -36,11 +50,19 @@
 // NOLINTEND(bugprone-macro-parentheses)
 #endif // MOMENTUM_FWD_DECLARE_CLASS
 
-// Forward-declare a templated class, define smart pointers for the class and its variants
-// Use the standard backward-compatible naming scheme:
-//    template <typename T> class BarT;
-//    using Bar = BarT<float>;
-//    using Bard = BarT<double>;
+/// Forward-declare a single-template-parameter class @p x##T and define
+/// `float`/`double` instantiation aliases plus their smart-pointer aliases.
+///
+/// Uses the project's backward-compatible naming scheme:
+/// @code
+///    template <typename T> class BarT;
+///    using Bar = BarT<float>;
+///    using Bard = BarT<double>;
+/// @endcode
+/// Smart-pointer aliases are generated for both `Bar` and `Bard`
+/// (e.g. `Bar_p`, `Bard_p`, ...).
+///
+/// @pre @p x##T must be a class template with exactly one type parameter.
 #ifndef MOMENTUM_FWD_DECLARE_TEMPLATE_CLASS
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define MOMENTUM_FWD_DECLARE_TEMPLATE_CLASS(x) \
@@ -53,11 +75,19 @@
 // NOLINTEND(bugprone-macro-parentheses)
 #endif // MOMENTUM_FWD_DECLARE_TEMPLATE_CLASS
 
-// Forward-declare a templated struct, define smart pointers for the struct and its variants
-// Use the standard backward-compatible naming scheme:
-//    template <typename T> struct BarT;
-//    using Bar = BarT<float>;
-//    using Bard = BarT<double>;
+/// Forward-declare a single-template-parameter struct @p x##T and define
+/// `float`/`double` instantiation aliases plus their smart-pointer aliases.
+///
+/// Uses the project's backward-compatible naming scheme:
+/// @code
+///    template <typename T> struct BarT;
+///    using Bar = BarT<float>;
+///    using Bard = BarT<double>;
+/// @endcode
+/// Smart-pointer aliases are generated for both `Bar` and `Bard`
+/// (e.g. `Bar_p`, `Bard_p`, ...).
+///
+/// @pre @p x##T must be a struct template with exactly one type parameter.
 #ifndef MOMENTUM_FWD_DECLARE_TEMPLATE_STRUCT
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define MOMENTUM_FWD_DECLARE_TEMPLATE_STRUCT(x) \

--- a/momentum/common/profile.h
+++ b/momentum/common/profile.h
@@ -7,22 +7,60 @@
 
 #pragma once
 
+/// @file
+/// Profiling macros that dispatch to one of three backends, selected at compile
+/// time:
+///   - XR Profiler when `MOMENTUM_WITH_XR_PROFILER` is defined (forwards to
+///     `XR_PROFILE_*` from `arvr/libraries/profile_redirect/annotate.hpp`).
+///   - Tracy when `MOMENTUM_WITH_TRACY_PROFILER` is defined (forwards to
+///     Tracy's `ZoneScoped` / `ZoneNamedN` / `FrameMark`, etc.).
+///   - No-op otherwise: every `MT_PROFILE_*` macro expands to nothing, so
+///     instrumentation can be left in source with zero runtime cost.
+///
+/// All macros are safe to use unconditionally in library code; the active
+/// backend is determined entirely by the build configuration.
+
 #if defined(MOMENTUM_WITH_XR_PROFILER)
 
 #include <arvr/libraries/profile_redirect/annotate.hpp>
 
+/// Scoped zone covering the enclosing function. Begins at the macro site and
+/// ends when the enclosing scope exits.
 #define MT_PROFILE_FUNCTION() XR_PROFILE_FUNCTION()
+/// Like `MT_PROFILE_FUNCTION` but tags the zone with @p CATEGORY for filtering.
+/// No-op under the Tracy backend, which has no equivalent concept here.
 #define MT_PROFILE_FUNCTION_CATEGORY(CATEGORY) XR_PROFILE_FUNCTION_CATEGORY(CATEGORY)
+/// Scoped zone with a static string @p NAME (must be a string literal).
 #define MT_PROFILE_EVENT(NAME) XR_PROFILE_EVENT(NAME)
+/// Scoped zone with a runtime-computed @p NAME. Prefer `MT_PROFILE_EVENT` when
+/// a literal works; the dynamic variant has higher overhead.
 #define MT_PROFILE_EVENT_DYNAMIC(NAME) XR_PROFILE_EVENT_DYNAMIC(NAME)
+/// Scoped zone tagged with both a @p NAME and a @p CATEGORY. No-op under Tracy.
 #define MT_PROFILE_CATEGORY(NAME, CATEGORY) XR_PROFILE_CATEGORY(NAME, CATEGORY)
+/// Declares the per-scope state used by `MT_PROFILE_PUSH` / `MT_PROFILE_POP`.
+/// Must appear in the enclosing scope before any push/pop pairs.
 #define MT_PROFILE_PREPARE_PUSH_POP() XR_PROFILE_PREPARE_PUSH_POP()
+/// Manually opens a zone with @p NAME. Each push must be balanced by a matching
+/// `MT_PROFILE_POP()` in the same scope, after a `MT_PROFILE_PREPARE_PUSH_POP()`.
 #define MT_PROFILE_PUSH(NAME) XR_PROFILE_PUSH(NAME)
+/// Closes the most recently opened push zone. Must be balanced with
+/// `MT_PROFILE_PUSH`.
 #define MT_PROFILE_POP() XR_PROFILE_POP()
+/// Registers the calling thread with the profiler under @p THREAD_NAME.
+///
+/// Side effect: assigns a human-readable name to the current thread in the
+/// profiler capture. Typically called once per thread on startup.
 #define MT_PROFILE_THREAD(THREAD_NAME) XR_PROFILE_THREAD(THREAD_NAME)
+/// Drives any per-update bookkeeping the backend requires. No-op under Tracy.
 #define MT_PROFILE_UPDATE() XR_PROFILE_UPDATE()
+/// Marks the beginning of a frame. Pair with `MT_PROFILE_END_FRAME()` under
+/// the XR backend; under Tracy this emits `FrameMark` and `MT_PROFILE_END_FRAME`
+/// is a no-op.
 #define MT_PROFILE_BEGIN_FRAME() XR_PROFILE_BEGIN_FRAME()
+/// Marks the end of a frame. No-op under Tracy.
 #define MT_PROFILE_END_FRAME() XR_PROFILE_END_FRAME()
+/// Attaches a @p NAME / @p DATA metadata pair to the current zone or capture.
+/// No-op under Tracy.
 #define MT_PROFILE_METADATA(NAME, DATA) XR_PROFILE_METADATA(NAME, DATA)
 
 #elif defined(MOMENTUM_WITH_TRACY_PROFILER)
@@ -40,6 +78,10 @@
 #define MT_PROFILE_EVENT(NAME) ZoneNamedN(_MT_PROFILE_MAKE_UNIQUE(__tracy), NAME, true)
 #define MT_PROFILE_EVENT_DYNAMIC(NAME) ZoneTransientN(_MT_PROFILE_MAKE_UNIQUE(__tracy), NAME, true)
 #define MT_PROFILE_CATEGORY(NAME, CATEGORY)
+// TODO: Rename `___tracy_xr_stack` — the `xr_` prefix is a leftover from the XR
+// backend and is misleading inside the Tracy block. The variable is a per-scope
+// stack of open zones; thread-safety is not required because each scope's
+// push/pop pairs are local to one thread.
 #define MT_PROFILE_PREPARE_PUSH_POP() std::stack<TracyCZoneCtx> ___tracy_xr_stack
 #define MT_PROFILE_PUSH(NAME)                                                                    \
   static const struct ___tracy_source_location_data TracyConcat(                                 \
@@ -49,11 +91,12 @@
 #define MT_PROFILE_POP()                  \
   TracyCZoneEnd(___tracy_xr_stack.top()); \
   ___tracy_xr_stack.pop()
-#define MT_PROFILE_THREAD(THREAD_NAME)           \
-  {                                              \
-    /* support both std::string and c strings */ \
-    std::string threadNameStr(THREAD_NAME);      \
-    TracyCSetThreadName(threadNameStr.c_str());  \
+// Wrap THREAD_NAME in a std::string so the macro accepts both std::string and
+// C-string arguments; TracyCSetThreadName requires a C string.
+#define MT_PROFILE_THREAD(THREAD_NAME)          \
+  {                                             \
+    std::string threadNameStr(THREAD_NAME);     \
+    TracyCSetThreadName(threadNameStr.c_str()); \
   }
 #define MT_PROFILE_UPDATE()
 #define MT_PROFILE_BEGIN_FRAME() FrameMark
@@ -62,6 +105,8 @@
 
 #else
 
+// No profiler backend selected: every macro expands to nothing, so
+// instrumentation has zero runtime cost in production builds.
 #define MT_PROFILE_FUNCTION()
 #define MT_PROFILE_FUNCTION_CATEGORY(CATEGORY)
 #define MT_PROFILE_EVENT(NAME)

--- a/momentum/common/progress_bar.cpp
+++ b/momentum/common/progress_bar.cpp
@@ -12,6 +12,8 @@ namespace momentum {
 ProgressBar::ProgressBar(const std::string& prefix, const size_t numOperations) {
   using namespace indicators;
 
+  // Reserve 9 columns for the brackets, leading space, and percentage suffix
+  // (e.g., " 100%") so the total rendered line stays within kMaxWidth.
   bar_.set_option(option::BarWidth(kMaxWidth - prefix.size() - 9));
   bar_.set_option(option::MaxProgress(numOperations));
   bar_.set_option(option::Start{"["});

--- a/momentum/common/progress_bar.h
+++ b/momentum/common/progress_bar.h
@@ -13,20 +13,33 @@
 
 namespace momentum {
 
-// A simple progress bar that prints hash marks (e.g., "Name [===>  ] 60%")
+/// A terminal progress bar rendered as `Name [===>   ] 60%`.
+///
+/// Wraps `indicators::ProgressBar` with a fixed visual style (bold, percentage
+/// shown). All mutating operations write to the terminal (stdout) as a side
+/// effect. Not thread-safe.
 class ProgressBar {
  public:
-  /// @param prefix Displayed prefix
-  /// @param numOperations Total operations (determines progress ratio)
+  /// Constructs the progress bar and renders its initial (zero-progress) state.
+  ///
+  /// @param prefix Text shown before the bar.
+  /// @param numOperations Total operation count corresponding to 100%.
+  /// @pre `prefix.size() + 9 < kMaxWidth`, otherwise the computed bar width
+  ///      underflows `size_t`.
+  // TODO: Validate that `prefix.size() + 9 < kMaxWidth` to avoid a size_t
+  // underflow when computing the bar width in the constructor.
   ProgressBar(const std::string& prefix, size_t numOperations);
 
-  /// Increments the progress by the given count (default 1)
+  /// Advances progress by `count` (default 1) and redraws the bar.
   void increment(size_t count = 1);
 
-  /// Sets the progress to the given count
+  /// Sets progress to the absolute value `count` and redraws the bar.
   void set(size_t count);
 
-  /// Returns the current progress in the range [0, 100]
+  /// Returns the current absolute progress count (not a percentage).
+  ///
+  /// The value is in the range [0, numOperations] as supplied to the
+  /// constructor.
   [[nodiscard]] size_t getCurrentProgress();
 
  private:

--- a/momentum/common/string.cpp
+++ b/momentum/common/string.cpp
@@ -44,14 +44,14 @@ tokenize(const std::string& inputString, const std::string& delimiters, const bo
     return {};
   }
 
-  // output vector
   std::vector<std::string> results;
 
-  // loop over the string
   size_t pos = 0;
   size_t lastPos = 0;
   while ((pos = inputString.find_first_of(delimiters, lastPos)) != std::string::npos) {
     const std::string res = inputString.substr(lastPos, pos - lastPos);
+    // When `trim` is true, drop empty tokens (collapsing runs of consecutive delimiters);
+    // otherwise preserve them so callers can distinguish empty fields.
     if (!res.empty() || !trim) {
       results.push_back(res);
     }
@@ -62,7 +62,6 @@ tokenize(const std::string& inputString, const std::string& delimiters, const bo
     results.push_back(res);
   }
 
-  // done
   return results;
 }
 
@@ -72,14 +71,13 @@ tokenize(std::string_view inputString, const std::string_view delimiters, const 
     return {};
   }
 
-  // output vector
   std::vector<std::string_view> results;
 
-  // loop over the string
   size_t pos = 0;
   size_t lastPos = 0;
   while ((pos = inputString.find_first_of(delimiters, lastPos)) != std::string::npos) {
     auto res = inputString.substr(lastPos, pos - lastPos);
+    // See `tokenize(std::string, ...)` above for the empty-token handling rationale.
     if (!res.empty() || !trim) {
       results.push_back(res);
     }
@@ -90,7 +88,6 @@ tokenize(std::string_view inputString, const std::string_view delimiters, const 
     results.push_back(res);
   }
 
-  // done
   return results;
 }
 

--- a/momentum/common/string.h
+++ b/momentum/common/string.h
@@ -13,39 +13,69 @@
 
 namespace momentum {
 
-/// Returns a copy of the string from which all the characters in whiteChars
-/// at the beginning or at the end of the string have been removed.
-/// @tparam StringType: The type of the string to trim (e.g., std::string, std::string_view)
-/// @param text: The string to trim
-/// @param whiteChars: A series of 1-byte characters to remove
-/// @return The trimmed string
+/// Returns a copy of the string with leading and trailing characters in @p whiteChars removed.
+///
+/// Comparison is byte-wise: each byte of @p text is checked against @p whiteChars via
+/// `std::strchr`. Multi-byte UTF-8 sequences are not interpreted as code points, so only
+/// single-byte (ASCII) whitespace characters can be specified in @p whiteChars. If @p text
+/// is empty or consists entirely of @p whiteChars, an empty string is returned.
+///
+/// @tparam StringType The type of the string to trim (e.g., std::string, std::string_view).
+///   For std::string_view inputs the returned view aliases the same underlying buffer as
+///   @p text and remains valid only as long as that buffer does.
+/// @param text The string to trim.
+/// @param whiteChars Null-terminated set of single-byte characters to strip from both ends.
+/// @return The trimmed string (or view).
 template <typename StringType>
 [[nodiscard]] StringType trim(const StringType& text, const char* whiteChars = " \t");
 
-/// Returns a copy of the string from which all the characters in whiteChars
-/// at the beginning or at the end of the string have been removed.
-/// @param text: The string to trim (null-terminated)
-/// @param whiteChars: A series of 1-byte characters to remove
-/// @return The trimmed string
+/// Returns a copy of the null-terminated C string with leading and trailing characters in
+/// @p whiteChars removed.
+///
+/// Allocates a new std::string (constructed from @p text) before trimming, so this overload
+/// always allocates regardless of whether any characters are stripped. See the templated
+/// overload for the byte-wise comparison semantics.
+///
+/// @param text The string to trim (must be null-terminated, must not be null).
+/// @param whiteChars Null-terminated set of single-byte characters to strip from both ends.
+/// @return The trimmed string.
 [[nodiscard]] std::string trim(const char* text, const char* whiteChars = " \t");
 
-/// Tokenize a string using the specified delimiters.
+/// Tokenizes a string using the specified single-byte delimiter characters.
+///
+/// Splits @p inputString at every occurrence of any character in @p delimiters. Comparison
+/// is byte-wise (via `std::string::find_first_of`), so multi-byte UTF-8 sequences in
+/// @p delimiters are treated as a set of independent bytes rather than code points.
+///
+/// When @p inputString is empty an empty vector is returned. Otherwise the result has at
+/// least one element, possibly empty. Each returned token is a freshly allocated copy of a
+/// substring of @p inputString.
 ///
 /// @param inputString The string to tokenize.
-/// @param delimiters The string containing delimiter characters.
-/// @param trim Whether to trim spaces around the tokens (default: true).
+/// @param delimiters The set of single-byte delimiter characters.
+/// @param trim When true (the default), empty tokens (produced by leading, trailing, or
+///   consecutive delimiters) are dropped from the result. When false, empty tokens are
+///   preserved. Note: this parameter does not strip whitespace from non-empty tokens
+///   despite its name.
 /// @return A vector of tokenized strings.
 std::vector<std::string> tokenize(
     const std::string& inputString,
     const std::string& delimiters = " \t\r\n",
     bool trim = true);
 
-/// Tokenize a string_view using the specified delimiters.
+/// Tokenizes a string_view using the specified single-byte delimiter characters.
+///
+/// Behaves identically to the std::string overload, except that the returned tokens are
+/// std::string_view instances aliasing @p inputString's underlying buffer. The caller must
+/// ensure that buffer outlives the returned vector.
 ///
 /// @param inputString The string_view to tokenize.
-/// @param delimiters The string_view containing delimiter characters.
-/// @param trim Whether to trim spaces around the tokens (default: true).
-/// @return A vector of tokenized string_views.
+/// @param delimiters The set of single-byte delimiter characters.
+/// @param trim When true (the default), empty tokens (produced by leading, trailing, or
+///   consecutive delimiters) are dropped from the result. When false, empty tokens are
+///   preserved. Note: this parameter does not strip whitespace from non-empty tokens
+///   despite its name.
+/// @return A vector of tokenized string_views aliasing @p inputString.
 std::vector<std::string_view>
 tokenize(std::string_view inputString, std::string_view delimiters = " \t\r\n", bool trim = true);
 


### PR DESCRIPTION
Summary:

Notable additions worth highlighting for review:

- `aligned.h`: fixed `deallocate`'s `param` name mismatch; documented `aligned_alloc` rounding behavior, throw conditions, and `aligned_free` ownership requirement.
- `checks.h`: new file-level note explaining the two backends (XR logger vs exception) selected by `MOMENTUM_WITH_XR_LOGGER`, plus per-macro contracts including the cross-backend difference that only the XR logger variant of `MT_CHECK_LT` auto-includes operand values.
- `exception.h`: `// TODO:` flagging that `MT_THROW_IF_T` lacks a `do { ... } while (0)` wrapper (real dangling-else hazard).
- `log.h`: fixed `LogLevel` doc that incorrectly claimed values were in descending order (they're ascending). Documented all `MT_LOG*` macro families in both XR_LOGGER and SPDLOG branches. `// TODO:`s flagging the `_MT_RUN_ONCE` reserved-identifier issue and the dangling-else hazard in spdlog `MT_LOG*_IF` macros.
- `profile.h`: `// TODO:` flagging the `___tracy_xr_stack` mis-prefix (looks like a leftover from the XR-specific helper inside the Tracy block).
- `progress_bar.h`: fixed `getCurrentProgress` doc that claimed a `[0, 100]` return range but it actually returns the absolute count. `// TODO:` flagging an unchecked `kMaxWidth - prefix.size() - 9` underflow risk.
- `string.h`: documented byte-wise (non-UTF-8) comparison, allocation behavior of the C-string `trim` overload, and the misleadingly named `trim` parameter on `tokenize` that actually drops empty tokens rather than trimming whitespace within them.

The TODOs are intentionally flagged for follow-up rather than fixed in this audit — keeping the audit comment-only avoids mixing behavior changes with documentation changes for review.

Reviewed By: cstollmeta

Differential Revision: D102437891
