### PR TITLE
Comment audit: camera/

### DIFF
--- a/momentum/camera/camera.cpp
+++ b/momentum/camera/camera.cpp
@@ -19,7 +19,7 @@
 
 namespace momentum {
 
-// Default constructor is VGA res.
+// Default is VGA resolution with a focal length corresponding to a 3.6 mm sensor and 5 mm lens.
 template <typename T>
 CameraT<T>::CameraT()
     : intrinsicsModel_(
@@ -29,14 +29,12 @@ CameraT<T>::CameraT()
               (5.0 / 3.6) * 640,
               (5.0 / 3.6) * 640)) {}
 
-// Constructor implementation for CameraT.
 template <typename T>
 CameraT<T>::CameraT(
     std::shared_ptr<const IntrinsicsModelT<T>> intrinsicsModel,
     const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld)
     : eyeFromWorld_(eyeFromWorld), intrinsicsModel_(intrinsicsModel) {}
 
-// Constructor for PinholeIntrinsicsModelT with explicit principal point.
 template <typename T>
 PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     int32_t imageWidth,
@@ -47,7 +45,6 @@ PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     T cy)
     : IntrinsicsModelT<T>(imageWidth, imageHeight), fx_(fx), fy_(fy), cx_(cx), cy_(cy) {}
 
-// Constructor for PinholeIntrinsicsModelT with principal point at image center.
 template <typename T>
 PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     int32_t imageWidth,
@@ -60,7 +57,6 @@ PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
       cx_(T(imageWidth) / T(2)),
       cy_(T(imageHeight) / T(2)) {}
 
-// Constructor for OpenCVIntrinsicsModelT with optional distortion parameters.
 template <typename T>
 OpenCVIntrinsicsModelT<T>::OpenCVIntrinsicsModelT(
     int32_t imageWidth,
@@ -80,11 +76,11 @@ OpenCVIntrinsicsModelT<T>::OpenCVIntrinsicsModelT(
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> PinholeIntrinsicsModelT<T>::project(
     const Vector3P<T>& point) const {
-  // Normalize the point by dividing by z
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity mask filters them out.
   Packet<T> x = point.x() / point.z();
   Packet<T> y = point.y() / point.z();
 
-  // Apply camera matrix to get pixel coordinates
   Packet<T> u = fx_ * x + this->cx();
   Packet<T> v = fy_ * y + this->cy();
 
@@ -94,11 +90,11 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> PinholeIntrinsicsModelT<T>:
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool> PinholeIntrinsicsModelT<T>::project(
     const Eigen::Vector3<T>& point) const {
-  // Normalize the point by dividing by z
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity flag filters them out.
   T x = point.x() / point.z();
   T y = point.y() / point.z();
 
-  // Apply camera matrix to get pixel coordinates
   T u = fx_ * x + this->cx();
   T v = fy_ * y + this->cy();
 
@@ -112,7 +108,6 @@ PinholeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) cons
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     return {Eigen::Vector3<T>::Zero(), Eigen::Matrix<T, 3, 3>::Zero(), false};
   }
@@ -120,28 +115,27 @@ PinholeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) cons
   const T z_inv = T(1) / z;
   const T z_inv_sq = z_inv * z_inv;
 
-  // Project the point
   const T u = fx_ * x * z_inv + cx_;
   const T v = fy_ * y * z_inv + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x3)
+  // Pinhole projection Jacobian:
+  //   u = fx * (x/z) + cx,  v = fy * (y/z) + cy,  z passes through unchanged.
+  // TODO: jacobian(0,1), jacobian(1,0), jacobian(2,0), jacobian(2,1) are redundant assignments
+  // since the matrix is zero-initialized; consider removing them in a separate code-change diff.
   Eigen::Matrix<T, 3, 3> jacobian = Eigen::Matrix<T, 3, 3>::Zero();
 
-  // Row 0: du/dx, du/dy, du/dz
-  jacobian(0, 0) = fx_ * z_inv; // du/dx = fx / z
-  jacobian(0, 1) = T(0); // du/dy = 0
-  jacobian(0, 2) = -fx_ * x * z_inv_sq; // du/dz = -fx * x / z^2
+  jacobian(0, 0) = fx_ * z_inv;
+  jacobian(0, 1) = T(0);
+  jacobian(0, 2) = -fx_ * x * z_inv_sq;
 
-  // Row 1: dv/dx, dv/dy, dv/dz
-  jacobian(1, 0) = T(0); // dv/dx = 0
-  jacobian(1, 1) = fy_ * z_inv; // dv/dy = fy / z
-  jacobian(1, 2) = -fy_ * y * z_inv_sq; // dv/dz = -fy * y / z^2
+  jacobian(1, 0) = T(0);
+  jacobian(1, 1) = fy_ * z_inv;
+  jacobian(1, 2) = -fy_ * y * z_inv_sq;
 
-  // Row 2: homogeneous coordinates (for completeness)
-  jacobian(2, 0) = T(0); // dz/dx = 0
-  jacobian(2, 1) = T(0); // dz/dy = 0
-  jacobian(2, 2) = T(1); // dz/dz = 1
+  jacobian(2, 0) = T(0);
+  jacobian(2, 1) = T(0);
+  jacobian(2, 2) = T(1);
 
   return {projectedPoint, jacobian, true};
 }
@@ -153,9 +147,9 @@ std::shared_ptr<const IntrinsicsModelT<T>> PinholeIntrinsicsModelT<T>::resize(
   T scaleX = T(imageWidth) / T(this->imageWidth());
   T scaleY = T(imageHeight) / T(this->imageHeight());
 
-  // Apply the correct formula for camera center as noted in the comment:
-  // cx = (old_cx + 0.5) * new_sizex / old_sizex - 0.5;
-  // cy = (old_cy + 0.5) * new_sizey / old_sizey - 0.5;
+  // Use the half-pixel-offset convention so that pixel centers map exactly between resolutions:
+  //   new_cx = (old_cx + 0.5) * scaleX - 0.5
+  //   new_cy = (old_cy + 0.5) * scaleY - 0.5
   T old_cx = this->cx();
   T old_cy = this->cy();
   T new_cx = (old_cx + T(0.5)) * scaleX - T(0.5);
@@ -171,7 +165,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> PinholeIntrinsicsModelT<T>::crop(
     int32_t left,
     int32_t newWidth,
     int32_t newHeight) const {
-  // Ensure the crop doesn't exceed the original image dimensions
+  // Clamp the crop region to stay inside the original image bounds.
   int32_t width = newWidth;
   if (left + width > this->imageWidth()) {
     width = this->imageWidth() - left;
@@ -182,7 +176,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> PinholeIntrinsicsModelT<T>::crop(
     height = this->imageHeight() - top;
   }
 
-  // Adjust the principal point by subtracting the crop offset
+  // Shift the principal point so it stays at the same physical location after cropping.
   T cameraCenter_cropped_cx = cx_ - T(left);
   T cameraCenter_cropped_cy = cy_ - T(top);
 
@@ -195,16 +189,14 @@ std::pair<Eigen::Vector3<T>, bool> PinholeIntrinsicsModelT<T>::unproject(
     const Eigen::Vector3<T>& imagePoint,
     int /*maxIterations*/,
     T /*tolerance*/) const {
-  // For pinhole cameras, unprojection is straightforward - no distortion to invert
+  // Pinhole has no distortion to invert, so unprojection is closed-form.
   const T u = imagePoint(0);
   const T v = imagePoint(1);
   const T depth = imagePoint(2);
 
-  // Convert to normalized camera coordinates
   const T x = (u - cx_) / fx_;
   const T y = (v - cy_) / fy_;
 
-  // Return 3D point in camera coordinates with the given depth
   return {Eigen::Vector3<T>(x * depth, y * depth, depth), depth > T(0)};
 }
 
@@ -249,50 +241,40 @@ PinholeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& p
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     Eigen::Matrix<T, 3, 4> zeroJacobian = Eigen::Matrix<T, 3, 4>::Zero();
     return {Eigen::Vector3<T>::Zero(), zeroJacobian, false};
   }
 
   const T z_inv = T(1) / z;
-  const T xn = x * z_inv; // x/z (normalized coordinate)
-  const T yn = y * z_inv; // y/z (normalized coordinate)
+  const T xn = x * z_inv;
+  const T yn = y * z_inv;
 
-  // Project the point: u = fx * x/z + cx, v = fy * y/z + cy
   const T u = fx_ * xn + cx_;
   const T v = fy_ * yn + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x4) with respect to [fx, fy, cx, cy]
-  // u = fx * (x/z) + cx
-  // v = fy * (y/z) + cy
-  // depth = z (unchanged)
-  //
-  // du/dfx = x/z,  du/dfy = 0,    du/dcx = 1,  du/dcy = 0
-  // dv/dfx = 0,    dv/dfy = y/z,  dv/dcx = 0,  dv/dcy = 1
-  // dz/d*  = 0     (depth is unchanged by intrinsics)
+  // Jacobian with respect to [fx, fy, cx, cy]:
+  //   du/dfx = x/z,  du/dfy = 0,    du/dcx = 1,  du/dcy = 0
+  //   dv/dfx = 0,    dv/dfy = y/z,  dv/dcx = 0,  dv/dcy = 1
+  //   dz/d*  = 0     (depth is independent of intrinsics)
+  // TODO: the explicit T(0) assignments below are redundant given the zero-init; keep here for
+  // readability symmetry with non-zero rows but consider removing in a separate code-change diff.
   Eigen::Matrix<T, 3, 4> jacobian = Eigen::Matrix<T, 3, 4>::Zero();
 
-  // Row 0: du/d[fx, fy, cx, cy]
-  jacobian(0, 0) = xn; // du/dfx = x/z
-  jacobian(0, 1) = T(0); // du/dfy = 0
-  jacobian(0, 2) = T(1); // du/dcx = 1
-  jacobian(0, 3) = T(0); // du/dcy = 0
+  jacobian(0, 0) = xn;
+  jacobian(0, 1) = T(0);
+  jacobian(0, 2) = T(1);
+  jacobian(0, 3) = T(0);
 
-  // Row 1: dv/d[fx, fy, cx, cy]
-  jacobian(1, 0) = T(0); // dv/dfx = 0
-  jacobian(1, 1) = yn; // dv/dfy = y/z
-  jacobian(1, 2) = T(0); // dv/dcx = 0
-  jacobian(1, 3) = T(1); // dv/dcy = 1
-
-  // Row 2: dz/d[fx, fy, cx, cy] = 0 (depth unchanged)
-  // Already set to zero above
+  jacobian(1, 0) = T(0);
+  jacobian(1, 1) = yn;
+  jacobian(1, 2) = T(0);
+  jacobian(1, 3) = T(1);
 
   return {projectedPoint, jacobian, true};
 }
 
-// Base class implementations for IntrinsicsModelT
 template <typename T>
 std::shared_ptr<const IntrinsicsModelT<T>> IntrinsicsModelT<T>::resample(T factor) const {
   return resize(
@@ -314,11 +296,12 @@ std::shared_ptr<const IntrinsicsModelT<T>> IntrinsicsModelT<T>::upsample(T facto
       static_cast<int32_t>(this->imageHeight() * factor));
 }
 
-// OpenCVIntrinsicsModelT implementation
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVIntrinsicsModelT<T>::project(
     const Vector3P<T>& point) const {
-  // Normalize the point by dividing by z
+  // OpenCV rational distortion model: rational radial polynomial in r^2 plus tangential terms.
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity mask filters them out.
   Packet<T> invZ = T(1) / point.z();
   Packet<T> xp = point.x() * invZ;
   Packet<T> yp = point.y() * invZ;
@@ -336,7 +319,6 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVIntrinsicsModelT<T>::
   Packet<T> ypp =
       yp * radialDistortion + dp.p1 * (rsqr + T(2) * drjit::square(yp)) + T(2) * dp.p2 * xp * yp;
 
-  // Apply camera matrix to get pixel coordinates
   Packet<T> u = fx_ * xpp + cx_;
   Packet<T> v = fy_ * ypp + cy_;
 
@@ -346,7 +328,8 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVIntrinsicsModelT<T>::
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::project(
     const Eigen::Vector3<T>& point) const {
-  // Normalize the point by dividing by z
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity flag filters them out.
   T invZ = T(1) / point.z();
   T xp = point.x() * invZ;
   T yp = point.y() * invZ;
@@ -362,7 +345,6 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::project(
   T xpp = xp * radialDistortion + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   T ypp = yp * radialDistortion + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
 
-  // Apply camera matrix to get pixel coordinates
   T u = fx_ * xpp + cx_;
   T v = fy_ * ypp + cy_;
 
@@ -376,7 +358,6 @@ OpenCVIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) const
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     return {Eigen::Vector3<T>::Zero(), Eigen::Matrix<T, 3, 3>::Zero(), false};
   }
@@ -384,34 +365,33 @@ OpenCVIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) const
   const T z_inv = T(1) / z;
   const T z_inv_sq = z_inv * z_inv;
 
-  // Normalized coordinates
   const T xp = x * z_inv;
   const T yp = y * z_inv;
   const T rsqr = xp * xp + yp * yp;
 
   const auto& dp = distortionParams_;
 
-  // Radial distortion components
+  // Radial factor = num/den, where num and den are even-degree polynomials in r.
   const T radial_num = T(1) + rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3));
   const T radial_den = T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6));
   const T radial_factor = radial_num / radial_den;
 
-  // Tangential distortion
+  // Tangential terms (Brown-Conrady).
   const T xpp = xp * radial_factor + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   const T ypp = yp * radial_factor + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Derivatives of radial distortion factor with respect to rsqr
+  // d(radial_factor)/d(rsqr) via the quotient rule.
   const T dradial_num_drsqr = dp.k1 + rsqr * (T(2) * dp.k2 + rsqr * T(3) * dp.k3);
   const T dradial_den_drsqr = dp.k4 + rsqr * (T(2) * dp.k5 + rsqr * T(3) * dp.k6);
   const T dradial_factor_drsqr =
       (dradial_num_drsqr * radial_den - radial_num * dradial_den_drsqr) / (radial_den * radial_den);
 
-  // Derivatives of distorted coordinates with respect to normalized coordinates
+  // Partials of (xpp, ypp) with respect to (xp, yp); chain rule will combine with
+  // d(xp,yp)/d(x,y,z).
   const T dxpp_dxp =
       radial_factor + xp * dradial_factor_drsqr * T(2) * xp + T(2) * dp.p1 * yp + dp.p2 * T(6) * xp;
   const T dxpp_dyp = xp * dradial_factor_drsqr * T(2) * yp + T(2) * dp.p1 * xp + dp.p2 * T(2) * yp;
@@ -419,23 +399,21 @@ OpenCVIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) const
   const T dypp_dyp =
       radial_factor + yp * dradial_factor_drsqr * T(2) * yp + dp.p1 * T(6) * yp + T(2) * dp.p2 * xp;
 
-  // Compute Jacobian matrix (3x3)
+  // TODO: jacobian(2,0) and jacobian(2,1) are redundant assignments since the matrix is
+  // zero-initialized; consider removing them in a separate code-change diff.
   Eigen::Matrix<T, 3, 3> jacobian = Eigen::Matrix<T, 3, 3>::Zero();
 
-  // Row 0: du/dx, du/dy, du/dz
-  jacobian(0, 0) = fx_ * dxpp_dxp * z_inv; // du/dx
-  jacobian(0, 1) = fx_ * dxpp_dyp * z_inv; // du/dy
-  jacobian(0, 2) = -fx_ * (dxpp_dxp * x * z_inv_sq + dxpp_dyp * y * z_inv_sq); // du/dz
+  jacobian(0, 0) = fx_ * dxpp_dxp * z_inv;
+  jacobian(0, 1) = fx_ * dxpp_dyp * z_inv;
+  jacobian(0, 2) = -fx_ * (dxpp_dxp * x * z_inv_sq + dxpp_dyp * y * z_inv_sq);
 
-  // Row 1: dv/dx, dv/dy, dv/dz
-  jacobian(1, 0) = fy_ * dypp_dxp * z_inv; // dv/dx
-  jacobian(1, 1) = fy_ * dypp_dyp * z_inv; // dv/dy
-  jacobian(1, 2) = -fy_ * (dypp_dxp * x * z_inv_sq + dypp_dyp * y * z_inv_sq); // dv/dz
+  jacobian(1, 0) = fy_ * dypp_dxp * z_inv;
+  jacobian(1, 1) = fy_ * dypp_dyp * z_inv;
+  jacobian(1, 2) = -fy_ * (dypp_dxp * x * z_inv_sq + dypp_dyp * y * z_inv_sq);
 
-  // Row 2: homogeneous coordinates (for completeness)
-  jacobian(2, 0) = T(0); // dz/dx = 0
-  jacobian(2, 1) = T(0); // dz/dy = 0
-  jacobian(2, 2) = T(1); // dz/dz = 1
+  jacobian(2, 0) = T(0);
+  jacobian(2, 1) = T(0);
+  jacobian(2, 2) = T(1);
 
   return {projectedPoint, jacobian, true};
 }
@@ -447,9 +425,8 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVIntrinsicsModelT<T>::resize(
   T scaleX = T(imageWidth) / T(this->imageWidth());
   T scaleY = T(imageHeight) / T(this->imageHeight());
 
-  // Apply the correct formula for camera center as noted in the comment:
-  // cx = (old_cx + 0.5) * new_sizex / old_sizex - 0.5;
-  // cy = (old_cy + 0.5) * new_sizey / old_sizey - 0.5;
+  // Use the half-pixel-offset convention (same as Pinhole resize).
+  // Distortion parameters are unitless in normalized coordinates and stay unchanged.
   T new_cx = (cx_ + T(0.5)) * scaleX - T(0.5);
   T new_cy = (cy_ + T(0.5)) * scaleY - T(0.5);
 
@@ -463,7 +440,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVIntrinsicsModelT<T>::crop(
     int32_t left,
     int32_t newWidth,
     int32_t newHeight) const {
-  // Ensure the crop doesn't exceed the original image dimensions
+  // Clamp the crop region to stay inside the original image bounds.
   int32_t width = newWidth;
   if (left + width > this->imageWidth()) {
     width = this->imageWidth() - left;
@@ -474,7 +451,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVIntrinsicsModelT<T>::crop(
     height = this->imageHeight() - top;
   }
 
-  // Adjust the principal point by subtracting the crop offset
+  // Shift the principal point so it stays at the same physical location after cropping.
   T cameraCenter_cropped_cx = cx_ - T(left);
   T cameraCenter_cropped_cy = cy_ - T(top);
 
@@ -491,60 +468,52 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
   const T v = imagePoint(1);
   const T depth = imagePoint(2);
 
-  // Check if depth is valid (positive)
   if (depth <= T(0)) {
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Initial guess: convert to normalized camera coordinates assuming no distortion
+  // Initial guess: ignore distortion. Distortion is small near the optical center, so this is
+  // typically within Newton's basin of convergence.
   const Eigen::Vector3<T> p_init((u - cx_) / fx_, (v - cy_) / fy_, depth);
   Eigen::Vector3<T> p_cur = p_init;
 
-  // Newton's method with backtracking line search to solve the nonlinear projection equation
+  // Gauss-Newton with backtracking (Armijo) line search to invert the nonlinear projection.
+  // On any failure (invalid point, singular Jacobian, line-search failure, no convergence) we
+  // return the undistorted initial guess together with isValid=false.
   for (int iter = 0; iter < maxIterations; ++iter) {
-    // Use projectJacobian to get both the projected point and Jacobian
     const auto [projectedPoint, jacobian, isValid] = projectJacobian(p_cur);
 
     if (!isValid) {
-      // Point is behind camera or other invalid condition
       return {p_init, false};
     }
 
-    // Compute residual
     const Eigen::Vector<T, 2> residual =
         projectedPoint.template head<2>() - imagePoint.template head<2>();
     const T residual_norm = residual.norm();
 
-    // Check convergence
     if (residual_norm < tolerance) {
       return {p_cur, true};
     }
 
-    // Extract the 2x3 Jacobian matrix from the 3x3 matrix (ignore the third row)
+    // Drop the depth pass-through row to get the 2x2 image-space Jacobian.
     Eigen::Matrix<T, 2, 2> J = jacobian.template topLeftCorner<2, 2>();
 
-    // Solve using QR decomposition for better numerical stability
-    // We want to solve: J * delta = -residual (least squares)
+    // Solve J * delta = -residual via Householder QR for numerical stability.
     Eigen::Vector<T, 2> rhs = -residual;
-
-    // Get the least squares solution using Eigen's QR decomposition (full Newton step)
     const Eigen::Vector<T, 2> delta = J.householderQr().solve(rhs);
 
-    // Check if the solution is valid (no NaN or infinite values)
     if (!delta.allFinite()) {
-      // QR solve failed, return failure
       return {p_init, false};
     }
 
-    // Backtracking line search to ensure we make progress
+    // Backtracking parameters.
     const T current_cost = residual_norm * residual_norm; // ||f(x)||^2
-    const T alpha_init = T(1.0); // Start with full Newton step
-    const T rho = T(0.5); // Backtracking factor
+    const T alpha_init = T(1.0);
+    const T rho = T(0.5);
     const T c1 = T(1e-4); // Armijo condition parameter
     const int max_line_search_iters = 10;
 
-    // Compute directional derivative: f'(x)^T * p = -||f(x)||^2 (since p = -J^T*f(x) for
-    // Gauss-Newton)
+    // For Gauss-Newton with step delta = -J^+ f, f'(x)^T * delta = -||f(x)||^2.
     const T directional_derivative = -current_cost;
 
     Eigen::Vector3<T> p_new = p_cur;
@@ -553,14 +522,12 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
     bool line_search_success = false;
 
     for (int ls_iter = 0; ls_iter < max_line_search_iters; ++ls_iter) {
-      // Try step: x_new = x + alpha * delta
       p_new.template head<2>() = p_cur.template head<2>() + alpha * delta;
 
-      // Evaluate cost at new point
       const auto [new_projectedPoint, new_isValid] = project(p_new);
 
       if (!new_isValid) {
-        // Point went behind camera, reduce step size
+        // Stepped behind the camera; shrink and retry.
         alpha *= rho;
         continue;
       }
@@ -569,13 +536,12 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
           new_projectedPoint.template head<2>() - imagePoint.template head<2>();
       new_cost = residualNew.squaredNorm();
 
-      // Armijo condition: f(x + alpha*p) <= f(x) + c1*alpha*f'(x)^T*p
+      // Armijo condition: f(x + alpha*p) <= f(x) + c1*alpha*f'(x)^T*p.
       if (new_cost <= current_cost + c1 * alpha * directional_derivative) {
         line_search_success = true;
         break;
       }
 
-      // Reduce step size
       alpha *= rho;
     }
 
@@ -583,11 +549,9 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
       return {p_init, false};
     }
 
-    // Update the 3D point
     p_cur = p_new;
   }
 
-  // If we reach here, Newton's method didn't converge
   return {p_init, false};
 }
 
@@ -644,7 +608,6 @@ OpenCVIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& po
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     Eigen::Matrix<T, 3, 14> zeroJacobian = Eigen::Matrix<T, 3, 14>::Zero();
     return {Eigen::Vector3<T>::Zero(), zeroJacobian, false};
@@ -652,108 +615,85 @@ OpenCVIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& po
 
   const T z_inv = T(1) / z;
 
-  // Normalized coordinates
   const T xp = x * z_inv;
   const T yp = y * z_inv;
   const T rsqr = xp * xp + yp * yp;
 
   const auto& dp = distortionParams_;
 
-  // Radial distortion components
-  // Note: the formula is radialDistortion = 1 + A/B where:
+  // radial_factor = 1 + A/B, where
   //   A = rsqr * (k1 + rsqr * (k2 + rsqr * k3))
   //   B = 1 + rsqr * (k4 + rsqr * (k5 + rsqr * k6))
   const T A = rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3));
   const T B = T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6));
   const T radial_factor = T(1) + A / B;
 
-  // Tangential distortion
   const T xpp = xp * radial_factor + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   const T ypp = yp * radial_factor + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x14) with respect to
-  // [fx, fy, cx, cy, k1, k2, k3, k4, k5, k6, p1, p2, p3, p4]
+  // Jacobian columns are ordered as [fx, fy, cx, cy, k1, k2, k3, k4, k5, k6, p1, p2, p3, p4],
+  // matching getIntrinsicParameters() and getParameterNames().
   Eigen::Matrix<T, 3, 14> jacobian = Eigen::Matrix<T, 3, 14>::Zero();
 
-  // Derivatives with respect to fx, fy, cx, cy (basic intrinsics)
-  // u = fx * xpp + cx
-  // v = fy * ypp + cy
-  jacobian(0, 0) = xpp; // du/dfx
-  jacobian(0, 2) = T(1); // du/dcx
-  jacobian(1, 1) = ypp; // dv/dfy
-  jacobian(1, 3) = T(1); // dv/dcy
+  // d/d{fx, fy, cx, cy}: u = fx * xpp + cx,  v = fy * ypp + cy.
+  jacobian(0, 0) = xpp;
+  jacobian(0, 2) = T(1);
+  jacobian(1, 1) = ypp;
+  jacobian(1, 3) = T(1);
 
-  // Derivatives with respect to distortion parameters
-  // radial_factor = 1 + A/B
-  // d(radial_factor)/dk_i = d(A/B)/dk_i
-
+  // For radial coefficients k_i, only radial_factor depends on them, so
+  //   d(xpp)/dk_i = xp * d(radial_factor)/dk_i, similarly for ypp.
+  //
+  // Numerator coefficients (k1, k2, k3): d(A/B)/dk_i = (dA/dk_i) / B with
+  //   dA/dk1 = rsqr, dA/dk2 = rsqr^2, dA/dk3 = rsqr^3.
+  // Denominator coefficients (k4, k5, k6): d(A/B)/dk_i = -A * (dB/dk_i) / B^2 with
+  //   dB/dk4 = rsqr, dB/dk5 = rsqr^2, dB/dk6 = rsqr^3.
   const T B_sq = B * B;
-
-  // For numerator coefficients k1, k2, k3:
-  // dA/dk1 = rsqr, dA/dk2 = rsqr^2, dA/dk3 = rsqr^3
-  // d(A/B)/dk_i = (dA/dk_i) / B
   const T rsqr2 = rsqr * rsqr;
   const T rsqr3 = rsqr2 * rsqr;
   const T drf_dk1 = rsqr / B;
   const T drf_dk2 = rsqr2 / B;
   const T drf_dk3 = rsqr3 / B;
-
-  // For denominator coefficients k4, k5, k6:
-  // dB/dk4 = rsqr, dB/dk5 = rsqr^2, dB/dk6 = rsqr^3
-  // d(A/B)/dk_i = -A * (dB/dk_i) / B^2
   const T drf_dk4 = -A * rsqr / B_sq;
   const T drf_dk5 = -A * rsqr2 / B_sq;
   const T drf_dk6 = -A * rsqr3 / B_sq;
 
-  // d(xpp)/dk_i = xp * d(radial_factor)/dk_i
-  // d(ypp)/dk_i = yp * d(radial_factor)/dk_i
-  jacobian(0, 4) = fx_ * xp * drf_dk1; // du/dk1
-  jacobian(1, 4) = fy_ * yp * drf_dk1; // dv/dk1
-  jacobian(0, 5) = fx_ * xp * drf_dk2; // du/dk2
-  jacobian(1, 5) = fy_ * yp * drf_dk2; // dv/dk2
-  jacobian(0, 6) = fx_ * xp * drf_dk3; // du/dk3
-  jacobian(1, 6) = fy_ * yp * drf_dk3; // dv/dk3
-  jacobian(0, 7) = fx_ * xp * drf_dk4; // du/dk4
-  jacobian(1, 7) = fy_ * yp * drf_dk4; // dv/dk4
-  jacobian(0, 8) = fx_ * xp * drf_dk5; // du/dk5
-  jacobian(1, 8) = fy_ * yp * drf_dk5; // dv/dk5
-  jacobian(0, 9) = fx_ * xp * drf_dk6; // du/dk6
-  jacobian(1, 9) = fy_ * yp * drf_dk6; // dv/dk6
+  jacobian(0, 4) = fx_ * xp * drf_dk1;
+  jacobian(1, 4) = fy_ * yp * drf_dk1;
+  jacobian(0, 5) = fx_ * xp * drf_dk2;
+  jacobian(1, 5) = fy_ * yp * drf_dk2;
+  jacobian(0, 6) = fx_ * xp * drf_dk3;
+  jacobian(1, 6) = fy_ * yp * drf_dk3;
+  jacobian(0, 7) = fx_ * xp * drf_dk4;
+  jacobian(1, 7) = fy_ * yp * drf_dk4;
+  jacobian(0, 8) = fx_ * xp * drf_dk5;
+  jacobian(1, 8) = fy_ * yp * drf_dk5;
+  jacobian(0, 9) = fx_ * xp * drf_dk6;
+  jacobian(1, 9) = fy_ * yp * drf_dk6;
 
-  // Derivatives with respect to tangential distortion p1, p2
-  // xpp = xp * radial_factor + 2*p1*xp*yp + p2*(rsqr + 2*xp^2)
-  // ypp = yp * radial_factor + p1*(rsqr + 2*yp^2) + 2*p2*xp*yp
+  // Tangential distortion (Brown-Conrady):
+  //   d(xpp)/dp1 = 2*xp*yp,           d(ypp)/dp1 = rsqr + 2*yp^2
+  //   d(xpp)/dp2 = rsqr + 2*xp^2,     d(ypp)/dp2 = 2*xp*yp
+  jacobian(0, 10) = fx_ * T(2) * xp * yp;
+  jacobian(1, 10) = fy_ * (rsqr + T(2) * yp * yp);
+  jacobian(0, 11) = fx_ * (rsqr + T(2) * xp * xp);
+  jacobian(1, 11) = fy_ * T(2) * xp * yp;
 
-  // d(xpp)/dp1 = 2*xp*yp
-  // d(ypp)/dp1 = rsqr + 2*yp^2
-  jacobian(0, 10) = fx_ * T(2) * xp * yp; // du/dp1
-  jacobian(1, 10) = fy_ * (rsqr + T(2) * yp * yp); // dv/dp1
-
-  // d(xpp)/dp2 = rsqr + 2*xp^2
-  // d(ypp)/dp2 = 2*xp*yp
-  jacobian(0, 11) = fx_ * (rsqr + T(2) * xp * xp); // du/dp2
-  jacobian(1, 11) = fy_ * T(2) * xp * yp; // dv/dp2
-
-  // Derivatives with respect to p3, p4 (thin prism coefficients)
-  // Note: The projection formula doesn't include p3 and p4 in the current implementation
-  // so their derivatives are zero
-  jacobian(0, 12) = T(0); // du/dp3
-  jacobian(1, 12) = T(0); // dv/dp3
-  jacobian(0, 13) = T(0); // du/dp4
-  jacobian(1, 13) = T(0); // dv/dp4
-
-  // Row 2: dz/d[all params] = 0 (depth unchanged)
-  // Already set to zero
+  // TODO: p3 and p4 (thin-prism coefficients) are exposed in OpenCVDistortionParametersT but the
+  // projection formula does not use them, so their derivatives are zero. Either implement
+  // thin-prism distortion or remove p3/p4 from the parameter set. The explicit T(0) writes below
+  // are also redundant given the zero-init.
+  jacobian(0, 12) = T(0);
+  jacobian(1, 12) = T(0);
+  jacobian(0, 13) = T(0);
+  jacobian(1, 13) = T(0);
 
   return {projectedPoint, jacobian, true};
 }
-
-// OpenCVFisheyeIntrinsicsModelT implementation
 
 template <typename T>
 OpenCVFisheyeIntrinsicsModelT<T>::OpenCVFisheyeIntrinsicsModelT(
@@ -771,17 +711,16 @@ OpenCVFisheyeIntrinsicsModelT<T>::OpenCVFisheyeIntrinsicsModelT(
       cy_(cy),
       distortionParams_(params),
       maxRSquared_(std::numeric_limits<T>::max()) {
-  // Compute default max valid angle from image bounds
+  // Initialize maxRSquared_ from the image bounds; callers may override via setMaxValidAngle().
   computeMaxValidAngleFromImageBounds();
 }
 
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsModelT<T>::project(
     const Vector3P<T>& point) const {
-  // Process each element in the packet individually since drjit::atan is not available
+  // Per-lane scalar loop because drjit::atan is not available; cannot vectorize the angular step.
   Vector3P<T> result;
 
-  // Track validity per element (z > 0 and rsqr <= maxRSquared_)
   typename Packet<T>::MaskType validMask;
   for (size_t i = 0; i < Packet<T>::Size; ++i) {
     validMask[i] = true;
@@ -800,15 +739,13 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsMode
       continue;
     }
 
-    // Normalize the point by dividing by z
     const T invZ = T(1) / z;
     const T a = x * invZ;
     const T b = y * invZ;
 
-    // Compute radius and angle
     const T rsqr = a * a + b * b;
 
-    // Check FOV validity
+    // Reject points outside the calibrated angular FOV (configured via setMaxValidAngle()).
     if (rsqr > maxRSquared_) {
       result.x()[i] = T(0);
       result.y()[i] = T(0);
@@ -822,7 +759,8 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsMode
 
     const auto& dp = distortionParams_;
 
-    // Apply distortion
+    // Equidistant fisheye distortion polynomial:
+    //   thetaD = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
     const T theta2 = theta * theta;
     const T theta4 = theta2 * theta2;
     const T theta6 = theta4 * theta2;
@@ -830,14 +768,12 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsMode
     const T thetaD =
         theta * (T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8);
 
-    // Compute scale factor
+    // Avoid division by zero at the optical axis; thetaD/r -> 1 as r -> 0.
     const T scale = (r > T(1e-8)) ? thetaD / r : T(1);
 
-    // Apply scale
     const T xpp = scale * a;
     const T ypp = scale * b;
 
-    // Apply camera matrix to get pixel coordinates
     result.x()[i] = fx_ * xpp + cx_;
     result.y()[i] = fy_ * ypp + cy_;
     result.z()[i] = z;
@@ -855,15 +791,13 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::project(
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Normalize the point by dividing by z
   T invZ = T(1) / z;
   T a = point.x() * invZ;
   T b = point.y() * invZ;
 
-  // Compute radius and angle
   T rsqr = a * a + b * b;
 
-  // Check FOV validity
+  // Reject points outside the calibrated angular FOV.
   if (rsqr > maxRSquared_) {
     return {Eigen::Vector3<T>::Zero(), false};
   }
@@ -873,21 +807,19 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::project(
 
   const auto& dp = distortionParams_;
 
-  // Apply distortion: theta_d = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
+  // theta_d = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
   T theta2 = theta * theta;
   T theta4 = theta2 * theta2;
   T theta6 = theta4 * theta2;
   T theta8 = theta4 * theta4;
   T thetaD = theta * (T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8);
 
-  // Compute scale factor: theta_d / r, handle r->0 singularity
+  // Avoid division by zero at the optical axis; thetaD/r -> 1 as r -> 0.
   T scale = (r > T(1e-8)) ? thetaD / r : T(1);
 
-  // Apply scale
   T xpp = scale * a;
   T ypp = scale * b;
 
-  // Apply camera matrix to get pixel coordinates
   T u = fx_ * xpp + cx_;
   T v = fy_ * ypp + cy_;
 
@@ -908,12 +840,10 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
   const T z_inv = T(1) / z;
   const T z_inv_sq = z_inv * z_inv;
 
-  // Normalized coordinates
   const T a = x * z_inv;
   const T b = y * z_inv;
   const T rsqr = a * a + b * b;
 
-  // Check FOV validity
   if (rsqr > maxRSquared_) {
     return {Eigen::Vector3<T>::Zero(), Eigen::Matrix<T, 3, 3>::Zero(), false};
   }
@@ -923,7 +853,7 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
 
   const auto& dp = distortionParams_;
 
-  // Distortion polynomial coefficients
+  // poly = 1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8;  thetaD = theta * poly.
   const T theta2 = theta * theta;
   const T theta4 = theta2 * theta2;
   const T theta6 = theta4 * theta2;
@@ -931,24 +861,20 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
   const T poly = T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8;
   const T thetaD = theta * poly;
 
-  // Handle r->0 singularity
   const bool nearCenter = r < T(1e-8);
   const T scale = nearCenter ? T(1) : thetaD / r;
 
-  // Distorted normalized coordinates
   const T xpp = scale * a;
   const T ypp = scale * b;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x3)
   Eigen::Matrix<T, 3, 3> jacobian = Eigen::Matrix<T, 3, 3>::Zero();
 
   if (nearCenter) {
-    // Near optical axis: Jacobian simplifies to pinhole-like behavior
+    // At the optical axis the fisheye reduces to the pinhole limit (scale -> 1, no cross-term).
     jacobian(0, 0) = fx_ * z_inv;
     jacobian(0, 2) = -fx_ * x * z_inv_sq;
     jacobian(1, 1) = fy_ * z_inv;
@@ -957,41 +883,29 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
     return {projectedPoint, jacobian, true};
   }
 
-  // Derivative of poly with respect to theta
+  // Build d(scale)/dr via the chain rule:
+  //   d(thetaD)/d(theta) = poly + theta * d(poly)/d(theta)
+  //   d(theta)/dr        = 1 / (1 + r^2)        (since theta = atan(r))
+  //   d(scale)/dr        = (d(thetaD)/dr * r - thetaD) / r^2     (quotient rule on thetaD/r)
   const T dpoly_dtheta = T(2) * dp.k1 * theta + T(4) * dp.k2 * theta * theta2 +
       T(6) * dp.k3 * theta * theta4 + T(8) * dp.k4 * theta * theta6;
   const T dthetaD_dtheta = poly + theta * dpoly_dtheta;
-
-  // Derivative of theta with respect to r: d(atan(r))/dr = 1/(1+r^2)
   const T dtheta_dr = T(1) / (T(1) + rsqr);
-
-  // Derivative of scale with respect to r
-  // scale = thetaD / r
-  // d(scale)/dr = (d(thetaD)/dr * r - thetaD) / r^2
-  //             = (dthetaD_dtheta * dtheta_dr * r - thetaD) / r^2
   const T r_inv = T(1) / r;
   const T dscale_dr = (dthetaD_dtheta * dtheta_dr * r - thetaD) * r_inv * r_inv;
 
-  // Derivatives of r with respect to a, b
-  // r = sqrt(a^2 + b^2)
+  // r = sqrt(a^2 + b^2) => dr/da = a/r, dr/db = b/r.
   const T dr_da = a * r_inv;
   const T dr_db = b * r_inv;
 
-  // Derivatives of xpp, ypp with respect to a, b
-  // xpp = scale * a
-  // dxpp/da = d(scale)/da * a + scale = dscale_dr * dr_da * a + scale
-  // dxpp/db = d(scale)/db * a = dscale_dr * dr_db * a
+  // (xpp, ypp) = scale * (a, b); product rule with d(scale)/d{a,b} = d(scale)/dr * d(r)/d{a,b}.
   const T dxpp_da = dscale_dr * dr_da * a + scale;
   const T dxpp_db = dscale_dr * dr_db * a;
   const T dypp_da = dscale_dr * dr_da * b;
   const T dypp_db = dscale_dr * dr_db * b + scale;
 
-  // Derivatives of a, b with respect to x, y, z
-  // a = x/z, b = y/z
-  // da/dx = 1/z, da/dy = 0, da/dz = -x/z^2
-  // db/dx = 0, db/dy = 1/z, db/dz = -y/z^2
-
-  // Chain rule: du/dx = fx * dxpp/dx = fx * (dxpp/da * da/dx + dxpp/db * db/dx)
+  // Compose with d(a, b)/d(x, y, z) where a = x/z, b = y/z:
+  //   da/dx = 1/z, da/dy = 0, da/dz = -x/z^2; analogously for b.
   jacobian(0, 0) = fx_ * dxpp_da * z_inv;
   jacobian(0, 1) = fx_ * dxpp_db * z_inv;
   jacobian(0, 2) = fx_ * (dxpp_da * (-x * z_inv_sq) + dxpp_db * (-y * z_inv_sq));
@@ -1012,7 +926,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVFisheyeIntrinsicsModelT<T>::res
   T scaleX = T(imageWidth) / T(this->imageWidth());
   T scaleY = T(imageHeight) / T(this->imageHeight());
 
-  // Apply the correct formula for camera center
+  // Use the half-pixel-offset convention; distortion parameters are unitless and stay unchanged.
   T new_cx = (cx_ + T(0.5)) * scaleX - T(0.5);
   T new_cy = (cy_ + T(0.5)) * scaleY - T(0.5);
 
@@ -1026,7 +940,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVFisheyeIntrinsicsModelT<T>::cro
     int32_t left,
     int32_t newWidth,
     int32_t newHeight) const {
-  // Ensure the crop doesn't exceed the original image dimensions
+  // Clamp the crop region to stay inside the original image bounds.
   int32_t width = newWidth;
   if (left + width > this->imageWidth()) {
     width = this->imageWidth() - left;
@@ -1037,7 +951,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVFisheyeIntrinsicsModelT<T>::cro
     height = this->imageHeight() - top;
   }
 
-  // Adjust the principal point by subtracting the crop offset
+  // Shift the principal point so it stays at the same physical location after cropping.
   T cameraCenter_cropped_cx = cx_ - T(left);
   T cameraCenter_cropped_cy = cy_ - T(top);
 
@@ -1058,22 +972,24 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::unproject(
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Convert to normalized distorted coordinates
+  // Strip intrinsics to recover normalized distorted coordinates (xpp, ypp); their length is
+  // thetaD.
   const T xpp = (u - cx_) / fx_;
   const T ypp = (v - cy_) / fy_;
 
-  // Compute distorted radius (thetaD)
   const T rDistorted = std::sqrt(xpp * xpp + ypp * ypp);
 
-  // Handle center case
+  // The optical-axis ray maps to the optical center; bypass Newton to avoid 0/0.
   if (rDistorted < T(1e-8)) {
     return {Eigen::Vector3<T>(T(0), T(0), depth), true};
   }
 
-  // Newton's method to solve: thetaD = theta * poly(theta)
-  // f(theta) = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8) - thetaD = 0
+  // Solve for theta in f(theta) = theta * poly(theta) - thetaD = 0 by Newton iteration.
+  // Initial guess theta == rDistorted is exact when distortion is zero.
+  // TODO: this loop silently returns the latest theta even when Newton fails to converge;
+  // consider returning isValid=false on non-convergence to match OpenCV's project() behavior.
   const auto& dp = distortionParams_;
-  T theta = rDistorted; // Initial guess
+  T theta = rDistorted;
 
   for (int iter = 0; iter < maxIterations; ++iter) {
     const T theta2 = theta * theta;
@@ -1088,7 +1004,7 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::unproject(
       break;
     }
 
-    // f'(theta) = poly + theta * dpoly/dtheta
+    // f'(theta) = poly + theta * d(poly)/d(theta).
     const T dpoly_dtheta = T(2) * dp.k1 * theta + T(4) * dp.k2 * theta * theta2 +
         T(6) * dp.k3 * theta * theta4 + T(8) * dp.k4 * theta * theta6;
     const T df = poly + theta * dpoly_dtheta;
@@ -1100,19 +1016,14 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::unproject(
     theta = theta - f / df;
   }
 
-  // Compute undistorted radius: r = tan(theta)
+  // Equidistant model: project(theta) = scale * (a, b) with scale = thetaD/r and r = tan(theta).
+  // Inverting that scale yields unscale = r/thetaD, applied to the distorted coords.
   const T r = std::tan(theta);
-
-  // Scale factor from distorted to undistorted
-  // distorted = scale * undistorted, where scale = thetaD / r
-  // So undistorted = distorted * r / thetaD
   const T unscale = (rDistorted > T(1e-8)) ? r / rDistorted : T(1);
 
-  // Undistorted normalized coordinates
   const T a = xpp * unscale;
   const T b = ypp * unscale;
 
-  // Convert to 3D point
   return {Eigen::Vector3<T>(a * depth, b * depth, depth), true};
 }
 
@@ -1171,12 +1082,10 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3
 
   const T z_inv = T(1) / z;
 
-  // Normalized coordinates
   const T a = x * z_inv;
   const T b = y * z_inv;
   const T rsqr = a * a + b * b;
 
-  // Check FOV validity
   if (rsqr > maxRSquared_) {
     Eigen::Matrix<T, 3, 8> zeroJacobian = Eigen::Matrix<T, 3, 8>::Zero();
     return {Eigen::Vector3<T>::Zero(), zeroJacobian, false};
@@ -1187,7 +1096,7 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3
 
   const auto& dp = distortionParams_;
 
-  // Distortion polynomial
+  // poly = 1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8;  thetaD = theta * poly.
   const T theta2 = theta * theta;
   const T theta4 = theta2 * theta2;
   const T theta6 = theta4 * theta2;
@@ -1195,58 +1104,47 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3
   const T poly = T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8;
   const T thetaD = theta * poly;
 
-  // Handle r->0 singularity
   const bool nearCenter = r < T(1e-8);
   const T scale = nearCenter ? T(1) : thetaD / r;
 
-  // Distorted normalized coordinates
   const T xpp = scale * a;
   const T ypp = scale * b;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x8) with respect to [fx, fy, cx, cy, k1, k2, k3, k4]
+  // Jacobian columns ordered as [fx, fy, cx, cy, k1, k2, k3, k4], matching getParameterNames().
   Eigen::Matrix<T, 3, 8> jacobian = Eigen::Matrix<T, 3, 8>::Zero();
 
-  // Derivatives with respect to fx, fy, cx, cy
-  jacobian(0, 0) = xpp; // du/dfx
-  jacobian(0, 2) = T(1); // du/dcx
-  jacobian(1, 1) = ypp; // dv/dfy
-  jacobian(1, 3) = T(1); // dv/dcy
+  jacobian(0, 0) = xpp;
+  jacobian(0, 2) = T(1);
+  jacobian(1, 1) = ypp;
+  jacobian(1, 3) = T(1);
 
   if (!nearCenter) {
-    // Derivatives with respect to distortion parameters k1, k2, k3, k4
-    // thetaD = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
-    // d(thetaD)/dk1 = theta * theta^2 = theta^3
-    // d(thetaD)/dk2 = theta * theta^4 = theta^5
-    // d(thetaD)/dk3 = theta * theta^6 = theta^7
-    // d(thetaD)/dk4 = theta * theta^8 = theta^9
-
-    // scale = thetaD / r
-    // d(scale)/dk_i = d(thetaD)/dk_i / r
-
+    // Distortion-parameter derivatives. From thetaD = theta * poly we get d(thetaD)/dk_i
+    // = theta^(2i+1), and scale = thetaD / r so d(scale)/dk_i = d(thetaD)/dk_i / r. Then
+    // d(xpp)/dk_i = a * d(scale)/dk_i, d(ypp)/dk_i = b * d(scale)/dk_i.
     const T r_inv = T(1) / r;
     const T dscale_dk1 = theta * theta2 * r_inv;
     const T dscale_dk2 = theta * theta4 * r_inv;
     const T dscale_dk3 = theta * theta6 * r_inv;
     const T dscale_dk4 = theta * theta8 * r_inv;
 
-    // xpp = scale * a, ypp = scale * b
-    // d(xpp)/dk_i = d(scale)/dk_i * a
-    // d(ypp)/dk_i = d(scale)/dk_i * b
-
-    jacobian(0, 4) = fx_ * dscale_dk1 * a; // du/dk1
-    jacobian(1, 4) = fy_ * dscale_dk1 * b; // dv/dk1
-    jacobian(0, 5) = fx_ * dscale_dk2 * a; // du/dk2
-    jacobian(1, 5) = fy_ * dscale_dk2 * b; // dv/dk2
-    jacobian(0, 6) = fx_ * dscale_dk3 * a; // du/dk3
-    jacobian(1, 6) = fy_ * dscale_dk3 * b; // dv/dk3
-    jacobian(0, 7) = fx_ * dscale_dk4 * a; // du/dk4
-    jacobian(1, 7) = fy_ * dscale_dk4 * b; // dv/dk4
+    jacobian(0, 4) = fx_ * dscale_dk1 * a;
+    jacobian(1, 4) = fy_ * dscale_dk1 * b;
+    jacobian(0, 5) = fx_ * dscale_dk2 * a;
+    jacobian(1, 5) = fy_ * dscale_dk2 * b;
+    jacobian(0, 6) = fx_ * dscale_dk3 * a;
+    jacobian(1, 6) = fy_ * dscale_dk3 * b;
+    jacobian(0, 7) = fx_ * dscale_dk4 * a;
+    jacobian(1, 7) = fy_ * dscale_dk4 * b;
   }
+  // TODO: when nearCenter, distortion-parameter columns are left at zero. That matches the
+  // limit (a, b -> 0 makes xpp, ypp insensitive to k_i to first order), but it differs subtly
+  // from the projectJacobian() near-center branch which just falls back to pinhole. Worth a
+  // unit test or comment update if the limit matters for solver behavior.
 
   return {projectedPoint, jacobian, true};
 }
@@ -1274,7 +1172,8 @@ void OpenCVFisheyeIntrinsicsModelT<T>::setMaxRSquared(T rsqr) {
 
 template <typename T>
 void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
-  // Find the farthest image corner from the principal point
+  // The maximum theta the camera should accept is the angle whose distorted projection lands at
+  // the farthest image corner. Find that pixel distance from the principal point first.
   const std::array<std::array<T, 2>, 4> corners = {
       {{T(0), T(0)},
        {T(this->imageWidth()), T(0)},
@@ -1290,8 +1189,8 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
   }
   const T maxDist = std::sqrt(maxDistSqr);
 
-  // The max distance in normalized image coordinates
-  // Using an average focal length for simplicity
+  // Convert pixel distance to normalized distorted radius. fx_ and fy_ are mixed via their
+  // average; this is an approximation that ignores anisotropy and slight off-axis stretch.
   const T avgF = (fx_ + fy_) / T(2);
   if (avgF <= T(0)) {
     maxRSquared_ = std::numeric_limits<T>::max();
@@ -1299,12 +1198,9 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
   }
   const T targetThetaD = maxDist / avgF;
 
-  // Use Newton iteration to find theta such that
-  // theta_d(theta) = targetThetaD
-  // where theta_d = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
-
+  // Newton iteration to invert thetaD = theta * (1 + k1*theta^2 + ... + k4*theta^8) for theta.
   const auto& dp = distortionParams_;
-  T theta = targetThetaD; // Initial guess (assumes small distortion)
+  T theta = targetThetaD; // Exact when distortion coefficients are zero.
 
   constexpr int maxIter = 20;
   constexpr T tol = T(1e-10);
@@ -1318,9 +1214,8 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
     const T poly = T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8;
     const T thetaD = theta * poly;
 
-    // Derivative of theta_d with respect to theta:
-    // d(theta_d)/d(theta) = poly + theta * d(poly)/d(theta)
-    // d(poly)/d(theta) = 2*k1*theta + 4*k2*theta^3 + 6*k3*theta^5 + 8*k4*theta^7
+    // d(thetaD)/d(theta) = poly + theta * d(poly)/d(theta), where
+    // d(poly)/d(theta) = 2*k1*theta + 4*k2*theta^3 + 6*k3*theta^5 + 8*k4*theta^7.
     const T dPolyDTheta = T(2) * dp.k1 * theta + T(4) * dp.k2 * theta2 * theta +
         T(6) * dp.k3 * theta4 * theta + T(8) * dp.k4 * theta6 * theta;
     const T dThetaDDTheta = poly + theta * dPolyDTheta;
@@ -1338,10 +1233,10 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
     }
   }
 
-  // Clamp theta to a reasonable range (0 to nearly 180 degrees)
+  // Clamp to [0, ~pi); tan() blows up beyond this and the equidistant model is undefined.
   theta = std::max(T(0), std::min(theta, T(3.1)));
 
-  // maxRSquared = tan^2(theta)
+  // Cache the squared tangent so the validity check in project() can stay multiplication-only.
   const T tanTheta = std::tan(theta);
   maxRSquared_ = tanTheta * tanTheta;
 }
@@ -1353,7 +1248,7 @@ CameraT<T> CameraT<T>::lookAt(
     const Eigen::Vector3<T>& up) const {
   const Eigen::Vector3<T> diff = target - position;
   if (diff.norm() == T(0)) {
-    // If target is the same as position, return the original camera
+    // Target coincides with position; the look direction is undefined, so leave the camera as-is.
     return *this;
   }
 
@@ -1362,12 +1257,12 @@ CameraT<T> CameraT<T>::lookAt(
   eyeToWorldMat.translation() = position;
 
   Eigen::Vector3<T> zVec = diff.normalized();
-  // Need to flip y upside down because y points down in image
-  // coordinates (pixel 0,0 is in the top left)
+  // Image y points down (pixel (0,0) is in the top-left), so flip the world up vector when
+  // building the camera basis.
   Eigen::Vector3<T> xVec = diff.cross(-up.normalized());
   if (xVec.norm() == T(0)) {
-    // Up vector is parallel to the target position vector, ignore it and just
-    // make sure we point the camera in the right direction
+    // Up is parallel to the look direction, so any rotation about z is valid; pick the one that
+    // aligns +Z with the look direction.
     Eigen::Quaternion<T> transform =
         Eigen::Quaternion<T>::FromTwoVectors(Eigen::Vector3<T>::UnitZ(), zVec);
     eyeToWorldMat.linear() = transform.toRotationMatrix();
@@ -1379,8 +1274,9 @@ CameraT<T> CameraT<T>::lookAt(
     eyeToWorldMat.linear().col(2) = zVec;
   }
 
+  // Sanity check: a proper rotation has determinant 1; bail out if numerics produced something
+  // degenerate.
   if (eyeToWorldMat.linear().determinant() < T(0.9)) {
-    // Error in creating rotation matrix, return the original camera
     return *this;
   }
 
@@ -1402,17 +1298,17 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
   const auto w = this->imageWidth();
   const auto h = this->imageHeight();
 
+  // Use the geometric image center, ignoring any principal-point offset, for framing math.
   const auto cx = w / T(2);
   const auto cy = h / T(2);
 
-  // Calculate bounding box of points in eye space
   Eigen::AlignedBox<T, 3> bbox_eye;
   for (const auto& p_world : points) {
-    // Transform world point to eye space
     bbox_eye.extend(eyeFromWorld_ * p_world);
   }
 
-  // Create a new camera centered on the points
+  // Step 1: re-center the camera laterally on the bounding-box midpoint and place its near plane
+  // at the closest point. After this transform the points are roughly centered in eye space.
   CameraT<T> camera_recentered = *this;
   Eigen::Transform<T, 3, Eigen::Affine> newTransform =
       Eigen::Translation<T, 3>(
@@ -1420,7 +1316,8 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
       eyeFromWorld_;
   camera_recentered.setEyeFromWorld(newTransform);
 
-  // Calculate the maximum distance needed to ensure all points are in view
+  // Step 2: dolly the camera back so all points fit within the image rect with edge padding.
+  // The half-width of the usable rect (after padding) constrains how much depth each point needs.
   const T max_x_pixel_diff = (T(1) - T(2) * edgePadding) * std::max(cx, T(w - 1) - cx);
   const T max_y_pixel_diff = (T(1) - T(2) * edgePadding) * std::max(cy, T(h - 1) - cy);
 
@@ -1428,7 +1325,7 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
   for (const auto& p_world : points) {
     const Eigen::Vector3<T> p_eye = newTransform * p_world;
 
-    // Make sure we're in front of the camera
+    // Each point imposes a min-z constraint (clip plane) and two FOV constraints (one per axis).
     if (p_eye.z() < minZ) {
       max_dz = std::max(max_dz, minZ - p_eye.z());
     }
@@ -1440,7 +1337,6 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
     return camera_recentered;
   }
 
-  // Create the final camera with adjusted position
   CameraT<T> camera_final = camera_recentered;
   camera_final.setEyeFromWorld(
       Eigen::Translation<T, 3>(T(0), T(0), max_dz) * camera_recentered.eyeFromWorld());
@@ -1450,17 +1346,16 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
 
 template <typename T>
 Vector3P<T> CameraT<T>::transformWorldToEye(const Vector3P<T>& worldPoints) const {
-  // Transform all world points to camera space using SIMD operations
+  // Hand-unrolled R * p + t to keep the multiplications inside the SIMD lane width; Eigen's
+  // operator* doesn't compose with Vector3P directly.
   const auto& R = eyeFromWorld_.linear();
   const auto& t = eyeFromWorld_.translation();
 
-  // Apply rotation matrix: R * worldPoints
   Vector3P<T> eyePoints;
   eyePoints.x() = R(0, 0) * worldPoints.x() + R(0, 1) * worldPoints.y() + R(0, 2) * worldPoints.z();
   eyePoints.y() = R(1, 0) * worldPoints.x() + R(1, 1) * worldPoints.y() + R(1, 2) * worldPoints.z();
   eyePoints.z() = R(2, 0) * worldPoints.x() + R(2, 1) * worldPoints.y() + R(2, 2) * worldPoints.z();
 
-  // Apply translation: eyePoints = R * worldPoints + t
   eyePoints.x() += t(0);
   eyePoints.y() += t(1);
   eyePoints.z() += t(2);
@@ -1470,50 +1365,40 @@ Vector3P<T> CameraT<T>::transformWorldToEye(const Vector3P<T>& worldPoints) cons
 
 template <typename T>
 Eigen::Vector3<T> CameraT<T>::transformWorldToEye(const Eigen::Vector3<T>& worldPoint) const {
-  // Transform world point to camera space using Eigen operations
   return eyeFromWorld_ * worldPoint;
 }
 
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> CameraT<T>::project(
     const Vector3P<T>& worldPoints) const {
-  // Transform all world points to camera space using SIMD operations
   const Vector3P<T> eyePoints = transformWorldToEye(worldPoints);
-
-  // Use the intrinsics model's SIMD project method directly
   return intrinsicsModel_->project(eyePoints);
 }
 
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool> CameraT<T>::project(const Eigen::Vector3<T>& worldPoint) const {
-  // Transform world point to camera space using helper function
   const Eigen::Vector3<T> eyePoint = transformWorldToEye(worldPoint);
-
-  // Use the intrinsics model to project to image coordinates
   return intrinsicsModel_->project(eyePoint);
 }
 
 template <typename T>
 std::tuple<Eigen::Vector3<T>, Eigen::Matrix<T, 2, 3>, bool> CameraT<T>::projectJacobian(
     const Eigen::Vector3<T>& worldPoint) const {
-  // Transform world point to camera space using helper function
   const Eigen::Vector3<T> eyePoint = transformWorldToEye(worldPoint);
 
-  // Get the Jacobian of projection with respect to camera coordinates
   const auto [projectedPoint, jacobian_eye, isValid] = intrinsicsModel_->projectJacobian(eyePoint);
 
   if (!isValid) {
     return {projectedPoint, Eigen::Matrix<T, 2, 3>::Zero(), false};
   }
 
-  // Extract the 2x3 Jacobian matrix from the 3x3 matrix (ignore the third row for homogeneous
-  // coordinates)
+  // The intrinsics Jacobian is 3x3 with a depth pass-through row; only the [du,dv]/d(eye) rows
+  // matter for projecting back to image space.
   const Eigen::Matrix<T, 2, 3> J_proj_eye = jacobian_eye.template topRows<2>();
 
-  // Get the rotation part of the world-to-eye transform
+  // Chain rule: d(image)/d(world) = d(image)/d(eye) * d(eye)/d(world). The world->eye Jacobian
+  // is just the rotation part of eyeFromWorld_ (translation drops out under differentiation).
   const Eigen::Matrix<T, 3, 3> R_eye_world = eyeFromWorld_.linear();
-
-  // Apply chain rule: J_proj_world = J_proj_eye * R_eye_world
   const Eigen::Matrix<T, 2, 3> J_proj_world = J_proj_eye * R_eye_world;
 
   return {projectedPoint, J_proj_world, true};
@@ -1524,31 +1409,26 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType>
 CameraT<T>::unproject(const Vector3P<T>& imagePoints, int maxIterations, T tolerance) const {
   using PacketT = Packet<T>;
 
-  // Process each point in the packet individually using the intrinsics model's unproject method
+  // Per-lane scalar fallback: the intrinsics models' unproject() iterates with Newton, which
+  // does not vectorize cleanly across packet lanes (different lanes converge in different steps).
   Vector3P<T> worldPoints;
   auto validMask = drjit::full<typename PacketT::MaskType>(true);
 
   for (size_t i = 0; i < PacketT::Size; ++i) {
-    // Extract 3D image point for this element (u, v, z)
     Eigen::Vector3<T> imagePoint(imagePoints.x()[i], imagePoints.y()[i], imagePoints.z()[i]);
 
-    // Unproject to camera space using the intrinsics model
     auto [eyePoint, isValid] = intrinsicsModel_->unproject(imagePoint, maxIterations, tolerance);
 
-    // Check if unprojection was successful
     if (!isValid) {
       validMask[i] = false;
-      // Set to zero for invalid points
       worldPoints.x()[i] = T(0);
       worldPoints.y()[i] = T(0);
       worldPoints.z()[i] = T(0);
       continue;
     }
 
-    // Transform from camera space to world space
     const Eigen::Vector3<T> worldPoint = worldFromEye() * eyePoint;
 
-    // Store the result
     worldPoints.x()[i] = worldPoint(0);
     worldPoints.y()[i] = worldPoint(1);
     worldPoints.z()[i] = worldPoint(2);
@@ -1560,20 +1440,17 @@ CameraT<T>::unproject(const Vector3P<T>& imagePoints, int maxIterations, T toler
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool>
 CameraT<T>::unproject(const Eigen::Vector3<T>& imagePoint, int maxIterations, T tolerance) const {
-  // Unproject to camera space using the intrinsics model
   auto [eyePoint, isValid] = intrinsicsModel_->unproject(imagePoint, maxIterations, tolerance);
 
   if (!isValid) {
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Transform from camera space to world space
   const Eigen::Vector3<T> worldPoint = worldFromEye() * eyePoint;
 
   return {worldPoint, true};
 }
 
-// Explicit template instantiations
 template class CameraT<float>;
 template class CameraT<double>;
 template class IntrinsicsModelT<float>;

--- a/momentum/camera/camera.h
+++ b/momentum/camera/camera.h
@@ -28,21 +28,15 @@ namespace momentum {
 template <typename T>
 class IntrinsicsModelT {
  public:
-  /// Constructor for intrinsics model.
-  ///
   /// @param imageWidth Width of the image in pixels
   /// @param imageHeight Height of the image in pixels
   IntrinsicsModelT(int32_t imageWidth, int32_t imageHeight)
       : imageWidth_(imageWidth), imageHeight_(imageHeight) {}
   virtual ~IntrinsicsModelT() = default;
 
-  /// Get the focal length in the x direction.
-  ///
   /// @return Focal length fx in pixels
   [[nodiscard]] virtual T fx() const = 0;
 
-  /// Get the focal length in the y direction.
-  ///
   /// @return Focal length fy in pixels
   [[nodiscard]] virtual T fy() const = 0;
 
@@ -62,13 +56,16 @@ class IntrinsicsModelT {
 
   /// Compute the Jacobian of the projection function with respect to 3D camera coordinates.
   ///
+  /// The returned point and Jacobian carry depth (z) through unchanged in their third
+  /// component so callers can chain projection with depth-aware operations.
+  ///
   /// @param point 3D point in camera coordinate space
-  /// @return Tuple of (projected point, Jacobian matrix, valid flag)
+  /// @return Tuple of (projected point [u, v, z], Jacobian matrix, valid flag)
   ///
   /// The Jacobian is a 3x3 matrix where:
   /// - Row 0: [du/dx, du/dy, du/dz]
   /// - Row 1: [dv/dx, dv/dy, dv/dz]
-  /// - Row 2: [0, 0, 1] (for homogeneous coordinates)
+  /// - Row 2: [0, 0, 1] (depth pass-through: dz/dx, dz/dy, dz/dz)
   [[nodiscard]] virtual std::tuple<Eigen::Vector3<T>, Eigen::Matrix<T, 3, 3>, bool> projectJacobian(
       const Eigen::Vector3<T>& point) const = 0;
 
@@ -120,59 +117,46 @@ class IntrinsicsModelT {
   [[nodiscard]] virtual std::shared_ptr<const IntrinsicsModelT<T>>
   crop(int32_t top, int32_t left, int32_t newWidth, int32_t newHeight) const = 0;
 
-  /// Get the image width.
-  ///
   /// @return Image width in pixels
   [[nodiscard]] int32_t imageWidth() const {
     return imageWidth_;
   }
 
-  /// Get the image height.
-  ///
   /// @return Image height in pixels
   [[nodiscard]] int32_t imageHeight() const {
     return imageHeight_;
   }
 
-  /// Get the number of intrinsic parameters for this model.
-  ///
   /// @return Number of parameters (e.g., 4 for pinhole, 14 for OpenCV)
   [[nodiscard]] virtual Eigen::Index numIntrinsicParameters() const = 0;
 
   /// Get all intrinsic parameters as a vector.
   ///
-  /// Parameter order is model-specific but consistent with setIntrinsicParameters().
-  ///
-  /// @return Vector of intrinsic parameters
+  /// Parameter order is model-specific but consistent with setIntrinsicParameters()
+  /// and getParameterNames().
   [[nodiscard]] virtual Eigen::VectorX<T> getIntrinsicParameters() const = 0;
 
   /// Set all intrinsic parameters from a vector.
   ///
-  /// @param params Vector of parameters (must match numIntrinsicParameters())
+  /// @param params Vector of parameters (must match numIntrinsicParameters() and the
+  ///   order returned by getParameterNames())
   virtual void setIntrinsicParameters(const Eigen::Ref<const Eigen::VectorX<T>>& params) = 0;
 
-  /// Create a deep copy of this intrinsics model.
-  ///
-  /// @return New shared pointer to a mutable copy of this model
+  /// @return New shared pointer to a mutable deep copy of this intrinsics model
   [[nodiscard]] virtual std::shared_ptr<IntrinsicsModelT<T>> clone() const = 0;
 
-  /// Get the name identifier for this camera.
-  ///
-  /// @return Name string (used for parameter transform naming)
+  /// @return Name identifier used for parameter transform naming (e.g., "cam0" yields
+  ///   parameter names like "intrinsics_cam0_fx")
   [[nodiscard]] const std::string& name() const {
     return name_;
   }
 
-  /// Set the name identifier for this camera.
-  ///
-  /// @param name Name string (e.g., "cam0" produces "intrinsics_cam0_fx")
   void setName(const std::string& name) {
     name_ = name;
   }
 
-  /// Get the names of intrinsic parameters for this model.
-  ///
-  /// @return Vector of parameter names (e.g., {"fx", "fy", "cx", "cy"})
+  /// @return Per-parameter names matching the order of getIntrinsicParameters()
+  ///   (e.g., {"fx", "fy", "cx", "cy"} for pinhole)
   [[nodiscard]] virtual std::vector<std::string> getParameterNames() const = 0;
 
   /// Compute the Jacobian of projection w.r.t. intrinsic parameters.
@@ -212,58 +196,40 @@ class CameraT {
       const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld =
           Eigen::Transform<T, 3, Eigen::Affine>::Identity());
 
-  /// Get the image width from the intrinsics model.
-  ///
   /// @return Image width in pixels
   [[nodiscard]] auto imageWidth() const {
     return intrinsicsModel_->imageWidth();
   }
 
-  /// Get the image height from the intrinsics model.
-  ///
   /// @return Image height in pixels
   [[nodiscard]] auto imageHeight() const {
     return intrinsicsModel_->imageHeight();
   }
 
-  /// Get the focal length in x direction from the intrinsics model.
-  ///
   /// @return Focal length fx in pixels
   [[nodiscard]] auto fx() const {
     return intrinsicsModel_->fx();
   }
 
-  /// Get the focal length in y direction from the intrinsics model.
-  ///
   /// @return Focal length fy in pixels
   [[nodiscard]] auto fy() const {
     return intrinsicsModel_->fy();
   }
 
-  /// Get the intrinsics model.
-  ///
-  /// @return Shared pointer to the intrinsics model
   [[nodiscard]] std::shared_ptr<const IntrinsicsModelT<T>> intrinsicsModel() const {
     return intrinsicsModel_;
   }
 
-  /// Get the eye-from-world transformation matrix.
-  ///
-  /// @return Reference to the transformation from world space to camera space
+  /// @return Transform from world space to camera/eye space
   [[nodiscard]] const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld() const {
     return eyeFromWorld_;
   }
 
-  /// Get the world-from-eye transformation matrix.
-  ///
-  /// @return Transformation from camera space to world space
+  /// @return Transform from camera/eye space to world space (inverse of eyeFromWorld())
   [[nodiscard]] Eigen::Transform<T, 3, Eigen::Affine> worldFromEye() const {
     return eyeFromWorld_.inverse();
   }
 
-  /// Set the eye-from-world transformation matrix.
-  ///
-  /// @param eyeFromWorld New transformation from world space to camera space
   void setEyeFromWorld(const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld) {
     eyeFromWorld_ = eyeFromWorld;
   }
@@ -359,9 +325,6 @@ class CameraT {
     return CameraT<T>(intrinsicsModel_->resize(imageWidth, imageHeight), eyeFromWorld_);
   }
 
-  /// Get a reference to the intrinsics model.
-  ///
-  /// @return Const reference to the intrinsics model
   [[nodiscard]] const IntrinsicsModelT<T>& getIntrinsicsModel() const {
     return *intrinsicsModel_;
   }
@@ -454,23 +417,16 @@ class OpenCVFisheyeIntrinsicsModelT : public IntrinsicsModelT<T> {
     return fy_;
   }
 
-  /// Get the principal point x-coordinate.
-  ///
   /// @return Principal point cx in pixels
   [[nodiscard]] T cx() const {
     return cx_;
   }
 
-  /// Get the principal point y-coordinate.
-  ///
   /// @return Principal point cy in pixels
   [[nodiscard]] T cy() const {
     return cy_;
   }
 
-  /// Get the distortion parameters.
-  ///
-  /// @return Reference to the OpenCV fisheye distortion parameters
   [[nodiscard]] const OpenCVFisheyeDistortionParametersT<T>& distortionParameters() const {
     return distortionParams_;
   }
@@ -596,15 +552,11 @@ class PinholeIntrinsicsModelT : public IntrinsicsModelT<T> {
     return fy_;
   }
 
-  /// Get the principal point x-coordinate.
-  ///
   /// @return Principal point cx in pixels
   [[nodiscard]] T cx() const {
     return cx_;
   }
 
-  /// Get the principal point y-coordinate.
-  ///
   /// @return Principal point cy in pixels
   [[nodiscard]] T cy() const {
     return cy_;
@@ -690,23 +642,16 @@ class OpenCVIntrinsicsModelT : public IntrinsicsModelT<T> {
     return fy_;
   }
 
-  /// Get the principal point x-coordinate.
-  ///
   /// @return Principal point cx in pixels
   [[nodiscard]] T cx() const {
     return cx_;
   }
 
-  /// Get the principal point y-coordinate.
-  ///
   /// @return Principal point cy in pixels
   [[nodiscard]] T cy() const {
     return cy_;
   }
 
-  /// Get the distortion parameters.
-  ///
-  /// @return Reference to the OpenCV distortion parameters
   [[nodiscard]] const OpenCVDistortionParametersT<T>& distortionParameters() const {
     return distortionParams_;
   }

--- a/momentum/camera/projection_utils.cpp
+++ b/momentum/camera/projection_utils.cpp
@@ -30,8 +30,6 @@ std::pair<Eigen::Matrix<T, 3, 4>, bool> projectionMatrixPixels(
   // At p = eyePoint itself, the residual is exactly zero.
   const auto [projected, jacobian, validJ] = camera.intrinsicsModel()->projectJacobian(eyePoint);
 
-  // Compose with the eye-from-world transform's upper 3x4 block:
-  // M = J * eyeFromWorld.topRows<3>()
   const Eigen::Matrix<T, 3, 4> eyeFromWorld34 =
       camera.eyeFromWorld().matrix().template topRows<3>();
   return {jacobian * eyeFromWorld34, true};
@@ -48,24 +46,20 @@ std::pair<Eigen::Matrix<T, 3, 4>, bool> projectionMatrixRadians(
     return {Eigen::Matrix<T, 3, 4>::Zero(), false};
   }
 
-  // Normalize to get the ray direction in eye-space.
   const Eigen::Vector3<T> rayDir = eyePoint.normalized();
 
-  // Compute a rotation that maps the target ray to the z-axis.
-  // After applying this rotation, any point on the target ray will have x=0, y=0,
-  // so (x/z, y/z) = (0, 0). For other rays, x/z and y/z give the tangent of the
-  // angle from the target ray.
+  // Compute a rotation that maps the target ray to the z-axis. After applying this
+  // rotation, any point on the target ray has x=0, y=0, so (x/z, y/z) = (0, 0). For
+  // other rays, x/z and y/z give the tangent of the angle from the target ray.
   const Eigen::Quaternion<T> rotation =
       Eigen::Quaternion<T>::FromTwoVectors(rayDir, Eigen::Vector3<T>::UnitZ());
   const Eigen::Matrix<T, 3, 3> R = rotation.toRotationMatrix();
 
-  // Compose with the eye-from-world transform's upper 3x4 block.
   const Eigen::Matrix<T, 3, 4> eyeFromWorld34 =
       camera.eyeFromWorld().matrix().template topRows<3>();
   return {R * eyeFromWorld34, true};
 }
 
-// Explicit template instantiations
 template std::pair<Eigen::Matrix<float, 3, 4>, bool> projectionMatrixPixels(
     const CameraT<float>& camera,
     const Eigen::Vector2<float>& targetPixel);


### PR DESCRIPTION
Summary:
* Removed restatement, constructor-label, and trailing per-cell Jacobian comments; 
* Kept and tightened algorithmic notes (Jacobian chain rule, distortion math, Gauss-Newton + Armijo loop, framePoints recenter-then-dolly), units, and FOV semantics. 
* Replaced the misleading "for homogeneous coordinates" annotation on `IntrinsicsModelT::projectJacobian` row 2 to clarify it's a depth pass-through. `projection_utils.h` was left unmodified — its docs already meet the rules.

Substantive `// TODO:` markers added (filed as follow-up tasks):
- `project()` does not guard `point.z() == 0` in either `PinholeIntrinsicsModelT` or `OpenCVIntrinsicsModelT` (SIMD and scalar paths) — division by zero leaks NaN/Inf before the validity mask filters it.
- `OpenCVDistortionParametersT::p3`/`p4` (thin-prism coefficients) are exposed in the parameter set but the projection formula ignores them, and their Jacobian columns are silently zero. Either implement thin-prism distortion or remove the params.
- Fisheye `unproject()` Newton iteration returns the latest `theta` even on non-convergence; should signal `isValid=false` to match OpenCV `project()` behavior.

Differential Revision: D102719314


