### PR TITLE
Add FbxBuilder::addAnimatedMesh and refactor jointParamToFbx

### DIFF
--- a/momentum/io/fbx/fbx_builder.cpp
+++ b/momentum/io/fbx/fbx_builder.cpp
@@ -120,6 +120,18 @@ void FbxBuilder::addRigidBody(
   auto skeletonResult = createSkeletonNodes(character, impl_->scene);
   addMetaData(skeletonResult.rootNode, character);
 
+  // Prefix skeleton joint names with charName to avoid collisions when
+  // multiple rigid bodies share the scene (e.g. "root" -> "controller_l:root").
+  if (!name.empty()) {
+    for (auto* node : skeletonResult.nodes) {
+      std::string prefixed = charName + ":" + node->GetName();
+      node->SetName(prefixed.c_str());
+      if (auto* attr = node->GetNodeAttribute()) {
+        attr->SetName(prefixed.c_str());
+      }
+    }
+  }
+
   // Resolve which joint node to parent the mesh under
   MT_THROW_IF(
       parentJoint >= skeletonResult.nodes.size(),
@@ -264,6 +276,129 @@ void FbxBuilder::addMotionWithJointParams(
       true); // skipActiveJointParamCheck = true
 }
 
+void FbxBuilder::addAnimatedMesh(
+    const Character& character,
+    const std::string& name,
+    float fps,
+    const MatrixXf& jointParams) {
+  MT_THROW_IF(!impl_, "FbxBuilder has been moved from or already saved");
+  MT_THROW_IF(!impl_->scene, "FBX scene is null");
+  MT_THROW_IF(character.mesh == nullptr, "Character has no mesh");
+  MT_THROW_IF(character.skeleton.joints.empty(), "Character skeleton has no joints");
+  MT_THROW_IF(jointParams.cols() == 0, "jointParams is empty");
+
+  auto* root = impl_->scene->GetRootNode();
+  MT_THROW_IF(root == nullptr, "Unable to get root node from FBX scene");
+
+  // Create mesh node directly under scene root (no skeleton)
+  const auto numVertices = static_cast<int>(character.mesh->vertices.size());
+  ::fbxsdk::FbxNode* meshNode = ::fbxsdk::FbxNode::Create(impl_->scene, name.c_str());
+  ::fbxsdk::FbxMesh* lMesh = ::fbxsdk::FbxMesh::Create(impl_->scene, (name + "_geo").c_str());
+  lMesh->SetControlPointCount(numVertices);
+  lMesh->InitNormals(numVertices);
+  for (int i = 0; i < numVertices; i++) {
+    lMesh->SetControlPointAt(
+        FbxVector4(
+            character.mesh->vertices[i].x(),
+            character.mesh->vertices[i].y(),
+            character.mesh->vertices[i].z()),
+        FbxVector4(
+            character.mesh->normals[i].x(),
+            character.mesh->normals[i].y(),
+            character.mesh->normals[i].z()),
+        i);
+  }
+  writePolygonsToFbxMesh(*character.mesh, lMesh);
+  lMesh->BuildMeshEdgeArray();
+  meshNode->SetNodeAttribute(lMesh);
+
+  if (!character.mesh->texcoords.empty()) {
+    const fbxsdk::FbxLayerElement::EType uvType = fbxsdk::FbxLayerElement::eTextureDiffuse;
+    lMesh->InitTextureUV(0, uvType);
+    lMesh->InitTextureUVIndices(::fbxsdk::FbxLayerElement::EMappingMode::eByPolygonVertex, uvType);
+    for (const auto& texcoords : character.mesh->texcoords) {
+      lMesh->AddTextureUV(::fbxsdk::FbxVector2(texcoords[0], 1.0f - texcoords[1]), uvType);
+    }
+    writeTextureUVIndicesToFbxMesh(*character.mesh, lMesh, uvType);
+  }
+
+  root->AddChild(meshNode);
+
+  // Animate the mesh node's transform using the root joint parameters.
+  // Joint params layout per joint: tx, ty, tz, rx, ry, rz, sx, sy, sz.
+  setFrameRate(impl_->scene, fps);
+  auto [animStack, animBaseLayer] =
+      getOrCreateAnimStackAndLayer(impl_->scene, "Skeleton Animation Stack");
+
+  meshNode->LclTranslation.GetCurveNode(true);
+  meshNode->LclRotation.GetCurveNode(true);
+  meshNode->LclScaling.GetCurveNode(true);
+
+  // Create all 9 curves for the root joint transform
+  std::array<::fbxsdk::FbxAnimCurve*, 9> curves = {
+      meshNode->LclTranslation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_X, true),
+      meshNode->LclTranslation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Y, true),
+      meshNode->LclTranslation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Z, true),
+      meshNode->LclRotation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_X, true),
+      meshNode->LclRotation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Y, true),
+      meshNode->LclRotation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Z, true),
+      meshNode->LclScaling.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_X, true),
+      meshNode->LclScaling.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Y, true),
+      meshNode->LclScaling.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Z, true),
+  };
+
+  // jointParams is (nJointParams x nFrames) in C++ convention.
+  // FBX curves use 9 channels (tx,ty,tz,rx,ry,rz,sx,sy,sz); momentum uses 7
+  // (uniform scale maps to all three scale channels via jointParamToFbx).
+  const auto nFrames = jointParams.cols();
+  const auto& rootJoint = character.skeleton.joints[0];
+
+  // Set static default transform, then only animate channels that vary
+  FbxDouble3 staticTrans(
+      jointParamToFbx(jointParams(0, 0), 0, rootJoint),
+      jointParamToFbx(jointParams(1, 0), 1, rootJoint),
+      jointParamToFbx(jointParams(2, 0), 2, rootJoint));
+  meshNode->LclTranslation.Set(staticTrans);
+  FbxDouble3 staticRot(
+      jointParamToFbx(jointParams(3, 0), 3, rootJoint),
+      jointParamToFbx(jointParams(4, 0), 4, rootJoint),
+      jointParamToFbx(jointParams(5, 0), 5, rootJoint));
+  meshNode->LclRotation.Set(staticRot);
+  const Eigen::Index scaleRow = std::min(static_cast<Eigen::Index>(6), jointParams.rows() - 1);
+  const float staticScale = jointParamToFbx(jointParams(scaleRow, 0), 6, rootJoint);
+  meshNode->LclScaling.Set(FbxDouble3(staticScale, staticScale, staticScale));
+
+  ::fbxsdk::FbxTime time;
+  for (size_t c = 0; c < 9; c++) {
+    const auto paramRow = static_cast<Eigen::Index>(std::min(c, size_t(6)));
+    if (paramRow >= jointParams.rows()) {
+      break;
+    }
+
+    // Skip channels where the value is constant across all frames
+    bool isConstant = true;
+    const float firstVal = jointParams(paramRow, 0);
+    for (Eigen::Index f = 1; f < nFrames; f++) {
+      if (jointParams(paramRow, f) != firstVal) {
+        isConstant = false;
+        break;
+      }
+    }
+    if (isConstant) {
+      continue;
+    }
+
+    curves[c]->KeyModifyBegin();
+    for (Eigen::Index f = 0; f < nFrames; f++) {
+      const float val = jointParamToFbx(jointParams(paramRow, f), c, rootJoint);
+      time.SetSecondDouble(static_cast<double>(f) / fps);
+      const auto keyIndex = curves[c]->KeyAdd(time);
+      curves[c]->KeySet(keyIndex, time, val);
+    }
+    curves[c]->KeyModifyEnd();
+  }
+}
+
 void FbxBuilder::addMarkerSequence(float fps, std::span<const std::vector<Marker>> markerSequence) {
   MT_THROW_IF(!impl_, "FbxBuilder has been moved from or already saved");
 
@@ -329,6 +464,10 @@ void FbxBuilder::addMotion(const Character&, float, const MatrixXf&, const Vecto
 }
 
 void FbxBuilder::addMotionWithJointParams(const Character&, float, const MatrixXf&) {
+  MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
+}
+
+void FbxBuilder::addAnimatedMesh(const Character&, const std::string&, float, const MatrixXf&) {
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 

--- a/momentum/io/fbx/fbx_builder.h
+++ b/momentum/io/fbx/fbx_builder.h
@@ -97,6 +97,22 @@ class FbxBuilder final {
   /// @param jointParams Joint parameters matrix with shape (nFrames x nJointParams).
   void addMotionWithJointParams(const Character& character, float fps, const MatrixXf& jointParams);
 
+  /// Add an animated mesh (mesh node with per-frame transform, no skeleton).
+  ///
+  /// Creates a standalone mesh node and animates its transform directly from
+  /// the root joint parameters. This is for props/objects that should appear
+  /// as a simple animated mesh without any skeleton hierarchy.
+  ///
+  /// @param character The character providing the mesh geometry.
+  /// @param name Name for the mesh node.
+  /// @param fps Animation frame rate in frames per second.
+  /// @param jointParams Joint parameters matrix with shape (nFrames x nJointParams).
+  void addAnimatedMesh(
+      const Character& character,
+      const std::string& name,
+      float fps,
+      const MatrixXf& jointParams);
+
   /// Add a marker sequence to the scene.
   ///
   /// @param fps Frame rate for the marker animation.

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -288,6 +288,27 @@ inline std::pair<::fbxsdk::FbxAnimStack*, ::fbxsdk::FbxAnimLayer*> getOrCreateAn
   return {animStack, animBaseLayer};
 }
 
+/// Convert a raw momentum joint parameter to the FBX-native value.
+///
+/// FBX curves use 9 channels per joint: tx,ty,tz (0-2), rx,ry,rz (3-5), sx,sy,sz (6-8).
+/// Momentum stores 7 params: translation, rotation (radians), uniform log2-scale.
+///   - Translation: adds the joint's rest-pose translationOffset.
+///   - Rotation: converts radians to degrees.
+///   - Scale: converts log2 to linear (exp2).
+///
+/// @param value Raw joint parameter value from the motion matrix.
+/// @param curveOffset FBX curve channel index (0-8).
+/// @param joint The joint providing the translation offset.
+inline float jointParamToFbx(float value, size_t curveOffset, const Joint& joint) {
+  if (curveOffset < 3) {
+    return value + joint.translationOffset[curveOffset];
+  } else if (curveOffset < 6) {
+    return toDeg(value);
+  } else {
+    return std::exp2(value);
+  }
+}
+
 struct JointCurveSetup {
   std::vector<::fbxsdk::FbxAnimCurve*> animCurves;
   std::vector<size_t> animCurvesIndex;
@@ -386,20 +407,11 @@ inline void createAnimationCurves(
     }
 
     // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
+    const auto& joint = character.skeleton.joints[jointIndex];
     animCurves[ai]->KeyModifyBegin();
     for (size_t f = 0; f < jointValues.cols(); f++) {
       time.SetSecondDouble(static_cast<double>(f) / framerate);
-
-      float jointVal = jointValues(parameterIndex, f);
-
-      if (jointOffset < 3 && jointIndex < character.skeleton.joints.size()) {
-        jointVal += character.skeleton.joints[jointIndex].translationOffset[jointOffset];
-      } else if (jointOffset >= 3 && jointOffset <= 5) {
-        jointVal = toDeg(jointVal);
-      } else {
-        jointVal = std::pow(2.0f, jointVal);
-      }
-
+      const float jointVal = jointParamToFbx(jointValues(parameterIndex, f), jointOffset, joint);
       const auto keyIndex = animCurves[ai]->KeyAdd(time);
       animCurves[ai]->KeySet(keyIndex, time, jointVal);
     }

--- a/pymomentum/geometry/fbx_builder_pybind.cpp
+++ b/pymomentum/geometry/fbx_builder_pybind.cpp
@@ -119,6 +119,33 @@ This is useful for rigid bodies or characters with simple parameterization.
           py::arg("fps") = 120.0f,
           py::arg("joint_params") = std::nullopt)
       .def(
+          "add_animated_mesh",
+          [](mm::FbxBuilder& builder,
+             const mm::Character& character,
+             const std::string& name,
+             float fps,
+             const std::optional<Eigen::MatrixXf>& jointParams) {
+            mm::MatrixXf transposedJointParams;
+            if (jointParams.has_value() && jointParams->size() > 0) {
+              transposedJointParams = jointParams->transpose();
+            }
+            builder.addAnimatedMesh(character, name, fps, transposedJointParams);
+          },
+          R"(Add an animated mesh (no skeleton) to the scene.
+
+Creates a standalone mesh node and animates its transform directly from
+the root joint parameters. Use this for props/objects that should appear
+as a simple animated mesh without any skeleton hierarchy.
+
+:param character: The character providing the mesh geometry.
+:param name: Name for the mesh node.
+:param fps: Animation frame rate in frames per second.
+:param joint_params: Joint parameters matrix with shape (nFrames, nJointParams).)",
+          py::arg("character"),
+          py::arg("name"),
+          py::arg("fps") = 120.0f,
+          py::arg("joint_params") = std::nullopt)
+      .def(
           "add_marker_sequence",
           [](mm::FbxBuilder& builder,
              float fps,


### PR DESCRIPTION
Summary:
Adds FbxBuilder::addAnimatedMesh() for adding standalone animated mesh nodes (no skeleton hierarchy) to an FBX scene. The mesh node transform is animated directly from root joint parameters, which is useful for props/objects that are simple rigid bodies.

Also refactors the joint-parameter-to-FBX conversion logic into a shared jointParamToFbx() helper in fbx_io_internal.h, replacing duplicated inline code in writeJointParamsToFbxScene. This helper handles translation offset addition, radian-to-degree conversion, and log2-to-linear scale conversion.

Additionally, addRigidBody() now prefixes skeleton joint names with the character name when a name override is provided (e.g. "controller_l:root"), preventing FBX auto-dedup collisions when multiple rigid bodies share a scene.

Reviewed By: cstollmeta

Differential Revision: D102523391


