### PR TITLE
Comment audit: math/ (#1342)

### DIFF
--- a/momentum/math/constants.h
+++ b/momentum/math/constants.h
@@ -12,12 +12,20 @@
 
 namespace momentum {
 
+/// Returns a quiet NaN value of type T.
 template <typename T = float>
 [[nodiscard]] constexpr T nan() noexcept {
   return std::numeric_limits<T>::quiet_NaN();
 }
 
-/// Returns the tolerance value based on the provided type T
+/// Returns a type-appropriate tolerance/epsilon value.
+///
+/// @param FloatEps Tolerance returned when T is `float` (default: 1e-7).
+/// @param DoubleEps Tolerance returned when T is `double` (default: 1e-16).
+/// @return The selected tolerance for T. Only `float` and `double` are supported;
+///         other types fall through and produce an undefined return value.
+// TODO: Add a static_assert or constexpr error path for unsupported T to avoid
+// silent undefined-return-value behavior for non-float/double types.
 template <typename T>
 [[nodiscard]] constexpr T Eps(T FloatEps = T(1e-7), T DoubleEps = T(1e-16)) {
   if constexpr (std::is_same_v<T, float>) {
@@ -27,16 +35,27 @@ template <typename T>
   }
 }
 
+/// Returns the natural logarithm of 2 (log_e 2).
 template <typename T = float>
 [[nodiscard]] constexpr T ln2() noexcept {
-  return 0.69314718055994530942; ///< log_e 2
+  return 0.69314718055994530942;
 }
 
+/// Returns the mathematical constant pi.
+///
+/// @note Use this instead of `M_PI`. Windows MSVC does not define `M_PI` by
+///       default (it requires `_USE_MATH_DEFINES` before `<cmath>`). This
+///       function is always available on all platforms.
 template <typename T = float>
 [[nodiscard]] constexpr T pi() noexcept {
   return 3.14159265358979323846;
 }
 
+/// Returns 2 * pi.
+///
+/// @note Use this instead of `2 * M_PI`. Windows MSVC does not define `M_PI`
+///       by default (it requires `_USE_MATH_DEFINES` before `<cmath>`). This
+///       function is always available on all platforms.
 template <typename T = float>
 [[nodiscard]] constexpr T twopi() noexcept {
   return T(2) * pi<T>();

--- a/momentum/math/coordinate_system.cpp
+++ b/momentum/math/coordinate_system.cpp
@@ -24,40 +24,58 @@ constexpr T unitInMeters(LengthUnit u) {
     case LengthUnit::Millimeter:
       return T(0.001);
   }
-  return T(1); // unreachable
+  // Defensive fallback for ill-formed LengthUnit values (e.g. cast from int).
+  // All declared enumerators are handled above, so this path is unreachable for valid inputs.
+  return T(1);
 }
 
 // Computes the signed permutation matrix P that converts coordinates from
 // system 'from' to system 'to': v_to = P * v_from.
 //
-// Each coordinate system defines a canonical assignment of semantic axes
-// (right, forward, up) to world axes (x, y, z):
-//   Y-up right-hand: right=+X, forward=-Z, up=+Y
-//   Z-up right-hand: right=+X, forward=+Y, up=+Z
+// Convention: each coordinate system maps the semantic axes
+// (right, forward, up) to world axes (x, y, z) as follows:
+//   Y-up right-hand: right=+X, forward=-Z, up=+Y  (OpenGL-style)
+//   Z-up right-hand: right=+X, forward=+Y, up=+Z  (Blender / robotics-style)
 //   X-up right-hand: right=+Y, forward=+Z, up=+X
-// For left-handed systems, the forward axis is negated.
+// For left-handed systems, only the forward axis is negated; right and up
+// keep the same world directions. This is the minimal flip that preserves
+// up alignment while reversing chirality.
+//
+// Note: only handedness changes the sign of det(axes); axis permutation
+// alone is always a proper rotation. The forward-only flip means
+// det(axes) = -1 iff Handedness::Left, so P keeps right vectors right
+// and up vectors up — only forward-pointing components flip when the
+// handedness differs between 'from' and 'to'.
 //
 // The change-of-basis matrix is: P = toAxes * fromAxes^T
-// where each column of 'axes' maps a semantic axis to its world direction.
+// where each column of 'axes' is the world-space direction of a semantic
+// axis: col(0)=right, col(1)=forward, col(2)=up. So 'axes' maps a vector
+// expressed in (right, forward, up) coordinates into world (x, y, z),
+// and 'axes^T' is its inverse (the matrix is orthogonal by construction).
 template <typename T>
 Matrix3<T> permutationMatrix(const CoordinateSystem& from, const CoordinateSystem& to) {
+  // Returns the 3x3 matrix whose columns are the world-axis directions of
+  // the (right, forward, up) semantic axes for the given (up, handedness).
   auto getAxes = [](UpAxis up, Handedness hand) -> Matrix3<T> {
     Matrix3<T> m;
     switch (up) {
       case UpAxis::Y:
-        m.col(0) = Vector3<T>(1, 0, 0);
+        m.col(0) = Vector3<T>(1, 0, 0); // right = +X
+        // forward = -Z (right-handed) or +Z (left-handed)
         m.col(1) = (hand == Handedness::Right) ? Vector3<T>(0, 0, -1) : Vector3<T>(0, 0, 1);
-        m.col(2) = Vector3<T>(0, 1, 0);
+        m.col(2) = Vector3<T>(0, 1, 0); // up = +Y
         break;
       case UpAxis::Z:
-        m.col(0) = Vector3<T>(1, 0, 0);
+        m.col(0) = Vector3<T>(1, 0, 0); // right = +X
+        // forward = +Y (right-handed) or -Y (left-handed)
         m.col(1) = (hand == Handedness::Right) ? Vector3<T>(0, 1, 0) : Vector3<T>(0, -1, 0);
-        m.col(2) = Vector3<T>(0, 0, 1);
+        m.col(2) = Vector3<T>(0, 0, 1); // up = +Z
         break;
       case UpAxis::X:
-        m.col(0) = Vector3<T>(0, 1, 0);
+        m.col(0) = Vector3<T>(0, 1, 0); // right = +Y
+        // forward = +Z (right-handed) or -Z (left-handed)
         m.col(1) = (hand == Handedness::Right) ? Vector3<T>(0, 0, 1) : Vector3<T>(0, 0, -1);
-        m.col(2) = Vector3<T>(1, 0, 0);
+        m.col(2) = Vector3<T>(1, 0, 0); // up = +X
         break;
     }
     return m;
@@ -65,6 +83,8 @@ Matrix3<T> permutationMatrix(const CoordinateSystem& from, const CoordinateSyste
 
   const Matrix3<T> fromAxes = getAxes(from.up, from.hand);
   const Matrix3<T> toAxes = getAxes(to.up, to.hand);
+  // 'axes' is orthogonal (columns are unit basis vectors with at most a sign
+  // flip), so transpose() == inverse() — no need for a numeric inverse.
   return toAxes * fromAxes.transpose();
 }
 
@@ -86,6 +106,10 @@ changeVector(const Vector3<T>& v, const CoordinateSystem& from, const Coordinate
 template <typename T>
 Quaternion<T>
 changeQuaternion(const Quaternion<T>& q, const CoordinateSystem& from, const CoordinateSystem& to) {
+  // Round-trip via rotation matrix: this transparently handles handedness
+  // flips. P*R*P^T has det = det(P)^2 * det(R) = +1 regardless of whether
+  // 'from' and 'to' share handedness, so the result is always a proper
+  // rotation that Eigen's Quaternion(Matrix3) constructor can normalize.
   const Matrix3<T> R = q.toRotationMatrix();
   const Matrix3<T> newR = changeRotationMatrix(R, from, to);
   return Quaternion<T>(newR);

--- a/momentum/math/coordinate_system.h
+++ b/momentum/math/coordinate_system.h
@@ -33,7 +33,7 @@ enum class LengthUnit {
 };
 
 /// A 3D coordinate system defined by its up axis, handedness, and length unit.
-/// Simple aggregate with no invariants.
+/// Plain aggregate; all member combinations are valid.
 struct CoordinateSystem {
   UpAxis up;
   Handedness hand;
@@ -46,10 +46,9 @@ inline constexpr CoordinateSystem kMomentumCoordinateSystem{
     Handedness::Right,
     LengthUnit::Centimeter};
 
-// --- General: any-to-any ---
-
-/// Returns the length scale factor when converting from one coordinate system to another.
-/// For example, scaleFactor(Meter, Centimeter) == 100.
+/// Returns the length scale factor when converting a length from `from`'s unit to `to`'s unit.
+/// For example, with `from.unit == Meter` and `to.unit == Centimeter` the result is 100.
+/// Depends only on the `unit` fields of `from` and `to`; ignores `up` and `hand`.
 template <typename T>
 [[nodiscard]] T scaleFactor(const CoordinateSystem& from, const CoordinateSystem& to);
 
@@ -60,40 +59,50 @@ template <typename T>
 changeVector(const Vector3<T>& v, const CoordinateSystem& from, const CoordinateSystem& to);
 
 /// Converts a quaternion rotation between coordinate systems.
-/// Applies axis permutation (and optional handedness flip). No unit scaling.
+/// Applies axis permutation (and optional handedness flip). No unit scaling — rotations are
+/// dimensionless.
 template <typename T>
 [[nodiscard]] Quaternion<T>
 changeQuaternion(const Quaternion<T>& q, const CoordinateSystem& from, const CoordinateSystem& to);
 
 /// Converts a 3x3 rotation matrix between coordinate systems.
-/// Computes R_to = P * R_from * P^T where P is the change-of-basis permutation matrix.
+/// Computes `R_to = P * R_from * P^T` where `P` is the change-of-basis permutation (and reflection
+/// for handedness flips) matrix. No unit scaling.
+/// @pre `m` is a proper rotation matrix (orthonormal, det == +1).
 template <typename T>
 [[nodiscard]] Matrix3<T>
 changeRotationMatrix(const Matrix3<T>& m, const CoordinateSystem& from, const CoordinateSystem& to);
 
-// --- Convenience: to/from Momentum's canonical coordinate system ---
+// Convenience wrappers for converting to/from Momentum's canonical coordinate system
+// (kMomentumCoordinateSystem: Y-up, right-handed, centimeters).
 
+/// Converts a position vector from `from` into Momentum's canonical coordinate system.
 template <typename T>
 [[nodiscard]] Vector3<T> toMomentumVector(const Vector3<T>& v, const CoordinateSystem& from);
 
+/// Converts a position vector from Momentum's canonical coordinate system into `to`.
 template <typename T>
 [[nodiscard]] Vector3<T> fromMomentumVector(const Vector3<T>& v, const CoordinateSystem& to);
 
+/// Converts a quaternion rotation from `from` into Momentum's canonical coordinate system.
 template <typename T>
 [[nodiscard]] Quaternion<T> toMomentumQuaternion(
     const Quaternion<T>& q,
     const CoordinateSystem& from);
 
+/// Converts a quaternion rotation from Momentum's canonical coordinate system into `to`.
 template <typename T>
 [[nodiscard]] Quaternion<T> fromMomentumQuaternion(
     const Quaternion<T>& q,
     const CoordinateSystem& to);
 
+/// Converts a 3x3 rotation matrix from `from` into Momentum's canonical coordinate system.
 template <typename T>
 [[nodiscard]] Matrix3<T> toMomentumRotationMatrix(
     const Matrix3<T>& m,
     const CoordinateSystem& from);
 
+/// Converts a 3x3 rotation matrix from Momentum's canonical coordinate system into `to`.
 template <typename T>
 [[nodiscard]] Matrix3<T> fromMomentumRotationMatrix(
     const Matrix3<T>& m,

--- a/momentum/math/covariance_matrix.cpp
+++ b/momentum/math/covariance_matrix.cpp
@@ -19,6 +19,11 @@ void LowRankCovarianceMatrixT<T>::reset(T sigma, Eigen::Ref<const Eigen::MatrixX
   const Eigen::Index n = A_.cols();
   const Eigen::Index m = A_.rows();
 
+  // Initialize the online QR with a sigma*I diagonal, then stream in the rows of A.
+  // The resulting R is the upper-triangular factor of the augmented matrix
+  //   A_aug = [ sigma*I ; A ]    so that   A_aug^T * A_aug = sigma^2*I + A^T*A = C.
+  // Equivalently, R is (up to sign of diagonals) the Cholesky factor of C.
+  // The dummy zero rhs is required by the online QR API but unused here.
   qrFactorization_.reset(n, sigma);
   Eigen::VectorX<T> b = Eigen::VectorX<T>::Zero(m);
   qrFactorization_.add(A_, b);
@@ -45,6 +50,8 @@ Eigen::VectorX<T> LowRankCovarianceMatrixT<T>::inverse_times_vec(
   const auto& R = qrFactorization_.R();
   MT_CHECK(R.rows() == rhs.size());
 
+  // C^{-1} * rhs = (R^T * R)^{-1} * rhs = R^{-1} * R^{-T} * rhs.
+  // Implemented as two triangular back-solves: first R^T y = rhs, then R x = y.
   return R.template triangularView<Eigen::Upper>().solve(
       R.template triangularView<Eigen::Upper>().transpose().solve(rhs));
 }
@@ -52,6 +59,9 @@ Eigen::VectorX<T> LowRankCovarianceMatrixT<T>::inverse_times_vec(
 template <typename T>
 Eigen::VectorX<T> LowRankCovarianceMatrixT<T>::times_vec(
     Eigen::Ref<const Eigen::VectorX<T>> rhs) const {
+  // C * rhs = (sigma^2 * I + A^T * A) * rhs computed directly from the stored
+  // basis A_; avoids forming the dense [n x n] matrix and exploits the low-rank
+  // structure (cost O(m*n) instead of O(n^2)).
   Eigen::VectorX<T> result = (sigma_ * sigma_) * rhs;
   result.noalias() += A_.transpose() * (A_ * rhs);
   return result;
@@ -63,6 +73,7 @@ Eigen::MatrixX<T> LowRankCovarianceMatrixT<T>::inverse_times_mat(
   const auto& R = qrFactorization_.R();
   MT_CHECK(rhs.rows() == dimension());
 
+  // Same C^{-1} = R^{-1} * R^{-T} solve as inverse_times_vec, applied column-wise.
   return R.template triangularView<Eigen::Upper>().solve(
       R.template triangularView<Eigen::Upper>().transpose().solve(rhs));
 }
@@ -82,19 +93,20 @@ const Eigen::MatrixX<T>& LowRankCovarianceMatrixT<T>::R() const {
 
 template <typename T>
 T LowRankCovarianceMatrixT<T>::logDeterminant() const {
-  // The determinant of a
   const auto& R = qrFactorization_.R();
 
-  // The determinant of a triangular matrix is the product of the
-  // diagonals, so the log of the determinant is the sum of the logs:
+  // log|R| = sum of log of diagonal entries (R is upper triangular).
+  // The MT_CHECK enforces strictly positive diagonals, which the
+  // OnlineHouseholderQR is expected to produce because the augmented matrix
+  // [sigma*I; A] has full column rank for any sigma > 0 (so R is non-singular)
+  // and the implementation chooses positive diagonal signs.
   T result = 0;
   for (Eigen::Index i = 0; i < dimension(); ++i) {
     MT_CHECK(R(i, i) > 0);
     result += std::log(R(i, i));
   }
 
-  // We actually have A = R^T*R, and the determinant of a product is the
-  // product of the determinants, so we need to double it:
+  // C = R^T * R, so log|C| = log|R^T| + log|R| = 2 * log|R|.
   return T(2) * result;
 }
 

--- a/momentum/math/covariance_matrix.h
+++ b/momentum/math/covariance_matrix.h
@@ -12,72 +12,76 @@
 
 namespace momentum {
 
-//
-// Efficient and numerically stable representation of the generalized
-// Gaussian covariance
-//   C = (sigma^2 * I + A^T * A)
-// providing access to the inverse covariance matrix (computed using
-// QR factorization).
-//
-// Note the dimensionality here: C and I are [n x n], A is [m x n]
-// where m can be either larger or smaller than n.
+/// Efficient and numerically stable representation of a low-rank-plus-diagonal
+/// Gaussian covariance matrix
+///   C = sigma^2 * I + A^T * A
+/// where C and I are [n x n] and the basis A is [m x n] (m may be larger or
+/// smaller than n). Access to C^{-1} is computed via the QR factorization of
+/// the augmented matrix [sigma*I; A], which keeps the construction
+/// numerically stable and avoids ever forming A^T * A explicitly.
+///
+/// @pre sigma > 0 (required for C to be strictly positive-definite and for
+///      the QR-based inverse to exist; the implementation does not check).
+/// @note C is symmetric positive-definite by construction.
 template <typename T>
 class LowRankCovarianceMatrixT {
  public:
   LowRankCovarianceMatrixT() = default;
 
+  /// (Re)build the covariance from a regularizer sigma and basis A.
+  /// Computes the QR factorization of [sigma*I; A] from scratch (batch
+  /// update; not an incremental/online refinement of any previous state).
+  /// @param sigma Diagonal regularizer; must be > 0.
+  /// @param A Low-rank basis with n columns and m rows.
   void reset(T sigma, Eigen::Ref<const Eigen::MatrixX<T>> A);
 
+  /// Returns n, the dimension of the covariance (number of columns of A).
   [[nodiscard]] Eigen::Index dimension() const;
 
+  /// Returns the stored basis A passed to reset().
   [[nodiscard]] const Eigen::MatrixX<T>& basis() const;
 
+  /// Returns the diagonal regularizer sigma passed to reset().
   [[nodiscard]] T sigma() const;
 
+  /// Returns C^{-1} * rhs, computed via two triangular solves on R.
   [[nodiscard]] Eigen::VectorX<T> inverse_times_vec(Eigen::Ref<const Eigen::VectorX<T>> rhs) const;
+  /// Returns C * rhs = sigma^2 * rhs + A^T * (A * rhs).
   [[nodiscard]] Eigen::VectorX<T> times_vec(Eigen::Ref<const Eigen::VectorX<T>> rhs) const;
 
+  /// Column-wise application of C^{-1} to a matrix rhs.
   [[nodiscard]] Eigen::MatrixX<T> inverse_times_mat(Eigen::Ref<const Eigen::MatrixX<T>> rhs) const;
+  /// Column-wise application of C to a matrix rhs.
   [[nodiscard]] Eigen::MatrixX<T> times_mat(Eigen::Ref<const Eigen::MatrixX<T>> rhs) const;
 
+  /// Returns the upper-triangular R factor of the QR factorization of
+  /// [sigma*I; A], so that C = R^T * R.
   [[nodiscard]] const Eigen::MatrixX<T>& R() const;
 
-  // The log of the determinant of the covariance matrix
+  /// Returns log(det(C)), computed stably as 2 * sum(log|diag(R)|).
   [[nodiscard]] T logDeterminant() const;
 
-  // The log of the determinant of the inverse covariance matrix
+  /// Returns log(det(C^{-1})) = -log(det(C)).
   [[nodiscard]] T inverse_logDeterminant() const;
 
  private:
-  // The QR factorization of A is defined by:
-  //   A = Q*R
-  // where Q is orthonormal and R is upper triangular.  This online QR solver
-  // used here happens to be particularly efficient for the case where the A
-  // matrix looks like:
-  //    A = [ lambda*I ]
-  //        [    B     ]
-  // The reason for this is that it allows initialization of the R matrix by
-  // a diagonal, and hence only needs to process the rows in W.  The
-  // resulting factorization is O(m*n^2) to compute, which may (for m << n)
-  // be a touch cheaper than the fully general O(n^3) that a "standard" QR
-  // factorization or Cholesky would require.
-  //
-  // Once we have A = Q*R, we can compute (A^T*A)^{-1} by
-  //     (A^T * A)^{-1} = (R^T * Q^T * Q * R)^{-1}
-  //                    = (R^T * R)^{-1}            by orthonormality
-  //                    = (R^{-1}) * R^{-T}         distributing the inverse
-  //
-  // Note that OnlineHouseholderQR does _not_ store the Q matrix (or the
-  // information required to reconstruct it, as is more typical) because it
-  // assumes that it will be used to solve least squares problems of the form
-  // min |Ax - b|_2 and hence can apply Q to b as it is being computed.  In
-  // our case, however, as noted above we won't be using the Q matrix so this
-  // is not a limitation.
+  /// QR factorization of the augmented matrix [sigma*I; A] = Q*R, where Q is
+  /// orthonormal and R is upper triangular. OnlineHouseholderQR is used
+  /// because it can initialize R from a diagonal (sigma*I) and then only
+  /// process the m rows of A, giving an O(m*n^2) construction that is
+  /// cheaper than a fully general O(n^3) QR/Cholesky when m << n.
+  ///
+  /// Given [sigma*I; A] = Q*R we have C = sigma^2*I + A^T*A = R^T*R, so
+  /// C^{-1} = R^{-1} * R^{-T} via two triangular solves (Q is never needed
+  /// and OnlineHouseholderQR does not store it; see online_householder_qr.h
+  /// for why -- it is intended for least-squares solves that apply Q to b
+  /// on the fly).
   OnlineHouseholderQR<T> qrFactorization_{0};
 
-  // Low-rank basis:
+  /// Low-rank basis A passed to reset(); shape [m x n].
   Eigen::MatrixX<T> A_;
 
+  /// Diagonal regularizer; assumed > 0.
   T sigma_ = 0;
 };
 

--- a/momentum/math/fmt_eigen.h
+++ b/momentum/math/fmt_eigen.h
@@ -10,9 +10,25 @@
 #include <fmt/ostream.h>
 #include <Eigen/Core>
 
+/// @file
+/// @brief libfmt formatter support for Eigen types.
+///
+/// Provides an `fmt::formatter` specialization for any type derived from
+/// `Eigen::DenseBase` (matrices, vectors, and expression templates). This
+/// makes Eigen objects directly usable with `fmt::format`, `fmt::print`, and
+/// related APIs by delegating to Eigen's `operator<<` via `ostream_formatter`.
+///
+/// Usage: simply `#include "momentum/math/fmt_eigen.h"` and format Eigen
+/// values normally, e.g. `fmt::format("{}", matrix)` or
+/// `fmt::print("v = {}\n", vector)`.
+///
+/// Only enabled for libfmt >= 10.0.0, which introduced `ostream_formatter`.
+/// Note: `Eigen::Quaternion` is not derived from `Eigen::DenseBase` and is
+/// therefore not covered by this formatter.
+
 #if FMT_VERSION > 100000
 
-// https://stackoverflow.com/a/73755864
+// See https://stackoverflow.com/a/73755864 for the SFINAE pattern.
 #ifndef MOMENTUM_FMT_EIGEN_SHARED_PTR_FORMATTER
 #define MOMENTUM_FMT_EIGEN_SHARED_PTR_FORMATTER
 template <typename T>

--- a/momentum/math/generalized_loss.cpp
+++ b/momentum/math/generalized_loss.cpp
@@ -16,7 +16,11 @@ namespace momentum {
 
 namespace {
 
-// No 0.5 factor so it can be reused.
+// L2 loss (alpha = 2):
+//   f(s) = s / c^2
+//   f'(s) = 1 / c^2
+// Note: the canonical Barron form has a 1/2 factor; it is intentionally omitted here so this
+// helper can be reused inside the other closed forms (L1/Cauchy/Welsch) without re-multiplying.
 template <typename T>
 T L2Loss(const T& sqrError, const T& invC2) {
   return sqrError * invC2;
@@ -27,9 +31,13 @@ T derivL2Loss(const T& /* sqrError */, const T& invC2) {
   return invC2;
 }
 
+// L1 / Pseudo-Huber loss (alpha = 1):
+//   f(s) = sqrt(s/c^2 + 1) - 1
+//   f'(s) = (1/2) * (1/c^2) / sqrt(s/c^2 + 1)
+// The "-1" offset is kept (rather than dropped as a constant) so that f(0) = 0 and the value
+// itself is interpretable as a loss magnitude.
 template <typename T>
 T L1Loss(const T& sqrError, const T& invC2) {
-  // decided not to skip the -1 so the value itself is meaningful
   return std::sqrt(L2Loss(sqrError, invC2) + T(1)) - T(1);
 }
 
@@ -38,6 +46,10 @@ T derivL1Loss(const T& sqrError, const T& invC2) {
   return T(0.5) * invC2 / std::sqrt(L2Loss(sqrError, invC2) + T(1));
 }
 
+// Cauchy / Lorentzian loss (alpha = 0, the limit):
+//   f(s) = log(1 + (1/2) * s/c^2)
+//   f'(s) = 1 / (s + 2*c^2) = (1/c^2) / (s/c^2 + 2)
+// The argument to log is always >= 1 for sqrError >= 0, so log is well-defined.
 template <typename T>
 T CauchyLoss(const T& sqrError, const T& invC2) {
   return std::log(T(0.5) * L2Loss(sqrError, invC2) + T(1));
@@ -48,6 +60,11 @@ T derivCauchyLoss(const T& sqrError, const T& invC2) {
   return invC2 / (invC2 * sqrError + T(2));
 }
 
+// Welsch / Leclerc loss (alpha -> -inf, the limit):
+//   f(s) = 1 - exp(-(1/2) * s/c^2)
+//   f'(s) = (1/2) * (1/c^2) * exp(-(1/2) * s/c^2)
+// Bounded in [0, 1); derivative decays to 0 for large residuals — outliers contribute essentially
+// nothing to the gradient. exp argument is <= 0, so no overflow.
 template <typename T>
 T WelschLoss(const T& sqrError, const T& invC2) {
   return T(1) - std::exp(T(-0.5) * L2Loss(sqrError, invC2));
@@ -64,7 +81,16 @@ template <typename T>
 GeneralizedLossT<T>::GeneralizedLossT(const T& a, const T& c) : alpha_(a), invC2_(T(1) / (c * c)) {
   MT_CHECK(c > 0, "Parameter c should be positive but received {}", c);
 
-  // Use a threshold around special values for both stability and speed
+  // Snap alpha to a closed-form branch when it is within kEps of a special value, both for
+  // numerical stability (the General formula has a removable singularity at alpha=2 from the
+  // |alpha - 2| factor, and a 0/0 form at alpha=0) and for speed (closed forms avoid pow/log).
+  // Note: kWelsch = -1e-9 is a sentinel for the alpha -> -inf limit; the branch below routes
+  // *any* alpha <= kWelsch to the Welsch closed form.
+  // TODO: This Welsch branch is too greedy — finite negative alphas like -2 (Geman-McClure),
+  // which the header documents as a supported case, are silently replaced by the alpha = -inf
+  // Welsch limit instead of being evaluated with the General formula. Tighten the predicate to
+  // something like `alpha_ < some_large_negative_threshold` (or check for -infinity explicitly)
+  // so that finite negative alphas fall through to LossType::General.
   if (alpha_ >= kL2 - kEps && alpha_ <= kL2 + kEps) {
     lossType_ = LossType::L2;
   } else if (alpha_ >= kL1 - kEps && alpha_ <= kL1 + kEps) {
@@ -90,7 +116,11 @@ T GeneralizedLossT<T>::value(const T& sqrError) const {
     case LossType::Welsch:
       return WelschLoss(sqrError, invC2_);
     case LossType::General:
-      // General case, slower
+      // Barron's general form (eq. 1 of arXiv:1701.03077), valid for finite alpha not in
+      // {2, 0}; the |alpha - 2| / alpha factor recovers the L2/Cauchy/Welsch limits as
+      // alpha -> 2, 0, -inf respectively. Slower than the closed forms above due to pow().
+      //   f(s) = (|alpha-2| / alpha) * ( (s/(c^2 * |alpha-2|) + 1)^(alpha/2) - 1 )
+      // Singularities at alpha == 2 and alpha == 0 are avoided by the kEps snap in the ctor.
       return (std::pow(L2Loss(sqrError, invC2_) / std::abs(alpha_ - T(2)) + T(1), T(0.5) * alpha_) -
               T(1)) *
           std::abs(alpha_ - T(2)) / alpha_;
@@ -113,7 +143,10 @@ T GeneralizedLossT<T>::deriv(const T& sqrError) const {
     case LossType::Welsch:
       return derivWelschLoss(sqrError, invC2_);
     case LossType::General:
-      // General case, slower
+      // Derivative of Barron's general form w.r.t. s (the squared error):
+      //   f'(s) = (1 / (2 c^2)) * ( s / (c^2 * |alpha-2|) + 1 )^(alpha/2 - 1)
+      // The |alpha-2| / alpha prefactor in f(s) cancels under differentiation, so it does not
+      // appear here. Slower than the closed forms above due to pow().
       return T(0.5) * invC2_ *
           std::pow(
                  L2Loss(sqrError, invC2_) / std::abs(alpha_ - T(2)) + T(1), T(0.5) * alpha_ - T(1));

--- a/momentum/math/generalized_loss.h
+++ b/momentum/math/generalized_loss.h
@@ -11,31 +11,61 @@ namespace momentum {
 
 /// Implementation of "A General and Adaptive Robust Loss Function"
 /// (https://arxiv.org/abs/1701.03077).
-/// This loss transforms a squared error value with parameters alpha and c.
-/// Alpha can be approximately thought of as the norm: alpha=2 is the squared L2 norm loss; alpha=1
-/// is a soft L1 norm or the L2-L1/pseudo-Huber loss. Alpha controls the effect of "outliers" (ie.
-/// "robust"). Smaller alpha reduces the contribution of large errors so they don't affect the
-/// result as much. c scales the gradient with respect to the squared error term inversely.
-/// This does not implement solving for alpha. It assumes alpha and c are given as input.
+///
+/// This loss transforms a squared error value with parameters @p alpha and @p c.
+/// @p alpha can be approximately thought of as the norm: alpha=2 is the squared L2 norm loss;
+/// alpha=1 is a soft L1 norm or the L2-L1/pseudo-Huber loss. @p alpha controls the effect of
+/// "outliers" (i.e., "robust"). Smaller @p alpha reduces the contribution of large errors so they
+/// don't affect the result as much. @p c scales the gradient with respect to the squared error
+/// term inversely.
+///
+/// This does not implement solving for @p alpha. It assumes @p alpha and @p c are given as input.
+///
+/// @par Alpha value reference
+/// - `alpha = 2.0` (`kL2`): L2 (quadratic). Standard least-squares. Fastest convergence, sensitive
+///   to outliers.
+/// - `alpha = 1.0` (`kL1`): Pseudo-Huber. Smooth approximation to Huber. Robust to moderate
+///   outliers.
+/// - `alpha = 0.0` (`kCauchy`): Cauchy (Lorentzian). Very robust to outliers. Much slower
+///   convergence.
+/// - `alpha = -2.0`: Geman-McClure. Extremely robust. Bounded influence — large outliers are
+///   essentially ignored.
+/// - `alpha = -inf` (`kWelsch`): Welsch. Limit case. Maximum robustness, slowest convergence.
+///
+/// The @p c parameter controls the transition scale: residuals << c behave like L2, residuals >> c
+/// are downweighted according to the loss shape.
+///
+/// In the Gauss-Newton solver, the loss function modifies both the residual and Jacobian via the
+/// chain rule. The `SimdGeneralizedLoss` class handles this vectorized computation for SIMD error
+/// functions. Generic error functions apply the loss via the `JointErrorFunctionT` base class
+/// automatically — subclasses implement `evalFunction()` with raw residuals.
 template <typename T>
 class GeneralizedLossT {
  public:
-  // Special case alpha values that are either at singularity or would simplify computation
+  /// Special-case alpha values that are either at a singularity in the general formula or simplify
+  /// to a closed-form computation.
   static constexpr T kL2 = T(2);
   static constexpr T kL1 = T(1);
   static constexpr T kCauchy = T(0);
-  static constexpr T kWelsch = -1e-9; // any number smaller is considered -inf
+  /// Sentinel for the Welsch (alpha = -inf) limit; any alpha less than this is treated as -inf.
+  static constexpr T kWelsch = -1e-9;
 
-  // Alpha can be [-inf, inf] in theory, but it will be numerically unstable if
-  // alpha is too large, eg. >100 (large alpha not needed in practice).
-  // Similarly, c scales the gradient inversely and quadratically. So too small a value for c will
-  // lead to instability.
-  // Calculations with log and exp usually require double precision.
+  /// Constructs a generalized loss with shape @p a and scale @p c.
+  ///
+  /// @param a Shape parameter alpha. Theoretically in [-inf, inf], but values with very large
+  ///   magnitude (e.g., > 100) are numerically unstable and not needed in practice.
+  /// @param c Scale parameter. Must be > 0. Very small values are unstable because the gradient
+  ///   scales with 1/c^2.
+  ///
+  /// @note Internal calculations involving `log`/`exp` are performed in double precision for
+  ///   numerical stability.
   GeneralizedLossT(const T& a = kL2, const T& c = T(1));
 
+  /// Returns the loss value for a given squared error.
+  /// @param sqrError Non-negative squared residual.
   [[nodiscard]] T value(const T& sqrError) const;
 
-  /// Derivative of the loss with respective to the input squared error.
+  /// Derivative of the loss with respect to the input squared error.
   /// This effectively scales the gradient of what's being squared.
   [[nodiscard]] T deriv(const T& sqrError) const;
 
@@ -59,12 +89,13 @@ class GeneralizedLossT {
     General,
   };
 
-  // A small threshold for special values
+  /// Small threshold used to detect proximity to special-case alpha values.
   static constexpr T kEps = 1e-9;
 
   const T alpha_;
 
-  // store 1/c^2 instead of c as a small optimization
+  /// Stored as 1/c^2 (instead of c) as a small optimization, since the loss formulas use this
+  /// quantity directly.
   const T invC2_;
 
   LossType lossType_;

--- a/momentum/math/intersection.cpp
+++ b/momentum/math/intersection.cpp
@@ -16,6 +16,15 @@ namespace momentum {
 
 namespace {
 
+// Signed area (twice) of the 2D triangle (p1, p2, p3) projected onto the z=0 plane.
+// Equivalent to the z-component of the cross product (p2-p1) x (p3-p1) using only
+// the x,y coordinates. The sign indicates the orientation (CCW positive, CW negative)
+// and is used to test whether p1 lies on a consistent side of the directed edge p2->p3.
+//
+// TODO: This always projects onto z=0, which is degenerate for triangles whose normal
+// is close to the world Z axis (i.e., nearly horizontal in the xy plane). A more robust
+// test should project onto the coordinate plane that drops the dominant component of
+// the triangle's normal, or use barycentric/edge-cross tests in 3D.
 template <typename T>
 T sign(const Eigen::Vector3<T>& p1, const Eigen::Vector3<T>& p2, const Eigen::Vector3<T>& p3) {
   return (p1[0] - p3[0]) * (p2[1] - p3[1]) - (p2[0] - p3[0]) * (p1[1] - p3[1]);
@@ -29,7 +38,11 @@ bool intersectFace(
     const std::vector<Vector3<T>>& faceNormals,
     const int32_t face0,
     const int32_t face1) {
-  // if the faces share a vertex, they are not intersecting
+  // Faces that share at least one vertex are treated as non-intersecting. This avoids
+  // false positives on adjacent triangles that meet along an edge or at a vertex but
+  // do not actually overlap in their interiors.
+  // TODO: This O(9) loop also rejects pairs that share only a single vertex, which can
+  // miss real interior intersections when two triangles fan out from a common vertex.
   for (size_t iVertex1 : mesh.faces[face0]) {
     for (size_t iVertex2 : mesh.faces[face1]) {
       if (iVertex1 == iVertex2) {
@@ -38,10 +51,14 @@ bool intersectFace(
     }
   }
 
+  // Two-pass edge-vs-plane test: for each ordering (A=face0,B=face1) and (A=face1,B=face0),
+  // intersect each of triangle A's three edges against triangle B's supporting plane and
+  // check whether the intersection point lies inside triangle B. If any edge-segment of
+  // either triangle pierces the other triangle's interior, the triangles intersect.
+  // Note: this is asymmetric and does not implement the full Möller separating-axis test;
+  // it can miss coplanar intersections and edge-on-edge contacts.
   size_t iFaceA = 0, iFaceB = 0;
   for (size_t i = 0; i < 2; i++) {
-    // check for overlap by casting edges of triangle A to plane of triangle B
-    // and checking if the point of intersection is inside triangle B
     if (i == 0) {
       iFaceA = face0;
       iFaceB = face1;
@@ -50,31 +67,43 @@ bool intersectFace(
       iFaceB = face0;
     }
 
-    // calculate plane of triangle B
+    // Plane of triangle B in the form n . x + d = 0, with n = faceNormals[iFaceB] and
+    // d = -n . v0. Any point x satisfies n . x + d = 0 iff x lies on the plane.
     const auto& faceVertsB = mesh.faces[iFaceB];
     T planeD = -(mesh.vertices[faceVertsB[0]].dot(faceNormals[iFaceB]));
 
     const auto& faceVertsA = mesh.faces[iFaceA];
 
     for (size_t iTriVertex = 0; iTriVertex < 3; iTriVertex++) {
-      // iterate edges of triangleA and ray cast onto plane of triangle B
+      // Treat edge (e0 -> e0+eRay) of triangle A as a parametric ray and intersect it
+      // with the plane of triangle B. Solve for t in: n . (e0 + t*eRay) + d = 0.
       const Eigen::Vector3<T>& e0 = mesh.vertices[faceVertsA[iTriVertex]];
       const Eigen::Vector3<T> eRay = mesh.vertices[faceVertsA[(iTriVertex + 1) % 3]] - e0;
+      // If eRay is (nearly) perpendicular to the plane normal, the edge is (nearly)
+      // parallel to the plane, so the denominator vanishes; skip to avoid division
+      // by zero. Tolerance is 1e-7 (float) / 1e-16 (double) on |eRay . n|, which is
+      // an absolute (not scale-invariant) threshold.
+      // TODO: Tolerance on |eRay . n| is not scale-invariant; it should be relative
+      // to ||eRay|| (and possibly ||n||, though n is unit-length here).
       if (abs(eRay.dot(faceNormals[iFaceB])) - momentum::Eps<T>(1e-7, 1e-16) < 0) {
-        // avoid divide by zero. If its almost 0, ray is almost parallel to plane
         continue;
       }
       const T rayUnitLength =
           -(e0.dot(faceNormals[iFaceB]) + planeD) / (eRay.dot(faceNormals[iFaceB]));
+      // Edge parametrization is t in [0,1]; values outside (0,1) mean the plane is
+      // hit beyond the edge endpoints. Endpoints (t=0 or t=1) are excluded, which
+      // matches the share-vertex early-out above and prevents double-counting.
       if (rayUnitLength <= 0 || rayUnitLength >= 1) {
-        // edge does not intersect with plane
         continue;
       }
 
-      // point of intersection between edge of triangle A and plane of triangle B
       const Eigen::Vector3<T> pIntersect = e0 + rayUnitLength * eRay;
 
-      // check if point is in triangle by projectio onto z=0 plane
+      // Point-in-triangle test using same-side-of-edges via 2D signed areas in the
+      // xy plane (see sign() above). pIntersect is inside triangle B iff all three
+      // signed areas have the same sign (or zero), i.e., NOT (some negative AND some
+      // positive). This 2D projection is degenerate for triangles whose normal is
+      // close to the world Z axis; see TODO on sign().
       const T s1 = sign(pIntersect, mesh.vertices[faceVertsB[0]], mesh.vertices[faceVertsB[1]]);
       const T s2 = sign(pIntersect, mesh.vertices[faceVertsB[1]], mesh.vertices[faceVertsB[2]]);
       const T s3 = sign(pIntersect, mesh.vertices[faceVertsB[2]], mesh.vertices[faceVertsB[0]]);
@@ -94,7 +123,10 @@ template <typename T>
 std::vector<std::pair<int32_t, int32_t>> intersectMeshBruteForce(const MeshT<T>& mesh) {
   std::vector<std::pair<int32_t, int32_t>> intersectingFaces;
 
-  // calculate face normals
+  // Per-face unit normals: n = (v1 - v0) x (v2 - v0) / ||...||. Degenerate (zero-area)
+  // triangles produce a zero cross product; .normalized() then returns NaN/zero, which
+  // can poison downstream tests in intersectFace.
+  // TODO: Skip or specially handle degenerate triangles where (v1-v0) x (v2-v0) ~= 0.
   std::vector<Vector3<T>> faceNormals(mesh.faces.size());
   for (size_t iFace = 0; iFace < mesh.faces.size(); iFace++) {
     const auto& faceVerts = mesh.faces[iFace];
@@ -103,7 +135,8 @@ std::vector<std::pair<int32_t, int32_t>> intersectMeshBruteForce(const MeshT<T>&
     const Eigen::Vector3<T> v2 = mesh.vertices[faceVerts[2]];
     faceNormals[iFace] = (v1 - v0).cross(v2 - v0).normalized();
   }
-  // calculate all face intersections brute force
+  // O(F^2) all-pairs check; iterate the upper-triangular pair set so each unordered
+  // pair is tested exactly once.
   for (size_t iFace0 = 0; iFace0 < mesh.faces.size(); iFace0++) {
     for (size_t iFace1 = iFace0 + 1; iFace1 < mesh.faces.size(); iFace1++) {
       if (intersectFace(
@@ -123,7 +156,9 @@ std::vector<std::pair<int32_t, int32_t>> intersectMesh(const MeshT<T>& mesh) {
   std::vector<axel::BoundingBox<T>> aabbs(mesh.faces.size());
   axel::Bvh<T> bvh;
 
-  // calculate face normals and bounding boxes
+  // Build per-face unit normals (see intersectMeshBruteForce for caveats on degenerate
+  // triangles) and per-face AABBs in a single pass. The AABB is seeded from v0 and then
+  // extended to include v1 and v2 so that min/max bound all three vertices.
   std::vector<Vector3<T>> faceNormals(mesh.faces.size());
   for (size_t iFace = 0; iFace < mesh.faces.size(); iFace++) {
     const auto& faceVerts = mesh.faces[iFace];
@@ -141,7 +176,9 @@ std::vector<std::pair<int32_t, int32_t>> intersectMesh(const MeshT<T>& mesh) {
   }
   bvh.setBoundingBoxes(aabbs);
 
-  // calculate all face intersections
+  // Use the BVH to enumerate only AABB-overlapping face pairs (broad phase), then run
+  // the exact triangle-triangle test (narrow phase) on each candidate. Returning true
+  // from the callback tells axel to continue traversal.
   bvh.traverseOverlappingPairs([&](size_t iFace0, size_t iFace1) {
     if (intersectFace(
             mesh, faceNormals, static_cast<int32_t>(iFace0), static_cast<int32_t>(iFace1))) {

--- a/momentum/math/intersection.h
+++ b/momentum/math/intersection.h
@@ -12,7 +12,20 @@
 
 namespace momentum {
 
-/// test whether two given faces of a mesh intersect with each other
+/// Tests whether two given triangle faces of a mesh intersect with each other.
+///
+/// @param mesh Source mesh providing vertex positions and triangle face indices.
+/// @param faceNormals Per-face normals, indexed by face id; must be sized to match
+///   `mesh.faces` and computed from the same vertex positions as `mesh`.
+/// @param face0 Index of the first face into `mesh.faces`.
+/// @param face1 Index of the second face into `mesh.faces`.
+/// @return True if the two triangles intersect, false otherwise. Faces that share
+///   one or more vertex indices are treated as non-intersecting (adjacent faces are
+///   ignored to avoid false positives along shared edges/vertices).
+/// @pre `face0` and `face1` are valid indices into `mesh.faces`.
+/// @pre `faceNormals.size() == mesh.faces.size()`.
+// TODO: Document the behavior for degenerate triangles (zero-area faces) and for
+// coplanar overlapping triangles, neither of which is explicitly specified here.
 template <typename T>
 bool intersectFace(
     const MeshT<T>& mesh,
@@ -20,12 +33,29 @@ bool intersectFace(
     int32_t face0,
     int32_t face1);
 
-/// test if the mesh self intersects anywhere and return all intersecting face pairs using brute
-/// force
+/// Tests if the mesh self-intersects anywhere and returns all intersecting face pairs
+/// using a brute-force O(n^2) pairwise check over all faces.
+///
+/// @param mesh Source mesh to test for self-intersection.
+/// @return All pairs `(i, j)` of face indices (with `i < j` by convention of the
+///   pairwise loop) whose triangles intersect according to `intersectFace`. Pairs of
+///   faces that share a vertex are excluded (see `intersectFace`). The returned
+///   vector is empty if no intersections are found.
+/// @note Intended primarily for correctness reference and small meshes; prefer
+///   `intersectMesh` for large meshes.
 template <typename T>
 std::vector<std::pair<int32_t, int32_t>> intersectMeshBruteForce(const MeshT<T>& mesh);
-/// test if the mesh self intersects anywhere and return all intersecting face pairs using a bvh
-/// tree
+
+/// Tests if the mesh self-intersects anywhere and returns all intersecting face pairs
+/// using a BVH (bounding volume hierarchy) acceleration structure.
+///
+/// @param mesh Source mesh to test for self-intersection.
+/// @return All unique pairs of face indices whose triangles intersect according to
+///   `intersectFace`. Pairs of faces that share a vertex are excluded. The returned
+///   vector is empty if no intersections are found. Order of pairs is implementation-
+///   defined and may differ from `intersectMeshBruteForce`.
+/// @note Functionally equivalent to `intersectMeshBruteForce` but asymptotically
+///   faster for large meshes.
 template <typename T>
 std::vector<std::pair<int32_t, int32_t>> intersectMesh(const MeshT<T>& mesh);
 

--- a/momentum/math/mesh.cpp
+++ b/momentum/math/mesh.cpp
@@ -15,20 +15,25 @@ namespace momentum {
 
 template <typename T>
 void MeshT<T>::updateNormals() {
-  // calculate normals
   normals.resize(vertices.size());
   std::fill(normals.begin(), normals.end(), Eigen::Vector3<T>::Zero());
   const auto verticesNum = static_cast<int>(vertices.size());
   for (const auto& face : faces) {
-    // Skip faces with out-of-boundaries indexes
+    // Skip faces with out-of-bounds vertex indices.
     if (std::any_of(face.begin(), face.end(), [verticesNum](int idx) {
           return idx < 0 || idx >= verticesNum;
         })) {
       continue;
     }
-    // calculate normal and add for each vertex
+    // The unnormalized cross product has magnitude equal to 2 * triangle area, so accumulating it
+    // across faces produces area-weighted vertex normals (larger faces contribute more). This is
+    // the standard Gouraud-style averaging and tends to produce better results than uniform
+    // averaging for meshes with mixed triangle sizes.
     const Eigen::Vector3<T> normal =
         (vertices[face[1]] - vertices[face[0]]).cross(vertices[face[2]] - vertices[face[0]]);
+    // Skip degenerate faces that produced NaN (e.g., from non-finite vertex coordinates).
+    // Collinear/zero-area triangles produce a zero vector, which contributes nothing and is safe.
+    // TODO: only checking normal[0] misses NaNs that appear only in y or z components.
     if (IsNanNoOpt(normal[0])) {
       continue;
     }
@@ -36,10 +41,9 @@ void MeshT<T>::updateNormals() {
       normals[faceIdx] += normal;
     }
   }
-  // re-normalize normals
   for (size_t i = 0; i < normals.size(); i++) {
     const T len = normals[i].norm();
-    // avoid divide-by-zero:
+    // Leave isolated/unreferenced vertices with a zero normal rather than dividing by zero.
     if (len != 0) {
       normals[i] /= len;
     }

--- a/momentum/math/mesh.h
+++ b/momentum/math/mesh.h
@@ -46,6 +46,8 @@ struct MeshT {
   /// For GLTF, Momentum stores and saves the texture coordinates as they are represented by the
   /// underlying GLTF parser. When dealing with FBX, the Y-axis is flipped. This distinction is
   /// crucial to understand when working with different formats.
+  // TODO: texcoords are hardcoded to float regardless of the mesh scalar type T; consider
+  // templating on T2 (or T) for consistency with vertices/normals/confidence.
   std::vector<Eigen::Vector2f> texcoords;
 
   /// List of texture coordinate indices per face

--- a/momentum/math/mppca.cpp
+++ b/momentum/math/mppca.cpp
@@ -23,34 +23,52 @@ void MppcaT<T>::set(
   d = mmu.cols();
   p = sigma2.rows();
 
-  // set the data
+  // TODO: Validate input dimensions: inPi.rows() == p, mmu.rows() == p, W.size() == p,
+  //       and each W[c] has d columns. Currently mismatches will trigger out-of-bounds
+  //       access or silent corruption rather than a clear error.
   Rpre.setZero(p);
   Cinv.resize(p);
   L.resize(p);
 
   CovarianceMatrix covariance;
 
+  // For each mixture component c, PPCA models the data covariance as
+  //     C_c = sigma_c^2 * I + W_c * W_c^T,
+  // i.e. low-rank signal (W_c) plus isotropic noise (sigma_c^2). The log of the
+  // Gaussian normalizer used in the per-component log-density is
+  //     -0.5 * d * log(2*pi)   (the half_d_log_2pi term below).
   const T half_d_log_2pi = T(0.5) * static_cast<T>(d) * std::log(twopi<T>());
 
   for (size_t c = 0; c < p; c++) {
+    // LowRankCovarianceMatrix takes A such that C = sigma^2*I + A^T*A; here A = W_c^T,
+    // so A^T*A = W_c * W_c^T as required by the PPCA model. It produces the QR
+    // factorization R with R^T * R = sigma^2*I + W_c * W_c^T = C_c.
     covariance.reset(std::sqrt(sigma2(c)), W[c].transpose());
 
-    // Back-substitution of the identity matrix gives the inverse:
+    // R is upper-triangular, so back-substituting the identity yields R^{-1}.
+    // L_tmp = R^{-T} (the lower-triangular factor of C^{-1} = R^{-1} * R^{-T}).
     const Eigen::MatrixX<T> L_tmp = covariance.R()
                                         .template triangularView<Eigen::Upper>()
                                         .solve(Eigen::MatrixX<T>::Identity(d, d))
                                         .transpose();
+    // Cinv = R^{-1} * R^{-T} = (R^T * R)^{-1} = C^{-1}.
     Cinv[c] = covariance.R().template triangularView<Eigen::Upper>().solve(L_tmp);
     L[c] = L_tmp;
 
     const T C_logDeterminant = covariance.logDeterminant();
 
-    // Rpre is the constant part of R that does not depend on the parameters, so we can precalculate
-    // it
+    // Per-component log responsibility for input x is
+    //     log r_c(x) = log pi_c - 0.5*log|C_c| - 0.5*d*log(2*pi) - 0.5*(x-mu_c)^T C_c^{-1}
+    //     (x-mu_c).
+    // Rpre stores the data-independent prefactor (everything but the quadratic term),
+    // so callers can add the cached -0.5 * Mahalanobis distance at evaluation time
+    // and apply log-sum-exp across components for a numerically stable mixture log-likelihood.
     Rpre(c) = std::log(inPi(c)) - T(0.5) * C_logDeterminant - half_d_log_2pi;
   }
   mu = mmu;
 
+  // Reset names to the data-space dimension; caller is expected to populate them
+  // afterwards if needed. Note: this discards any names previously set on the model.
   names = std::vector<std::string>(d);
 }
 

--- a/momentum/math/mppca.h
+++ b/momentum/math/mppca.h
@@ -11,56 +11,89 @@
 
 namespace momentum {
 
-/// Mixture of Probabilistic Principal Component Analysis (MPPCA)
+/// Mixture of Probabilistic Principal Component Analyzers (MPPCA).
+///
+/// Each component models the data as `x = W_c z + mu_c + epsilon`, where `z`
+/// is a low-dimensional latent vector and `epsilon ~ N(0, sigma_c^2 I)` is
+/// isotropic noise. The full mixture density is
+/// `p(x) = sum_c pi_c N(x | mu_c, C_c)` with `C_c = W_c W_c^T + sigma_c^2 I`.
+///
+/// After `set()`, the model stores precomputed quantities so that the
+/// per-component log-likelihood of a sample `x` can be evaluated as
+/// `Rpre(c) - 0.5 * (x - mu.row(c))^T * Cinv[c] * (x - mu.row(c))`.
+///
 /// Based on: http://www.miketipping.com/papers/met-mppca.pdf
 ///
-/// @tparam T Scalar type (float or double)
+/// @tparam T Scalar type (float or double).
 template <typename T>
 struct MppcaT {
-  /// Dimension of data space
+  /// Dimensionality of the data space `x`.
   size_t d = 0;
 
-  /// Number of mixture components
+  /// Number of mixture components.
   size_t p = 0;
 
-  /// Parameter names (should match dimension d)
+  /// Optional human-readable names for each of the `d` data dimensions.
+  /// `set()` resizes this to `d` empty strings; callers may overwrite entries.
   std::vector<std::string> names;
 
-  /// Mean vectors (p×d matrix)
+  /// Per-component mean vectors stored as a `p x d` matrix; row `c` is `mu_c`.
   Eigen::MatrixX<T> mu;
 
-  /// Inverse covariance matrices
+  /// Per-component inverse covariance matrices `C_c^{-1}` of size `d x d`.
+  /// `Cinv.size() == p` after `set()`.
   std::vector<Eigen::MatrixX<T>> Cinv;
 
-  /// Matrices for efficient computation
+  /// Per-component lower-triangular factors derived from the Cholesky-like
+  /// decomposition of `C_c` (used as a whitening transform when sampling or
+  /// evaluating the Mahalanobis term efficiently). `L.size() == p` after
+  /// `set()`.
   std::vector<Eigen::MatrixX<T>> L;
 
-  /// Precomputed responsibility terms
+  /// Per-component constant term of the log-likelihood:
+  /// `Rpre(c) = log(pi_c) - 0.5 * log|C_c| - (d/2) * log(2*pi)`.
+  /// Add the `-0.5 * Mahalanobis` term to obtain the log-density of `x` under
+  /// component `c`. Length is `p` after `set()`.
   Eigen::VectorX<T> Rpre;
 
-  /// Sets model parameters and precomputes matrices
+  /// Initializes the model from raw mixture parameters and precomputes
+  /// `Cinv`, `L`, and `Rpre` for fast log-likelihood evaluation.
   ///
-  /// @param[in] pi Mixture weights
-  /// @param[in] mmu Mean vectors
-  /// @param[in] W Principal axes matrices
-  /// @param[in] sigma2 Noise variances
+  /// @param[in] pi Mixture weights, length `p`. Must sum to 1 and be > 0.
+  /// @param[in] mmu Per-component means as a `p x d` matrix (row `c` is `mu_c`).
+  /// @param[in] W Per-component factor-loading matrices `W_c`; expected to be
+  ///   of size `d x q_c` where `q_c < d` is the latent dimension. Length `p`.
+  /// @param[in] sigma2 Per-component isotropic noise variances `sigma_c^2`,
+  ///   length `p`. Must be strictly positive.
+  /// @pre `pi.size() == p`, `mmu.rows() == p`, `W.size() == p`,
+  ///   `sigma2.size() == p`, and `W[c].rows() == mmu.cols()` for all `c`.
+  /// @post `d == mmu.cols()`, `p == sigma2.rows()`, and `Cinv`, `L`, `Rpre`,
+  ///   `mu`, `names` are sized consistently.
+  // TODO: Parameter is named `pi` here but `inPi` in the .cpp definition;
+  //   align the names for clarity.
+  // TODO: `pi` is consumed only to compute `Rpre` and is not retained as a
+  //   member. Document this or expose `pi` directly so callers can recover
+  //   mixture weights without inverting the precomputation.
   void set(
       const VectorX<T>& pi,
       const MatrixX<T>& mmu,
       momentum::span<const MatrixX<T>> W,
       const VectorX<T>& sigma2);
 
-  /// Converts to a different scalar type
+  /// Returns a copy of this model with all numeric data converted to scalar
+  /// type `T2`. Names and dimensions are copied unchanged.
   ///
-  /// @tparam T2 Target scalar type
-  /// @return Converted MPPCA model
+  /// @tparam T2 Target scalar type.
+  /// @return Converted MPPCA model.
   template <typename T2>
   [[nodiscard]] MppcaT<T2> cast() const;
 
-  /// Checks approximate equality with another model
+  /// Returns true if every member matches `mppcaT` exactly (`d`, `p`, `names`)
+  /// or approximately (`mu`, `Cinv`, `L`, `Rpre`) using Eigen's `isApprox`
+  /// default tolerance.
   ///
-  /// @param[in] mppcaT Model to compare with
-  /// @return true if approximately equal
+  /// @param[in] mppcaT Model to compare with.
+  /// @return True if approximately equal.
   [[nodiscard]] bool isApprox(const MppcaT<T>& mppcaT) const;
 };
 

--- a/momentum/math/online_householder_qr.cpp
+++ b/momentum/math/online_householder_qr.cpp
@@ -27,6 +27,8 @@ T sqr(T val) {
 //   y = [ y_1 y_2m... ]^T
 // and v is implicitly assumed to have 1 stored in its first entry,
 //   v = [ 1 v_2m ]^T
+// Splitting v_1=1 out of storage saves one multiply per dot product and lets
+// computeHouseholderVec reuse the input column to store v_2m in place.
 template <typename T>
 void applyHouseholderTransformation(
     T beta,
@@ -35,18 +37,22 @@ void applyHouseholderTransformation(
     Eigen::Ref<Eigen::Matrix<T, Eigen::Dynamic, 1>> y_2m) {
   MT_CHECK(v_2m.size() == y_2m.size());
 
-  // Compute v^T * y.  Note that v_1 is assumed to be 1 here.
+  // dotProd = v^T * y, exploiting v_1 = 1 implicitly.
   const T dotProd = y_1 + v_2m.dot(y_2m);
   const T scalar = dotProd * beta;
 
-  // Subtract off (beta * v * v^T * A)
+  // y <- y - beta * v * (v^T * y)
   y_1 -= scalar;
   y_2m.noalias() -= scalar * v_2m;
 }
 
-// Apply the Householder transformation to a block of columns in a ColumnIndexedMatrix.
-// Falls back to column-by-column processing.
-// Y_1 should be the full row; colStart and colEnd specify which columns to process.
+// Apply the Householder transformation to columns [colStart, colEnd) of a
+// ColumnIndexedMatrix. Y_1 holds the leading row entries (full width); Y_2m
+// holds the trailing rows used to form v_2m.
+//
+// TODO: this currently only iterates column-by-column. The "Block" name and
+// the loop structure suggest that a true blocked variant (e.g. WY-form
+// updates) was intended but never implemented.
 template <typename T, typename MatrixType, typename RowType>
 void applyHouseholderTransformationBlock(
     T beta,
@@ -59,6 +65,7 @@ void applyHouseholderTransformationBlock(
   MT_CHECK(v_2m.rows() == Y_2m.rows());
   MT_CHECK(colStart <= colEnd);
   MT_CHECK(colEnd <= nCols);
+  // TODO: duplicate of the assertion immediately above.
   MT_CHECK(colEnd <= nCols);
   MT_CHECK(Y_1.cols() == nCols);
 
@@ -67,7 +74,6 @@ void applyHouseholderTransformationBlock(
   auto jCol = colStart;
 
   while (jCol < colEnd) {
-    // Process column-by-column
     applyHouseholderTransformation<T>(beta, v_2m, Y_1(jCol), Y_2m.col(jCol));
     ++jCol;
   }
@@ -75,10 +81,25 @@ void applyHouseholderTransformationBlock(
 
 // Computes the Householder reflection vector for the column [x1 x2...xm]^T
 // (x1 is passed in separately because it comes from the R matrix rather than A).
-// Uses the stable algorithm from Golub and van Loan.
+// Uses the stable algorithm from Golub and van Loan, "Matrix Computations" 4e,
+// Algorithm 5.1.1.
 // The result of applying the Householder transform (I - beta*v*v^T) is a vector of the form
 //     [mu 0 0 0 ... 0]^T
-// Returns the pair [beta, mu].
+// Returns the pair [beta, mu]. Side effect: `vec` is overwritten in place with
+// v_2m (the implicit v_1 = 1 is not stored). Caller must treat `vec` as the
+// reflector vector after this call, not the original column data.
+//
+// Numerical-stability notes:
+//   - When x1 > 0, computing v1 = x1 - mu would suffer cancellation
+//     (mu ~ |x1| when sigma is small), so we use the algebraically-equivalent
+//     -sigma / (x1 + mu) form. The x1 <= 0 branch is already cancellation-free.
+//   - sigma == 0 means the trailing entries are exactly zero, so x1 already
+//     sits in the [mu 0 ... 0] form; we return beta = 0 to signal "skip".
+//     Callers must check beta == 0 before applying the transform; otherwise
+//     `vec` would be divided by an undefined v1.
+//   - mu has the sign opposite to v1 by construction, so the diagonal entry of
+//     R may be negative. This is standard and downstream solves only depend on
+//     R^T R, so the sign is irrelevant.
 template <typename T>
 std::pair<T, T> computeHouseholderVec(
     T x1,
@@ -87,7 +108,6 @@ std::pair<T, T> computeHouseholderVec(
 {
   const T sigma = vec.squaredNorm();
   if (sigma == 0) {
-    // No need to apply a transform if the vector is already zeroed out.
     return {0, x1};
   }
 
@@ -116,6 +136,8 @@ void OnlineHouseholderQR<T>::reset(const Eigen::Index n, T lambda) {
   R_.resize(n, n);
   R_.setZero();
   if (lambda != 0) {
+    // Seed the diagonal with `lambda` so the first add() effectively appends
+    // a Tikhonov regularizer block (lambda*I, 0) to (A, b).
     R_.diagonal().setConstant(lambda);
   }
 
@@ -123,6 +145,8 @@ void OnlineHouseholderQR<T>::reset(const Eigen::Index n, T lambda) {
   y_.setZero();
 }
 
+// TODO: this helper appears to be unused inside this translation unit. If it
+// is not part of the public interface, consider removing or marking it static.
 void validateColumnIndices(momentum::span<const Eigen::Index> colIndices, Eigen::Index maxEntry) {
 #ifndef NDEBUG
   {
@@ -130,7 +154,6 @@ void validateColumnIndices(momentum::span<const Eigen::Index> colIndices, Eigen:
       MT_CHECK(idx < maxEntry);
     }
 
-    // check for duplicates:
     std::vector<Eigen::Index> colsCheckDups(std::begin(colIndices), std::end(colIndices));
     std::sort(colsCheckDups.begin(), colsCheckDups.end());
     MT_CHECK(std::unique(colsCheckDups.begin(), colsCheckDups.end()) == colsCheckDups.end());
@@ -152,6 +175,13 @@ void OnlineHouseholderQR<T>::addMutating(
     Eigen::Ref<VectorType> b) {
   MT_PROFILE_FUNCTION();
 
+  // Conceptually we form the stacked matrix [R; A] and reduce it back to upper
+  // triangular by sweeping a Householder reflector down each column. R already
+  // satisfies the upper-triangular invariant from prior calls, so for column
+  // iCol we only need to zero the new rows in A.col(iCol) below R_(iCol, iCol).
+  // Side effect: A and b are overwritten in place — A.col(iCol) is replaced
+  // with v_2m (the reflector for column iCol), and rhs entries are mixed into
+  // y_. Caller must not reuse A/b after this call.
   const Eigen::Index n = R_.rows();
   MT_CHECK(A.rows() == b.rows());
   MT_CHECK(A.cols() == n);
@@ -172,6 +202,8 @@ void OnlineHouseholderQR<T>::addMutating(
     // This will zero out the ith column.
     const auto [beta, mu] = computeHouseholderVec<T>(R_(iCol, iCol), A.col(iCol));
     if (beta == 0) {
+      // A.col(iCol) was already zero below R_(iCol,iCol); R is unchanged for
+      // this column and nothing needs to be applied to the trailing columns.
       continue;
     }
 
@@ -179,13 +211,13 @@ void OnlineHouseholderQR<T>::addMutating(
     // results in a vector [mu 0 ... 0].
     R_(iCol, iCol) = mu;
 
-    // Apply the Householder vector to the remaining columns.
+    // v2m aliases A.col(iCol), which now stores the reflector tail (see
+    // computeHouseholderVec side effect).
     const auto& v2m = A.col(iCol);
     for (Eigen::Index jCol = iCol + 1; jCol < n; ++jCol) {
       applyHouseholderTransformation<T>(beta, v2m, R_(iCol, jCol), A.col(jCol));
     }
 
-    // Apply the Householder vector to the rhs.
     applyHouseholderTransformation<T>(beta, v2m, y_(iCol), b);
   }
 }
@@ -203,8 +235,9 @@ typename OnlineHouseholderQR<T>::VectorType OnlineHouseholderQR<T>::At_times_b()
 
 template <typename T>
 typename OnlineHouseholderQR<T>::VectorType OnlineHouseholderQR<T>::result() const {
-  // TODO consider checking that the back-substitution is okay here, and
-  // "fixing it up" if we encounter zeroes on the diagonal.
+  // TODO: detect zeros on R_'s diagonal (rank deficiency, e.g. when lambda == 0
+  // and a column was never seen) and either return a damped solution or signal
+  // failure rather than dividing by zero in back-substitution.
   return R_.template triangularView<Eigen::Upper>().solve(y_);
 }
 
@@ -258,8 +291,14 @@ void OnlineBlockHouseholderQR<T>::addMutating(
   auto& R_in = R_in_[iBlock];
   auto& R_nn = R_nn_;
 
+  // Phase 1: zero out the per-block diagonal columns A_diag. Each reflector
+  // also touches A_common (cross-block fill) so that the running R has the
+  // arrowhead structure [R_ii R_in; 0 R_nn].
   for (Eigen::Index iCol = 0; iCol < n_diag; ++iCol) {
     if (A_diag.col(iCol).isZero()) {
+      // Fast skip for empty Jacobian columns. Note that this is stricter than
+      // the beta == 0 check below: a column whose squared norm underflows to 0
+      // would be caught there too, but isZero() avoids the squaredNorm() cost.
       continue;
     }
 
@@ -286,21 +325,23 @@ void OnlineBlockHouseholderQR<T>::addMutating(
     // results in a vector [mu 0 ... 0].
     R_ii(iCol, iCol) = mu;
 
-    // Apply the Householder vector to the remaining columns.
     const auto& v2m = A_diag.col(iCol);
     if (iCol + 1 < n_diag) {
       applyHouseholderTransformationBlock<T>(beta, v2m, R_ii.row(iCol), A_diag, iCol + 1, n_diag);
     }
 
     if (n_common > 0) {
+      // Couple the per-block rotation into the common columns; this is what
+      // lets the block solve later subtract R_in * x_n.
       applyHouseholderTransformationBlock<T>(beta, v2m, R_in.row(iCol), A_common, 0, n_common);
     }
 
-    // Apply the Householder vector to the rhs.
     applyHouseholderTransformation<T>(beta, v2m, y_i(iCol), b);
   }
 
-  // Now for the common parameters:
+  // Phase 2: with A_diag now zero in this block, fold the residual A_common
+  // and b into the shared (R_nn, y_n) tail. This is the same algorithm as
+  // OnlineHouseholderQR::addMutating but operating on the bottom-right block.
   for (Eigen::Index iCol = 0; iCol < n_common; ++iCol) {
     const auto [beta, mu] = computeHouseholderVec<T>(R_nn(iCol, iCol), A_common.col(iCol));
     if (beta == 0) {
@@ -315,7 +356,6 @@ void OnlineBlockHouseholderQR<T>::addMutating(
           beta, v2m, R_nn_(iCol, jCol_common), A_common.col(jCol_common));
     }
 
-    // Apply the Householder vector to the rhs.
     applyHouseholderTransformation<T>(beta, v2m, y_n_(iCol), b);
   }
 }
@@ -371,6 +411,11 @@ typename OnlineBlockHouseholderQR<T>::MatrixType OnlineBlockHouseholderQR<T>::y_
 
 template <typename T>
 typename OnlineBlockHouseholderQR<T>::VectorType OnlineBlockHouseholderQR<T>::x_dense() const {
+  // Solve the arrowhead system in two stages, exploiting that R has structure
+  //   [R_ii   R_in] [x_i]   [y_i]
+  //   [  0    R_nn] [x_n] = [y_n]
+  // 1) Back-solve R_nn * x_n = y_n once for the shared parameters.
+  // 2) For each block: back-solve R_ii * x_i = y_i - R_in * x_n.
   const auto nBlocks = R_ii_.size();
   Eigen::Index nRows_diag = 0;
   for (const auto& block : R_ii_) {
@@ -410,12 +455,16 @@ typename OnlineBlockHouseholderQR<T>::VectorType OnlineBlockHouseholderQR<T>::x_
 template <typename T>
 typename OnlineBlockHouseholderQR<T>::VectorType OnlineBlockHouseholderQR<T>::At_times_b_i(
     size_t iBlock) const {
-  // As noted above, A^T*b = R^T*y
+  // A^T*b = R^T*y because Q is orthonormal (see OnlineHouseholderQR::At_times_b
+  // for the derivation). For block i this restricts to R_ii^T*y_i since R_ii
+  // is the only block that interacts with the per-block parameters.
   return R_ii_[iBlock].transpose() * y_i_[iBlock];
 }
 
 template <typename T>
 typename OnlineBlockHouseholderQR<T>::VectorType OnlineBlockHouseholderQR<T>::At_times_b_n() const {
+  // For the common parameters every block contributes via its R_in coupling
+  // term, so we sum R_in_[i]^T * y_i_[i] across blocks alongside R_nn^T * y_n.
   VectorType result = R_nn_.transpose() * y_n_;
   for (size_t iBlock = 0; iBlock < R_ii_.size(); ++iBlock) {
     result.noalias() += R_in_[iBlock].transpose() * y_i_[iBlock];
@@ -476,6 +525,11 @@ OnlineBandedHouseholderQR<T>::OnlineBandedHouseholderQR(
       R_common_{Eigen::MatrixX<T>::Zero(n_band + n_common, n_common)},
       R_band_{Eigen::MatrixX<T>::Zero(bandwidth, n_band)},
       y_{Eigen::VectorX<T>::Zero(n_band + n_common)} {
+  // R_band_ uses a packed banded layout: R_band_(i, j) stores the (i, j+k)
+  // entry of the dense R for some shift k determined by R_band_entry. Rows of
+  // the storage matrix correspond to diagonals (the last row is the main
+  // diagonal), columns correspond to the global column index.
+  //
   // Bandwidth is only allowed to be zero if there are no parameters in the banded part,
   // in which case it falls back to behaving the same as a regular Householder QR (for
   // the common part).
@@ -486,6 +540,10 @@ OnlineBandedHouseholderQR<T>::OnlineBandedHouseholderQR(
 
 template <typename T>
 void OnlineBandedHouseholderQR<T>::initializeDiagonal() {
+  // Seeds the Tikhonov regularizer lambda*I on R's diagonal in both storage
+  // layouts: the bottom-right square of R_common_ (regular dense storage), and
+  // the bottom row of R_band_ (which holds the main diagonal in banded
+  // storage).
   const auto n_common = R_common_.cols();
 
   if (n_common != 0) {
@@ -524,10 +582,13 @@ void OnlineBandedHouseholderQR<T>::zeroBandedPart(
     Eigen::Ref<VectorType> b) {
   const auto n_common = R_common_.cols();
 
+  // A_band.cols() bounds bandwidth because each new column can only fill in
+  // rows up to (bandwidth - 1) above its diagonal entry.
   MT_CHECK(A_band.cols() <= R_band_.rows());
   MT_CHECK(iCol_offset + A_band.cols() <= R_band_.cols());
 
-  // TODO what to assert about A_band?
+  // TODO: also assert A_band.rows() == b.rows() (matches the cousin
+  // OnlineBlockHouseholderQR::addMutating contract).
   MT_CHECK(A_common.cols() == n_common);
 
   for (Eigen::Index iCol_local = 0; iCol_local < A_band.cols(); ++iCol_local) {
@@ -557,18 +618,18 @@ void OnlineBandedHouseholderQR<T>::zeroBandedPart(
     // results in a vector [mu 0 ... 0].
     R_band_entry(iCol_global, iCol_global) = mu;
 
-    // Apply the Householder vector to the remaining columns.
     const auto& v2m = A_band.col(iCol_local);
 
-    // For the banded part, we can't use block operations because R_band_ uses
-    // special banded storage format, so fall back to column-by-column
+    // R_band_ uses packed banded storage, so its row(iCol_global) cannot be
+    // expressed as a contiguous Eigen row expression — we must address each
+    // (iCol_global, jCol_global) entry individually via R_band_entry.
     for (Eigen::Index jCol_local = iCol_local + 1; jCol_local < A_band.cols(); ++jCol_local) {
       const auto jCol_global = jCol_local + iCol_offset;
       applyHouseholderTransformation<T>(
           beta, v2m, R_band_entry(iCol_global, jCol_global), A_band.col(jCol_local));
     }
 
-    // For the common part, we can use block operations since R_common_ is a regular matrix
+    // R_common_ is a dense matrix, so the block-friendly helper applies.
     if (n_common > 0) {
       applyHouseholderTransformationBlock<T>(
           beta, v2m, R_common_.row(iCol_global), A_common, 0, n_common);
@@ -582,13 +643,17 @@ template <typename T>
 void OnlineBandedHouseholderQR<T>::addMutating(
     ColumnIndexedMatrix<MatrixType> A_common,
     Eigen::Ref<VectorType> b) {
+  // Reduce A_common into the bottom-right (n_common x n_common) block of
+  // R_common_. R_common_ stores the common columns of R as a dense matrix
+  // whose top n_band rows hold the cross-coupling against the banded part;
+  // the diagonal of R_common itself begins at row n_band, which is why every
+  // row index below is shifted by n_band.
   const auto n_common = R_common_.cols();
   const auto n_band = R_band_.cols();
 
-  // TODO what to assert about A_band?
+  // TODO: tighten this to also assert b.rows() matches A_common.rows().
   MT_CHECK(A_common.cols() == n_common);
 
-  // Now for the common parameters:
   for (Eigen::Index iCol = 0; iCol < n_common; ++iCol) {
     const auto [beta, mu] =
         computeHouseholderVec<T>(R_common_(iCol + n_band, iCol), A_common.col(iCol));
@@ -610,6 +675,10 @@ void OnlineBandedHouseholderQR<T>::addMutating(
 
 template <typename T>
 typename OnlineBandedHouseholderQR<T>::MatrixType OnlineBandedHouseholderQR<T>::R_dense() const {
+  // Unpack the banded + common storage into a single dense upper-triangular
+  // matrix. Row of the dense result corresponds to a row of R; the banded
+  // block occupies rows/cols [0, n_band) and the common block occupies
+  // [n_band, n_band+n_common).
   const auto n_common = R_common_.cols();
   const auto n_band = R_band_.cols();
   const auto bandwidth = R_band_.rows();
@@ -618,6 +687,8 @@ typename OnlineBandedHouseholderQR<T>::MatrixType OnlineBandedHouseholderQR<T>::
 
   MatrixType result = MatrixType::Zero(n_total, n_total);
 
+  // Walk each banded column upward at most `bandwidth` rows; rows above are
+  // structurally zero in band storage.
   for (Eigen::Index iCol_band = 0; iCol_band < n_band; ++iCol_band) {
     for (Eigen::Index jRow = iCol_band; (iCol_band - jRow) < bandwidth && jRow >= 0; --jRow) {
       result(jRow, iCol_band) = R_band_entry(jRow, iCol_band);
@@ -635,6 +706,12 @@ typename OnlineBandedHouseholderQR<T>::MatrixType OnlineBandedHouseholderQR<T>::
 
 template <typename T>
 typename OnlineBandedHouseholderQR<T>::VectorType OnlineBandedHouseholderQR<T>::x_dense() const {
+  // Two-stage back-substitution analogous to OnlineBlockHouseholderQR::x_dense:
+  //   1) Solve the dense common block first to obtain x_n.
+  //   2) Sweep the banded block from bottom to top, subtracting R_in coupling
+  //      via R_common_.row(iRow).dot(x_n) and the in-band tail via R_band_entry.
+  // The inner loop's bandwidth_cur clamp avoids reading past the rightmost
+  // banded column (n_band - 1).
   VectorType result = VectorType::Zero(R_band_.cols() + R_common_.cols());
 
   const auto n_common = R_common_.cols();
@@ -648,6 +725,9 @@ typename OnlineBandedHouseholderQR<T>::VectorType OnlineBandedHouseholderQR<T>::
   }
 
   if (n_band > 0) {
+    // TODO: result(iRow) divides by R_band_entry(iRow, iRow). With lambda == 0
+    // and a row that never received any contribution, this can be zero — same
+    // rank-deficiency issue noted in OnlineHouseholderQR::result.
     for (Eigen::Index iRow = n_band - 1; iRow >= 0; --iRow) {
       T dotProd = n_common > 0 ? R_common_.row(iRow).dot(result.tail(n_common)) : T(0);
 
@@ -664,7 +744,10 @@ typename OnlineBandedHouseholderQR<T>::VectorType OnlineBandedHouseholderQR<T>::
 
 template <typename T>
 typename OnlineBandedHouseholderQR<T>::VectorType OnlineBandedHouseholderQR<T>::At_times_b() const {
-  // As noted above, A^T*b = R^T*y
+  // A^T*b = R^T*y (Q is orthonormal). Computed by accumulating column sums:
+  // each row iRow of R contributes R(iRow, jCol)*y(iRow) into result(jCol).
+  // The banded loop walks only the in-band entries; the common columns are
+  // dense and folded in by the final R_common_.transpose() * y_.
   VectorType result = VectorType::Zero(R_band_.cols() + R_common_.cols());
 
   const auto n_common = R_common_.cols();

--- a/momentum/math/online_householder_qr.h
+++ b/momentum/math/online_householder_qr.h
@@ -19,10 +19,21 @@
 
 namespace momentum {
 
+/// Validates that every entry in @p colIndices is in [0, maxEntry); throws otherwise.
+/// @param colIndices Column indices to validate.
+/// @param maxEntry Exclusive upper bound (typically the underlying matrix's `cols()`).
 void validateColumnIndices(momentum::span<const Eigen::Index> colIndices, Eigen::Index maxEntry);
 
-// Remaps the matrix such that A_new.col(i) = A_orig.col(colIndices[i]).
-// This can be used to perform QR on a subset of the matrix columns.
+/// View over a matrix that exposes a (possibly reordered) subset of its columns.
+///
+/// When constructed with a `colIndices` span, accessing column @c i of this view returns
+/// the underlying matrix's column @c colIndices[i]. This lets callers run QR on a column
+/// subset without copying the matrix. When constructed without indices, this is a thin
+/// pass-through to the wrapped Eigen reference.
+///
+/// @note Holds an `Eigen::Ref` and a non-owning `span` — the underlying matrix and index
+///   buffer must outlive this view. The view is mutable: mutations through `col()` write
+///   back into the wrapped matrix.
 template <typename MatrixType>
 class ColumnIndexedMatrix {
  public:
@@ -61,6 +72,12 @@ class ColumnIndexedMatrix {
     return columnIndices_;
   }
 
+  /// Computes `this->transpose() * b`, returning a vector of length `cols()`.
+  /// @param b Vector with `rows()` entries.
+  /// @return Vector with `cols()` entries; entry @c i equals `view.col(i).dot(b)`.
+  // TODO: When `useColumnIndices_` is true, the loop reads `mat_.col(iCol)` instead of
+  //   `mat_.col(columnIndices_[iCol])`. This silently ignores the remap and returns the
+  //   wrong values whenever `colIndices` is a non-identity permutation/subset.
   [[nodiscard]] VectorType transpose_times(Eigen::Ref<VectorType> b) const {
     if (useColumnIndices_) {
       VectorType result(columnIndices_.size());
@@ -79,149 +96,193 @@ class ColumnIndexedMatrix {
   bool useColumnIndices_;
 };
 
-// This class is designed to solve least squares problems of the form:
-//   min || A * x - b ||_2
-// where
-//   a. n is small-ish,
-//   b. A is tall and _sparse_ (m >> n), BUT
-//   c. (A^T * A) is _dense_.
-//
-// This turns out to be the common case for hand model IK, because:
-//   a. The hand has only ~22 DOF,
-//   b. Each constraint touches only a few DOFs (typically the 3-4 on a single finger), but
-//   c. Constraints that touch the global DOFs tend to densify A^T*A.
-// From the perspective of a QR factorization: since the R matrix
-// has the same sparsity pattern as the L matrix in the Cholesky factorization of
-// A^T*A, there is no point trying to exploit sparsity in the computation of R
-// (e.g. by reordering columns).  So instead, we'll accept the O(n^2) cost of
-// having a dense R and try to exploit sparsity in A.
-//
-// It turns out that it is possible to exploit sparsity in A if you do the factorization
-// _row-wise_ instead of column-wise as is generally done.  One paper that uses Givens
-// rotations to zero out one row at a time is this one:
-//   Solution of Sparse Linear Squares Problems using Givens Rotations (1980)
-//   by Alan George and Michael T. Heath
-//
-// However, Givens rotations aren't really ideal for our case because you have
-// to compute a c/s pair for each entry of the matrix, and it involves a square
-// root.  Also, row-wise operations are kind of slow in general due to poor
-// cache locality on Eigen matrices.  What we can do instead is to apply
-// Householder reflections to (k x n) blocks of the matrix; computing a
-// Householder vector for a whole column only requires one square root, and
-// it can be applied as a level-2 BLAS operation.  Moreover, this maps
-// perfectly to our problem; a Jacobian matrix from a single constraint has
-// the sparsity pattern where entire columns are dropped, and these zero
-// columns can just be skipped entirely by the Householder process provided
-// we are careful about the order we process them in.  And by processing the
-// J submatrices one at a time, we need never assemble the full A matrix,
-// eliminating one major disadvantage of QR relative to the normal equations
-// (hence the name "OnlineHouseholderQR").
-//
-// Even better, we can do the whole operation in-place: the caller passes in
-// the J and r matrix, and the columns of the J matrix are rotated out one by
-// one, revealing the R matrix.  At the end, a simple back-substitution using
-// R gives the x vector.  (in fact, the answer for the current submatrix of
-// A,b is always available, as a consequence of doing the factorization sort-of
-// row-wise).
-//
-// Note that because we apply the transforms as we go, this method is not currently
-// suitable for multiple right-hand-sides.
+/// Online (incremental) Householder QR solver for tall, column-sparse least-squares
+/// problems.
+///
+/// Solves
+/// \code
+///   min || A * x - b ||_2
+/// \endcode
+/// where
+///   a. n (the number of unknowns) is small-ish,
+///   b. A is tall and _sparse_ (m >> n), BUT
+///   c. (A^T * A) is _dense_.
+///
+/// This turns out to be the common case for hand-model IK, because:
+///   a. The hand has only ~22 DOF,
+///   b. Each constraint touches only a few DOFs (typically the 3-4 on a single finger), but
+///   c. Constraints that touch the global DOFs tend to densify A^T*A.
+/// From the perspective of a QR factorization: since the R matrix has the same sparsity
+/// pattern as the L matrix in the Cholesky factorization of A^T*A, there is no point
+/// trying to exploit sparsity in the computation of R (e.g. by reordering columns). So
+/// instead, we accept the O(n^2) cost of a dense R and try to exploit sparsity in A.
+///
+/// It is possible to exploit sparsity in A if you do the factorization _row-wise_
+/// instead of column-wise as is generally done. One paper that uses Givens rotations to
+/// zero out one row at a time is:
+///   Solution of Sparse Linear Squares Problems using Givens Rotations (1980)
+///   by Alan George and Michael T. Heath
+///
+/// However, Givens rotations aren't really ideal for our case because you have to
+/// compute a c/s pair for each entry of the matrix, and it involves a square root. Also,
+/// row-wise operations are slow in general due to poor cache locality on Eigen matrices.
+/// What we do instead is apply Householder reflections to (k x n) blocks of the matrix;
+/// computing a Householder vector for a whole column only requires one square root, and
+/// it can be applied as a level-2 BLAS operation. Moreover, this maps perfectly to our
+/// problem; a Jacobian matrix from a single constraint has the sparsity pattern where
+/// entire columns are dropped, and these zero columns can just be skipped entirely by
+/// the Householder process provided we are careful about the order we process them in.
+/// And by processing the J submatrices one at a time, we never assemble the full A
+/// matrix, eliminating one major disadvantage of QR relative to the normal equations
+/// (hence the name "OnlineHouseholderQR").
+///
+/// Even better, we can do the whole operation in-place: the caller passes in the J and r
+/// matrix, and the columns of the J matrix are rotated out one by one, revealing the R
+/// matrix. At the end, a simple back-substitution using R gives the x vector. (In fact,
+/// the answer for the current submatrix of A,b is always available, as a consequence of
+/// doing the factorization sort-of row-wise.)
+///
+/// @note Because the transforms are applied as we go, this method is not currently
+///   suitable for multiple right-hand-sides.
+///
+/// ### Usage contract
+/// 1. Construct with the number of unknowns @c n and (optionally) a Levenberg-Marquardt
+///    damping @c lambda.
+/// 2. Call `add()`/`addMutating()` once per Jacobian/residual block. Internal state
+///    (`R_`, `y_`) is mutated incrementally on each call.
+/// 3. Call `result()` to back-substitute and recover @c x. `R()`, `y()`, and
+///    `At_times_b()` are also valid at any point and reflect the data accumulated so far.
+/// 4. Call `reset()` to discard accumulated state and reuse the solver.
 template <typename T>
 class OnlineHouseholderQR {
  public:
   using MatrixType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
   using VectorType = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
-  // The lambda here lets you pass in a lambda for a Gauss-Newton/Levenberg-Marquardt solver.
-  // Basically this emulates solving the following system, but without needing to append the
-  // extra matrix:
-  //   | [ lambda * I ] [ x ] - [ 0 ] |^2
-  //   | [     A      ]         [ b ] |
+  /// Constructs a solver for problems with @p n unknowns.
+  ///
+  /// The @p lambda parameter implements Gauss-Newton/Levenberg-Marquardt damping,
+  /// emulating the augmented least-squares system
+  /// \code
+  ///   | [ lambda * I ] [ x ] - [ 0 ] |^2
+  ///   | [     A      ]         [ b ] |
+  /// \endcode
+  /// without materializing the extra `lambda * I` rows. R is initialized with
+  /// `lambda` on its diagonal so the first `add()` call sees the regularization.
   explicit OnlineHouseholderQR(Eigen::Index n, T lambda = T(0));
 
+  /// In-place overload: factorizes @p A and @p b directly, mutating both buffers.
+  /// Convenience wrapper that wraps @p A in a `ColumnIndexedMatrix`.
   void addMutating(Eigen::Ref<MatrixType> A, Eigen::Ref<VectorType> b) {
     addMutating(ColumnIndexedMatrix<MatrixType>(A), b);
   }
 
-  // We require passing in both A and rhs so that we can multiply rhs by Q
-  // as R is being constructed.
-  // This is an 'in-place' version which computes the factorization inside the
-  // passed-in matrix; it is here so that use cases that don't need to re-use
-  // the matrix can avoid copying.
+  /// In-place addition of a Jacobian/residual block to the running QR factorization.
+  ///
+  /// Both @p A and @p b are required so we can apply Q to the right-hand side as R is
+  /// being constructed. The factorization is computed inside the passed-in buffers, so
+  /// callers who do not need the original data can avoid a copy.
+  ///
+  /// @pre `A.cols()` equals the @c n passed to the constructor.
+  /// @pre `A.rows()` equals `b.size()`.
+  /// @post Internal `R_` and `y_` are updated to reflect the combined (prior + new) data.
+  ///   The contents of @p A and @p b are arbitrary on return.
   void addMutating(ColumnIndexedMatrix<MatrixType> A, Eigen::Ref<VectorType> b);
 
-  // This version can be made efficient if you std::move() the passed-in matrices.
+  /// Copying overload of `addMutating()`.
+  /// @note Pass the arguments via `std::move` to avoid the internal copy when the caller
+  ///   no longer needs them.
   void add(MatrixType A, VectorType b);
 
+  /// Solves `R * x = y` by back-substitution using the currently accumulated state and
+  /// returns @c x.
+  /// @return Vector of length @c n containing the least-squares solution for the data
+  ///   added so far.
   [[nodiscard]] VectorType result() const;
 
+  /// @return Upper-triangular R factor of the current accumulated factorization.
   [[nodiscard]] const MatrixType& R() const {
     return R_;
   }
+  /// @return The transformed right-hand side `Q * b` (top @c n entries).
   [[nodiscard]] const VectorType& y() const {
     return y_;
   }
+  /// @return `A^T * b` for the data accumulated so far, computed from `R^T * y` without
+  ///   needing the original A.
   [[nodiscard]] VectorType At_times_b() const;
 
+  /// Discards accumulated state, keeping the existing @c n and @c lambda.
   void reset();
+  /// Discards accumulated state and reconfigures the solver with new @p n and @p lambda.
   void reset(Eigen::Index n, T lambda = T(0));
 
  private:
-  // R is defined by
-  //   Q*A = ( R )
-  //         ( 0 )
+  /// Upper-triangular factor defined by `Q*A = (R; 0)`.
   MatrixType R_;
 
-  // We define y as
-  //   Q*b = y
+  /// Transformed right-hand side defined by `Q*b = y` (top @c n entries).
   VectorType y_;
 };
 
-// This class is designed to solve least squares problems of the form:
-//   min || A * x - b ||_2
-// where A has the block structure:
-//   [ A_11                    A_1n ]
-//   [       A_22              A_2n ]
-//   [              A_33       A_3n ]
-//   [                     ... ...  ]
-//
-// Basically, you have these blocks along the diagonal where each set of
-// x parameters is disjoint and then you have a set of x's that are common
-// to all blocks.
-//
-// This is basically the case for calibration problems, where each hand
-// pose is independent but you have a set of common calibration parameters
-// that connect them.
-//
-// Besides the blockwise structure, the behavior of this solver should be
-// identical to the OnlineHouseholderQR solver above, so please see those
-// note for more details.  The key takeaway is that this can be used in an
-// _online_ fashion, so you can pass in the individual poses one at a time
-// and then throw away the Jacobians (in fact, a future version of this class
-// could even consider throwing away the intermediate R matrices if memory
-// becomes an issue).
+/// Online Householder QR solver for least-squares problems with block-arrowhead structure.
+///
+/// Solves
+/// \code
+///   min || A * x - b ||_2
+/// \endcode
+/// where A has the block structure
+/// \code
+///   [ A_11                    A_1n ]
+///   [       A_22              A_2n ]
+///   [              A_33       A_3n ]
+///   [                     ... ...  ]
+/// \endcode
+/// i.e. independent diagonal blocks `A_ii` (one set of disjoint `x_i` per block) plus a
+/// shared set of "common" columns `A_in` that are used by every block.
+///
+/// This is the case for calibration problems, where each hand pose is independent but a
+/// shared set of calibration parameters connects them.
+///
+/// Besides the blockwise structure, the behavior of this solver is identical to
+/// OnlineHouseholderQR — see that class's notes for the algorithmic details. The key
+/// takeaway is that this can be used in an _online_ fashion: poses are passed in one at
+/// a time and the Jacobians can then be thrown away.
+///
+/// @note A future version could also discard the intermediate `R_ii_` and `R_in_`
+///   blocks if memory becomes an issue (only `R_nn_` is required to compute `x_n()`).
+///
+/// ### Usage contract
+/// 1. Construct with the number of common unknowns @c n_common and (optionally)
+///    @c lambda damping. Diagonal block sizes are inferred from each `add()` call.
+/// 2. Call `add()`/`addMutating()` once per block, supplying a unique @c iBlock index.
+///    Internal `R_ii_`, `R_in_`, `R_nn_`, `y_i_`, and `y_n_` are mutated incrementally.
+/// 3. Retrieve results via `x_dense()`, `x_i(iBlock)`, or `x_n()`.
+/// 4. Call `reset()` to discard accumulated state and reuse the solver.
 template <typename T>
 class OnlineBlockHouseholderQR {
  public:
   using MatrixType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
   using VectorType = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
-  // The lambda here lets you pass in a lambda for a Gauss-Newton/Levenberg-Marquardt solver.
-  // Basically this emulates solving the following system, but without needing to append the
-  // extra matrix:
-  //   | [ lambda * I ] [ x ] - [ 0 ] |^2
-  //   | [     A      ]         [ b ] |
+  /// Constructs a solver for problems with @p n_common shared unknowns.
+  ///
+  /// Per-block unknown counts are determined from the first `add()` call for each block.
+  /// @p lambda implements LM-style damping, emulating
+  /// \code
+  ///   | [ lambda * I ] [ x ] - [ 0 ] |^2
+  ///   | [     A      ]         [ b ] |
+  /// \endcode
+  /// without materializing the extra rows.
   explicit OnlineBlockHouseholderQR(Eigen::Index n_common, T lambda = T(0));
 
+  /// Copying overload of `addMutating()`.
   void add(size_t iBlock, MatrixType A_diag, MatrixType A_common, VectorType b) {
     addMutating(iBlock, A_diag, A_common, b);
   }
 
-  // We require passing in both A and rhs so that we can multiply rhs by Q
-  // as R is being constructed.
-  // This is an 'in-place' version which computes the factorization inside the
-  // passed-in matrix; it is here so that use cases that don't need to re-use
-  // the matrix can avoid copying.
+  /// In-place addition; convenience wrapper that wraps the matrices in
+  /// `ColumnIndexedMatrix` views without remapping.
   void addMutating(
       size_t iBlock,
       Eigen::Ref<MatrixType> A_diag,
@@ -234,8 +295,19 @@ class OnlineBlockHouseholderQR {
         b);
   }
 
-  // Mutating addition operator that also remaps the columns, allowing passing in arbitrary subsets
-  // of the columns in A_diag and A_common.
+  /// In-place addition that also accepts column-remapped views, so callers can pass
+  /// arbitrary subsets of the columns in @p A_diag and @p A_common.
+  ///
+  /// @param iBlock Index identifying the diagonal block this contribution belongs to.
+  ///   The first call with a given @p iBlock fixes the size of `R_ii_[iBlock]`; later
+  ///   calls must provide a matching `A_diag.cols()`.
+  /// @param A_diag Block-local Jacobian columns for this @c iBlock. `A_diag.cols()`
+  ///   defines the per-block unknown count.
+  /// @param A_common Jacobian columns for the shared unknowns. Must have
+  ///   `n_common` columns.
+  /// @param b Residual vector with `A_diag.rows()` entries.
+  /// @post `R_ii_[iBlock]`, `R_in_[iBlock]`, `R_nn_`, `y_i_[iBlock]`, and `y_n_` are
+  ///   updated. The contents of @p A_diag, @p A_common, and @p b are arbitrary on return.
   void addMutating(
       size_t iBlock,
       ColumnIndexedMatrix<MatrixType> A_diag,
@@ -249,13 +321,15 @@ class OnlineBlockHouseholderQR {
   // for the final rows every time, but for the common case where the last set
   // of variables is very small this should not be an issue.
 
-  // Retrieve the full dense result:
+  /// Retrieves the full dense result `[x_0; x_1; ...; x_{B-1}; x_n]`.
   [[nodiscard]] VectorType x_dense() const;
 
-  // Retrieve the answer for a single block:
+  /// Retrieves the answer for a single diagonal block @p iBlock.
+  /// @note Re-runs the back-substitution for the final ("common") rows on each call;
+  ///   batch-retrieve via `x_dense()` if calling for many blocks.
   [[nodiscard]] VectorType x_i(size_t iBlock) const;
 
-  // Retrieve the answer for just the final "common" rows.
+  /// Retrieves the answer for just the final "common" rows.
   [[nodiscard]] VectorType x_n() const;
 
   [[nodiscard]] const MatrixType& R_ii(size_t iBlock) const {
@@ -279,83 +353,88 @@ class OnlineBlockHouseholderQR {
  private:
   const double lambda_;
 
-  // R is defined by
-  //   Q*A = ( R )
-  //         ( 0 )
-  // R looks like:
-  //   [ R_ii[0]                          R_in[0] ]
-  //   [            R_ii[1]               R_in[1] ]
-  //   [                         R_ii[2]  R_in[2] ]
-  //   [                                  R_nn    ]
+  /// Components of R defined by `Q*A = (R; 0)` with the block-arrowhead layout
+  /// \code
+  ///   [ R_ii[0]                          R_in[0] ]
+  ///   [            R_ii[1]               R_in[1] ]
+  ///   [                         R_ii[2]  R_in[2] ]
+  ///   [                                  R_nn    ]
+  /// \endcode
   std::deque<MatrixType> R_ii_;
   std::deque<MatrixType> R_in_;
   MatrixType R_nn_;
 
-  // We define y as
-  //   Q*b = y
-  // y looks like:
-  //   [ y_i ]
-  //   [ ... ]
-  //   [ y_n ]
+  /// Transformed right-hand side defined by `Q*b = y`, laid out as
+  /// `[ y_i_[0]; y_i_[1]; ...; y_n_ ]`.
   std::deque<VectorType> y_i_;
   VectorType y_n_;
 };
 
-// Another online QR solver, but for matrices that have a particular
-// type of band structure.  The left-hand part of the matrix is
-// required to have a limited bandwidth, and we permit a "common"
-// section at the right-hand side of the matrix, like this:
-//      ...b a n d e d...     common
-//   [ a_11                   a_15 ]
-//   [ a_21  a_22             a_25 ]
-//   [ a_31  a_32             a_35 ]
-//   [       a_42  a_43       a_45 ]
-//   [             a_53  a_54 a_55 ]
-//   [                   a_64 a_65 ]
-// Here, the "bandwidth" is in _columns_; that is, the above matrix
-// has a bandwidth of 2 because no row spans more than two columns (excepting
-// the "common" section).
-// We also allow a "common" section at the right-hand side of the matrix
-// which contains parameters that are allowed to be shared between all rows.
-// This might seem very specialized, but it maps to an extremely common
-// set of problems, where the band structure maps to the time dimension
-// (where smoothness constraints tend to connect adjacent timepoints) while
-// common parameters map to a set of common optimized parameters.  For example:
-//   body tracking: band structure maps to smoothness constraints between adjacent frames,
-//     while common parameters control body scale
-//   camera calibration: band structure maps to smoothness constraints between
-//     adjacent frames of the extrinsics, while common parameters refer to
-//     intrinsics.
+/// Online Householder QR solver for band-plus-arrowhead matrices.
+///
+/// The left-hand part of the matrix is required to have a limited column-bandwidth, and
+/// a "common" section is permitted on the right, like this:
+/// \code
+///        ...b a n d e d...     common
+///     [ a_11                   a_15 ]
+///     [ a_21  a_22             a_25 ]
+///     [ a_31  a_32             a_35 ]
+///     [       a_42  a_43       a_45 ]
+///     [             a_53  a_54 a_55 ]
+///     [                   a_64 a_65 ]
+/// \endcode
+/// Here "bandwidth" is in _columns_; the matrix above has a bandwidth of 2 because no
+/// row spans more than two columns (excluding the common section). The common section
+/// holds parameters shared by every row.
+///
+/// While this seems specialized, it maps to a very common class of problems where the
+/// band structure represents a time dimension (smoothness constraints tend to connect
+/// adjacent timepoints) and the common parameters are shared across time. For example:
+///   - body tracking: band structure maps to smoothness constraints between adjacent
+///     frames, while common parameters control body scale.
+///   - camera calibration: band structure maps to smoothness constraints between
+///     adjacent frames of the extrinsics, while common parameters refer to intrinsics.
+///
+/// ### Usage contract
+/// 1. Construct with `n_band` (number of banded unknowns), `n_common` (shared unknowns),
+///    `bandwidth`, and optional `lambda` damping.
+/// 2. Add contributions via `add()`/`addMutating()`. Pass an `iCol_offset` indicating
+///    where the contribution's left-most banded column lives in the global numbering.
+///    Contributions touching only the common columns use the no-offset overload.
+/// 3. Optionally use `zeroBandedPart()` to parallelize the banded sweep over disjoint
+///    column ranges; the matching `addMutating(A_common, b)` call must be serialized.
+/// 4. Retrieve results via `x_dense()` (and inspect via `R_dense()`/`y_dense()`).
+/// 5. Call `reset()` to discard accumulated state and reuse the solver.
 template <typename T>
 class OnlineBandedHouseholderQR {
  public:
   using MatrixType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
   using VectorType = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
-  // The lambda here lets you pass in a lambda for a Gauss-Newton/Levenberg-Marquardt solver.
-  // Basically this emulates solving the following system, but without needing to append the
-  // extra matrix:
-  //   | [ lambda * I ] [ x ] - [ 0 ] |^2
-  //   | [     A      ]         [ b ] |
+  /// Constructs a banded solver.
+  /// @param n_band Number of banded (per-time) unknowns.
+  /// @param n_common Number of common unknowns (the right-hand "arrowhead").
+  /// @param bandwidth Maximum number of banded columns any single row may touch.
+  /// @param lambda LM-style damping; emulates the augmented system
+  ///   `| [lambda*I; A] [x] - [0; b] |^2` without materializing the extra rows.
   explicit OnlineBandedHouseholderQR(
       Eigen::Index n_band,
       Eigen::Index n_common,
       Eigen::Index bandwidth,
       T lambda = T(0));
 
+  /// Copying overload of `addMutating()` that takes both banded and common contributions.
   void add(size_t iCol_offset, MatrixType A_band, MatrixType A_common, VectorType b) {
     addMutating(iCol_offset, A_band, A_common, b);
   }
 
+  /// Copying overload for contributions that only touch the common columns.
   void add(MatrixType A_common, VectorType b) {
     addMutating(A_common, b);
   }
 
-  // We require passing in both A and rhs so that we can multiply rhs by Q
-  // as R is being constructed.
-  // This is an 'in-place' version which computes the factorization inside the
-  // passed-in matrix; it is here so that use cases that don't need to re-use
-  // the matrix can avoid copying.
+  /// In-place addition; convenience wrapper that wraps the matrices in
+  /// `ColumnIndexedMatrix` views without remapping.
   void addMutating(
       const Eigen::Index iCol_offset,
       Eigen::Ref<MatrixType> A_band,
@@ -368,30 +447,47 @@ class OnlineBandedHouseholderQR {
         b);
   }
 
+  /// In-place addition for contributions that only touch the common columns.
   void addMutating(Eigen::Ref<MatrixType> A_common, Eigen::Ref<VectorType> b) {
     addMutating(ColumnIndexedMatrix<MatrixType>(A_common), b);
   }
 
-  // Mutating addition operator that also remaps the columns, allowing passing in arbitrary subsets
-  // of the columns in A_diag and A_common.
+  /// In-place addition that accepts column-remapped views, so callers can pass arbitrary
+  /// subsets of the columns in @p A_band and @p A_common.
+  ///
+  /// @param iCol_offset Global column index of `A_band`'s left-most column. Must satisfy
+  ///   `iCol_offset + A_band.cols() <= n_band()`.
+  /// @param A_band Banded contribution. `A_band.cols()` must be at most `bandwidth()`.
+  /// @param A_common Common contribution. `A_common.cols()` must equal `n_common()`.
+  /// @param b Residual vector with `A_band.rows()` entries.
+  /// @post Internal `R_band_`, `R_common_`, and `y_` are updated. The contents of
+  ///   @p A_band, @p A_common, and @p b are arbitrary on return.
   void addMutating(
       Eigen::Index iCol_offset,
       ColumnIndexedMatrix<MatrixType> A_band,
       ColumnIndexedMatrix<MatrixType> A_common,
       Eigen::Ref<VectorType> b);
 
+  /// Common-only addition overload. Use when a contribution touches no banded columns.
   void addMutating(ColumnIndexedMatrix<MatrixType> A_common, Eigen::Ref<VectorType> b);
 
-  // Zeroes out just the banded part of the matrix; applies Householder rotations that
-  // zero out everything in A_band.  The A_common will still have nonzero entries so
-  // after calling this you should call addMutating(A_common, b) to complete adding the
-  // columns to the matrix.
-  //
-  // Why is this useful?  If you are careful about it, you can call zeroBandedPart on
-  // multiple non-overlapping segments of the banded matrix at a time, but processing
-  // A_common must be serialized.  Since in many problems the number of common variables
-  // is much smaller than the number of banded variables this can provide a substantial
-  // speedup in practice.
+  /// Zeros out just the banded part of @p A_band by applying Householder rotations.
+  /// @p A_common is updated in place but will still have nonzero entries on return, so
+  /// after calling this you should follow up with `addMutating(A_common, b)` to fold the
+  /// remaining common contribution into the factorization.
+  ///
+  /// Why is this useful? If you are careful, you can call `zeroBandedPart` on multiple
+  /// non-overlapping segments of the banded matrix in parallel; only the `A_common`
+  /// processing must be serialized. Because the number of common variables is usually
+  /// much smaller than the number of banded variables, this can provide a substantial
+  /// speedup in practice.
+  ///
+  /// @pre @p iCol_offset, @p A_band, @p A_common, @p b satisfy the same shape rules as
+  ///   `addMutating()`.
+  /// @pre The column range `[iCol_offset, iCol_offset + A_band.cols())` does not overlap
+  ///   any concurrently in-flight `zeroBandedPart` call on the same solver.
+  /// @post `R_band_` is updated; @p A_band is zeroed; @p A_common and @p b are mutated
+  ///   and must be passed to the common-only `addMutating()` to finish the contribution.
   void zeroBandedPart(
       Eigen::Index iCol_offset,
       ColumnIndexedMatrix<MatrixType> A_band,
@@ -405,15 +501,20 @@ class OnlineBandedHouseholderQR {
   // for the final rows every time, but for the common case where the last set
   // of variables is very small this should not be an issue.
 
-  // Retrieve the full dense result:
+  /// Retrieves the full dense result vector of length `n_band() + n_common()`.
   [[nodiscard]] VectorType x_dense() const;
+  /// @return R as a dense matrix of size `(n_band+n_common) x (n_band+n_common)`,
+  ///   reconstructed from the banded and common storage.
   [[nodiscard]] MatrixType R_dense() const;
+  /// @return The transformed right-hand side `Q * b`.
   [[nodiscard]] MatrixType y_dense() const {
     return y_;
   }
 
+  /// @return `A^T * b` for the data accumulated so far.
   [[nodiscard]] VectorType At_times_b() const;
 
+  /// Discards accumulated state, keeping the existing dimensions and damping.
   void reset();
 
   [[nodiscard]] Eigen::Index bandwidth() const {
@@ -429,7 +530,8 @@ class OnlineBandedHouseholderQR {
   }
 
  private:
-  // Sets the diagonal of the R matrix to lambda.
+  /// Initializes the diagonal of R with @c lambda_ to bake LM damping into the
+  /// factorization without materializing the `lambda*I` augmentation.
   void initializeDiagonal();
 
   [[nodiscard]] T R_band_entry(Eigen::Index iRow, Eigen::Index jCol) const {
@@ -448,27 +550,31 @@ class OnlineBandedHouseholderQR {
 
   const double lambda_;
 
-  // R is defined by
-  //   Q*A = ( R )
-  //         ( 0 )
-  // R looks like:
-  //   [ *  *  *        *  * ]
-  //   [    *  *  *     *  * ]
-  //   [       *  *  *  *  * ]
-  //   [          *  *  *  * ]
-  //   [             *  *  * ]
-  //   [                *  * ]
-  //   [                   * ]
-  //     ^^^^^^^^^      ^^^^
-  //     R_band_      R_common_
+  /// R defined by `Q*A = (R; 0)`, split between the banded and common columns:
+  /// \code
+  ///   [ *  *  *        *  * ]
+  ///   [    *  *  *     *  * ]
+  ///   [       *  *  *  *  * ]
+  ///   [          *  *  *  * ]
+  ///   [             *  *  * ]
+  ///   [                *  * ]
+  ///   [                   * ]
+  ///     ^^^^^^^^^      ^^^^
+  ///     R_band_      R_common_
+  /// \endcode
   MatrixType R_common_;
 
-  // Uses "banded" storage, which looks like this:
-  //  [ r_11 r_12           ]
-  //  [      r_22 r_23      ]
-  //  [           r_33 r_34 ]
+  /// Banded part of R using compact diagonal storage of shape `(bandwidth, n_band)`,
+  /// representing the upper-triangular band:
+  /// \code
+  ///   [ r_11 r_12           ]
+  ///   [      r_22 r_23      ]
+  ///   [           r_33 r_34 ]
+  /// \endcode
+  /// See `R_band_entry()` for the row/col -> storage index mapping.
   MatrixType R_band_;
 
+  /// Transformed right-hand side `Q * b`.
   VectorType y_;
 };
 

--- a/momentum/math/random-inl.h
+++ b/momentum/math/random-inl.h
@@ -23,9 +23,10 @@ using UniformIntDist = std::uniform_int_distribution<IntType>;
 template <typename RealType>
 using NormalRealDist = std::normal_distribution<RealType>;
 
-/// Check whether \c T can be used for std::uniform_int_distribution<T>
-/// Reference:
-/// https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
+// Whitelists the integer types that std::uniform_int_distribution<T> permits.
+// The standard restricts the IntType template parameter to (un)signed
+// short/int/long/long long; using e.g. char or int8_t is undefined behavior.
+// Ref: https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
 template <typename T>
 struct is_compatible_to_uniform_int_distribution
     : std::disjunction<
@@ -57,49 +58,49 @@ using is_base_of_matrix = is_base_of_template<Eigen::MatrixBase, T>;
 template <typename T>
 inline constexpr bool is_base_of_matrix_v = is_base_of_matrix<T>::value;
 
+// Note: when T is neither floating-point nor a whitelisted integer type
+// (e.g. bool, char, int8_t, uint8_t), no branch is taken and the function
+// returns a value-initialized T. TODO: consider a static_assert to fail at
+// compile time instead of silently returning T{}.
 template <typename T, typename Generator>
 [[nodiscard]] T generateScalarUniform(const T& min, const T& max, Generator& generator) {
-  // Real types
   if constexpr (std::is_floating_point_v<T>) {
+    // std::uniform_real_distribution generates on the half-open interval
+    // [min, max); some implementations may return max due to rounding.
     UniformRealDist<T> dist(min, max);
     return dist(generator);
-  }
-  // Integer types
-  else if constexpr (is_compatible_to_uniform_int_distribution_v<T>) {
+  } else if constexpr (is_compatible_to_uniform_int_distribution_v<T>) {
+    // Closed interval [min, max] for integer distribution.
     UniformIntDist<T> dist(min, max);
     return dist(generator);
   }
 }
 
-// Generates a random vector/matrix element-wisely
+// Generates a random vector/matrix element-wise. The four `if constexpr`
+// branches dispatch to the matching Eigen NullaryExpr overload (matrix vs
+// vector, dynamic vs fixed) since each takes a different signature for the
+// size arguments and the generator lambda.
 template <typename Derived, typename Generator>
 [[nodiscard]] typename Derived::PlainObject generateMatrixUniform(
     const Eigen::MatrixBase<Derived>& min,
     const Eigen::MatrixBase<Derived>& max,
     Generator& generator) {
-  // Dynamic matrix
   if constexpr (!Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime == Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr(
         min.rows(), min.cols(), [&](const Eigen::Index i, const Eigen::Index j) {
           return generateScalarUniform<typename Derived::Scalar>(min(i, j), max(i, j), generator);
         });
-  }
-  // Fixed matrix
-  else if constexpr (
+  } else if constexpr (
       !Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime != Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr([&](const Eigen::Index i, const Eigen::Index j) {
       return generateScalarUniform<typename Derived::Scalar>(min(i, j), max(i, j), generator);
     });
-  }
-  // Dynamic vector
-  else if constexpr (
+  } else if constexpr (
       Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime == Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr(min.size(), [&](const Eigen::Index i) {
       return generateScalarUniform<typename Derived::Scalar>(min[i], max[i], generator);
     });
-  }
-  // Fixed vector
-  else if constexpr (
+  } else if constexpr (
       Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime != Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr([&](const Eigen::Index i) {
       return generateScalarUniform<typename Derived::Scalar>(min[i], max[i], generator);
@@ -109,59 +110,53 @@ template <typename Derived, typename Generator>
 
 template <typename T, typename Generator>
 [[nodiscard]] T generateUniform(const T& min, const T& max, Generator& generator) {
-  // Scalar types
   if constexpr (std::is_arithmetic_v<T>) {
     return generateScalarUniform(min, max, generator);
-  }
-  // Matrix types
-  else if constexpr (is_base_of_matrix_v<T>) {
+  } else if constexpr (is_base_of_matrix_v<T>) {
     return generateMatrixUniform(min, max, generator);
   }
 }
 
 template <typename T, typename Generator>
 [[nodiscard]] T generateScalarNormal(const T& mean, const T& sigma, Generator& generator) {
-  // Real types
   if constexpr (std::is_floating_point_v<T>) {
     NormalRealDist<T> dist(mean, sigma);
     return dist(generator);
-  }
-  // Integer types
-  else if constexpr (is_compatible_to_uniform_int_distribution_v<T>) {
+  } else if constexpr (is_compatible_to_uniform_int_distribution_v<T>) {
+    // No discrete normal distribution exists in <random>; sample from a float
+    // normal then round to the nearest integer. TODO: this can overflow T for
+    // tail samples — `std::round` returns a float that is then implicitly
+    // narrowed without bounds checking. Also, using float (not double) limits
+    // precision for 64-bit integer T.
     const float realNumber = NormalRealDist<float>(mean, sigma)(generator);
     return std::round(realNumber);
   }
 }
 
-// Generates a random vector/matrix element-wisely
+// Generates a random vector/matrix element-wise. Each element is drawn
+// independently — this is NOT a multivariate normal (no covariance structure);
+// `sigma` supplies a per-element standard deviation.
 template <typename Derived, typename Generator>
 [[nodiscard]] typename Derived::PlainObject generateMatrixNormal(
     const Eigen::MatrixBase<Derived>& mean,
     const Eigen::MatrixBase<Derived>& sigma,
     Generator& generator) {
-  // Dynamic matrix
   if constexpr (!Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime == Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr(
         mean.rows(), mean.cols(), [&](const Eigen::Index i, const Eigen::Index j) {
           return generateScalarNormal<typename Derived::Scalar>(mean(i, j), sigma(i, j), generator);
         });
-  }
-  // Fixed matrix
-  else if constexpr (
+  } else if constexpr (
       !Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime != Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr([&](const Eigen::Index i, const Eigen::Index j) {
       return generateScalarNormal<typename Derived::Scalar>(mean(i, j), sigma(i, j), generator);
     });
-  }
-  // Dynamic vector
-  else if constexpr (
+  } else if constexpr (
       Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime == Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr(mean.size(), [&](const Eigen::Index i) {
       return generateScalarNormal<typename Derived::Scalar>(mean[i], sigma[i], generator);
     });
-  }
-  // Fixed vector
-  else if constexpr (
+  } else if constexpr (
       Derived::IsVectorAtCompileTime && Derived::SizeAtCompileTime != Eigen::Dynamic) {
     return Derived::PlainObject::NullaryExpr([&](const Eigen::Index i) {
       return generateScalarNormal<typename Derived::Scalar>(mean[i], sigma[i], generator);
@@ -171,12 +166,9 @@ template <typename Derived, typename Generator>
 
 template <typename T, typename Generator>
 [[nodiscard]] T generateNormal(const T& mean, const T& sigma, Generator& generator) {
-  // Scalar types
   if constexpr (std::is_arithmetic_v<T>) {
     return generateScalarNormal(mean, sigma, generator);
-  }
-  // Matrix types
-  else if constexpr (is_base_of_matrix_v<T>) {
+  } else if constexpr (is_base_of_matrix_v<T>) {
     return generateMatrixNormal(mean, sigma, generator);
   }
 }
@@ -190,9 +182,7 @@ Random<Generator>& Random<Generator>::GetSingleton() {
 }
 
 template <typename Generator>
-Random<Generator>::Random(uint32_t seed) : seed_(seed), generator_(seed_) {
-  // Do nothing
-}
+Random<Generator>::Random(uint32_t seed) : seed_(seed), generator_(seed_) {}
 
 template <typename Generator>
 template <typename T>
@@ -261,6 +251,11 @@ Affine3<T> Random<Generator>::uniformAffine3(
     const Vector3<T>& min,
     const Vector3<T>& max) {
   Affine3<T> out = Affine3<T>::Identity();
+  // Linear part is rotation * isotropic_scale; this samples a single scale
+  // factor applied to all three axes, not a full anisotropic affine.
+  // TODO: the public name `uniformAffine3` is misleading — it does not
+  // sample uniformly over the space of affine transforms (which would need
+  // anisotropic scale and shear); consider renaming or extending.
   out.linear() = uniformRotationMatrix<T>() * uniform<T>(scaleMin, scaleMax);
   out.translation().noalias() = uniform<Vector3<T>>(min, max);
   return out;

--- a/momentum/math/random.h
+++ b/momentum/math/random.h
@@ -13,44 +13,64 @@
 
 namespace momentum {
 
-/// A consolidated random number generator to provide convenient APIs wrapping around the random
-/// library of C++ standard library <random>.
+/// A consolidated random number generator providing convenient APIs wrapping the C++ standard
+/// library `<random>`.
 ///
-/// The default engine used in this class is std::mt19937, but it can be replaced, by specifying the
-/// template argument, with any preferable engines (see:
+/// The default engine is `std::mt19937`; any engine satisfying the C++ UniformRandomBitGenerator
+/// requirements can be substituted via the template parameter (see:
 /// https://en.cppreference.com/w/cpp/numeric/random).
+///
+/// @note Reproducibility: given the same seed and the same Generator type, the sequence of
+/// engine outputs is deterministic. However, the values produced by `uniform()` / `normal()` are
+/// **not** guaranteed to be portable across platforms or standard library implementations because
+/// `std::uniform_int_distribution`, `std::uniform_real_distribution`, and
+/// `std::normal_distribution` are implementation-defined.
+///
+/// @warning Thread safety: instances are **not** thread-safe. The internal generator holds mutable
+/// state that is mutated on every call. Concurrent use of the same instance (including the
+/// singleton returned by GetSingleton()) requires external synchronization.
 template <typename Generator_ = std::mt19937>
 class Random final {
  public:
   using Generator = Generator_;
 
-  /// Returns the singleton instance
+  /// Returns the process-wide singleton instance.
+  ///
+  /// @warning The returned instance is shared across all callers and is **not** thread-safe.
+  /// See class-level thread-safety note.
+  // TODO: Document or enforce the seeding policy of the singleton (currently seeded once via
+  // std::random_device on first call, which makes test reproducibility difficult without an
+  // explicit setSeed()).
   [[nodiscard]] static Random& GetSingleton();
 
-  /// Constructor
+  /// Constructs a generator seeded with the given value.
+  ///
+  /// @param seed Seed for the underlying engine. Defaults to a non-deterministic value drawn from
+  /// `std::random_device`, which makes default-constructed instances non-reproducible.
   explicit Random(uint32_t seed = std::random_device{}());
 
-  /// Generates a random scalar/vector/matrix from the uniform distribution
+  /// Generates a random scalar/vector/matrix from the uniform distribution.
   ///
-  /// The supported types are scalar, vector, or matrix where the elements can be either integer or
-  /// real. The supported integer types are whichever supported by std::uniform_int_distribution<T>
-  /// (see: https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution), and the
-  /// supported real types are whichever std::is_floating_point<T>::value is true (see:
-  /// https://en.cppreference.com/w/cpp/types/is_floating_point).
+  /// Supported element types are integer types accepted by `std::uniform_int_distribution<T>`
+  /// (see: https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution) and any type
+  /// for which `std::is_floating_point<T>::value` is true (see:
+  /// https://en.cppreference.com/w/cpp/types/is_floating_point). T may be a scalar, a fixed-size
+  /// Eigen vector/matrix, or a dynamic-size Eigen vector/matrix (in which case the result has the
+  /// same dimensions as `min`).
   ///
-  /// The generated random number is in the range of [min, max] for integer types or [min, max) for
-  /// real types. However, when built with the -ffast-math flag, the range for real types could be
-  /// [min, max] instead.
+  /// @pre `min <= max` element-wise.
+  /// @pre For dynamic-size types, `min` and `max` must have matching dimensions.
   ///
-  /// @warning While the upper bound is typically exclusive for real types according to
-  /// std::uniform_real_distribution, there may be instances where the sampled value equals the
-  /// upper bound, depending on the platform and compiler specifics.
+  /// The result lies in `[min, max]` for integer types and `[min, max)` for real types.
   ///
-  /// For vector/matrix types, the bounds can be specified in either scalar or (the same dimension
-  /// of) vector/matrix. Use this function to specify the bounds in vector/matrix to apply different
-  /// bounds for each element in the generated vector/matrix. Use other versions of uniform() that
-  /// specify the bounds in scalar to apply the same bounds to all the elements of the generated
-  /// vector/matrix.
+  /// @warning While the upper bound is mathematically exclusive for real types according to
+  /// `std::uniform_real_distribution`, there are instances where the sampled value can equal the
+  /// upper bound:
+  ///   - When built with `-ffast-math`, rounding can yield exactly `max`.
+  ///   - Some standard library implementations have known edge cases producing the upper bound.
+  ///
+  /// For vector/matrix types, supplying vector/matrix bounds applies a per-element range; use the
+  /// scalar-bounds overload to apply the same range to every element.
   ///
   /// @code
   /// Random rand;
@@ -60,34 +80,37 @@ class Random final {
   /// auto r4 = rand.uniform(Vector2f(0, 1), Vector2f(2, 3)); // random Vector2f in ([0, 2], [1, 3))
   /// @endcode
   ///
-  /// @tparam T The random number type to be generated
-  /// @param[in] min The lower bound of the random number
-  /// @param[in] max The upper bound of the random number
+  /// @tparam T Scalar, fixed-size, or dynamic-size Eigen type.
+  /// @param[in] min Inclusive lower bound (element-wise).
+  /// @param[in] max Upper bound (inclusive for integer types, exclusive for real types).
   template <typename T>
   [[nodiscard]] T uniform(const T& min, const T& max);
 
-  /// Generates a random vector/matrix from the uniform distribution, where the size is fixed
+  /// Generates a fixed-size vector/matrix from the uniform distribution with a single scalar
+  /// range applied to every element.
   ///
-  /// This is a special case of T uniform(const T&, const T&) where the random number type is fixed
-  /// size of vector/matrix and the bounds are specified by the scalar type.
+  /// Same range semantics as `uniform(const T&, const T&)`.
   ///
   /// @code
   /// Random rand;
-  /// auto r0 = rand.uniform<Vector2f>(0, 1); // random Vector2f in ([0, 1], [0, 1))
+  /// auto r0 = rand.uniform<Vector2f>(0, 1); // random Vector2f in ([0, 1), [0, 1))
   /// @endcode
   ///
-  /// @tparam FixedSizeT The random vector/matrix type to be generated
-  /// @param[in] min The lower bound in scalar.
-  /// @param[in] max The upper bound in scalar.
+  /// @tparam FixedSizeT Fixed-size Eigen vector/matrix type.
+  /// @param[in] min Inclusive lower bound applied to every element.
+  /// @param[in] max Upper bound applied to every element (inclusive for integer scalars,
+  /// exclusive for real scalars).
+  // TODO: The original example claimed `([0, 1], [0, 1))` which is inconsistent — both elements
+  // share the same distribution and same bounds.
   template <typename FixedSizeT>
   [[nodiscard]] FixedSizeT uniform(
       typename FixedSizeT::Scalar min,
       typename FixedSizeT::Scalar max);
 
-  /// Generates a random vector from the uniform distribution, where the size is dynamic
+  /// Generates a dynamic-size vector from the uniform distribution with a single scalar range
+  /// applied to every element.
   ///
-  /// This is a special case of T uniform(const T&, const T&) where the random number type is
-  /// dynamic size of vector and the bounds are specified by the scalar type.
+  /// Same range semantics as `uniform(const T&, const T&)`.
   ///
   /// @code
   /// Random rand;
@@ -95,20 +118,22 @@ class Random final {
   /// element is in [0, 1)
   /// @endcode
   ///
-  /// @tparam DynamicVector The random vector type to be generated
-  /// @param[in] size The size of the vector.
-  /// @param[in] min The lower bound in scalar.
-  /// @param[in] max The upper bound in scalar.
+  /// @tparam DynamicVector Dynamic-size Eigen vector type.
+  /// @param[in] size Number of elements in the result.
+  /// @param[in] min Inclusive lower bound applied to every element.
+  /// @param[in] max Upper bound applied to every element (inclusive for integer scalars,
+  /// exclusive for real scalars).
+  /// @pre `size >= 0`.
   template <typename DynamicVector>
   [[nodiscard]] DynamicVector uniform(
       Eigen::Index size,
       typename DynamicVector::Scalar min,
       typename DynamicVector::Scalar max);
 
-  /// Generates a random matrix from the uniform distribution, where the size is dynamic
+  /// Generates a dynamic-size matrix from the uniform distribution with a single scalar range
+  /// applied to every element.
   ///
-  /// This is a special case of T uniform(const T&, const T&) where the random number type is
-  /// dynamic size of matrix and the bounds are specified by the scalar type.
+  /// Same range semantics as `uniform(const T&, const T&)`.
   ///
   /// @code
   /// Random rand;
@@ -116,11 +141,13 @@ class Random final {
   /// element is in [0, 1)
   /// @endcode
   ///
-  /// @tparam DynamicMatrix The random matrix type to be generated
-  /// @param[in] rows The row size of the matrix.
-  /// @param[in] cols The column size of the matrix.
-  /// @param[in] min The lower bound in scalar.
-  /// @param[in] max The upper bound in scalar.
+  /// @tparam DynamicMatrix Dynamic-size Eigen matrix type.
+  /// @param[in] rows Number of rows in the result.
+  /// @param[in] cols Number of columns in the result.
+  /// @param[in] min Inclusive lower bound applied to every element.
+  /// @param[in] max Upper bound applied to every element (inclusive for integer scalars,
+  /// exclusive for real scalars).
+  /// @pre `rows >= 0` and `cols >= 0`.
   template <typename DynamicMatrix>
   [[nodiscard]] DynamicMatrix uniform(
       Eigen::Index rows,
@@ -128,40 +155,38 @@ class Random final {
       typename DynamicMatrix::Scalar min,
       typename DynamicMatrix::Scalar max);
 
-  /// Generates a random quaternion from a uniform distribution on SO(3)
+  /// Generates a random unit quaternion uniformly distributed on SO(3) (Haar measure).
   template <typename T>
   [[nodiscard]] Quaternion<T> uniformQuaternion();
 
-  /// Generates a random rotation matrix from a uniform distribution on SO(3)
+  /// Generates a random rotation matrix uniformly distributed on SO(3) (Haar measure).
   template <typename T>
   [[nodiscard]] Matrix3<T> uniformRotationMatrix();
 
-  /// Generates a random isometry (rigid transformation) from a uniform distribution on SE(3)
-  /// based on input minimum and maximum 3D vectors for the translation part.
+  /// Generates a random isometry (rigid transformation) on SE(3) with rotation drawn uniformly
+  /// from SO(3) and translation drawn uniformly from the box `[min, max]`.
   ///
-  /// @tparam Generator The type of random number generator.
-  /// @tparam T The type of isometry component, typically a float or double.
-  /// @param min The minimum 3D vector for the translation part.
-  /// @param max The maximum 3D vector for the translation part.
-  /// @return A random Isometry3 of type T.
+  /// @tparam T Scalar type of the isometry components, typically `float` or `double`.
+  /// @param min Inclusive lower bound on the translation component (per axis).
+  /// @param max Inclusive upper bound on the translation component (per axis).
+  /// @return A random Isometry3<T>.
   template <typename T>
   [[nodiscard]] Isometry3<T> uniformIsometry3(
       const Vector3<T>& min = Vector3<T>::Zero(),
       const Vector3<T>& max = Vector3<T>::Ones());
 
-  /// Generates a random affine transformation from a uniform distribution on the space of all
-  /// affine transformations.
+  /// Generates a random affine transformation with rotation drawn uniformly from SO(3), uniform
+  /// scale drawn from `[scaleMin, scaleMax]`, and translation drawn uniformly from the box
+  /// `[min, max]`.
   ///
-  /// The transformation is created based on input minimum and maximum 3D vectors for the
-  /// translation part, and minimum and maximum scale factors for the linear part.
-  ///
-  /// @tparam Generator The type of random number generator.
-  /// @tparam T The type of affine transformation component, typically a float or double.
-  /// @param scaleMin The minimum scale factor for the linear part.
-  /// @param scaleMax The maximum scale factor for the linear part.
-  /// @param min The minimum 3D vector for the translation part.
-  /// @param max The maximum 3D vector for the translation part.
-  /// @return A random Affine3 of type T.
+  /// @tparam T Scalar type of the affine components, typically `float` or `double`.
+  /// @param scaleMin Inclusive lower bound on the uniform scale factor.
+  /// @param scaleMax Inclusive upper bound on the uniform scale factor.
+  /// @param min Inclusive lower bound on the translation component (per axis).
+  /// @param max Inclusive upper bound on the translation component (per axis).
+  /// @return A random Affine3<T>.
+  // TODO: The default `scaleMin = 0.1` / `scaleMax = 10.0` only makes sense when T is a floating
+  // type; instantiation with an integer T would silently truncate the defaults.
   template <typename T>
   [[nodiscard]] Affine3<T> uniformAffine3(
       T scaleMin = 0.1,
@@ -169,43 +194,55 @@ class Random final {
       const Vector3<T>& min = Vector3<T>::Zero(),
       const Vector3<T>& max = Vector3<T>::Ones());
 
-  /// Generates a random value from the Gaussian distribution
+  /// Generates a value from a normal (Gaussian) distribution N(mean, sigma^2). Each element of a
+  /// vector/matrix result is drawn independently.
   ///
-  /// @tparam T The random number type to be generated
-  /// @param[in] mean The mean of the Gaussian distribution
-  /// @param[in] sigma The standard deviation of the Gaussian distribution
+  /// Backed by `std::normal_distribution`, which requires a real (floating-point) scalar type.
+  ///
+  /// @pre `sigma >= 0`.
+  ///
+  /// @tparam T Scalar, fixed-size, or dynamic-size Eigen type with floating-point scalar.
+  /// @param[in] mean Distribution mean (mu).
+  /// @param[in] sigma Distribution standard deviation (sigma).
   template <typename T>
   [[nodiscard]] T normal(const T& mean, const T& sigma);
 
-  /// Generates a random value from the Gaussian distribution
+  /// Generates a fixed-size vector/matrix with each element drawn independently from
+  /// N(mean, sigma^2).
   ///
-  /// @tparam FixedSizeT The random vector/matrix type to be generated
-  /// @param[in] mean The mean of the Gaussian distribution
-  /// @param[in] sigma The standard deviation of the Gaussian distribution
+  /// @pre `sigma >= 0`.
+  ///
+  /// @tparam FixedSizeT Fixed-size Eigen vector/matrix type with floating-point scalar.
+  /// @param[in] mean Distribution mean applied to every element.
+  /// @param[in] sigma Distribution standard deviation applied to every element.
   template <typename FixedSizeT>
   [[nodiscard]] FixedSizeT normal(
       typename FixedSizeT::Scalar mean,
       typename FixedSizeT::Scalar sigma);
 
-  /// Generates a random value from the Gaussian distribution
+  /// Generates a dynamic-size vector with each element drawn independently from N(mean, sigma^2).
   ///
-  /// @tparam DynamicVector The random vector type to be generated
-  /// @param[in] size The size of the vector.
-  /// @param[in] mean The mean of the Gaussian distribution
-  /// @param[in] sigma The standard deviation of the Gaussian distribution
+  /// @pre `sigma >= 0` and `size >= 0`.
+  ///
+  /// @tparam DynamicVector Dynamic-size Eigen vector type with floating-point scalar.
+  /// @param[in] size Number of elements in the result.
+  /// @param[in] mean Distribution mean applied to every element.
+  /// @param[in] sigma Distribution standard deviation applied to every element.
   template <typename DynamicVector>
   [[nodiscard]] DynamicVector normal(
       Eigen::Index size,
       typename DynamicVector::Scalar mean,
       typename DynamicVector::Scalar sigma);
 
-  /// Generates a random value from the Gaussian distribution
+  /// Generates a dynamic-size matrix with each element drawn independently from N(mean, sigma^2).
   ///
-  /// @tparam DynamicMatrix The random matrix type to be generated
-  /// @param[in] rows The row size of the matrix.
-  /// @param[in] cols The column size of the matrix.
-  /// @param[in] mean The mean of the Gaussian distribution
-  /// @param[in] sigma The standard deviation of the Gaussian distribution
+  /// @pre `sigma >= 0`, `rows >= 0`, and `cols >= 0`.
+  ///
+  /// @tparam DynamicMatrix Dynamic-size Eigen matrix type with floating-point scalar.
+  /// @param[in] rows Number of rows in the result.
+  /// @param[in] cols Number of columns in the result.
+  /// @param[in] mean Distribution mean applied to every element.
+  /// @param[in] sigma Distribution standard deviation applied to every element.
   template <typename DynamicMatrix>
   [[nodiscard]] DynamicMatrix normal(
       Eigen::Index rows,
@@ -213,38 +250,46 @@ class Random final {
       typename DynamicMatrix::Scalar mean,
       typename DynamicMatrix::Scalar sigma);
 
-  /// Returns the seed.
+  /// Returns the seed last used to initialize the engine.
+  ///
+  /// @note This reflects the value passed to the constructor or the most recent `setSeed()` call;
+  /// it does not encode the engine's current state, so it cannot be used alone to resume a
+  /// sequence after some samples have been drawn.
   [[nodiscard]] uint32_t getSeed() const;
 
-  /// Sets a new seed for the internal random number engine.
+  /// Re-seeds the internal engine, resetting its state to the deterministic sequence implied by
+  /// `seed`.
   void setSeed(uint32_t seed);
 
  private:
-  /// The seed used for the internal random number engine.
   uint32_t seed_;
 
-  /// The internal random number engine.
   Generator generator_;
 };
 
-/// Generates a random type T from the uniform distribution, using the global random number
-/// generator Random
+/// Convenience wrappers that forward to `Random<>::GetSingleton()`.
+///
+/// @warning These share the singleton's mutable engine state and inherit its non-thread-safe
+/// behavior; concurrent calls from different threads must be externally synchronized. Range and
+/// distribution semantics match the corresponding `Random` member functions.
+
+/// Uniformly distributed value via the global `Random` singleton. See `Random::uniform`.
 template <typename T>
 [[nodiscard]] T uniform(const T& min, const T& max);
 
-/// Generates a random fixed size vector/matrix from the uniform distribution, using the global
-/// random number generator Random
+/// Uniformly distributed fixed-size vector/matrix via the global `Random` singleton.
+/// See `Random::uniform`.
 template <typename FixedSizeT>
 [[nodiscard]] FixedSizeT uniform(typename FixedSizeT::Scalar min, typename FixedSizeT::Scalar max);
 
-/// Generates a random dynamic size vector from the uniform distribution, using the global random
-/// number generator Random
+/// Uniformly distributed dynamic-size vector via the global `Random` singleton.
+/// See `Random::uniform`. @pre `size >= 0`.
 template <typename DynamicVector>
 [[nodiscard]] DynamicVector
 uniform(Eigen::Index size, typename DynamicVector::Scalar min, typename DynamicVector::Scalar max);
 
-/// Generates a random type dynamic size matrix from the uniform distribution, using the global
-/// random number generator Random
+/// Uniformly distributed dynamic-size matrix via the global `Random` singleton.
+/// See `Random::uniform`. @pre `rows >= 0` and `cols >= 0`.
 template <typename DynamicMatrix>
 [[nodiscard]] DynamicMatrix uniform(
     Eigen::Index rows,
@@ -252,23 +297,23 @@ template <typename DynamicMatrix>
     typename DynamicMatrix::Scalar min,
     typename DynamicMatrix::Scalar max);
 
-/// Generates a random quaternion from a uniform distribution on SO(3)
+/// Uniformly distributed unit quaternion on SO(3) via the global `Random` singleton.
 template <typename T>
 [[nodiscard]] Quaternion<T> uniformQuaternion();
 
-/// Generates a random rotation matrix from a uniform distribution on SO(3)
+/// Uniformly distributed rotation matrix on SO(3) via the global `Random` singleton.
 template <typename T>
 [[nodiscard]] Matrix3<T> uniformRotationMatrix();
 
-/// Generates a random isometry (rigid transformation) from a uniform distribution on SE(3)
-/// based on input minimum and maximum 3D vectors for the translation part.
+/// Random isometry on SE(3) via the global `Random` singleton (uniform rotation, uniform
+/// translation in `[min, max]`).
 template <typename T>
 [[nodiscard]] Isometry3<T> uniformIsometry3(
     const Vector3<T>& min = Vector3<T>::Zero(),
     const Vector3<T>& max = Vector3<T>::Ones());
 
-/// Generates a random affine transformation from a uniform distribution on the space of all
-/// affine transformations.
+/// Random affine transformation via the global `Random` singleton (uniform rotation, uniform
+/// scale in `[scaleMin, scaleMax]`, uniform translation in `[min, max]`).
 template <typename T>
 [[nodiscard]] Affine3<T> uniformAffine3(
     T scaleMin = 0.1,
@@ -276,28 +321,28 @@ template <typename T>
     const Vector3<T>& min = Vector3<T>::Zero(),
     const Vector3<T>& max = Vector3<T>::Ones());
 
-/// Generates a random type T from the Gaussian distribution, using the global random number
-/// generator Random
+/// Normally distributed value via the global `Random` singleton. See `Random::normal`.
+/// @pre `sigma >= 0`.
 template <typename T>
 [[nodiscard]] T normal(const T& mean, const T& sigma);
 
-/// Generates a random fixed size vector/matrix from the Gaussian distribution, using the global
-/// random number generator Random
+/// Normally distributed fixed-size vector/matrix via the global `Random` singleton.
+/// See `Random::normal`. @pre `sigma >= 0`.
 template <typename FixedSizeT>
 [[nodiscard]] FixedSizeT normal(
     typename FixedSizeT::Scalar mean,
     typename FixedSizeT::Scalar sigma);
 
-/// Generates a random dynamic size vector from the Gaussian distribution, using the global random
-/// number generator Random
+/// Normally distributed dynamic-size vector via the global `Random` singleton.
+/// See `Random::normal`. @pre `sigma >= 0` and `size >= 0`.
 template <typename DynamicVector>
 [[nodiscard]] DynamicVector normal(
     Eigen::Index size,
     typename DynamicVector::Scalar mean,
     typename DynamicVector::Scalar sigma);
 
-/// Generates a random dynamic size matrix from the Gaussian distribution, using the global random
-/// number generator Random
+/// Normally distributed dynamic-size matrix via the global `Random` singleton.
+/// See `Random::normal`. @pre `sigma >= 0`, `rows >= 0`, and `cols >= 0`.
 template <typename DynamicMatrix>
 [[nodiscard]] DynamicMatrix normal(
     Eigen::Index rows,

--- a/momentum/math/resizeable_matrix.h
+++ b/momentum/math/resizeable_matrix.h
@@ -15,32 +15,64 @@
 
 namespace momentum {
 
-/// A matrix class that can be resized without reallocating memory when shrinking.
+/// A dense column-major matrix whose underlying storage capacity grows monotonically and is
+/// reused across resizes, unlike `Eigen::Matrix<T, Dynamic, Dynamic>` which reallocates on
+/// every `resize()` / `conservativeResize()` call.
 ///
-/// The native Eigen matrix type reallocates the matrix every time you call
-/// either resize() or conservativeResize(), which means there is no way to
-/// have a matrix that reuses memory. This is inconvenient, because there are
-/// definitely cases where we want to be able to reuse the same memory over
-/// and over for slightly different matrix sizes (for example, if we are computing
-/// our Jacobian blockwise).
+/// Motivation: solver inner loops repeatedly build matrices (e.g. blockwise Jacobians) whose
+/// logical dimensions vary slightly from iteration to iteration. Using a plain Eigen matrix
+/// triggers a heap allocation each time the size changes; this class amortizes those costs by
+/// only growing the backing buffer when the requested element count exceeds the current
+/// capacity. Storage shrinks only when the object is destroyed.
+///
+/// Capacity vs. logical size: `rows()` / `cols()` report the logical size requested by the
+/// last `resizeAndSetZero()`. The backing `std::vector` capacity may be larger and is never
+/// returned to the allocator while the object lives.
+///
+/// Layout: data is stored contiguously in column-major order (matching Eigen's default) and
+/// is aligned to `kAlignment` bytes so that the returned `Eigen::Map<..., Eigen::Aligned128>`
+/// can use aligned SIMD loads/stores.
+///
+/// Thread safety: not thread-safe. Concurrent calls to any non-const method, or a non-const
+/// method concurrent with any other access, are data races. Multiple readers via `const`
+/// accessors are safe provided no writer is active.
 template <typename T>
 class ResizeableMatrix {
  public:
-  /// Alignment in bytes for SIMD and cache efficiency
+  /// Alignment in bytes for the underlying storage. Chosen to satisfy `Eigen::Aligned128`
+  /// so the `Eigen::Map` accessors below can perform aligned SIMD loads/stores.
   static constexpr std::size_t kAlignment = 128;
 
   using MatrixType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
   ResizeableMatrix() = default;
+
+  /// Constructs a matrix of the given logical size and zero-initializes all entries.
+  /// @param rows Number of rows in the logical matrix.
+  /// @param cols Number of columns in the logical matrix; defaults to 1 (column vector).
   explicit ResizeableMatrix(Eigen::Index rows, Eigen::Index cols = 1) {
     resizeAndSetZero(rows, cols);
   }
 
+  /// Sets the logical size to `rows x cols` and zeroes every element.
+  ///
+  /// The backing buffer is reused if its current capacity is sufficient; otherwise it grows.
+  /// Capacity never shrinks. Any `Eigen::Map` previously returned by `mat()` / `vec()` is
+  /// invalidated by this call (storage may have been reallocated, and existing contents are
+  /// overwritten with zeros regardless).
+  ///
+  /// @param rows Number of rows in the new logical matrix.
+  /// @param cols Number of columns in the new logical matrix; defaults to 1.
+  /// @post `this->rows() == rows && this->cols() == cols` and every entry is `T(0)`.
   void resizeAndSetZero(Eigen::Index rows, Eigen::Index cols = 1) {
     rows_ = rows;
     cols_ = cols;
 
-    // This will not reallocate unless needed.
+    // clear() + resize() relies on std::vector preserving capacity across clear(); the
+    // resize() therefore only reallocates when rows*cols exceeds the previous capacity.
+    // TODO: this default-inserts (zero-initializes) `rows*cols` elements every call, which
+    // is wasted work when the caller is about to overwrite all of them. Consider adding a
+    // separate `resizeWithoutZero()` for that case.
     data_.clear();
     data_.resize(rows * cols);
   }
@@ -52,17 +84,27 @@ class ResizeableMatrix {
     return cols_;
   }
 
+  /// Returns an aligned, mutable `Eigen::Map` view of the logical `rows() x cols()` matrix.
+  /// The map is invalidated by any subsequent call to `resizeAndSetZero()`.
   Eigen::Map<MatrixType, Eigen::Aligned128> mat() {
     return Eigen::Map<MatrixType, Eigen::Aligned128>(data_.data(), rows_, cols_);
   }
+
+  /// Const overload of `mat()`.
   Eigen::Map<const MatrixType, Eigen::Aligned128> mat() const {
     return Eigen::Map<const MatrixType, Eigen::Aligned128>(data_.data(), rows_, cols_);
   }
 
-  /// Vector accessor for single-column matrices
+  /// Returns an aligned, mutable `Eigen::Map` view interpreting the storage as a length-`rows()`
+  /// column vector. The `cols()` value is ignored; intended for the single-column case.
+  /// The map is invalidated by any subsequent call to `resizeAndSetZero()`.
+  /// TODO: `vec()` ignores `cols_` and only exposes the first column when `cols_ > 1`. Either
+  /// document this contract loudly or assert `cols_ == 1`.
   Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>, Eigen::Aligned128> vec() {
     return Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>, Eigen::Aligned128>(data_.data(), rows_);
   }
+
+  /// Const overload of `vec()`.
   Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>, Eigen::Aligned128> vec() const {
     return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>, Eigen::Aligned128>(
         data_.data(), rows_);

--- a/momentum/math/simd_generalized_loss.cpp
+++ b/momentum/math/simd_generalized_loss.cpp
@@ -17,20 +17,28 @@ namespace momentum {
 
 namespace {
 
-// No 0.5 factor so it can be reused.
+// SIMD mirrors of the scalar helpers in generalized_loss.cpp. Each takes a Packet of squared
+// errors and broadcasts the scalar `invC2` over the lanes via DrJit's overloaded operators.
+// Math intrinsics are dispatched through `drjit::sqrt/log/exp/pow` to vectorize across the packet
+// instead of falling back to per-lane `std::*` calls.
+
+// L2: returns invC2 * sqrError (no 0.5 factor — kept separate so the result can be reused as the
+// inner term of the L1/Cauchy/Welsch/General formulas).
 template <typename T>
 Packet<T> L2Loss(const Packet<T>& sqrError, T invC2) {
   return sqrError * invC2;
 }
 
+// d/dsqrError of L2Loss is the constant invC2 — broadcast implicitly to a Packet at the call site.
 template <typename T>
 Packet<T> derivL2Loss(const Packet<T>& /* sqrError */, T invC2) {
   return invC2;
 }
 
+// L1 (pseudo-Huber, alpha = 1): sqrt(invC2 * sqrError + 1) - 1.
+// The trailing `- 1` is intentionally kept so value() at sqrError=0 is exactly 0.
 template <typename T>
 Packet<T> L1Loss(const Packet<T>& sqrError, T invC2) {
-  // decided not to skip the -1 so the value itself is meaningful
   return drjit::sqrt(L2Loss(sqrError, invC2) + T(1)) - T(1);
 }
 
@@ -39,6 +47,7 @@ Packet<T> derivL1Loss(const Packet<T>& sqrError, T invC2) {
   return T(0.5) * invC2 / drjit::sqrt(L2Loss(sqrError, invC2) + T(1));
 }
 
+// Cauchy / Lorentzian (alpha = 0): log(0.5 * invC2 * sqrError + 1).
 template <typename T>
 Packet<T> CauchyLoss(const Packet<T>& sqrError, T invC2) {
   return drjit::log(T(0.5) * L2Loss(sqrError, invC2) + T(1));
@@ -49,6 +58,7 @@ Packet<T> derivCauchyLoss(const Packet<T>& sqrError, T invC2) {
   return invC2 / (invC2 * sqrError + T(2));
 }
 
+// Welsch (alpha -> -inf limit): 1 - exp(-0.5 * invC2 * sqrError). Bounded in [0, 1).
 template <typename T>
 Packet<T> WelschLoss(const Packet<T>& sqrError, T invC2) {
   return T(1) - drjit::exp(T(-0.5) * L2Loss(sqrError, invC2));
@@ -62,10 +72,11 @@ Packet<T> derivWelschLoss(const Packet<T>& sqrError, T invC2) {
 } // namespace
 
 template <typename T>
-SimdGeneralizedLossT<T>::SimdGeneralizedLossT(const T& a, const T& c) : Base(a, c) {
-  // Empty
-}
+SimdGeneralizedLossT<T>::SimdGeneralizedLossT(const T& a, const T& c) : Base(a, c) {}
 
+// Branching is on the scalar `lossType_` cached at construction (Base classifies alpha into one
+// of L2/L1/Cauchy/Welsch/General). All packet lanes follow the same branch — no per-lane mask or
+// `drjit::select` is needed because alpha is uniform across the packet.
 template <typename T>
 Packet<T> SimdGeneralizedLossT<T>::value(const Packet<T>& sqrError) const {
   switch (this->lossType_) {
@@ -76,21 +87,30 @@ Packet<T> SimdGeneralizedLossT<T>::value(const Packet<T>& sqrError) const {
     case Base::LossType::Cauchy:
       return CauchyLoss(sqrError, this->invC2_);
     case Base::LossType::Welsch:
+      // Welsch limit is taken when alpha <= kWelsch (alpha == -inf is handled by the same branch
+      // since Base classifies any sufficiently negative alpha as Welsch).
       return WelschLoss(sqrError, this->invC2_);
     case Base::LossType::General:
-      // General case, slower
+      // General Barron loss for alpha not near 0, 1, 2, or -inf. The packet `pow` is the slow
+      // path; the special cases above exist precisely to avoid it. The scalar prefactor
+      // `|alpha - 2| / alpha` is computed once outside the packet expression.
       return (drjit::pow(
                   L2Loss(sqrError, this->invC2_) / std::fabs(this->alpha_ - T(2)) + T(1),
                   T(0.5) * this->alpha_) -
               T(1)) *
           (std::fabs(this->alpha_ - T(2)) / this->alpha_);
     default: {
+      // TODO: returning a default-constructed Packet here may yield uninitialized lanes; consider
+      // returning drjit::zeros<Packet<T>>() or asserting in debug builds so callers don't silently
+      // propagate garbage on a corrupted lossType_.
       MT_LOGE("Invalid lossType_ ({})", static_cast<int>(this->lossType_));
       return {};
     }
   }
 }
 
+// Same lane-uniform switch structure as value(); see notes there. Returns d(loss)/d(sqrError) so
+// callers can chain-rule into the Jacobian of the underlying residual.
 template <typename T>
 Packet<T> SimdGeneralizedLossT<T>::deriv(const Packet<T>& sqrError) const {
   switch (this->lossType_) {
@@ -103,12 +123,13 @@ Packet<T> SimdGeneralizedLossT<T>::deriv(const Packet<T>& sqrError) const {
     case Base::LossType::Welsch:
       return derivWelschLoss(sqrError, this->invC2_);
     case Base::LossType::General:
-      // General case, slower
+      // General Barron derivative; uses packet `pow` and is the slow path.
       return (T(0.5) * this->invC2_) *
           drjit::pow(
                  L2Loss(sqrError, this->invC2_) / std::fabs(this->alpha_ - T(2)) + T(1),
                  T(0.5) * this->alpha_ - T(1));
     default: {
+      // TODO: see value() — same uninitialized-lane concern on the default branch.
       MT_LOGE("Invalid lossType_ ({})", static_cast<int>(this->lossType_));
       return {};
     }

--- a/momentum/math/simd_generalized_loss.h
+++ b/momentum/math/simd_generalized_loss.h
@@ -12,28 +12,44 @@
 
 namespace momentum {
 
-/// SIMD version of the generalized loss function.
+/// SIMD (vectorized) variant of `GeneralizedLossT` that operates on DrJit `Packet<T>` lanes
+/// instead of individual scalars. See `GeneralizedLossT` for the full mathematical description,
+/// the meaning of @p alpha and @p c, and the alpha-value reference (L2, L1/pseudo-Huber, Cauchy,
+/// Geman-McClure, Welsch).
+///
+/// Inherits the scalar `value()` / `deriv()` overloads and the cached `lossType_` / `invC2_`
+/// state from the base class. Branching on the loss type is uniform across all packet lanes
+/// (alpha is fixed at construction), so no per-lane masking is needed in the implementation.
+///
+/// @par When to use
+/// Use this class inside SIMD error functions that process multiple constraints in a single
+/// packet (e.g., `Simd*ErrorFunction`). For scalar error functions or one-off evaluations,
+/// prefer the base `GeneralizedLossT` directly.
+///
+/// @par Thread safety
+/// Instances are immutable after construction (all state is `const` in the base class), so
+/// concurrent reads from multiple threads are safe. Each evaluation is stateless.
 template <typename T>
 class SimdGeneralizedLossT : public GeneralizedLossT<T> {
  public:
   using Base = GeneralizedLossT<T>;
 
-  /// Constructs a SIMD generalized loss function
+  /// Constructs a SIMD generalized loss with shape @p a and scale @p c.
   ///
-  /// @param a Alpha parameter controlling the shape of the loss function
-  /// @param c Scale parameter controlling the width of the quadratic region
+  /// @param a Shape parameter alpha. See `GeneralizedLossT` for the alpha-value reference and
+  ///   the special-case constants (`kL2`, `kL1`, `kCauchy`, `kWelsch`).
+  /// @param c Scale parameter. Must be > 0.
   explicit SimdGeneralizedLossT(const T& a = Base::kL2, const T& c = T(1));
 
-  /// Computes the loss value for a given squared error
-  ///
-  /// @param sqrError Squared error term (SIMD packet)
-  /// @return Loss value as a SIMD packet
+  /// Returns the loss value for each lane of @p sqrError.
+  /// @param sqrError Packet of non-negative squared residuals (one per lane).
+  /// @return Packet of loss values, one per input lane.
   [[nodiscard]] Packet<T> value(const Packet<T>& sqrError) const;
 
-  /// Computes the derivative of the loss function
-  ///
-  /// @param sqrError Squared error term (SIMD packet)
-  /// @return Derivative value as a SIMD packet
+  /// Returns d(loss)/d(sqrError) for each lane of @p sqrError. Used to chain-rule the loss
+  /// into the Jacobian of the underlying residual.
+  /// @param sqrError Packet of non-negative squared residuals (one per lane).
+  /// @return Packet of derivatives, one per input lane.
   [[nodiscard]] Packet<T> deriv(const Packet<T>& sqrError) const;
 };
 

--- a/momentum/math/span_compat.h
+++ b/momentum/math/span_compat.h
@@ -11,10 +11,22 @@
 /// @brief Provides a C++17-compatible span type alias.
 ///
 /// This header provides `momentum::span<T>` which aliases to `std::span<T>` when
-/// C++20 is available, and falls back to `gsl::span<T>` for C++17 compilers.
-/// This enables cross-platform compatibility for platforms that don't yet support C++20.
+/// C++20 is available, and falls back to `gsl::span<T>` for C++17 compilers /
+/// platforms whose standard library does not yet ship `<span>` (e.g. older
+/// Apple/Clang toolchains, certain Android NDK versions, and any build
+/// configured to target C++17).
+///
+/// @note Use `momentum::span<T>` everywhere within momentum sources instead of
+/// `std::span<T>` directly, until the project drops C++17 support. Once all
+/// supported platforms provide `<span>`, this shim can be removed and call
+/// sites switched to `std::span<T>`.
+// TODO: Remove this shim and switch call sites to `std::span<T>` once the
+// project no longer needs to support C++17 toolchains.
 
-// Detect C++20 support
+/// @def MOMENTUM_HAS_CPP20_SPAN
+/// Defined to `1` when the compiler advertises C++20 (via `__cplusplus` or
+/// MSVC's `_MSVC_LANG`), `0` otherwise. Gates whether `<span>` or `<gsl/span>`
+/// is included.
 #if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #define MOMENTUM_HAS_CPP20_SPAN 1
 #else

--- a/momentum/math/transform.cpp
+++ b/momentum/math/transform.cpp
@@ -58,11 +58,17 @@ template <typename T>
 TransformT<T> TransformT<T>::fromMatrix(const Matrix4<T>& other) {
   TransformT<T> result;
   result.translation = other.template topRightCorner<3, 1>();
-  // Calculate the scale by taking the norm of the first column, assuming uniform scaling
+  // Recover scale from the norm of column 0. This relies on the upper-left 3x3 being
+  // s*R where R is orthonormal (uniform scale, no shear, no reflection). For non-uniform
+  // scaling, shear, or negative determinant, the resulting rotation will be incorrect.
   const auto& scaledR = other.template topLeftCorner<3, 3>();
   result.scale = scaledR.col(0).norm();
+  // Guard against near-zero or near-infinite scale before dividing.
   MT_CHECK(result.scale >= Eps<T>(), "Scale is too small: {}", result.scale);
   MT_CHECK(result.scale < T(1) / Eps<T>(), "Inverse scale is too small: {}", result.scale);
+  // TODO: Detect non-uniform scale / shear / reflection (e.g. via SVD) and either error
+  // or project to the closest rigid+uniform-scale transform; current quaternion ctor
+  // silently ignores non-orthonormal input.
   result.rotation = scaledR / result.scale;
   return result;
 }
@@ -106,7 +112,8 @@ TransformT<T> blendTransforms(
   // http://www.acsu.buffalo.edu/~johnc/ave_quat07.pdf
   //
   // i.e. Stack quaternion coeffs in Q, compute M = Q^T x Q, and yield the eigenvector corresponding
-  // to the largest eigenvalue as the average rotation
+  // to the largest eigenvalue as the average rotation. This handles the q vs -q double-cover
+  // ambiguity correctly (since q*q^T == (-q)*(-q)^T) without needing manual sign alignment.
   Matrix4<T> QtQ = Matrix4<T>::Zero();
 
   const auto n = transforms.size();
@@ -132,6 +139,9 @@ TransformT<T> blendTransforms(
     weightSum += weights[i];
   }
 
+  // TODO: When weightSum is zero (e.g. all weights zero, or weights cancel), pos and scale
+  // are left at 0 which produces a degenerate transform; consider returning identity or
+  // the first input instead.
   if (weightSum != 0) {
     pos /= weightSum;
     scale /= weightSum;

--- a/momentum/math/transform.h
+++ b/momentum/math/transform.h
@@ -14,111 +14,122 @@
 
 namespace momentum {
 
-/// Lightweight transform with separate rotation, translation, and uniform scaling
+/// Lightweight transform with separate rotation, translation, and uniform scaling.
 ///
-/// This class provides a more efficient alternative to Eigen's Affine3 for transformations
-/// that only involve rotation, translation, and uniform scaling. It stores these components
-/// separately, which allows for more efficient operations and memory usage.
+/// Applied to a point as: `p' = translation + rotation * (scale * p)`.
 ///
-/// @tparam T The scalar type (float or double)
+/// @tparam T The scalar type (float or double).
+///
+/// @par Design rationale
+/// `TransformT` stores rotation (quaternion), translation, and uniform scale separately
+/// instead of as a 4x4 matrix. Preferred over `Eigen::Affine3` throughout Momentum because:
+/// - Composition is faster: quaternion multiply + scaled translation is cheaper than 4x4
+///   matrix multiply for uniform-scale transforms.
+/// - Decomposition is free: extracting rotation, translation, or scale is a field access,
+///   not a matrix decomposition.
+/// - FK derivatives are simpler: the Jacobian of rotation, translation, and scale are
+///   computed independently (see `JointStateT`).
+///
+/// Use `Eigen::Affine3` only at IO boundaries (FBX, glTF) where the format stores 4x4
+/// matrices. Convert via `TransformT::fromAffine3()` / `toAffine3()`.
 template <typename T>
 struct TransformT {
+  /// Unit quaternion encoding the rotation. Not enforced — callers are responsible for
+  /// keeping it normalized; non-unit quaternions will scale the rotated vector.
   Quaternion<T> rotation;
   Vector3<T> translation;
+  /// Uniform scale factor applied before rotation and translation.
   T scale;
 
-  /// Creates a transform with only rotation
+  /// Creates a transform with the given rotation, identity translation, and unit scale.
   [[nodiscard]] static TransformT<T> makeRotation(const Quaternion<T>& rotation_in);
 
-  /// Creates a transform with only translation
+  /// Creates a transform with the given translation, identity rotation, and unit scale.
   [[nodiscard]] static TransformT<T> makeTranslation(const Vector3<T>& translation_in);
 
-  /// Creates a transform with only scaling
+  /// Creates a transform with the given scale, identity rotation, and zero translation.
   [[nodiscard]] static TransformT<T> makeScale(const T& scale_in);
 
-  /// Creates a random transform
+  /// Creates a random transform.
   ///
-  /// @param[in] translation If true, use random translation (-1 to 1)
-  /// @param[in] rotation If true, use random rotation
-  /// @param[in] scale If true, use random scale (0.5 to 2.0)
+  /// @param[in] translation If true, sample translation uniformly in [-1, 1] per axis;
+  ///   otherwise zero.
+  /// @param[in] rotation If true, sample a uniformly random unit quaternion; otherwise
+  ///   identity.
+  /// @param[in] scale If true, sample scale uniformly in [0.5, 2.0]; otherwise 1.
   [[nodiscard]] static TransformT<T>
   makeRandom(bool translation = true, bool rotation = true, bool scale = true);
 
-  /// Converts from Eigen's Affine3
+  /// Decomposes an `Eigen::Affine3` into rotation, translation, and uniform scale.
+  /// @pre `other.linear()` is a uniformly scaled rotation (no shear, isotropic scale);
+  /// the result is undefined for general affine transforms.
   [[nodiscard]] static TransformT<T> fromAffine3(const Affine3<T>& other);
 
-  /// Converts from 4x4 matrix
+  /// Decomposes a 4x4 homogeneous matrix into rotation, translation, and uniform scale.
+  /// @pre The upper-left 3x3 block is a uniformly scaled rotation and the bottom row is
+  /// `[0 0 0 1]`; the result is undefined otherwise.
   [[nodiscard]] static TransformT<T> fromMatrix(const Matrix4<T>& other);
 
-  /// Creates identity transform
-  TransformT() : rotation(Quaternion<T>::Identity()), translation(Vector3<T>::Zero()), scale(1) {
-    // Empty
-  }
+  /// Creates the identity transform (zero translation, identity rotation, unit scale).
+  TransformT() : rotation(Quaternion<T>::Identity()), translation(Vector3<T>::Zero()), scale(1) {}
 
-  /// Copy constructor with type conversion
-  ///
-  /// @tparam T2 Source scalar type
+  /// @tparam T2 Source scalar type.
   template <typename T2>
   explicit TransformT(const TransformT<T2>& other)
       : rotation(other.rotation.template cast<T>()),
         translation(other.translation.template cast<T>()),
-        scale(other.scale) {
-    // Empty
-  }
+        scale(other.scale) {}
 
-  /// Constructor with components
   explicit TransformT(
       const Vector3<T>& translation_in,
       const Quaternion<T>& rotation_in = Quaternion<T>::Identity(),
       const T& scale_in = T(1))
-      : rotation(rotation_in), translation(translation_in), scale(scale_in) {
-    // Empty
-  }
+      : rotation(rotation_in), translation(translation_in), scale(scale_in) {}
 
-  /// Move constructor
   explicit TransformT(
       Vector3<T>&& translation_in,
       Quaternion<T>&& rotation_in = Quaternion<T>::Identity(),
       T&& scale_in = T(1))
       : rotation(std::move(rotation_in)),
         translation(std::move(translation_in)),
-        scale(std::move(scale_in)) {
-    // Empty
-  }
+        scale(std::move(scale_in)) {}
 
-  /// Constructor from Affine3
+  /// @see fromAffine3 for preconditions.
   explicit TransformT(const Affine3<T>& other) {
     *this = fromAffine3(other);
   }
 
-  /// Constructor from 4x4 matrix
+  /// @see fromMatrix for preconditions.
   explicit TransformT(const Matrix4<T>& other) {
     *this = fromMatrix(other);
   }
 
-  /// Assignment from Affine3
+  /// @see fromAffine3 for preconditions.
   TransformT<T>& operator=(const Affine3<T>& other) {
     *this = fromAffine3(other);
     return *this;
   }
 
-  /// Assignment from 4x4 matrix
+  /// @see fromMatrix for preconditions.
   TransformT<T>& operator=(const Matrix4<T>& other) {
     *this = fromMatrix(other);
     return *this;
   }
 
-  /// Combines transforms (applies other first, then this)
+  /// Composes transforms: `(*this) * other` applies `other` first, then `*this`.
+  ///
+  /// Equivalent to multiplying the homogeneous matrices:
+  ///     [ s_1*R_1 t_1 ] * [ s_2*R_2 t_2 ] = [ s_1*s_2*R_1*R_2  s_1*R_1*t_2 + t_1 ]
+  ///     [     0    1  ]   [     0    1  ]   [        0                     1     ]
   [[nodiscard]] TransformT<T> operator*(const TransformT<T>& other) const {
-    // [ s_1*R_1 t_1 ] * [ s_2*R_2 t_2 ] = [ s_1*s_2*R_1*R_2  s_1*R_1*t_2 + t_1 ]
-    // [     0    1  ]   [     0    1  ]   [        0                     1     ]
     const Vector3<T> trans = translation + rotation * (scale * other.translation);
     const Quaternion<T> rot = rotation * other.rotation;
     const T newScale = scale * other.scale;
     return TransformT<T>(std::move(trans), std::move(rot), std::move(newScale));
   }
 
-  /// Multiplies with Affine3
+  /// Composes with an `Affine3`. The result is a general `Affine3` because `other` may
+  /// contain shear or non-uniform scale that cannot be represented by a `TransformT`.
   [[nodiscard]] Affine3<T> operator*(const Affine3<T>& other) const {
     Affine3<T> out = Affine3<T>::Identity();
     out.linear().noalias() = toLinear() * other.linear();
@@ -126,20 +137,17 @@ struct TransformT {
     return out;
   }
 
-  /// Transforms a point
   [[nodiscard]] Vector3<T> operator*(const Vector3<T>& other) const {
     return transformPoint(other);
   }
 
-  /// Converts to Affine3
   explicit operator Affine3<T>() const {
     return toAffine3();
   }
 
-  /// Converts to Affine3
   [[nodiscard]] Affine3<T> toAffine3() const;
 
-  /// Converts to 4x4 matrix
+  /// Returns the equivalent 4x4 homogeneous matrix `[s*R | t; 0 0 0 1]`.
   [[nodiscard]] Matrix4<T> toMatrix() const {
     Matrix4<T> out = Matrix4<T>::Zero();
     out.template topLeftCorner<3, 3>().noalias() = rotation.toRotationMatrix() * scale;
@@ -148,19 +156,21 @@ struct TransformT {
     return out;
   }
 
-  /// Returns rotation as 3x3 matrix
+  /// Returns the rotation as a 3x3 orthogonal matrix (scale not included).
   [[nodiscard]] Matrix3<T> toRotationMatrix() const {
     return rotation.toRotationMatrix();
   }
 
-  /// Returns rotation*scale as 3x3 matrix
+  /// Returns `scale * R`, the linear part of the transform.
   [[nodiscard]] Matrix3<T> toLinear() const {
     return toRotationMatrix() * scale;
   }
 
-  /// Gets the X axis of the rotation
+  /// Returns the rotated unit-X axis (i.e. the first column of the rotation matrix).
+  /// Inlined hand-expansion of `Eigen::Quaternion::toRotationMatrix()` for the X column;
+  /// faster than constructing the full 3x3 matrix when only one axis is needed.
+  /// @pre `rotation` is a unit quaternion; otherwise the returned vector is scaled.
   [[nodiscard]] Vector3<T> getAxisX() const {
-    // Optimized version of Eigen::Quaternion::toRotationMatrix()
     Vector3<T> axis;
 
     const T ty = T(2) * rotation.y();
@@ -179,20 +189,19 @@ struct TransformT {
     return axis;
   }
 
-  /// Applies full transform to a point
+  /// Applies the full transform to a point: `translation + rotation * (scale * pt)`.
   [[nodiscard]] Vector3<T> transformPoint(const Vector3<T>& pt) const {
     return translation + rotation * (scale * pt).eval();
   }
 
-  /// Applies only rotation to a vector
+  /// Applies only the rotation to a direction vector (translation and scale are ignored).
   [[nodiscard]] Vector3<T> rotate(const Vector3<T>& vec) const;
 
-  /// Computes inverse transform
+  /// Returns the inverse transform such that `(*this) * inverse() == identity`.
+  /// @pre `scale != 0`.
   [[nodiscard]] TransformT<T> inverse() const;
 
-  /// Converts to different scalar type
-  ///
-  /// @tparam T2 Target scalar type
+  /// @tparam T2 Target scalar type.
   template <typename T2>
   [[nodiscard]] TransformT<T2> cast() const {
     return TransformT<T2>(
@@ -201,25 +210,32 @@ struct TransformT {
         static_cast<T2>(this->scale));
   }
 
-  /// Checks if this transform is approximately equal to another
+  /// Approximate equality test using `tol` as a relative precision.
+  /// Currently routed through the `Affine3` representation; this conflates rotation,
+  /// translation, and scale tolerances.
+  // TODO: Compare components directly so the tolerance has well-defined meaning per
+  // component (and so two quaternions that differ by sign compare equal).
   [[nodiscard]] bool isApprox(
       const TransformT<T>& other,
       T tol = Eigen::NumTraits<T>::dummy_precision()) const {
-    // TODO: Improve
     return toAffine3().isApprox(other.toAffine3(), tol);
   }
 };
 
+/// Per-joint transform list describing the state of all joints in a skeleton (one entry
+/// per joint, indexed by joint id).
 template <typename T>
-using TransformListT =
-    std::vector<TransformT<T>>; // structure describing a the state of all joints in a skeleton
+using TransformListT = std::vector<TransformT<T>>;
 
+/// Weighted blend of transforms: rotations are blended via averaged quaternions,
+/// translations and scales linearly. `transforms` and `weights` must have the same size.
 template <typename T>
 TransformT<T> blendTransforms(
     momentum::span<const TransformT<T>> transforms,
     momentum::span<const T> weights);
 
-/// Spherical linear interpolation between two transforms
+/// Spherical linear interpolation between two transforms.
+/// @param weight Interpolation parameter in [0, 1]; 0 returns `t1`, 1 returns `t2`.
 template <typename T>
 TransformT<T> slerp(const TransformT<T>& t1, const TransformT<T>& t2, T weight);
 

--- a/momentum/math/types.h
+++ b/momentum/math/types.h
@@ -10,10 +10,6 @@
 #include <bitset>
 #include <cstdint>
 
-//------------------------------------------------------------------------------
-// Momentum specific Eigen defines
-//------------------------------------------------------------------------------
-
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4456) // hidden local declaration
@@ -28,16 +24,15 @@
 
 #include "momentum/math/span_compat.h"
 
-//------------------------------------------------------------------------------
-// Define some additional Eigen types
-//------------------------------------------------------------------------------
-
 namespace Eigen {
+/// 3D vector of unsigned bytes; commonly used for RGB color storage in momentum (see ColorArray).
 using Vector3b = Vector3<uint8_t>;
-}
+} // namespace Eigen
 
 namespace momentum {
 
+/// Re-export of `Eigen::Dynamic` for use as a compile-time dimension token in momentum's type
+/// aliases (e.g., `MatrixX`, `VectorX`).
 inline constexpr int Dynamic = Eigen::Dynamic;
 
 template <class T>
@@ -78,6 +73,8 @@ using Box3d = Box3<double>;
 using Box2i = Box2<std::int32_t>;
 using Box3i = Box3<std::int32_t>;
 
+/// Dynamic-size, column-major dense matrix. Default Eigen storage order; suitable for general
+/// solver use where dimensions are not known at compile time.
 template <typename T>
 using MatrixX = Eigen::Matrix<T, Dynamic, Dynamic>;
 
@@ -151,6 +148,9 @@ using Matrix4i = Matrix4<std::int32_t>;
 using Matrix5i = Matrix5<std::int32_t>;
 using Matrix6i = Matrix6<std::int32_t>;
 
+/// 3-row, dynamic-column matrix. Each column represents a 3D point/vector; column-major storage
+/// makes per-point access contiguous in memory. Used by VertexArray, NormalArray, ColorArray,
+/// TriangleArray.
 template <typename T>
 using Matrix3X = Eigen::Matrix<T, 3, Dynamic>;
 using Matrix3Xf = Matrix3X<float>;
@@ -169,11 +169,15 @@ using MatrixX3s = MatrixX3<std::uint16_t>;
 using MatrixX3u = MatrixX3<std::uint32_t>;
 using MatrixX3i = MatrixX3<std::int32_t>;
 
+/// Row-major dense matrix alias. Use when interoperating with row-major external buffers (e.g.,
+/// numpy arrays via pymomentum) or when iterating row-by-row is the dominant access pattern.
 template <typename T, int N, int M = N>
 using RowMatrix = Eigen::Matrix<T, N, M, Eigen::RowMajor>;
 template <typename T>
 using RowMatrixX = RowMatrix<T, Dynamic>;
 
+/// Column-major sparse matrix. Used by solver paths that build Jacobians/JtJ in compressed sparse
+/// column form.
 template <typename T>
 using SparseMatrix = Eigen::SparseMatrix<T>;
 using SparseMatrixf = SparseMatrix<float>;
@@ -192,9 +196,12 @@ using SparseRowMatrixs = SparseRowMatrix<std::uint16_t>;
 using SparseRowMatrixu = SparseRowMatrix<std::uint32_t>;
 using SparseRowMatrixi = SparseRowMatrix<std::int32_t>;
 
+/// Column vector alias (an `Nx1` Eigen matrix). `Options` allows callers to opt into row-major or
+/// alignment flags when needed.
 template <typename T, int Dim, int Options = 0>
 using Vector = Eigen::Matrix<T, Dim, 1, Options>;
 
+/// Dynamic-size column vector. Common return type for solver residuals and parameter vectors.
 template <typename T>
 using VectorX = Vector<T, Dynamic>;
 
@@ -367,6 +374,12 @@ using AngleAxis = Eigen::AngleAxis<T>;
 using AngleAxisf = AngleAxis<float>;
 using AngleAxisd = AngleAxis<double>;
 
+/// Unit quaternion representing a 3D rotation.
+///
+/// @note Eigen's storage order is `[x, y, z, w]` (vector part first, scalar last) when accessed
+/// via `coeffs()`, but the constructor `Quaternion(w, x, y, z)` takes the scalar first. Be careful
+/// when serializing/deserializing or interoperating with libraries that use a different
+/// convention.
 template <typename T>
 using Quaternion = Eigen::Quaternion<T>;
 using Quaternionf = Quaternion<float>;
@@ -377,32 +390,45 @@ using Translation3 = Eigen::Translation<T, 3>;
 using Translation3f = Translation3<float>;
 using Translation3d = Translation3<double>;
 
+/// 3D rigid transform (rotation + translation, no scale or shear). Preferred for joint/world
+/// transforms that should preserve distances.
 template <typename T>
 using Isometry3 = Eigen::Transform<T, 3, Eigen::Isometry>;
 using Isometry3f = Isometry3<float>;
 using Isometry3d = Isometry3<double>;
 
+/// 3D affine transform (linear part + translation). Allows non-uniform scale and shear; used by
+/// momentum for joint/skinning transforms that include scale.
 template <typename T>
 using Affine3 = Eigen::Transform<T, 3, Eigen::Affine>;
 using Affine3f = Affine3<float>;
 using Affine3d = Affine3<double>;
 
-// Some aligned arrays
+/// One affine transform per joint, indexed by joint id. Typical use: joint-to-world transforms
+/// for a posed skeleton.
 using TransformationList = std::vector<Affine3f>;
+/// Scalar-templated counterpart of `TransformationList`.
 template <typename T>
 using TransformationListT = std::vector<Affine3<T>>;
 
+/// Mesh vertex positions; column `i` is the position of vertex `i` (size: 3 x numVertices).
 using VertexArray = Matrix3Xf;
+/// Per-vertex normals matching the layout of `VertexArray` (size: 3 x numVertices).
 using NormalArray = Matrix3Xf;
+/// Triangle index buffer; column `i` holds the three vertex indices of triangle `i`
+/// (size: 3 x numTriangles).
 using TriangleArray = Matrix3Xi;
+/// Per-vertex RGB color in `[0, 255]` bytes (size: 3 x numVertices).
 using ColorArray = Matrix3Xb;
 
-// define a parameter set
-constexpr size_t kMaxModelParams = 2048; // at most 2048 parameters per frame
+/// Maximum number of model parameters supported per frame across any character. This is a
+/// compile-time bound that sizes `ParameterSet`; raising it grows every `ParameterSet` instance.
+constexpr size_t kMaxModelParams = 2048;
+/// Bitset for model parameter enablement. Size is fixed at compile time (large enough for any
+/// character's parameter count). Used by the solver to select which parameters to optimize.
 using ParameterSet = std::bitset<kMaxModelParams>;
 
-/// @brief A utility struct that facilitates the deduction of a `momentum::span` type from a given
-/// type.
+/// A utility struct that facilitates the deduction of a `momentum::span` type from a given type.
 ///
 /// This utility is particularly useful when a function accepts a `momentum::span<Vector3<T>>` as an
 /// argument, where the template argument of `momentum::span` is also a template. In such cases,
@@ -437,7 +463,6 @@ struct DeduceSpanType {
 /// `OtherScalar` matches the original type, the original container is returned.
 template <typename OtherScalar, template <typename...> class ContainerType, typename ObjectType>
 [[nodiscard]] decltype(auto) cast(const ContainerType<ObjectType>& originalContainer) {
-  // Check for Scalar typedef
   using Scalar = typename ObjectType::Scalar;
 
   if constexpr (std::is_same_v<OtherScalar, Scalar>) {
@@ -447,7 +472,7 @@ template <typename OtherScalar, template <typename...> class ContainerType, type
         std::remove_reference_t<decltype(std::declval<ObjectType>().template cast<OtherScalar>())>>;
 
     ContainerType<CastedType> castedContainer;
-    castedContainer.reserve(originalContainer.size()); // Optional, for performance
+    castedContainer.reserve(originalContainer.size());
 
     std::transform(
         originalContainer.begin(),

--- a/momentum/math/utility.cpp
+++ b/momentum/math/utility.cpp
@@ -42,15 +42,16 @@ Quaternion<T> quaternionExpMap(const Vector3<T>& v) {
   constexpr T kSmallAngleThreshold = Eps<T>(T(3.5e-4), T(1.5e-8));
 
   if (theta < kSmallAngleThreshold) {
-    // Taylor series expansion of exp map near zero:
-    // exp(v) ≈ [1, v/2] for small ||v||
-    // We can refine this with higher order terms for better accuracy
+    // Taylor expansion of exp(v) = [cos(theta/2), sin(theta/2)/theta * v] about
+    // theta = 0, truncated at O(theta^2). The expansion avoids the cancellation that
+    // would occur in 1 - cos(theta/2) and the 0/0 division in sin(theta/2)/theta for
+    // tiny theta. The truncation error is ~O(theta^4), which at the threshold
+    // (sqrt(eps)) is on the order of eps^2 — well below floating-point precision.
+    // The explicit normalize() compensates for the residual ~theta^4 deviation from
+    // unit norm; the standard branch below produces a unit quaternion analytically
+    // and so does not need it.
     const T theta2 = theta * theta;
-
-    // Second-order approximation: scalar = 1 - theta^2/8
     const T w = T(1) - theta2 / T(8);
-
-    // Second-order approximation: vector = v/2 * (1 - theta^2/24)
     const T scale = T(0.5) * (T(1) - theta2 / T(24));
 
     Quaternion<T> q(w, scale * v.x(), scale * v.y(), scale * v.z());
@@ -86,43 +87,33 @@ Vector3<T> quaternionLogMap(const Quaternion<T>& q) {
   constexpr T kSmallAngleThreshold = Eps<T>(T(3.5e-4), T(1.5e-8));
 
   if (vecNorm < kSmallAngleThreshold) {
-    // Quaternion is close to identity or -identity
     if (w > T(0)) {
-      // Close to identity: log(q) ≈ 2 * vec * (1 + vec.squaredNorm()/6)
-      // Using first-order approximation is sufficient for stability
+      // Close to identity: Taylor-expand log(q) = 2*atan2(||v||,w)/||v|| * v about
+      // ||v||=0 keeping w = sqrt(1-||v||^2). To O(||v||^2): log(q) ≈ 2*v*(1 + ||v||^2/6).
+      // This avoids the 0/0 in atan2/||v||.
       const T vecNorm2 = vec.squaredNorm();
       const T scale = T(2) * (T(1) + vecNorm2 / T(6));
       return scale * vec;
     } else {
-      // Close to -identity (180-degree rotation)
-      // The log is not unique here; we need to choose a branch
-      // Return a rotation of pi radians around an arbitrary axis
-      // We pick the x-axis for consistency
+      // Close to -identity (a pi rotation): the log is multi-valued — any axis n
+      // gives the same -identity quaternion via exp(pi*n). We pick the x-axis
+      // arbitrarily for determinism. Callers that need a continuous log near pi
+      // should track the rotation axis externally.
       return Vector3<T>(pi<T>(), T(0), T(0));
     }
   }
 
-  // Standard computation: log([w, v]) = atan2(||v||, w) / ||v|| * v
+  // Standard computation: log([w, v]) = 2 * atan2(||v||, w) / ||v|| * v.
+  // atan2 (rather than acos(w)) is used for accuracy near both 0 and pi.
   const T theta = T(2) * std::atan2(vecNorm, w);
   const T scale = theta / vecNorm;
 
   return scale * vec;
 }
 
-/// Computes the derivative of the logmap with respect to quaternion components.
-///
-/// Given a quaternion q with coeffs [x, y, z, w], computes the Jacobian matrix J where:
-/// J(i,j) = d(log(q)[i]) / dq.coeffs()[j]
-/// where log(q) is the 3D rotation vector and q.coeffs() = [x, y, z, w].
-///
-/// Reference: "Practical Parameterization of Rotations Using the Exponential Map"
-/// by F. Sebastian Grassia, Journal of Graphics Tools, 1998.
-/// https://www.cs.cmu.edu/~spiff/moedit99/expmap.pdf
-///
-/// @tparam T The scalar type
-/// @param q The input quaternion (should be normalized)
-/// @return 3x4 Jacobian matrix where column j is the gradient w.r.t. q.coeffs()[j]
-///         i.e., columns are ordered as [d/dx, d/dy, d/dz, d/dw]
+// Reference: "Practical Parameterization of Rotations Using the Exponential Map"
+// by F. Sebastian Grassia, Journal of Graphics Tools, 1998.
+// https://www.cs.cmu.edu/~spiff/moedit99/expmap.pdf
 template <typename T>
 Eigen::Matrix<T, 3, 4> quaternionLogMapDerivative(const Quaternion<T>& q) {
   // Ensure the quaternion is normalized
@@ -214,7 +205,7 @@ Vector3<T> rotationMatrixToEulerXYZ(const Matrix3<T>& m, EulerConvention convent
   // Reference: https://en.wikipedia.org/wiki/Euler_angles
   // Rotation matrix representation:
   // | r00 r01 r02 |   |  cy*cz             -cy*sz              sy    |
-  // | r10 r11 r12 | = |  cx*sz + sx*sy*cz   cx*cz - s1*s2*s3  -sx*cy |
+  // | r10 r11 r12 | = |  cx*sz + sx*sy*cz   cx*cz - sx*sy*sz  -sx*cy |
   // | r20 r21 r22 |   |  ...                ...                cx*cy |
 
   // Computes the rotation matrix from Euler angles similarly in the following way but with a
@@ -227,17 +218,17 @@ Vector3<T> rotationMatrixToEulerXYZ(const Matrix3<T>& m, EulerConvention convent
       res.y() = std::asin(m(0, 2));
       res.z() = std::atan2(-m(0, 1), m(0, 0));
     } else {
-      // Case sin(y) is close to -1:
-      // So cos(y) == 0 which leads to m(0, 0), m(0, 1), m(0, 1), and m(0, 2) becoming
-      // zero. So we use other non-zero elements in the rotation matrix
+      // Gimbal lock at sin(y) == -1: cos(y) == 0, so all entries with cy as a factor
+      // (m(0,0), m(0,1), m(1,2), m(2,2)) become zero. Use the remaining non-zero
+      // elements (m(1,0), m(1,1)) and choose res.x() = 0 to resolve the family of
+      // solutions; analytically the result has -res.x() - atan2(...) freedom.
       res.x() = 0; // any angle can be OK, but we choose zero
       res.y() = -pi<T>() * T(0.5); // choose in [-pi, pi]
       res.z() = std::atan2(m(1, 0), m(1, 1)); // -res.x() - atan2(...) but we use res.x() == 0
     }
   } else {
-    // Case sin(y) is close to 1:
-    // So cos(y) == 0 which leads to m(0, 0), m(0, 1), m(0, 1), and m(0, 2) becoming
-    // zero. So we use other non-zero elements in the rotation matrix
+    // Gimbal lock at sin(y) == 1: same zero pattern as the sin(y) == -1 branch above;
+    // here the analytical freedom is res.x() - atan2(...).
     res.x() = 0; // any angle can be OK, but we choose zero
     res.y() = pi<T>() * T(0.5); // choose in [-pi, pi]
     res.z() = std::atan2(m(1, 0), m(1, 1)); // res.x() - atan2(...) but we use res.x() == 0
@@ -253,7 +244,11 @@ Vector3<T> rotationMatrixToEulerZYX(const Matrix3<T>& m, EulerConvention convent
   }
 
   // Reference: https://en.wikipedia.org/wiki/Euler_angles
-  // Rotation matrix representation:
+  // Rotation matrix representation. NOTE: in the matrix below, (cx,sx) denotes cos/sin
+  // of the FIRST returned angle (the Z rotation in ZYX), and (cz,sz) denotes the LAST
+  // (the X rotation). This labels-by-output-position convention is the opposite of the
+  // labels-by-rotation-axis convention used by eulerZYXToRotationMatrix; the indices
+  // and signs below are consistent under this aliasing.
   // | r00 r01 r02 |   |  cx*cy   cx*sy*sz - sx*cz   sx*sz + cx*sy*cz |
   // | r10 r11 r12 | = |  sx*cy   ...                ...              |
   // | r20 r21 r22 |   | -sy      cy*sz              cy*cz            |
@@ -268,21 +263,22 @@ Vector3<T> rotationMatrixToEulerZYX(const Matrix3<T>& m, EulerConvention convent
       res.y() = std::asin(-m(2, 0));
       res.z() = std::atan2(m(2, 1), m(2, 2));
     } else {
-      // Case sin(y) is close to 1:
-      // So cos(y) == 0 which leads to m(0, 0), m(1, 0), m(2, 1), and m(2, 2) becoming
-      // zero. So we use other non-zero elements in the rotation matrix
+      // Gimbal lock at sin(y) close to 1 (since m(2,0) == -sin(y) is close to -1):
+      // cos(y) == 0 zeros m(0,0), m(1,0), m(2,1), m(2,2). Recover res.z from the
+      // remaining non-zero entries m(0,1), m(0,2); res.x has analytic freedom and
+      // we pin it to 0.
       res.x() = 0; // any angle can be OK, but we choose zero
       res.y() = pi<T>() * T(0.5); // choose in [-pi, pi]
       res.z() = std::atan2(m(0, 1), m(0, 2)); // res.x() - atan2(...) but we use res.x() == 0
     }
   } else {
-    // Case sin(y) is close to -1:
-    // So cos(y) == 0 which leads to m(0, 0), m(1, 0), m(2, 1), and m(2, 2) becoming
-    // zero. So we use other non-zero elements in the rotation matrix
+    // Gimbal lock at sin(y) close to -1 (since m(2,0) == -sin(y) is close to 1):
+    // same zero pattern as above. The negated arguments to atan2 below are required
+    // because the analytic family is -res.x() - atan2(...), which simplifies to
+    // atan2(-m(0,1), -m(0,2)) at res.x()==0 — NOT the same as atan2(m(0,1),m(0,2)).
     res.x() = 0; // any angle can be OK, but we choose zero
     res.y() = -pi<T>() * T(0.5); // choose in [-pi, pi]
     res.z() = std::atan2(-m(0, 1), -m(0, 2)); // -res.x() - atan2(...) but we use res.x() == 0
-    // Note that this is not identical to std::atan2(m(0, 1), m(0, 2))
   }
   return res;
 }
@@ -385,6 +381,11 @@ Matrix3<T> eulerZYXToRotationMatrix(const Vector3<T>& angles, EulerConvention co
 
 template <typename T>
 Vector3<T> quaternionToEuler(const Quaternion<T>& q) {
+  // Standard closed-form XYZ Tait-Bryan extraction. Caller must pass a normalized
+  // quaternion; if not, the asin argument can exceed [-1,1] and produce NaN. There
+  // is no gimbal-lock guard here because callers (skeleton_state) work in regimes
+  // where |2(wy - zx)| < 1.
+  // TODO: Clamp the asin argument to [-1, 1] for robustness if non-unit inputs are possible.
   Vector3<T> res;
   res.x() =
       std::atan2(T(2) * (q.w() * q.x() + q.y() * q.z()), T(1) - T(2) * (sqr(q.x()) + sqr(q.y())));
@@ -395,9 +396,16 @@ Vector3<T> quaternionToEuler(const Quaternion<T>& q) {
 }
 
 Quaternionf quaternionAverage(momentum::span<const Quaternionf> q, momentum::span<const float> w) {
+  // Markley et al. "Averaging Quaternions": the average is the unit eigenvector of
+  // M = sum_i w_i^2 * q_i * q_i^T corresponding to the largest eigenvalue. This is
+  // sign-invariant (q and -q produce the same outer product), so it sidesteps the
+  // double-cover ambiguity that breaks naive coefficient averaging.
+  // NOTE: When the i-th weight is missing, this falls back to weight 1, NOT to
+  // (sum of provided weights)/N — partially-specified weight vectors will yield
+  // an unevenly weighted average. Pass a complete `w` or none at all.
+  // NOTE: Weights enter quadratically because each q_i contributes (w_i*q_i)(w_i*q_i)^T.
   Matrix4f Q = Matrix4f::Zero();
 
-  // calculate the matrix
   for (size_t i = 0; i < q.size(); i++) {
     if (i < w.size()) {
       Q += (q[i].coeffs() * w[i]) * (q[i].coeffs() * w[i]).transpose();
@@ -406,7 +414,8 @@ Quaternionf quaternionAverage(momentum::span<const Quaternionf> q, momentum::spa
     }
   }
 
-  // get the largest eigenvector of the matrix
+  // SelfAdjointEigenSolver sorts eigenvalues ascending, so col(3) is the eigenvector
+  // for the largest eigenvalue — i.e. the average quaternion (up to sign).
   return Quaternionf(Eigen::SelfAdjointEigenSolver<Matrix4f>(Q).eigenvectors().col(3));
 }
 
@@ -437,6 +446,13 @@ std::tuple<bool, T, Eigen::Vector2<T>> closestPointsOnSegments(
     const Eigen::Vector3<T>& o2,
     const Eigen::Vector3<T>& d2,
     const T maxDist) {
+  // Standard "closest points on two segments" algorithm: parametrize the segments as
+  // o_i + t * d_i for t in [0,1] and minimize the squared distance subject to that
+  // box constraint. The variables a,b,c,d,e and D = ac-b^2 are the standard names from
+  // the Geometric Tools formulation; sN/sD and tN/tD are the numerator/denominator of
+  // the s and t parameters carried as fractions to defer division until after clamping.
+  // d1 and d2 are NOT required to be unit vectors; their magnitudes set the segment
+  // length, and the returned res values are the parametric distances along d1/d2.
   Eigen::Vector2<T> res;
 
   const T maxSquareDist = maxDist * maxDist;
@@ -454,7 +470,12 @@ std::tuple<bool, T, Eigen::Vector2<T>> closestPointsOnSegments(
   T tN;
   T tD = D;
 
-  // check if lines are nearly parallel
+  // D is the determinant of the 2x2 normal-equations matrix; when small, the segments
+  // are nearly parallel (or one direction has near-zero length) and the linear system
+  // is ill-conditioned, so we pin s=0 and solve for t along d2 only.
+  // TODO: T(1e-7) is a hard-coded tolerance independent of T's precision. For double
+  // this is conservative but for float it is roughly 1 ulp at unit scale; consider
+  // using Eps<T>(...) like the Euler routines do.
   if (D < T(1e-7)) {
     sN = T(0);
     sD = T(1);
@@ -637,13 +658,13 @@ template std::tuple<bool, double, Eigen::Vector2<double>> closestPointsOnSegment
 
 namespace {
 
-/// Computes a rotation matrix for a single axis rotation.
+// Rotation matrix for a single axis rotation.
 template <typename T>
 Matrix3<T> singleAxisRotationMatrix(int axis, T angle) {
   return AngleAxis<T>(angle, Vector3<T>::Unit(axis)).toRotationMatrix();
 }
 
-/// Computes the derivative of a single axis rotation matrix with respect to the angle.
+// Derivative of a single axis rotation matrix with respect to the angle.
 template <typename T>
 Matrix3<T> singleAxisRotationMatrixDerivative(int axis, T angle) {
   Matrix3<T> dR = Matrix3<T>::Zero();
@@ -670,13 +691,15 @@ Matrix3<T> singleAxisRotationMatrixDerivative(int axis, T angle) {
   return dR;
 }
 
-/// Computes a rotation matrix for two axis rotations.
+// Rotation matrix for a composition R(axis1) * R(axis0). Note the order: axis0 is
+// applied first (innermost), then axis1 — this matches the intrinsic angle ordering
+// used by the Levenberg-Marquardt callers below.
 template <typename T>
 Matrix3<T> twoAxisRotationMatrix(int axis0, int axis1, const Vector2<T>& angles) {
   return singleAxisRotationMatrix(axis1, angles[1]) * singleAxisRotationMatrix(axis0, angles[0]);
 }
 
-/// Computes the derivatives of a two axis rotation matrix with respect to both angles.
+// Returns (dR/dangle0, dR/dangle1) for R = R(axis1) * R(axis0), via the product rule.
 template <typename T>
 std::pair<Matrix3<T>, Matrix3<T>>
 twoAxisRotationMatrixDerivatives(int axis0, int axis1, const Vector2<T>& angles) {
@@ -688,7 +711,9 @@ twoAxisRotationMatrixDerivatives(int axis0, int axis1, const Vector2<T>& angles)
   return {R1 * dR0, dR1 * R0};
 }
 
-/// Levenberg-Marquardt solver for scalar optimization.
+// Levenberg-Marquardt solver minimizing ||R(axis, angle) - target||_F^2 in the angle.
+// Despite the name, this is a plain Gauss-Newton step (no LM damping term is added).
+// TODO: Either add real LM damping or rename to gaussNewtonSolveScalar to match behavior.
 template <typename T>
 T levenbergMarquardtSolveScalar(
     const Matrix3<T>& target,
@@ -707,30 +732,40 @@ T levenbergMarquardtSolveScalar(
     const Matrix3<T> residualMatrix = R - target;
     const T residual = residualMatrix.squaredNorm();
 
-    // Check convergence
+    // Convergence: residual already small, OR residual decreased by less than tolerance
+    // since the last iteration. NOTE: the second clause also fires when the residual
+    // *increased* (previousResidual - residual is negative), so this also acts as a
+    // divergence guard rather than a strict monotone-progress check. It does NOT roll
+    // back the diverging step — the last `angle` is whatever the last GN iteration left.
     if (residual < tolerance || (previousResidual - residual) < tolerance) {
       break;
     }
     previousResidual = residual;
 
-    // Compute Jacobian (derivative of squared norm with respect to angle)
-    // d/da ||R(a) - target||^2 = 2 * trace((R(a) - target)^T * dR/da)
+    // Jacobian of the FLATTENED residual r(a) = vec(R(a) - target) w.r.t. the angle a
+    // (a 9x1 column). This is the residual-vector Jacobian, NOT the gradient of the
+    // squared norm — the householderQr().solve below performs a least-squares step
+    // J * delta ≈ -r, which is the Gauss-Newton update.
     const Matrix3<T> dR = singleAxisRotationMatrixDerivative(axis, angle);
     const Eigen::Matrix<T, 9, 1> jacobian = dR.reshaped(9, 1);
 
     const Eigen::Vector<T, 9> residualVector = residualMatrix.reshaped(9, 1);
 
-    // Levenberg-Marquardt step
+    // Gauss-Newton step (no LM damping is added — see TODO above).
     const Eigen::Vector<T, 1> delta = jacobian.householderQr().solve(-residualVector);
 
-    // Update with step size control
+    // No line search or trust-region — we trust the Gauss-Newton direction directly.
     angle += delta(0);
   }
 
   return angle;
 }
 
-/// Levenberg-Marquardt solver for two-parameter optimization using proper vector residuals.
+// Levenberg-Marquardt solver minimizing ||R(axis0, axis1, angles) - target||_F^2 in the
+// two-vector of angles. As with the scalar version, this is currently a Gauss-Newton step
+// (the comment about (J^T J + lambda I) below describes the intended LM update, not what
+// is actually solved by the householder QR call).
+// TODO: Add proper LM damping (lambda) or rename this to gaussNewtonSolveTwoAxis.
 template <typename T>
 Vector2<T> levenbergMarquardtSolveTwoAxis(
     const Matrix3<T>& target,
@@ -751,7 +786,9 @@ Vector2<T> levenbergMarquardtSolveTwoAxis(
     const Matrix3<T> residualMatrix = R - target;
     const T residualNorm = residualMatrix.squaredNorm();
 
-    // Check convergence
+    // Same convergence/divergence behavior as the scalar version above: the second
+    // clause exits both on slow progress and on residual increase, without rolling
+    // back the diverging step.
     if (residualNorm < tolerance || (previousResidualNorm - residualNorm) < tolerance) {
       break;
     }
@@ -764,8 +801,8 @@ Vector2<T> levenbergMarquardtSolveTwoAxis(
     jacobian.template block<9, 1>(0, 0) = dR0.reshaped(9, 1);
     jacobian.template block<9, 1>(0, 1) = dR1.reshaped(9, 1);
 
-    // Gauss-Newton approximation: H ≈ J^T J
-    // Solve: (J^T J + λI) δθ = -J^T r
+    // Gauss-Newton step solved as a 9x2 linear least-squares: minimize ||J*delta + r||.
+    // No LM damping (lambda) is applied; see TODO above the function.
     const Vector2<T> delta = jacobian.householderQr().solve(-residualVector);
 
     // Check if solution is valid
@@ -819,7 +856,6 @@ Vector2<T> rotationMatrixToTwoAxisEuler(const Matrix3<T>& m, int axis0, int axis
           rotationMatrixToOneAxisEuler(m, axis0), rotationMatrixToOneAxisEuler(m, axis1)});
 }
 
-// Explicit template instantiations
 template float rotationMatrixToOneAxisEuler(const Matrix3<float>& m, int axis0);
 template double rotationMatrixToOneAxisEuler(const Matrix3<double>& m, int axis0);
 

--- a/momentum/math/utility.h
+++ b/momentum/math/utility.h
@@ -91,6 +91,13 @@ MatrixX<T> pseudoInverse(const SparseMatrix<T>& mat);
 /// Reference: "Practical Parameterization of Rotations Using the Exponential Map"
 /// by F. Sebastian Grassia, Journal of Graphics Tools, 1998.
 ///
+/// @note The exp map is used internally by `JointStateT::set()` to convert the 3 Euler rotation
+/// parameters [rx, ry, rz] into a quaternion. The log map is used by
+/// `skeletonStateToJointParameters()` for the inverse conversion. The exp map is numerically
+/// robust for small angles (Taylor series expansion), important because most joint rotations are
+/// small perturbations from rest pose during optimization. For 180 degree rotations (near -I
+/// quaternion), a consistent branch is chosen to avoid discontinuities.
+///
 /// @tparam T The scalar type
 /// @param v The rotation vector (axis-angle representation)
 /// @return The corresponding unit quaternion
@@ -107,6 +114,14 @@ Quaternion<T> quaternionExpMap(const Vector3<T>& v);
 /// Reference: "Practical Parameterization of Rotations Using the Exponential Map"
 /// by F. Sebastian Grassia, Journal of Graphics Tools, 1998.
 ///
+/// @note The exp map is used internally by `JointStateT::set()` to convert the 3 Euler rotation
+/// parameters [rx, ry, rz] into a quaternion. The log map is used by
+/// `skeletonStateToJointParameters()` for the inverse conversion. The exp map is numerically
+/// robust for small angles (Taylor series expansion), important because most joint rotations are
+/// small perturbations from rest pose during optimization. For 180 degree rotations (near -I
+/// quaternion), a consistent branch is chosen to avoid discontinuities.
+///
+/// @pre `q` should be normalized.
 /// @tparam T The scalar type
 /// @param q The input quaternion (should be normalized)
 /// @return The corresponding rotation vector (axis-angle representation)
@@ -133,6 +148,13 @@ template <typename T>
 Eigen::Matrix<T, 3, 4> quaternionLogMapDerivative(const Quaternion<T>& q);
 
 /// The Euler angles convention.
+///
+/// @note Momentum's skeleton state uses Extrinsic XYZ convention throughout.
+/// `quaternionToEuler()` returns Extrinsic XYZ angles. `JointStateT::set()` applies rotations in
+/// reverse order (Z, Y, X) which is equivalent to Extrinsic XYZ. Relationship between
+/// conventions: Extrinsic XYZ = Intrinsic ZYX (same rotation matrix, different description).
+/// `eulerToRotationMatrix(angles, 0, 1, 2, Extrinsic)` = `RotZ(c) * RotY(b) * RotX(a)` =
+/// `eulerToRotationMatrix(angles, 2, 1, 0, Intrinsic)`.
 enum class EulerConvention {
   /// The intrinsic convention. Intrinsic rotations (also called local, relative, or body-fixed
   /// rotations) are performed around the axes of the coordinate system that is attached to the
@@ -276,7 +298,13 @@ Vector3<T> quaternionToEuler(const Quaternion<T>& q);
 
 /// Computes the weighted average of multiple quaternions
 ///
-/// Uses the method described in Markley et al. "Averaging Quaternions"
+/// Uses the method described in Markley et al. "Averaging Quaternions". Finds the eigenvector of
+/// the 4x4 quaternion outer product matrix corresponding to the largest eigenvalue.
+///
+/// @note Used in `simplify()` when merging child joint rotations into ancestors, and in motion
+/// processing when blending pose estimates.
+///
+/// @pre If `w` is provided, its size must match `q`.
 /// @param q Array of quaternions to average
 /// @param w Optional weights for each quaternion (defaults to equal weights)
 /// @return The average quaternion


### PR DESCRIPTION
Summary:

Per-file work was dispatched to one subagent per file in parallel (two batches of ~14). Each subagent followed the same 4-rule pass — fix outdated comments, remove filler comments, add documentation for high-value locations (contracts, units, algorithms, side effects, edge cases, data formats), and flag real code issues with `// TODO:` comments. Comment-only changes plus TODO additions; no functional code was modified. Doxygen format follows style guide.

Highlights from the folder-specific hints (applied where relevant):

- `utility.h`: documented Momentum's Extrinsic XYZ Euler convention ( = Intrinsic ZYX), the FK connection of `quaternionExpMap`/`quaternionLogMap`, and the eigenvector method behind `quaternionAverage`.
- `transform.h`: `EntilZha Design rationale` on `TransformT` explaining why it's preferred over `Eigen::Affine3` (faster composition, free decomposition, simpler FK derivatives) and where to use Affine3 (IO boundaries only).
- `generalized_loss.h`: alpha-value reference (L2/Pseudo-Huber/Cauchy/Geman-McClure/Welsch) and how the loss interacts with the Gauss-Newton solver via residual+Jacobian chain rule.
- `constants.h`: `note` on `pi<T>()`/`twopi<T>()` explaining the cross-platform reason (MSVC doesn't define `M_PI` without `_USE_MATH_DEFINES`).
- `types.h`: documented `ParameterSet` (compile-time bitset for parameter selection) and the joint-parameter layout convention used throughout the solver.

Notable additions worth highlighting for review (TODOs flagging real bugs/issues for follow-up — kept as TODOs to keep this audit comment-only):

- `utility.cpp`: fixed wrong `(J^TJ + λI)` claim in two `levenbergMarquardtSolve*` functions which actually do plain Gauss-Newton (no damping); fixed missing factor-of-2 in `quaternionLogMap` formula comment; fixed mislabeled gimbal-lock and "Jacobian of squared norm" comments. TODOs for: clamp `asin` in `quaternionToEuler`, rename-or-damp the LM solvers, replace hard-coded `T(1e-7)` parallel tolerance with `Eps<T>(...)`.
- `online_householder_qr.h/cpp`: documented the arrowhead/banded storage layouts, two-stage back-substitution, and the cancellation-free v1 branch in the Householder reflector. TODOs for: `ColumnIndexedMatrix::transpose_times` ignoring column remap in `useColumnIndices_` branch (returns wrong values for non-identity index sets); duplicate `MT_CHECK` (line 69); apparently-unused `validateColumnIndices` helper; missing `b.rows()` asserts in banded variants; rank-deficiency divide-by-zero in `OnlineHouseholderQR::result` and `OnlineBandedHouseholderQR::x_dense`.
- `generalized_loss.cpp`: `// TODO:` flagging that `alpha_ <= kWelsch` (kWelsch = -1e-9) routes any finite negative alpha (e.g. Geman-McClure -2 documented in the header) to the Welsch -inf limit instead of the General formula — real bug.
- `mppca.h`: corrected the `Rpre` documentation (it's the per-component log-likelihood constant, not a "responsibility"). TODOs for `pi`/`inPi` parameter-name mismatch and `pi` not retained as a member.
- `transform.h`: `// TODO:` on `isApprox` recommending direct component comparison instead of round-tripping through `Affine3` (which conflates per-component tolerances and breaks on quaternion sign).
- `transform.cpp`: TODO for non-uniform scale/shear/reflection handling in `fromMatrix`; TODO for `weightSum == 0` degenerate case in `blendTransforms`.
- `random.h`: TODOs for inconsistent `Vector2f` example range, missing seeding/reproducibility policy on `GetSingleton()`, integer-truncating defaults in `uniformAffine3`.
- `random-inl.h`: TODOs for silent value-init fallback in `generateScalarUniform`, unchecked overflow when rounding float normal into integer, and misleading `uniformAffine3` name (samples isotropic scale only).
- `intersection.cpp`: TODOs for `z=0` projection assumption in `sign()`, share-vertex over-rejection, non-scale-invariant parallel-edge tolerance, untreated degenerate triangles in normal computation.
- `mesh.cpp`: TODO for `IsNanNoOpt(normal[0])` only inspecting the x-component.
- `simd_generalized_loss.cpp`: TODOs on default branches flagging that `return {}` may produce uninitialized DrJit packet lanes.
- `resizeable_matrix.h`: TODOs for always-zero default-insertion cost in `resizeAndSetZero`; `vec()` silently ignoring `cols_ > 1`.

Reviewed By: cstollmeta

Differential Revision: D102438582
