### PR TITLE
Comment audit: character/

### DIFF
--- a/momentum/camera/camera.cpp
+++ b/momentum/camera/camera.cpp
@@ -19,7 +19,7 @@
 
 namespace momentum {
 
-// Default constructor is VGA res.
+// Default is VGA resolution with a focal length corresponding to a 3.6 mm sensor and 5 mm lens.
 template <typename T>
 CameraT<T>::CameraT()
     : intrinsicsModel_(
@@ -29,14 +29,12 @@ CameraT<T>::CameraT()
               (5.0 / 3.6) * 640,
               (5.0 / 3.6) * 640)) {}
 
-// Constructor implementation for CameraT.
 template <typename T>
 CameraT<T>::CameraT(
     std::shared_ptr<const IntrinsicsModelT<T>> intrinsicsModel,
     const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld)
     : eyeFromWorld_(eyeFromWorld), intrinsicsModel_(intrinsicsModel) {}
 
-// Constructor for PinholeIntrinsicsModelT with explicit principal point.
 template <typename T>
 PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     int32_t imageWidth,
@@ -47,7 +45,6 @@ PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     T cy)
     : IntrinsicsModelT<T>(imageWidth, imageHeight), fx_(fx), fy_(fy), cx_(cx), cy_(cy) {}
 
-// Constructor for PinholeIntrinsicsModelT with principal point at image center.
 template <typename T>
 PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
     int32_t imageWidth,
@@ -60,7 +57,6 @@ PinholeIntrinsicsModelT<T>::PinholeIntrinsicsModelT(
       cx_(T(imageWidth) / T(2)),
       cy_(T(imageHeight) / T(2)) {}
 
-// Constructor for OpenCVIntrinsicsModelT with optional distortion parameters.
 template <typename T>
 OpenCVIntrinsicsModelT<T>::OpenCVIntrinsicsModelT(
     int32_t imageWidth,
@@ -80,11 +76,11 @@ OpenCVIntrinsicsModelT<T>::OpenCVIntrinsicsModelT(
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> PinholeIntrinsicsModelT<T>::project(
     const Vector3P<T>& point) const {
-  // Normalize the point by dividing by z
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity mask filters them out.
   Packet<T> x = point.x() / point.z();
   Packet<T> y = point.y() / point.z();
 
-  // Apply camera matrix to get pixel coordinates
   Packet<T> u = fx_ * x + this->cx();
   Packet<T> v = fy_ * y + this->cy();
 
@@ -94,11 +90,11 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> PinholeIntrinsicsModelT<T>:
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool> PinholeIntrinsicsModelT<T>::project(
     const Eigen::Vector3<T>& point) const {
-  // Normalize the point by dividing by z
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity flag filters them out.
   T x = point.x() / point.z();
   T y = point.y() / point.z();
 
-  // Apply camera matrix to get pixel coordinates
   T u = fx_ * x + this->cx();
   T v = fy_ * y + this->cy();
 
@@ -112,7 +108,6 @@ PinholeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) cons
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     return {Eigen::Vector3<T>::Zero(), Eigen::Matrix<T, 3, 3>::Zero(), false};
   }
@@ -120,28 +115,27 @@ PinholeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) cons
   const T z_inv = T(1) / z;
   const T z_inv_sq = z_inv * z_inv;
 
-  // Project the point
   const T u = fx_ * x * z_inv + cx_;
   const T v = fy_ * y * z_inv + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x3)
+  // Pinhole projection Jacobian:
+  //   u = fx * (x/z) + cx,  v = fy * (y/z) + cy,  z passes through unchanged.
+  // TODO: jacobian(0,1), jacobian(1,0), jacobian(2,0), jacobian(2,1) are redundant assignments
+  // since the matrix is zero-initialized; consider removing them in a separate code-change diff.
   Eigen::Matrix<T, 3, 3> jacobian = Eigen::Matrix<T, 3, 3>::Zero();
 
-  // Row 0: du/dx, du/dy, du/dz
-  jacobian(0, 0) = fx_ * z_inv; // du/dx = fx / z
-  jacobian(0, 1) = T(0); // du/dy = 0
-  jacobian(0, 2) = -fx_ * x * z_inv_sq; // du/dz = -fx * x / z^2
+  jacobian(0, 0) = fx_ * z_inv;
+  jacobian(0, 1) = T(0);
+  jacobian(0, 2) = -fx_ * x * z_inv_sq;
 
-  // Row 1: dv/dx, dv/dy, dv/dz
-  jacobian(1, 0) = T(0); // dv/dx = 0
-  jacobian(1, 1) = fy_ * z_inv; // dv/dy = fy / z
-  jacobian(1, 2) = -fy_ * y * z_inv_sq; // dv/dz = -fy * y / z^2
+  jacobian(1, 0) = T(0);
+  jacobian(1, 1) = fy_ * z_inv;
+  jacobian(1, 2) = -fy_ * y * z_inv_sq;
 
-  // Row 2: homogeneous coordinates (for completeness)
-  jacobian(2, 0) = T(0); // dz/dx = 0
-  jacobian(2, 1) = T(0); // dz/dy = 0
-  jacobian(2, 2) = T(1); // dz/dz = 1
+  jacobian(2, 0) = T(0);
+  jacobian(2, 1) = T(0);
+  jacobian(2, 2) = T(1);
 
   return {projectedPoint, jacobian, true};
 }
@@ -153,9 +147,9 @@ std::shared_ptr<const IntrinsicsModelT<T>> PinholeIntrinsicsModelT<T>::resize(
   T scaleX = T(imageWidth) / T(this->imageWidth());
   T scaleY = T(imageHeight) / T(this->imageHeight());
 
-  // Apply the correct formula for camera center as noted in the comment:
-  // cx = (old_cx + 0.5) * new_sizex / old_sizex - 0.5;
-  // cy = (old_cy + 0.5) * new_sizey / old_sizey - 0.5;
+  // Use the half-pixel-offset convention so that pixel centers map exactly between resolutions:
+  //   new_cx = (old_cx + 0.5) * scaleX - 0.5
+  //   new_cy = (old_cy + 0.5) * scaleY - 0.5
   T old_cx = this->cx();
   T old_cy = this->cy();
   T new_cx = (old_cx + T(0.5)) * scaleX - T(0.5);
@@ -171,7 +165,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> PinholeIntrinsicsModelT<T>::crop(
     int32_t left,
     int32_t newWidth,
     int32_t newHeight) const {
-  // Ensure the crop doesn't exceed the original image dimensions
+  // Clamp the crop region to stay inside the original image bounds.
   int32_t width = newWidth;
   if (left + width > this->imageWidth()) {
     width = this->imageWidth() - left;
@@ -182,7 +176,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> PinholeIntrinsicsModelT<T>::crop(
     height = this->imageHeight() - top;
   }
 
-  // Adjust the principal point by subtracting the crop offset
+  // Shift the principal point so it stays at the same physical location after cropping.
   T cameraCenter_cropped_cx = cx_ - T(left);
   T cameraCenter_cropped_cy = cy_ - T(top);
 
@@ -195,16 +189,14 @@ std::pair<Eigen::Vector3<T>, bool> PinholeIntrinsicsModelT<T>::unproject(
     const Eigen::Vector3<T>& imagePoint,
     int /*maxIterations*/,
     T /*tolerance*/) const {
-  // For pinhole cameras, unprojection is straightforward - no distortion to invert
+  // Pinhole has no distortion to invert, so unprojection is closed-form.
   const T u = imagePoint(0);
   const T v = imagePoint(1);
   const T depth = imagePoint(2);
 
-  // Convert to normalized camera coordinates
   const T x = (u - cx_) / fx_;
   const T y = (v - cy_) / fy_;
 
-  // Return 3D point in camera coordinates with the given depth
   return {Eigen::Vector3<T>(x * depth, y * depth, depth), depth > T(0)};
 }
 
@@ -249,50 +241,40 @@ PinholeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& p
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     Eigen::Matrix<T, 3, 4> zeroJacobian = Eigen::Matrix<T, 3, 4>::Zero();
     return {Eigen::Vector3<T>::Zero(), zeroJacobian, false};
   }
 
   const T z_inv = T(1) / z;
-  const T xn = x * z_inv; // x/z (normalized coordinate)
-  const T yn = y * z_inv; // y/z (normalized coordinate)
+  const T xn = x * z_inv;
+  const T yn = y * z_inv;
 
-  // Project the point: u = fx * x/z + cx, v = fy * y/z + cy
   const T u = fx_ * xn + cx_;
   const T v = fy_ * yn + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x4) with respect to [fx, fy, cx, cy]
-  // u = fx * (x/z) + cx
-  // v = fy * (y/z) + cy
-  // depth = z (unchanged)
-  //
-  // du/dfx = x/z,  du/dfy = 0,    du/dcx = 1,  du/dcy = 0
-  // dv/dfx = 0,    dv/dfy = y/z,  dv/dcx = 0,  dv/dcy = 1
-  // dz/d*  = 0     (depth is unchanged by intrinsics)
+  // Jacobian with respect to [fx, fy, cx, cy]:
+  //   du/dfx = x/z,  du/dfy = 0,    du/dcx = 1,  du/dcy = 0
+  //   dv/dfx = 0,    dv/dfy = y/z,  dv/dcx = 0,  dv/dcy = 1
+  //   dz/d*  = 0     (depth is independent of intrinsics)
+  // TODO: the explicit T(0) assignments below are redundant given the zero-init; keep here for
+  // readability symmetry with non-zero rows but consider removing in a separate code-change diff.
   Eigen::Matrix<T, 3, 4> jacobian = Eigen::Matrix<T, 3, 4>::Zero();
 
-  // Row 0: du/d[fx, fy, cx, cy]
-  jacobian(0, 0) = xn; // du/dfx = x/z
-  jacobian(0, 1) = T(0); // du/dfy = 0
-  jacobian(0, 2) = T(1); // du/dcx = 1
-  jacobian(0, 3) = T(0); // du/dcy = 0
+  jacobian(0, 0) = xn;
+  jacobian(0, 1) = T(0);
+  jacobian(0, 2) = T(1);
+  jacobian(0, 3) = T(0);
 
-  // Row 1: dv/d[fx, fy, cx, cy]
-  jacobian(1, 0) = T(0); // dv/dfx = 0
-  jacobian(1, 1) = yn; // dv/dfy = y/z
-  jacobian(1, 2) = T(0); // dv/dcx = 0
-  jacobian(1, 3) = T(1); // dv/dcy = 1
-
-  // Row 2: dz/d[fx, fy, cx, cy] = 0 (depth unchanged)
-  // Already set to zero above
+  jacobian(1, 0) = T(0);
+  jacobian(1, 1) = yn;
+  jacobian(1, 2) = T(0);
+  jacobian(1, 3) = T(1);
 
   return {projectedPoint, jacobian, true};
 }
 
-// Base class implementations for IntrinsicsModelT
 template <typename T>
 std::shared_ptr<const IntrinsicsModelT<T>> IntrinsicsModelT<T>::resample(T factor) const {
   return resize(
@@ -314,11 +296,12 @@ std::shared_ptr<const IntrinsicsModelT<T>> IntrinsicsModelT<T>::upsample(T facto
       static_cast<int32_t>(this->imageHeight() * factor));
 }
 
-// OpenCVIntrinsicsModelT implementation
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVIntrinsicsModelT<T>::project(
     const Vector3P<T>& point) const {
-  // Normalize the point by dividing by z
+  // OpenCV rational distortion model: rational radial polynomial in r^2 plus tangential terms.
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity mask filters them out.
   Packet<T> invZ = T(1) / point.z();
   Packet<T> xp = point.x() * invZ;
   Packet<T> yp = point.y() * invZ;
@@ -336,7 +319,6 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVIntrinsicsModelT<T>::
   Packet<T> ypp =
       yp * radialDistortion + dp.p1 * (rsqr + T(2) * drjit::square(yp)) + T(2) * dp.p2 * xp * yp;
 
-  // Apply camera matrix to get pixel coordinates
   Packet<T> u = fx_ * xpp + cx_;
   Packet<T> v = fy_ * ypp + cy_;
 
@@ -346,7 +328,8 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVIntrinsicsModelT<T>::
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::project(
     const Eigen::Vector3<T>& point) const {
-  // Normalize the point by dividing by z
+  // TODO: project() does not guard against point.z() == 0; division by zero will produce NaN/Inf
+  // before the validity flag filters them out.
   T invZ = T(1) / point.z();
   T xp = point.x() * invZ;
   T yp = point.y() * invZ;
@@ -362,7 +345,6 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::project(
   T xpp = xp * radialDistortion + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   T ypp = yp * radialDistortion + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
 
-  // Apply camera matrix to get pixel coordinates
   T u = fx_ * xpp + cx_;
   T v = fy_ * ypp + cy_;
 
@@ -376,7 +358,6 @@ OpenCVIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) const
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     return {Eigen::Vector3<T>::Zero(), Eigen::Matrix<T, 3, 3>::Zero(), false};
   }
@@ -384,34 +365,33 @@ OpenCVIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) const
   const T z_inv = T(1) / z;
   const T z_inv_sq = z_inv * z_inv;
 
-  // Normalized coordinates
   const T xp = x * z_inv;
   const T yp = y * z_inv;
   const T rsqr = xp * xp + yp * yp;
 
   const auto& dp = distortionParams_;
 
-  // Radial distortion components
+  // Radial factor = num/den, where num and den are even-degree polynomials in r.
   const T radial_num = T(1) + rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3));
   const T radial_den = T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6));
   const T radial_factor = radial_num / radial_den;
 
-  // Tangential distortion
+  // Tangential terms (Brown-Conrady).
   const T xpp = xp * radial_factor + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   const T ypp = yp * radial_factor + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Derivatives of radial distortion factor with respect to rsqr
+  // d(radial_factor)/d(rsqr) via the quotient rule.
   const T dradial_num_drsqr = dp.k1 + rsqr * (T(2) * dp.k2 + rsqr * T(3) * dp.k3);
   const T dradial_den_drsqr = dp.k4 + rsqr * (T(2) * dp.k5 + rsqr * T(3) * dp.k6);
   const T dradial_factor_drsqr =
       (dradial_num_drsqr * radial_den - radial_num * dradial_den_drsqr) / (radial_den * radial_den);
 
-  // Derivatives of distorted coordinates with respect to normalized coordinates
+  // Partials of (xpp, ypp) with respect to (xp, yp); chain rule will combine with
+  // d(xp,yp)/d(x,y,z).
   const T dxpp_dxp =
       radial_factor + xp * dradial_factor_drsqr * T(2) * xp + T(2) * dp.p1 * yp + dp.p2 * T(6) * xp;
   const T dxpp_dyp = xp * dradial_factor_drsqr * T(2) * yp + T(2) * dp.p1 * xp + dp.p2 * T(2) * yp;
@@ -419,23 +399,21 @@ OpenCVIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) const
   const T dypp_dyp =
       radial_factor + yp * dradial_factor_drsqr * T(2) * yp + dp.p1 * T(6) * yp + T(2) * dp.p2 * xp;
 
-  // Compute Jacobian matrix (3x3)
+  // TODO: jacobian(2,0) and jacobian(2,1) are redundant assignments since the matrix is
+  // zero-initialized; consider removing them in a separate code-change diff.
   Eigen::Matrix<T, 3, 3> jacobian = Eigen::Matrix<T, 3, 3>::Zero();
 
-  // Row 0: du/dx, du/dy, du/dz
-  jacobian(0, 0) = fx_ * dxpp_dxp * z_inv; // du/dx
-  jacobian(0, 1) = fx_ * dxpp_dyp * z_inv; // du/dy
-  jacobian(0, 2) = -fx_ * (dxpp_dxp * x * z_inv_sq + dxpp_dyp * y * z_inv_sq); // du/dz
+  jacobian(0, 0) = fx_ * dxpp_dxp * z_inv;
+  jacobian(0, 1) = fx_ * dxpp_dyp * z_inv;
+  jacobian(0, 2) = -fx_ * (dxpp_dxp * x * z_inv_sq + dxpp_dyp * y * z_inv_sq);
 
-  // Row 1: dv/dx, dv/dy, dv/dz
-  jacobian(1, 0) = fy_ * dypp_dxp * z_inv; // dv/dx
-  jacobian(1, 1) = fy_ * dypp_dyp * z_inv; // dv/dy
-  jacobian(1, 2) = -fy_ * (dypp_dxp * x * z_inv_sq + dypp_dyp * y * z_inv_sq); // dv/dz
+  jacobian(1, 0) = fy_ * dypp_dxp * z_inv;
+  jacobian(1, 1) = fy_ * dypp_dyp * z_inv;
+  jacobian(1, 2) = -fy_ * (dypp_dxp * x * z_inv_sq + dypp_dyp * y * z_inv_sq);
 
-  // Row 2: homogeneous coordinates (for completeness)
-  jacobian(2, 0) = T(0); // dz/dx = 0
-  jacobian(2, 1) = T(0); // dz/dy = 0
-  jacobian(2, 2) = T(1); // dz/dz = 1
+  jacobian(2, 0) = T(0);
+  jacobian(2, 1) = T(0);
+  jacobian(2, 2) = T(1);
 
   return {projectedPoint, jacobian, true};
 }
@@ -447,9 +425,8 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVIntrinsicsModelT<T>::resize(
   T scaleX = T(imageWidth) / T(this->imageWidth());
   T scaleY = T(imageHeight) / T(this->imageHeight());
 
-  // Apply the correct formula for camera center as noted in the comment:
-  // cx = (old_cx + 0.5) * new_sizex / old_sizex - 0.5;
-  // cy = (old_cy + 0.5) * new_sizey / old_sizey - 0.5;
+  // Use the half-pixel-offset convention (same as Pinhole resize).
+  // Distortion parameters are unitless in normalized coordinates and stay unchanged.
   T new_cx = (cx_ + T(0.5)) * scaleX - T(0.5);
   T new_cy = (cy_ + T(0.5)) * scaleY - T(0.5);
 
@@ -463,7 +440,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVIntrinsicsModelT<T>::crop(
     int32_t left,
     int32_t newWidth,
     int32_t newHeight) const {
-  // Ensure the crop doesn't exceed the original image dimensions
+  // Clamp the crop region to stay inside the original image bounds.
   int32_t width = newWidth;
   if (left + width > this->imageWidth()) {
     width = this->imageWidth() - left;
@@ -474,7 +451,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVIntrinsicsModelT<T>::crop(
     height = this->imageHeight() - top;
   }
 
-  // Adjust the principal point by subtracting the crop offset
+  // Shift the principal point so it stays at the same physical location after cropping.
   T cameraCenter_cropped_cx = cx_ - T(left);
   T cameraCenter_cropped_cy = cy_ - T(top);
 
@@ -491,60 +468,52 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
   const T v = imagePoint(1);
   const T depth = imagePoint(2);
 
-  // Check if depth is valid (positive)
   if (depth <= T(0)) {
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Initial guess: convert to normalized camera coordinates assuming no distortion
+  // Initial guess: ignore distortion. Distortion is small near the optical center, so this is
+  // typically within Newton's basin of convergence.
   const Eigen::Vector3<T> p_init((u - cx_) / fx_, (v - cy_) / fy_, depth);
   Eigen::Vector3<T> p_cur = p_init;
 
-  // Newton's method with backtracking line search to solve the nonlinear projection equation
+  // Gauss-Newton with backtracking (Armijo) line search to invert the nonlinear projection.
+  // On any failure (invalid point, singular Jacobian, line-search failure, no convergence) we
+  // return the undistorted initial guess together with isValid=false.
   for (int iter = 0; iter < maxIterations; ++iter) {
-    // Use projectJacobian to get both the projected point and Jacobian
     const auto [projectedPoint, jacobian, isValid] = projectJacobian(p_cur);
 
     if (!isValid) {
-      // Point is behind camera or other invalid condition
       return {p_init, false};
     }
 
-    // Compute residual
     const Eigen::Vector<T, 2> residual =
         projectedPoint.template head<2>() - imagePoint.template head<2>();
     const T residual_norm = residual.norm();
 
-    // Check convergence
     if (residual_norm < tolerance) {
       return {p_cur, true};
     }
 
-    // Extract the 2x3 Jacobian matrix from the 3x3 matrix (ignore the third row)
+    // Drop the depth pass-through row to get the 2x2 image-space Jacobian.
     Eigen::Matrix<T, 2, 2> J = jacobian.template topLeftCorner<2, 2>();
 
-    // Solve using QR decomposition for better numerical stability
-    // We want to solve: J * delta = -residual (least squares)
+    // Solve J * delta = -residual via Householder QR for numerical stability.
     Eigen::Vector<T, 2> rhs = -residual;
-
-    // Get the least squares solution using Eigen's QR decomposition (full Newton step)
     const Eigen::Vector<T, 2> delta = J.householderQr().solve(rhs);
 
-    // Check if the solution is valid (no NaN or infinite values)
     if (!delta.allFinite()) {
-      // QR solve failed, return failure
       return {p_init, false};
     }
 
-    // Backtracking line search to ensure we make progress
+    // Backtracking parameters.
     const T current_cost = residual_norm * residual_norm; // ||f(x)||^2
-    const T alpha_init = T(1.0); // Start with full Newton step
-    const T rho = T(0.5); // Backtracking factor
+    const T alpha_init = T(1.0);
+    const T rho = T(0.5);
     const T c1 = T(1e-4); // Armijo condition parameter
     const int max_line_search_iters = 10;
 
-    // Compute directional derivative: f'(x)^T * p = -||f(x)||^2 (since p = -J^T*f(x) for
-    // Gauss-Newton)
+    // For Gauss-Newton with step delta = -J^+ f, f'(x)^T * delta = -||f(x)||^2.
     const T directional_derivative = -current_cost;
 
     Eigen::Vector3<T> p_new = p_cur;
@@ -553,14 +522,12 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
     bool line_search_success = false;
 
     for (int ls_iter = 0; ls_iter < max_line_search_iters; ++ls_iter) {
-      // Try step: x_new = x + alpha * delta
       p_new.template head<2>() = p_cur.template head<2>() + alpha * delta;
 
-      // Evaluate cost at new point
       const auto [new_projectedPoint, new_isValid] = project(p_new);
 
       if (!new_isValid) {
-        // Point went behind camera, reduce step size
+        // Stepped behind the camera; shrink and retry.
         alpha *= rho;
         continue;
       }
@@ -569,13 +536,12 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
           new_projectedPoint.template head<2>() - imagePoint.template head<2>();
       new_cost = residualNew.squaredNorm();
 
-      // Armijo condition: f(x + alpha*p) <= f(x) + c1*alpha*f'(x)^T*p
+      // Armijo condition: f(x + alpha*p) <= f(x) + c1*alpha*f'(x)^T*p.
       if (new_cost <= current_cost + c1 * alpha * directional_derivative) {
         line_search_success = true;
         break;
       }
 
-      // Reduce step size
       alpha *= rho;
     }
 
@@ -583,11 +549,9 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::unproject(
       return {p_init, false};
     }
 
-    // Update the 3D point
     p_cur = p_new;
   }
 
-  // If we reach here, Newton's method didn't converge
   return {p_init, false};
 }
 
@@ -644,7 +608,6 @@ OpenCVIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& po
   const T y = point(1);
   const T z = point(2);
 
-  // Check if point is in front of camera
   if (z <= T(0)) {
     Eigen::Matrix<T, 3, 14> zeroJacobian = Eigen::Matrix<T, 3, 14>::Zero();
     return {Eigen::Vector3<T>::Zero(), zeroJacobian, false};
@@ -652,108 +615,85 @@ OpenCVIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& po
 
   const T z_inv = T(1) / z;
 
-  // Normalized coordinates
   const T xp = x * z_inv;
   const T yp = y * z_inv;
   const T rsqr = xp * xp + yp * yp;
 
   const auto& dp = distortionParams_;
 
-  // Radial distortion components
-  // Note: the formula is radialDistortion = 1 + A/B where:
+  // radial_factor = 1 + A/B, where
   //   A = rsqr * (k1 + rsqr * (k2 + rsqr * k3))
   //   B = 1 + rsqr * (k4 + rsqr * (k5 + rsqr * k6))
   const T A = rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3));
   const T B = T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6));
   const T radial_factor = T(1) + A / B;
 
-  // Tangential distortion
   const T xpp = xp * radial_factor + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   const T ypp = yp * radial_factor + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x14) with respect to
-  // [fx, fy, cx, cy, k1, k2, k3, k4, k5, k6, p1, p2, p3, p4]
+  // Jacobian columns are ordered as [fx, fy, cx, cy, k1, k2, k3, k4, k5, k6, p1, p2, p3, p4],
+  // matching getIntrinsicParameters() and getParameterNames().
   Eigen::Matrix<T, 3, 14> jacobian = Eigen::Matrix<T, 3, 14>::Zero();
 
-  // Derivatives with respect to fx, fy, cx, cy (basic intrinsics)
-  // u = fx * xpp + cx
-  // v = fy * ypp + cy
-  jacobian(0, 0) = xpp; // du/dfx
-  jacobian(0, 2) = T(1); // du/dcx
-  jacobian(1, 1) = ypp; // dv/dfy
-  jacobian(1, 3) = T(1); // dv/dcy
+  // d/d{fx, fy, cx, cy}: u = fx * xpp + cx,  v = fy * ypp + cy.
+  jacobian(0, 0) = xpp;
+  jacobian(0, 2) = T(1);
+  jacobian(1, 1) = ypp;
+  jacobian(1, 3) = T(1);
 
-  // Derivatives with respect to distortion parameters
-  // radial_factor = 1 + A/B
-  // d(radial_factor)/dk_i = d(A/B)/dk_i
-
+  // For radial coefficients k_i, only radial_factor depends on them, so
+  //   d(xpp)/dk_i = xp * d(radial_factor)/dk_i, similarly for ypp.
+  //
+  // Numerator coefficients (k1, k2, k3): d(A/B)/dk_i = (dA/dk_i) / B with
+  //   dA/dk1 = rsqr, dA/dk2 = rsqr^2, dA/dk3 = rsqr^3.
+  // Denominator coefficients (k4, k5, k6): d(A/B)/dk_i = -A * (dB/dk_i) / B^2 with
+  //   dB/dk4 = rsqr, dB/dk5 = rsqr^2, dB/dk6 = rsqr^3.
   const T B_sq = B * B;
-
-  // For numerator coefficients k1, k2, k3:
-  // dA/dk1 = rsqr, dA/dk2 = rsqr^2, dA/dk3 = rsqr^3
-  // d(A/B)/dk_i = (dA/dk_i) / B
   const T rsqr2 = rsqr * rsqr;
   const T rsqr3 = rsqr2 * rsqr;
   const T drf_dk1 = rsqr / B;
   const T drf_dk2 = rsqr2 / B;
   const T drf_dk3 = rsqr3 / B;
-
-  // For denominator coefficients k4, k5, k6:
-  // dB/dk4 = rsqr, dB/dk5 = rsqr^2, dB/dk6 = rsqr^3
-  // d(A/B)/dk_i = -A * (dB/dk_i) / B^2
   const T drf_dk4 = -A * rsqr / B_sq;
   const T drf_dk5 = -A * rsqr2 / B_sq;
   const T drf_dk6 = -A * rsqr3 / B_sq;
 
-  // d(xpp)/dk_i = xp * d(radial_factor)/dk_i
-  // d(ypp)/dk_i = yp * d(radial_factor)/dk_i
-  jacobian(0, 4) = fx_ * xp * drf_dk1; // du/dk1
-  jacobian(1, 4) = fy_ * yp * drf_dk1; // dv/dk1
-  jacobian(0, 5) = fx_ * xp * drf_dk2; // du/dk2
-  jacobian(1, 5) = fy_ * yp * drf_dk2; // dv/dk2
-  jacobian(0, 6) = fx_ * xp * drf_dk3; // du/dk3
-  jacobian(1, 6) = fy_ * yp * drf_dk3; // dv/dk3
-  jacobian(0, 7) = fx_ * xp * drf_dk4; // du/dk4
-  jacobian(1, 7) = fy_ * yp * drf_dk4; // dv/dk4
-  jacobian(0, 8) = fx_ * xp * drf_dk5; // du/dk5
-  jacobian(1, 8) = fy_ * yp * drf_dk5; // dv/dk5
-  jacobian(0, 9) = fx_ * xp * drf_dk6; // du/dk6
-  jacobian(1, 9) = fy_ * yp * drf_dk6; // dv/dk6
+  jacobian(0, 4) = fx_ * xp * drf_dk1;
+  jacobian(1, 4) = fy_ * yp * drf_dk1;
+  jacobian(0, 5) = fx_ * xp * drf_dk2;
+  jacobian(1, 5) = fy_ * yp * drf_dk2;
+  jacobian(0, 6) = fx_ * xp * drf_dk3;
+  jacobian(1, 6) = fy_ * yp * drf_dk3;
+  jacobian(0, 7) = fx_ * xp * drf_dk4;
+  jacobian(1, 7) = fy_ * yp * drf_dk4;
+  jacobian(0, 8) = fx_ * xp * drf_dk5;
+  jacobian(1, 8) = fy_ * yp * drf_dk5;
+  jacobian(0, 9) = fx_ * xp * drf_dk6;
+  jacobian(1, 9) = fy_ * yp * drf_dk6;
 
-  // Derivatives with respect to tangential distortion p1, p2
-  // xpp = xp * radial_factor + 2*p1*xp*yp + p2*(rsqr + 2*xp^2)
-  // ypp = yp * radial_factor + p1*(rsqr + 2*yp^2) + 2*p2*xp*yp
+  // Tangential distortion (Brown-Conrady):
+  //   d(xpp)/dp1 = 2*xp*yp,           d(ypp)/dp1 = rsqr + 2*yp^2
+  //   d(xpp)/dp2 = rsqr + 2*xp^2,     d(ypp)/dp2 = 2*xp*yp
+  jacobian(0, 10) = fx_ * T(2) * xp * yp;
+  jacobian(1, 10) = fy_ * (rsqr + T(2) * yp * yp);
+  jacobian(0, 11) = fx_ * (rsqr + T(2) * xp * xp);
+  jacobian(1, 11) = fy_ * T(2) * xp * yp;
 
-  // d(xpp)/dp1 = 2*xp*yp
-  // d(ypp)/dp1 = rsqr + 2*yp^2
-  jacobian(0, 10) = fx_ * T(2) * xp * yp; // du/dp1
-  jacobian(1, 10) = fy_ * (rsqr + T(2) * yp * yp); // dv/dp1
-
-  // d(xpp)/dp2 = rsqr + 2*xp^2
-  // d(ypp)/dp2 = 2*xp*yp
-  jacobian(0, 11) = fx_ * (rsqr + T(2) * xp * xp); // du/dp2
-  jacobian(1, 11) = fy_ * T(2) * xp * yp; // dv/dp2
-
-  // Derivatives with respect to p3, p4 (thin prism coefficients)
-  // Note: The projection formula doesn't include p3 and p4 in the current implementation
-  // so their derivatives are zero
-  jacobian(0, 12) = T(0); // du/dp3
-  jacobian(1, 12) = T(0); // dv/dp3
-  jacobian(0, 13) = T(0); // du/dp4
-  jacobian(1, 13) = T(0); // dv/dp4
-
-  // Row 2: dz/d[all params] = 0 (depth unchanged)
-  // Already set to zero
+  // TODO: p3 and p4 (thin-prism coefficients) are exposed in OpenCVDistortionParametersT but the
+  // projection formula does not use them, so their derivatives are zero. Either implement
+  // thin-prism distortion or remove p3/p4 from the parameter set. The explicit T(0) writes below
+  // are also redundant given the zero-init.
+  jacobian(0, 12) = T(0);
+  jacobian(1, 12) = T(0);
+  jacobian(0, 13) = T(0);
+  jacobian(1, 13) = T(0);
 
   return {projectedPoint, jacobian, true};
 }
-
-// OpenCVFisheyeIntrinsicsModelT implementation
 
 template <typename T>
 OpenCVFisheyeIntrinsicsModelT<T>::OpenCVFisheyeIntrinsicsModelT(
@@ -771,17 +711,16 @@ OpenCVFisheyeIntrinsicsModelT<T>::OpenCVFisheyeIntrinsicsModelT(
       cy_(cy),
       distortionParams_(params),
       maxRSquared_(std::numeric_limits<T>::max()) {
-  // Compute default max valid angle from image bounds
+  // Initialize maxRSquared_ from the image bounds; callers may override via setMaxValidAngle().
   computeMaxValidAngleFromImageBounds();
 }
 
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsModelT<T>::project(
     const Vector3P<T>& point) const {
-  // Process each element in the packet individually since drjit::atan is not available
+  // Per-lane scalar loop because drjit::atan is not available; cannot vectorize the angular step.
   Vector3P<T> result;
 
-  // Track validity per element (z > 0 and rsqr <= maxRSquared_)
   typename Packet<T>::MaskType validMask;
   for (size_t i = 0; i < Packet<T>::Size; ++i) {
     validMask[i] = true;
@@ -800,15 +739,13 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsMode
       continue;
     }
 
-    // Normalize the point by dividing by z
     const T invZ = T(1) / z;
     const T a = x * invZ;
     const T b = y * invZ;
 
-    // Compute radius and angle
     const T rsqr = a * a + b * b;
 
-    // Check FOV validity
+    // Reject points outside the calibrated angular FOV (configured via setMaxValidAngle()).
     if (rsqr > maxRSquared_) {
       result.x()[i] = T(0);
       result.y()[i] = T(0);
@@ -822,7 +759,8 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsMode
 
     const auto& dp = distortionParams_;
 
-    // Apply distortion
+    // Equidistant fisheye distortion polynomial:
+    //   thetaD = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
     const T theta2 = theta * theta;
     const T theta4 = theta2 * theta2;
     const T theta6 = theta4 * theta2;
@@ -830,14 +768,12 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVFisheyeIntrinsicsMode
     const T thetaD =
         theta * (T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8);
 
-    // Compute scale factor
+    // Avoid division by zero at the optical axis; thetaD/r -> 1 as r -> 0.
     const T scale = (r > T(1e-8)) ? thetaD / r : T(1);
 
-    // Apply scale
     const T xpp = scale * a;
     const T ypp = scale * b;
 
-    // Apply camera matrix to get pixel coordinates
     result.x()[i] = fx_ * xpp + cx_;
     result.y()[i] = fy_ * ypp + cy_;
     result.z()[i] = z;
@@ -855,15 +791,13 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::project(
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Normalize the point by dividing by z
   T invZ = T(1) / z;
   T a = point.x() * invZ;
   T b = point.y() * invZ;
 
-  // Compute radius and angle
   T rsqr = a * a + b * b;
 
-  // Check FOV validity
+  // Reject points outside the calibrated angular FOV.
   if (rsqr > maxRSquared_) {
     return {Eigen::Vector3<T>::Zero(), false};
   }
@@ -873,21 +807,19 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::project(
 
   const auto& dp = distortionParams_;
 
-  // Apply distortion: theta_d = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
+  // theta_d = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
   T theta2 = theta * theta;
   T theta4 = theta2 * theta2;
   T theta6 = theta4 * theta2;
   T theta8 = theta4 * theta4;
   T thetaD = theta * (T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8);
 
-  // Compute scale factor: theta_d / r, handle r->0 singularity
+  // Avoid division by zero at the optical axis; thetaD/r -> 1 as r -> 0.
   T scale = (r > T(1e-8)) ? thetaD / r : T(1);
 
-  // Apply scale
   T xpp = scale * a;
   T ypp = scale * b;
 
-  // Apply camera matrix to get pixel coordinates
   T u = fx_ * xpp + cx_;
   T v = fy_ * ypp + cy_;
 
@@ -908,12 +840,10 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
   const T z_inv = T(1) / z;
   const T z_inv_sq = z_inv * z_inv;
 
-  // Normalized coordinates
   const T a = x * z_inv;
   const T b = y * z_inv;
   const T rsqr = a * a + b * b;
 
-  // Check FOV validity
   if (rsqr > maxRSquared_) {
     return {Eigen::Vector3<T>::Zero(), Eigen::Matrix<T, 3, 3>::Zero(), false};
   }
@@ -923,7 +853,7 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
 
   const auto& dp = distortionParams_;
 
-  // Distortion polynomial coefficients
+  // poly = 1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8;  thetaD = theta * poly.
   const T theta2 = theta * theta;
   const T theta4 = theta2 * theta2;
   const T theta6 = theta4 * theta2;
@@ -931,24 +861,20 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
   const T poly = T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8;
   const T thetaD = theta * poly;
 
-  // Handle r->0 singularity
   const bool nearCenter = r < T(1e-8);
   const T scale = nearCenter ? T(1) : thetaD / r;
 
-  // Distorted normalized coordinates
   const T xpp = scale * a;
   const T ypp = scale * b;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x3)
   Eigen::Matrix<T, 3, 3> jacobian = Eigen::Matrix<T, 3, 3>::Zero();
 
   if (nearCenter) {
-    // Near optical axis: Jacobian simplifies to pinhole-like behavior
+    // At the optical axis the fisheye reduces to the pinhole limit (scale -> 1, no cross-term).
     jacobian(0, 0) = fx_ * z_inv;
     jacobian(0, 2) = -fx_ * x * z_inv_sq;
     jacobian(1, 1) = fy_ * z_inv;
@@ -957,41 +883,29 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point
     return {projectedPoint, jacobian, true};
   }
 
-  // Derivative of poly with respect to theta
+  // Build d(scale)/dr via the chain rule:
+  //   d(thetaD)/d(theta) = poly + theta * d(poly)/d(theta)
+  //   d(theta)/dr        = 1 / (1 + r^2)        (since theta = atan(r))
+  //   d(scale)/dr        = (d(thetaD)/dr * r - thetaD) / r^2     (quotient rule on thetaD/r)
   const T dpoly_dtheta = T(2) * dp.k1 * theta + T(4) * dp.k2 * theta * theta2 +
       T(6) * dp.k3 * theta * theta4 + T(8) * dp.k4 * theta * theta6;
   const T dthetaD_dtheta = poly + theta * dpoly_dtheta;
-
-  // Derivative of theta with respect to r: d(atan(r))/dr = 1/(1+r^2)
   const T dtheta_dr = T(1) / (T(1) + rsqr);
-
-  // Derivative of scale with respect to r
-  // scale = thetaD / r
-  // d(scale)/dr = (d(thetaD)/dr * r - thetaD) / r^2
-  //             = (dthetaD_dtheta * dtheta_dr * r - thetaD) / r^2
   const T r_inv = T(1) / r;
   const T dscale_dr = (dthetaD_dtheta * dtheta_dr * r - thetaD) * r_inv * r_inv;
 
-  // Derivatives of r with respect to a, b
-  // r = sqrt(a^2 + b^2)
+  // r = sqrt(a^2 + b^2) => dr/da = a/r, dr/db = b/r.
   const T dr_da = a * r_inv;
   const T dr_db = b * r_inv;
 
-  // Derivatives of xpp, ypp with respect to a, b
-  // xpp = scale * a
-  // dxpp/da = d(scale)/da * a + scale = dscale_dr * dr_da * a + scale
-  // dxpp/db = d(scale)/db * a = dscale_dr * dr_db * a
+  // (xpp, ypp) = scale * (a, b); product rule with d(scale)/d{a,b} = d(scale)/dr * d(r)/d{a,b}.
   const T dxpp_da = dscale_dr * dr_da * a + scale;
   const T dxpp_db = dscale_dr * dr_db * a;
   const T dypp_da = dscale_dr * dr_da * b;
   const T dypp_db = dscale_dr * dr_db * b + scale;
 
-  // Derivatives of a, b with respect to x, y, z
-  // a = x/z, b = y/z
-  // da/dx = 1/z, da/dy = 0, da/dz = -x/z^2
-  // db/dx = 0, db/dy = 1/z, db/dz = -y/z^2
-
-  // Chain rule: du/dx = fx * dxpp/dx = fx * (dxpp/da * da/dx + dxpp/db * db/dx)
+  // Compose with d(a, b)/d(x, y, z) where a = x/z, b = y/z:
+  //   da/dx = 1/z, da/dy = 0, da/dz = -x/z^2; analogously for b.
   jacobian(0, 0) = fx_ * dxpp_da * z_inv;
   jacobian(0, 1) = fx_ * dxpp_db * z_inv;
   jacobian(0, 2) = fx_ * (dxpp_da * (-x * z_inv_sq) + dxpp_db * (-y * z_inv_sq));
@@ -1012,7 +926,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVFisheyeIntrinsicsModelT<T>::res
   T scaleX = T(imageWidth) / T(this->imageWidth());
   T scaleY = T(imageHeight) / T(this->imageHeight());
 
-  // Apply the correct formula for camera center
+  // Use the half-pixel-offset convention; distortion parameters are unitless and stay unchanged.
   T new_cx = (cx_ + T(0.5)) * scaleX - T(0.5);
   T new_cy = (cy_ + T(0.5)) * scaleY - T(0.5);
 
@@ -1026,7 +940,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVFisheyeIntrinsicsModelT<T>::cro
     int32_t left,
     int32_t newWidth,
     int32_t newHeight) const {
-  // Ensure the crop doesn't exceed the original image dimensions
+  // Clamp the crop region to stay inside the original image bounds.
   int32_t width = newWidth;
   if (left + width > this->imageWidth()) {
     width = this->imageWidth() - left;
@@ -1037,7 +951,7 @@ std::shared_ptr<const IntrinsicsModelT<T>> OpenCVFisheyeIntrinsicsModelT<T>::cro
     height = this->imageHeight() - top;
   }
 
-  // Adjust the principal point by subtracting the crop offset
+  // Shift the principal point so it stays at the same physical location after cropping.
   T cameraCenter_cropped_cx = cx_ - T(left);
   T cameraCenter_cropped_cy = cy_ - T(top);
 
@@ -1058,22 +972,24 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::unproject(
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Convert to normalized distorted coordinates
+  // Strip intrinsics to recover normalized distorted coordinates (xpp, ypp); their length is
+  // thetaD.
   const T xpp = (u - cx_) / fx_;
   const T ypp = (v - cy_) / fy_;
 
-  // Compute distorted radius (thetaD)
   const T rDistorted = std::sqrt(xpp * xpp + ypp * ypp);
 
-  // Handle center case
+  // The optical-axis ray maps to the optical center; bypass Newton to avoid 0/0.
   if (rDistorted < T(1e-8)) {
     return {Eigen::Vector3<T>(T(0), T(0), depth), true};
   }
 
-  // Newton's method to solve: thetaD = theta * poly(theta)
-  // f(theta) = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8) - thetaD = 0
+  // Solve for theta in f(theta) = theta * poly(theta) - thetaD = 0 by Newton iteration.
+  // Initial guess theta == rDistorted is exact when distortion is zero.
+  // TODO: this loop silently returns the latest theta even when Newton fails to converge;
+  // consider returning isValid=false on non-convergence to match OpenCV's project() behavior.
   const auto& dp = distortionParams_;
-  T theta = rDistorted; // Initial guess
+  T theta = rDistorted;
 
   for (int iter = 0; iter < maxIterations; ++iter) {
     const T theta2 = theta * theta;
@@ -1088,7 +1004,7 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::unproject(
       break;
     }
 
-    // f'(theta) = poly + theta * dpoly/dtheta
+    // f'(theta) = poly + theta * d(poly)/d(theta).
     const T dpoly_dtheta = T(2) * dp.k1 * theta + T(4) * dp.k2 * theta * theta2 +
         T(6) * dp.k3 * theta * theta4 + T(8) * dp.k4 * theta * theta6;
     const T df = poly + theta * dpoly_dtheta;
@@ -1100,19 +1016,14 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVFisheyeIntrinsicsModelT<T>::unproject(
     theta = theta - f / df;
   }
 
-  // Compute undistorted radius: r = tan(theta)
+  // Equidistant model: project(theta) = scale * (a, b) with scale = thetaD/r and r = tan(theta).
+  // Inverting that scale yields unscale = r/thetaD, applied to the distorted coords.
   const T r = std::tan(theta);
-
-  // Scale factor from distorted to undistorted
-  // distorted = scale * undistorted, where scale = thetaD / r
-  // So undistorted = distorted * r / thetaD
   const T unscale = (rDistorted > T(1e-8)) ? r / rDistorted : T(1);
 
-  // Undistorted normalized coordinates
   const T a = xpp * unscale;
   const T b = ypp * unscale;
 
-  // Convert to 3D point
   return {Eigen::Vector3<T>(a * depth, b * depth, depth), true};
 }
 
@@ -1171,12 +1082,10 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3
 
   const T z_inv = T(1) / z;
 
-  // Normalized coordinates
   const T a = x * z_inv;
   const T b = y * z_inv;
   const T rsqr = a * a + b * b;
 
-  // Check FOV validity
   if (rsqr > maxRSquared_) {
     Eigen::Matrix<T, 3, 8> zeroJacobian = Eigen::Matrix<T, 3, 8>::Zero();
     return {Eigen::Vector3<T>::Zero(), zeroJacobian, false};
@@ -1187,7 +1096,7 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3
 
   const auto& dp = distortionParams_;
 
-  // Distortion polynomial
+  // poly = 1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8;  thetaD = theta * poly.
   const T theta2 = theta * theta;
   const T theta4 = theta2 * theta2;
   const T theta6 = theta4 * theta2;
@@ -1195,58 +1104,47 @@ OpenCVFisheyeIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3
   const T poly = T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8;
   const T thetaD = theta * poly;
 
-  // Handle r->0 singularity
   const bool nearCenter = r < T(1e-8);
   const T scale = nearCenter ? T(1) : thetaD / r;
 
-  // Distorted normalized coordinates
   const T xpp = scale * a;
   const T ypp = scale * b;
 
-  // Project the point
   const T u = fx_ * xpp + cx_;
   const T v = fy_ * ypp + cy_;
   Eigen::Vector3<T> projectedPoint(u, v, z);
 
-  // Compute Jacobian matrix (3x8) with respect to [fx, fy, cx, cy, k1, k2, k3, k4]
+  // Jacobian columns ordered as [fx, fy, cx, cy, k1, k2, k3, k4], matching getParameterNames().
   Eigen::Matrix<T, 3, 8> jacobian = Eigen::Matrix<T, 3, 8>::Zero();
 
-  // Derivatives with respect to fx, fy, cx, cy
-  jacobian(0, 0) = xpp; // du/dfx
-  jacobian(0, 2) = T(1); // du/dcx
-  jacobian(1, 1) = ypp; // dv/dfy
-  jacobian(1, 3) = T(1); // dv/dcy
+  jacobian(0, 0) = xpp;
+  jacobian(0, 2) = T(1);
+  jacobian(1, 1) = ypp;
+  jacobian(1, 3) = T(1);
 
   if (!nearCenter) {
-    // Derivatives with respect to distortion parameters k1, k2, k3, k4
-    // thetaD = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
-    // d(thetaD)/dk1 = theta * theta^2 = theta^3
-    // d(thetaD)/dk2 = theta * theta^4 = theta^5
-    // d(thetaD)/dk3 = theta * theta^6 = theta^7
-    // d(thetaD)/dk4 = theta * theta^8 = theta^9
-
-    // scale = thetaD / r
-    // d(scale)/dk_i = d(thetaD)/dk_i / r
-
+    // Distortion-parameter derivatives. From thetaD = theta * poly we get d(thetaD)/dk_i
+    // = theta^(2i+1), and scale = thetaD / r so d(scale)/dk_i = d(thetaD)/dk_i / r. Then
+    // d(xpp)/dk_i = a * d(scale)/dk_i, d(ypp)/dk_i = b * d(scale)/dk_i.
     const T r_inv = T(1) / r;
     const T dscale_dk1 = theta * theta2 * r_inv;
     const T dscale_dk2 = theta * theta4 * r_inv;
     const T dscale_dk3 = theta * theta6 * r_inv;
     const T dscale_dk4 = theta * theta8 * r_inv;
 
-    // xpp = scale * a, ypp = scale * b
-    // d(xpp)/dk_i = d(scale)/dk_i * a
-    // d(ypp)/dk_i = d(scale)/dk_i * b
-
-    jacobian(0, 4) = fx_ * dscale_dk1 * a; // du/dk1
-    jacobian(1, 4) = fy_ * dscale_dk1 * b; // dv/dk1
-    jacobian(0, 5) = fx_ * dscale_dk2 * a; // du/dk2
-    jacobian(1, 5) = fy_ * dscale_dk2 * b; // dv/dk2
-    jacobian(0, 6) = fx_ * dscale_dk3 * a; // du/dk3
-    jacobian(1, 6) = fy_ * dscale_dk3 * b; // dv/dk3
-    jacobian(0, 7) = fx_ * dscale_dk4 * a; // du/dk4
-    jacobian(1, 7) = fy_ * dscale_dk4 * b; // dv/dk4
+    jacobian(0, 4) = fx_ * dscale_dk1 * a;
+    jacobian(1, 4) = fy_ * dscale_dk1 * b;
+    jacobian(0, 5) = fx_ * dscale_dk2 * a;
+    jacobian(1, 5) = fy_ * dscale_dk2 * b;
+    jacobian(0, 6) = fx_ * dscale_dk3 * a;
+    jacobian(1, 6) = fy_ * dscale_dk3 * b;
+    jacobian(0, 7) = fx_ * dscale_dk4 * a;
+    jacobian(1, 7) = fy_ * dscale_dk4 * b;
   }
+  // TODO: when nearCenter, distortion-parameter columns are left at zero. That matches the
+  // limit (a, b -> 0 makes xpp, ypp insensitive to k_i to first order), but it differs subtly
+  // from the projectJacobian() near-center branch which just falls back to pinhole. Worth a
+  // unit test or comment update if the limit matters for solver behavior.
 
   return {projectedPoint, jacobian, true};
 }
@@ -1274,7 +1172,8 @@ void OpenCVFisheyeIntrinsicsModelT<T>::setMaxRSquared(T rsqr) {
 
 template <typename T>
 void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
-  // Find the farthest image corner from the principal point
+  // The maximum theta the camera should accept is the angle whose distorted projection lands at
+  // the farthest image corner. Find that pixel distance from the principal point first.
   const std::array<std::array<T, 2>, 4> corners = {
       {{T(0), T(0)},
        {T(this->imageWidth()), T(0)},
@@ -1290,8 +1189,8 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
   }
   const T maxDist = std::sqrt(maxDistSqr);
 
-  // The max distance in normalized image coordinates
-  // Using an average focal length for simplicity
+  // Convert pixel distance to normalized distorted radius. fx_ and fy_ are mixed via their
+  // average; this is an approximation that ignores anisotropy and slight off-axis stretch.
   const T avgF = (fx_ + fy_) / T(2);
   if (avgF <= T(0)) {
     maxRSquared_ = std::numeric_limits<T>::max();
@@ -1299,12 +1198,9 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
   }
   const T targetThetaD = maxDist / avgF;
 
-  // Use Newton iteration to find theta such that
-  // theta_d(theta) = targetThetaD
-  // where theta_d = theta * (1 + k1*theta^2 + k2*theta^4 + k3*theta^6 + k4*theta^8)
-
+  // Newton iteration to invert thetaD = theta * (1 + k1*theta^2 + ... + k4*theta^8) for theta.
   const auto& dp = distortionParams_;
-  T theta = targetThetaD; // Initial guess (assumes small distortion)
+  T theta = targetThetaD; // Exact when distortion coefficients are zero.
 
   constexpr int maxIter = 20;
   constexpr T tol = T(1e-10);
@@ -1318,9 +1214,8 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
     const T poly = T(1) + dp.k1 * theta2 + dp.k2 * theta4 + dp.k3 * theta6 + dp.k4 * theta8;
     const T thetaD = theta * poly;
 
-    // Derivative of theta_d with respect to theta:
-    // d(theta_d)/d(theta) = poly + theta * d(poly)/d(theta)
-    // d(poly)/d(theta) = 2*k1*theta + 4*k2*theta^3 + 6*k3*theta^5 + 8*k4*theta^7
+    // d(thetaD)/d(theta) = poly + theta * d(poly)/d(theta), where
+    // d(poly)/d(theta) = 2*k1*theta + 4*k2*theta^3 + 6*k3*theta^5 + 8*k4*theta^7.
     const T dPolyDTheta = T(2) * dp.k1 * theta + T(4) * dp.k2 * theta2 * theta +
         T(6) * dp.k3 * theta4 * theta + T(8) * dp.k4 * theta6 * theta;
     const T dThetaDDTheta = poly + theta * dPolyDTheta;
@@ -1338,10 +1233,10 @@ void OpenCVFisheyeIntrinsicsModelT<T>::computeMaxValidAngleFromImageBounds() {
     }
   }
 
-  // Clamp theta to a reasonable range (0 to nearly 180 degrees)
+  // Clamp to [0, ~pi); tan() blows up beyond this and the equidistant model is undefined.
   theta = std::max(T(0), std::min(theta, T(3.1)));
 
-  // maxRSquared = tan^2(theta)
+  // Cache the squared tangent so the validity check in project() can stay multiplication-only.
   const T tanTheta = std::tan(theta);
   maxRSquared_ = tanTheta * tanTheta;
 }
@@ -1353,7 +1248,7 @@ CameraT<T> CameraT<T>::lookAt(
     const Eigen::Vector3<T>& up) const {
   const Eigen::Vector3<T> diff = target - position;
   if (diff.norm() == T(0)) {
-    // If target is the same as position, return the original camera
+    // Target coincides with position; the look direction is undefined, so leave the camera as-is.
     return *this;
   }
 
@@ -1362,12 +1257,12 @@ CameraT<T> CameraT<T>::lookAt(
   eyeToWorldMat.translation() = position;
 
   Eigen::Vector3<T> zVec = diff.normalized();
-  // Need to flip y upside down because y points down in image
-  // coordinates (pixel 0,0 is in the top left)
+  // Image y points down (pixel (0,0) is in the top-left), so flip the world up vector when
+  // building the camera basis.
   Eigen::Vector3<T> xVec = diff.cross(-up.normalized());
   if (xVec.norm() == T(0)) {
-    // Up vector is parallel to the target position vector, ignore it and just
-    // make sure we point the camera in the right direction
+    // Up is parallel to the look direction, so any rotation about z is valid; pick the one that
+    // aligns +Z with the look direction.
     Eigen::Quaternion<T> transform =
         Eigen::Quaternion<T>::FromTwoVectors(Eigen::Vector3<T>::UnitZ(), zVec);
     eyeToWorldMat.linear() = transform.toRotationMatrix();
@@ -1379,8 +1274,9 @@ CameraT<T> CameraT<T>::lookAt(
     eyeToWorldMat.linear().col(2) = zVec;
   }
 
+  // Sanity check: a proper rotation has determinant 1; bail out if numerics produced something
+  // degenerate.
   if (eyeToWorldMat.linear().determinant() < T(0.9)) {
-    // Error in creating rotation matrix, return the original camera
     return *this;
   }
 
@@ -1402,17 +1298,17 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
   const auto w = this->imageWidth();
   const auto h = this->imageHeight();
 
+  // Use the geometric image center, ignoring any principal-point offset, for framing math.
   const auto cx = w / T(2);
   const auto cy = h / T(2);
 
-  // Calculate bounding box of points in eye space
   Eigen::AlignedBox<T, 3> bbox_eye;
   for (const auto& p_world : points) {
-    // Transform world point to eye space
     bbox_eye.extend(eyeFromWorld_ * p_world);
   }
 
-  // Create a new camera centered on the points
+  // Step 1: re-center the camera laterally on the bounding-box midpoint and place its near plane
+  // at the closest point. After this transform the points are roughly centered in eye space.
   CameraT<T> camera_recentered = *this;
   Eigen::Transform<T, 3, Eigen::Affine> newTransform =
       Eigen::Translation<T, 3>(
@@ -1420,7 +1316,8 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
       eyeFromWorld_;
   camera_recentered.setEyeFromWorld(newTransform);
 
-  // Calculate the maximum distance needed to ensure all points are in view
+  // Step 2: dolly the camera back so all points fit within the image rect with edge padding.
+  // The half-width of the usable rect (after padding) constrains how much depth each point needs.
   const T max_x_pixel_diff = (T(1) - T(2) * edgePadding) * std::max(cx, T(w - 1) - cx);
   const T max_y_pixel_diff = (T(1) - T(2) * edgePadding) * std::max(cy, T(h - 1) - cy);
 
@@ -1428,7 +1325,7 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
   for (const auto& p_world : points) {
     const Eigen::Vector3<T> p_eye = newTransform * p_world;
 
-    // Make sure we're in front of the camera
+    // Each point imposes a min-z constraint (clip plane) and two FOV constraints (one per axis).
     if (p_eye.z() < minZ) {
       max_dz = std::max(max_dz, minZ - p_eye.z());
     }
@@ -1440,7 +1337,6 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
     return camera_recentered;
   }
 
-  // Create the final camera with adjusted position
   CameraT<T> camera_final = camera_recentered;
   camera_final.setEyeFromWorld(
       Eigen::Translation<T, 3>(T(0), T(0), max_dz) * camera_recentered.eyeFromWorld());
@@ -1450,17 +1346,16 @@ CameraT<T>::framePoints(const std::vector<Eigen::Vector3<T>>& points, T minZ, T 
 
 template <typename T>
 Vector3P<T> CameraT<T>::transformWorldToEye(const Vector3P<T>& worldPoints) const {
-  // Transform all world points to camera space using SIMD operations
+  // Hand-unrolled R * p + t to keep the multiplications inside the SIMD lane width; Eigen's
+  // operator* doesn't compose with Vector3P directly.
   const auto& R = eyeFromWorld_.linear();
   const auto& t = eyeFromWorld_.translation();
 
-  // Apply rotation matrix: R * worldPoints
   Vector3P<T> eyePoints;
   eyePoints.x() = R(0, 0) * worldPoints.x() + R(0, 1) * worldPoints.y() + R(0, 2) * worldPoints.z();
   eyePoints.y() = R(1, 0) * worldPoints.x() + R(1, 1) * worldPoints.y() + R(1, 2) * worldPoints.z();
   eyePoints.z() = R(2, 0) * worldPoints.x() + R(2, 1) * worldPoints.y() + R(2, 2) * worldPoints.z();
 
-  // Apply translation: eyePoints = R * worldPoints + t
   eyePoints.x() += t(0);
   eyePoints.y() += t(1);
   eyePoints.z() += t(2);
@@ -1470,50 +1365,40 @@ Vector3P<T> CameraT<T>::transformWorldToEye(const Vector3P<T>& worldPoints) cons
 
 template <typename T>
 Eigen::Vector3<T> CameraT<T>::transformWorldToEye(const Eigen::Vector3<T>& worldPoint) const {
-  // Transform world point to camera space using Eigen operations
   return eyeFromWorld_ * worldPoint;
 }
 
 template <typename T>
 std::pair<Vector3P<T>, typename Packet<T>::MaskType> CameraT<T>::project(
     const Vector3P<T>& worldPoints) const {
-  // Transform all world points to camera space using SIMD operations
   const Vector3P<T> eyePoints = transformWorldToEye(worldPoints);
-
-  // Use the intrinsics model's SIMD project method directly
   return intrinsicsModel_->project(eyePoints);
 }
 
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool> CameraT<T>::project(const Eigen::Vector3<T>& worldPoint) const {
-  // Transform world point to camera space using helper function
   const Eigen::Vector3<T> eyePoint = transformWorldToEye(worldPoint);
-
-  // Use the intrinsics model to project to image coordinates
   return intrinsicsModel_->project(eyePoint);
 }
 
 template <typename T>
 std::tuple<Eigen::Vector3<T>, Eigen::Matrix<T, 2, 3>, bool> CameraT<T>::projectJacobian(
     const Eigen::Vector3<T>& worldPoint) const {
-  // Transform world point to camera space using helper function
   const Eigen::Vector3<T> eyePoint = transformWorldToEye(worldPoint);
 
-  // Get the Jacobian of projection with respect to camera coordinates
   const auto [projectedPoint, jacobian_eye, isValid] = intrinsicsModel_->projectJacobian(eyePoint);
 
   if (!isValid) {
     return {projectedPoint, Eigen::Matrix<T, 2, 3>::Zero(), false};
   }
 
-  // Extract the 2x3 Jacobian matrix from the 3x3 matrix (ignore the third row for homogeneous
-  // coordinates)
+  // The intrinsics Jacobian is 3x3 with a depth pass-through row; only the [du,dv]/d(eye) rows
+  // matter for projecting back to image space.
   const Eigen::Matrix<T, 2, 3> J_proj_eye = jacobian_eye.template topRows<2>();
 
-  // Get the rotation part of the world-to-eye transform
+  // Chain rule: d(image)/d(world) = d(image)/d(eye) * d(eye)/d(world). The world->eye Jacobian
+  // is just the rotation part of eyeFromWorld_ (translation drops out under differentiation).
   const Eigen::Matrix<T, 3, 3> R_eye_world = eyeFromWorld_.linear();
-
-  // Apply chain rule: J_proj_world = J_proj_eye * R_eye_world
   const Eigen::Matrix<T, 2, 3> J_proj_world = J_proj_eye * R_eye_world;
 
   return {projectedPoint, J_proj_world, true};
@@ -1524,31 +1409,26 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType>
 CameraT<T>::unproject(const Vector3P<T>& imagePoints, int maxIterations, T tolerance) const {
   using PacketT = Packet<T>;
 
-  // Process each point in the packet individually using the intrinsics model's unproject method
+  // Per-lane scalar fallback: the intrinsics models' unproject() iterates with Newton, which
+  // does not vectorize cleanly across packet lanes (different lanes converge in different steps).
   Vector3P<T> worldPoints;
   auto validMask = drjit::full<typename PacketT::MaskType>(true);
 
   for (size_t i = 0; i < PacketT::Size; ++i) {
-    // Extract 3D image point for this element (u, v, z)
     Eigen::Vector3<T> imagePoint(imagePoints.x()[i], imagePoints.y()[i], imagePoints.z()[i]);
 
-    // Unproject to camera space using the intrinsics model
     auto [eyePoint, isValid] = intrinsicsModel_->unproject(imagePoint, maxIterations, tolerance);
 
-    // Check if unprojection was successful
     if (!isValid) {
       validMask[i] = false;
-      // Set to zero for invalid points
       worldPoints.x()[i] = T(0);
       worldPoints.y()[i] = T(0);
       worldPoints.z()[i] = T(0);
       continue;
     }
 
-    // Transform from camera space to world space
     const Eigen::Vector3<T> worldPoint = worldFromEye() * eyePoint;
 
-    // Store the result
     worldPoints.x()[i] = worldPoint(0);
     worldPoints.y()[i] = worldPoint(1);
     worldPoints.z()[i] = worldPoint(2);
@@ -1560,20 +1440,17 @@ CameraT<T>::unproject(const Vector3P<T>& imagePoints, int maxIterations, T toler
 template <typename T>
 std::pair<Eigen::Vector3<T>, bool>
 CameraT<T>::unproject(const Eigen::Vector3<T>& imagePoint, int maxIterations, T tolerance) const {
-  // Unproject to camera space using the intrinsics model
   auto [eyePoint, isValid] = intrinsicsModel_->unproject(imagePoint, maxIterations, tolerance);
 
   if (!isValid) {
     return {Eigen::Vector3<T>::Zero(), false};
   }
 
-  // Transform from camera space to world space
   const Eigen::Vector3<T> worldPoint = worldFromEye() * eyePoint;
 
   return {worldPoint, true};
 }
 
-// Explicit template instantiations
 template class CameraT<float>;
 template class CameraT<double>;
 template class IntrinsicsModelT<float>;

--- a/momentum/camera/camera.h
+++ b/momentum/camera/camera.h
@@ -28,21 +28,15 @@ namespace momentum {
 template <typename T>
 class IntrinsicsModelT {
  public:
-  /// Constructor for intrinsics model.
-  ///
   /// @param imageWidth Width of the image in pixels
   /// @param imageHeight Height of the image in pixels
   IntrinsicsModelT(int32_t imageWidth, int32_t imageHeight)
       : imageWidth_(imageWidth), imageHeight_(imageHeight) {}
   virtual ~IntrinsicsModelT() = default;
 
-  /// Get the focal length in the x direction.
-  ///
   /// @return Focal length fx in pixels
   [[nodiscard]] virtual T fx() const = 0;
 
-  /// Get the focal length in the y direction.
-  ///
   /// @return Focal length fy in pixels
   [[nodiscard]] virtual T fy() const = 0;
 
@@ -62,13 +56,16 @@ class IntrinsicsModelT {
 
   /// Compute the Jacobian of the projection function with respect to 3D camera coordinates.
   ///
+  /// The returned point and Jacobian carry depth (z) through unchanged in their third
+  /// component so callers can chain projection with depth-aware operations.
+  ///
   /// @param point 3D point in camera coordinate space
-  /// @return Tuple of (projected point, Jacobian matrix, valid flag)
+  /// @return Tuple of (projected point [u, v, z], Jacobian matrix, valid flag)
   ///
   /// The Jacobian is a 3x3 matrix where:
   /// - Row 0: [du/dx, du/dy, du/dz]
   /// - Row 1: [dv/dx, dv/dy, dv/dz]
-  /// - Row 2: [0, 0, 1] (for homogeneous coordinates)
+  /// - Row 2: [0, 0, 1] (depth pass-through: dz/dx, dz/dy, dz/dz)
   [[nodiscard]] virtual std::tuple<Eigen::Vector3<T>, Eigen::Matrix<T, 3, 3>, bool> projectJacobian(
       const Eigen::Vector3<T>& point) const = 0;
 
@@ -120,59 +117,46 @@ class IntrinsicsModelT {
   [[nodiscard]] virtual std::shared_ptr<const IntrinsicsModelT<T>>
   crop(int32_t top, int32_t left, int32_t newWidth, int32_t newHeight) const = 0;
 
-  /// Get the image width.
-  ///
   /// @return Image width in pixels
   [[nodiscard]] int32_t imageWidth() const {
     return imageWidth_;
   }
 
-  /// Get the image height.
-  ///
   /// @return Image height in pixels
   [[nodiscard]] int32_t imageHeight() const {
     return imageHeight_;
   }
 
-  /// Get the number of intrinsic parameters for this model.
-  ///
   /// @return Number of parameters (e.g., 4 for pinhole, 14 for OpenCV)
   [[nodiscard]] virtual Eigen::Index numIntrinsicParameters() const = 0;
 
   /// Get all intrinsic parameters as a vector.
   ///
-  /// Parameter order is model-specific but consistent with setIntrinsicParameters().
-  ///
-  /// @return Vector of intrinsic parameters
+  /// Parameter order is model-specific but consistent with setIntrinsicParameters()
+  /// and getParameterNames().
   [[nodiscard]] virtual Eigen::VectorX<T> getIntrinsicParameters() const = 0;
 
   /// Set all intrinsic parameters from a vector.
   ///
-  /// @param params Vector of parameters (must match numIntrinsicParameters())
+  /// @param params Vector of parameters (must match numIntrinsicParameters() and the
+  ///   order returned by getParameterNames())
   virtual void setIntrinsicParameters(const Eigen::Ref<const Eigen::VectorX<T>>& params) = 0;
 
-  /// Create a deep copy of this intrinsics model.
-  ///
-  /// @return New shared pointer to a mutable copy of this model
+  /// @return New shared pointer to a mutable deep copy of this intrinsics model
   [[nodiscard]] virtual std::shared_ptr<IntrinsicsModelT<T>> clone() const = 0;
 
-  /// Get the name identifier for this camera.
-  ///
-  /// @return Name string (used for parameter transform naming)
+  /// @return Name identifier used for parameter transform naming (e.g., "cam0" yields
+  ///   parameter names like "intrinsics_cam0_fx")
   [[nodiscard]] const std::string& name() const {
     return name_;
   }
 
-  /// Set the name identifier for this camera.
-  ///
-  /// @param name Name string (e.g., "cam0" produces "intrinsics_cam0_fx")
   void setName(const std::string& name) {
     name_ = name;
   }
 
-  /// Get the names of intrinsic parameters for this model.
-  ///
-  /// @return Vector of parameter names (e.g., {"fx", "fy", "cx", "cy"})
+  /// @return Per-parameter names matching the order of getIntrinsicParameters()
+  ///   (e.g., {"fx", "fy", "cx", "cy"} for pinhole)
   [[nodiscard]] virtual std::vector<std::string> getParameterNames() const = 0;
 
   /// Compute the Jacobian of projection w.r.t. intrinsic parameters.
@@ -212,58 +196,40 @@ class CameraT {
       const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld =
           Eigen::Transform<T, 3, Eigen::Affine>::Identity());
 
-  /// Get the image width from the intrinsics model.
-  ///
   /// @return Image width in pixels
   [[nodiscard]] auto imageWidth() const {
     return intrinsicsModel_->imageWidth();
   }
 
-  /// Get the image height from the intrinsics model.
-  ///
   /// @return Image height in pixels
   [[nodiscard]] auto imageHeight() const {
     return intrinsicsModel_->imageHeight();
   }
 
-  /// Get the focal length in x direction from the intrinsics model.
-  ///
   /// @return Focal length fx in pixels
   [[nodiscard]] auto fx() const {
     return intrinsicsModel_->fx();
   }
 
-  /// Get the focal length in y direction from the intrinsics model.
-  ///
   /// @return Focal length fy in pixels
   [[nodiscard]] auto fy() const {
     return intrinsicsModel_->fy();
   }
 
-  /// Get the intrinsics model.
-  ///
-  /// @return Shared pointer to the intrinsics model
   [[nodiscard]] std::shared_ptr<const IntrinsicsModelT<T>> intrinsicsModel() const {
     return intrinsicsModel_;
   }
 
-  /// Get the eye-from-world transformation matrix.
-  ///
-  /// @return Reference to the transformation from world space to camera space
+  /// @return Transform from world space to camera/eye space
   [[nodiscard]] const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld() const {
     return eyeFromWorld_;
   }
 
-  /// Get the world-from-eye transformation matrix.
-  ///
-  /// @return Transformation from camera space to world space
+  /// @return Transform from camera/eye space to world space (inverse of eyeFromWorld())
   [[nodiscard]] Eigen::Transform<T, 3, Eigen::Affine> worldFromEye() const {
     return eyeFromWorld_.inverse();
   }
 
-  /// Set the eye-from-world transformation matrix.
-  ///
-  /// @param eyeFromWorld New transformation from world space to camera space
   void setEyeFromWorld(const Eigen::Transform<T, 3, Eigen::Affine>& eyeFromWorld) {
     eyeFromWorld_ = eyeFromWorld;
   }
@@ -359,9 +325,6 @@ class CameraT {
     return CameraT<T>(intrinsicsModel_->resize(imageWidth, imageHeight), eyeFromWorld_);
   }
 
-  /// Get a reference to the intrinsics model.
-  ///
-  /// @return Const reference to the intrinsics model
   [[nodiscard]] const IntrinsicsModelT<T>& getIntrinsicsModel() const {
     return *intrinsicsModel_;
   }
@@ -454,23 +417,16 @@ class OpenCVFisheyeIntrinsicsModelT : public IntrinsicsModelT<T> {
     return fy_;
   }
 
-  /// Get the principal point x-coordinate.
-  ///
   /// @return Principal point cx in pixels
   [[nodiscard]] T cx() const {
     return cx_;
   }
 
-  /// Get the principal point y-coordinate.
-  ///
   /// @return Principal point cy in pixels
   [[nodiscard]] T cy() const {
     return cy_;
   }
 
-  /// Get the distortion parameters.
-  ///
-  /// @return Reference to the OpenCV fisheye distortion parameters
   [[nodiscard]] const OpenCVFisheyeDistortionParametersT<T>& distortionParameters() const {
     return distortionParams_;
   }
@@ -596,15 +552,11 @@ class PinholeIntrinsicsModelT : public IntrinsicsModelT<T> {
     return fy_;
   }
 
-  /// Get the principal point x-coordinate.
-  ///
   /// @return Principal point cx in pixels
   [[nodiscard]] T cx() const {
     return cx_;
   }
 
-  /// Get the principal point y-coordinate.
-  ///
   /// @return Principal point cy in pixels
   [[nodiscard]] T cy() const {
     return cy_;
@@ -690,23 +642,16 @@ class OpenCVIntrinsicsModelT : public IntrinsicsModelT<T> {
     return fy_;
   }
 
-  /// Get the principal point x-coordinate.
-  ///
   /// @return Principal point cx in pixels
   [[nodiscard]] T cx() const {
     return cx_;
   }
 
-  /// Get the principal point y-coordinate.
-  ///
   /// @return Principal point cy in pixels
   [[nodiscard]] T cy() const {
     return cy_;
   }
 
-  /// Get the distortion parameters.
-  ///
-  /// @return Reference to the OpenCV distortion parameters
   [[nodiscard]] const OpenCVDistortionParametersT<T>& distortionParameters() const {
     return distortionParams_;
   }

--- a/momentum/camera/projection_utils.cpp
+++ b/momentum/camera/projection_utils.cpp
@@ -30,8 +30,6 @@ std::pair<Eigen::Matrix<T, 3, 4>, bool> projectionMatrixPixels(
   // At p = eyePoint itself, the residual is exactly zero.
   const auto [projected, jacobian, validJ] = camera.intrinsicsModel()->projectJacobian(eyePoint);
 
-  // Compose with the eye-from-world transform's upper 3x4 block:
-  // M = J * eyeFromWorld.topRows<3>()
   const Eigen::Matrix<T, 3, 4> eyeFromWorld34 =
       camera.eyeFromWorld().matrix().template topRows<3>();
   return {jacobian * eyeFromWorld34, true};
@@ -48,24 +46,20 @@ std::pair<Eigen::Matrix<T, 3, 4>, bool> projectionMatrixRadians(
     return {Eigen::Matrix<T, 3, 4>::Zero(), false};
   }
 
-  // Normalize to get the ray direction in eye-space.
   const Eigen::Vector3<T> rayDir = eyePoint.normalized();
 
-  // Compute a rotation that maps the target ray to the z-axis.
-  // After applying this rotation, any point on the target ray will have x=0, y=0,
-  // so (x/z, y/z) = (0, 0). For other rays, x/z and y/z give the tangent of the
-  // angle from the target ray.
+  // Compute a rotation that maps the target ray to the z-axis. After applying this
+  // rotation, any point on the target ray has x=0, y=0, so (x/z, y/z) = (0, 0). For
+  // other rays, x/z and y/z give the tangent of the angle from the target ray.
   const Eigen::Quaternion<T> rotation =
       Eigen::Quaternion<T>::FromTwoVectors(rayDir, Eigen::Vector3<T>::UnitZ());
   const Eigen::Matrix<T, 3, 3> R = rotation.toRotationMatrix();
 
-  // Compose with the eye-from-world transform's upper 3x4 block.
   const Eigen::Matrix<T, 3, 4> eyeFromWorld34 =
       camera.eyeFromWorld().matrix().template topRows<3>();
   return {R * eyeFromWorld34, true};
 }
 
-// Explicit template instantiations
 template std::pair<Eigen::Matrix<float, 3, 4>, bool> projectionMatrixPixels(
     const CameraT<float>& camera,
     const Eigen::Vector2<float>& targetPixel);

--- a/momentum/character/blend_shape.cpp
+++ b/momentum/character/blend_shape.cpp
@@ -53,25 +53,30 @@ VectorXf BlendShape::estimateCoefficients(
   const Map<const VectorXf> baseVec(&baseShape_[0][0], baseShape_.size() * 3);
   const Map<const VectorXf> vertexVec(&vertices[0][0], vertices.size() * 3);
 
-  // if we're not using weights, use default pipeline
+  // Unweighted path: reuse the cached SVD of shapeVectors_ across calls. Note that
+  // `regularization` is ignored here — the SVD-based pseudoinverse already provides
+  // implicit regularization on near-zero singular values.
+  // TODO: regularization is silently ignored on this branch; either honor it (e.g.
+  // damped least squares) or document it on the header.
   if (weights.size() != static_cast<Eigen::Index>(vertices.size())) {
-    // check if factorization is valid
     if (!factorizationValid_) {
       factorization_.compute(shapeVectors_, Eigen::ComputeThinU | Eigen::ComputeThinV);
       factorizationValid_ = true;
     }
 
-    // estimate the shapeVectors for the given vertices
     return factorization_.solve(vertexVec - baseVec);
   } else {
-    // if we have weights, we definitely have to compute a new factorization that incorporates the
-    // weights
+    // Weighted path: solve the regularized weighted least-squares problem
+    //   min ||W (shapeVectors_ x - (vertexVec - baseVec))||^2 + regularization^2 ||x||^2
+    // by stacking the weighted system on top of an identity block (Tikhonov form)
+    // and solving the resulting normal equations with LDLT. Each per-vertex weight is
+    // replicated 3x to cover x/y/z components. The cached SVD is not used here and is
+    // not invalidated, since shapeVectors_ itself is unchanged.
     VectorXf wts(weights.size() * 3);
     Eigen::Map<VectorXf, 0, Eigen::Stride<1, 3>>(&wts(0), weights.size()) = weights;
     Eigen::Map<VectorXf, 0, Eigen::Stride<1, 3>>(&wts(1), weights.size()) = weights;
     Eigen::Map<VectorXf, 0, Eigen::Stride<1, 3>>(&wts(2), weights.size()) = weights;
 
-    // calculate weighted coefficient matrix and rhs
     const auto rows = shapeVectors_.rows();
     const auto cols = shapeVectors_.cols();
     MatrixXf A(rows + cols, cols);
@@ -83,7 +88,6 @@ VectorXf BlendShape::estimateCoefficients(
     VectorXf b = VectorXf::Zero(rows + cols);
     b.topRows(rows) = (vertexVec - baseVec).cwiseProduct(wts);
 
-    // solve normal equations to get results
     return (A.transpose() * A).ldlt().solve(A.transpose() * b);
   }
 }
@@ -102,7 +106,8 @@ void BlendShape::setShapeVector(
     std::string_view name) {
   BlendShapeBase::setShapeVector(index, shape, name);
 
-  // mark as not up to date
+  // shapeVectors_ has changed, so the cached SVD used by estimateCoefficients
+  // must be recomputed on next use.
   factorizationValid_ = false;
 }
 

--- a/momentum/character/blend_shape.h
+++ b/momentum/character/blend_shape.h
@@ -53,33 +53,43 @@ struct BlendShape : public BlendShapeBase {
   [[nodiscard]] std::vector<Eigen::Vector3<T>> computeShape(
       const BlendWeightsT<T>& coefficients) const;
 
-  /// Output parameter version of computeShape
+  /// Output parameter version of computeShape, for callers that want to reuse a
+  /// preallocated buffer.
   ///
   /// @tparam T Scalar type (float or double)
   /// @param coefficients Weights for each shape vector
-  /// @param output [out] Resulting deformed shape
+  /// @param output [out] Resulting deformed shape; resized to the base shape's vertex count.
   template <typename T>
   void computeShape(const BlendWeightsT<T>& coefficients, std::vector<Eigen::Vector3<T>>& output)
       const;
 
-  /// Solves for blend weights that best approximate a target shape
+  /// Solves for blend weights that best approximate a target shape.
   ///
-  /// Uses SVD to find optimal coefficients with optional regularization
-  /// and per-vertex weighting
+  /// Uses a thin SVD of the shape vectors when no per-vertex weights are
+  /// supplied (the factorization is cached and reused across calls). When
+  /// weights are supplied, builds a weighted normal-equation system with
+  /// Tikhonov regularization on each call.
   ///
-  /// @param vertices Target shape to approximate
-  /// @param regularization Higher values produce smaller coefficients
-  /// @param weights Optional per-vertex importance weights
-  /// @return Estimated blend shape coefficients
+  /// @pre `vertices.size() == getBaseShape().size()`.
+  /// @param vertices Target shape to approximate, in the same vertex order as the base shape.
+  /// @param regularization Tikhonov regularization weight; higher values bias coefficients toward
+  /// zero.
+  ///   Only used when per-vertex `weights` are supplied.
+  /// @param weights Optional per-vertex importance weights. Ignored unless its size equals
+  ///   `vertices.size()`; when ignored, the cached unweighted SVD path is used.
+  /// @return Estimated blend shape coefficients (length = number of shape vectors).
   [[nodiscard]] VectorXf estimateCoefficients(
       momentum::span<const Vector3f> vertices,
       float regularization = 1.0f,
       const VectorXf& weights = VectorXf()) const;
 
-  /// Overrides base method to also invalidate factorization
+  /// Overrides base method to also invalidate the cached SVD factorization used by
+  /// `estimateCoefficients`.
   ///
   /// @param index Index of the shape vector to set
   /// @param shapeVector Vector of vertex offsets
+  /// @param name Optional name for the shape vector; if empty, the name is auto-generated
+  ///   as `"shape_<index>"`.
   void setShapeVector(
       size_t index,
       momentum::span<const Vector3f> shapeVector,

--- a/momentum/character/blend_shape_base.h
+++ b/momentum/character/blend_shape_base.h
@@ -72,7 +72,6 @@ struct BlendShapeBase {
     return shapeVectors_.cols();
   }
 
-  /// Returns number of vertices (rows/3)
   [[nodiscard]] size_t modelSize() const {
     return shapeVectors_.rows() / 3;
   }

--- a/momentum/character/blend_shape_skinning.cpp
+++ b/momentum/character/blend_shape_skinning.cpp
@@ -68,7 +68,6 @@ void skinWithBlendShapes(
   const auto& inverseBindPose = character.inverseBindPose;
   const auto& skin = *character.skinWeights;
 
-  // some sanity checks
   MT_CHECK(
       state.jointState.size() == inverseBindPose.size(),
       "{} is not {}",
@@ -85,7 +84,8 @@ void skinWithBlendShapes(
       skin.weight.rows(),
       character.mesh->vertices.size());
 
-  // first create a list of transformations from bindpose to final output pose
+  // Compose per-joint world transforms with the inverse bind pose, so each matrix
+  // maps a vertex from bind-pose space directly to the posed (skinned) space.
   std::vector<Eigen::Matrix4<T>> transformations(state.jointState.size());
   for (size_t i = 0; i < state.jointState.size(); i++) {
     transformations[i] = (state.jointState[i].transform * inverseBindPose[i].cast<T>()).matrix();
@@ -100,8 +100,6 @@ void skinWithBlendShapes(
 
   outputMesh.vertices.resize(character.mesh->vertices.size(), Eigen::Vector3<T>::Zero());
 
-  // go over all vertices and perform transformation
-  // SSE version for linux/windows
   dispenso::parallel_for(
       dispenso::makeChunkedRange(0, skin.index.rows(), dispenso::ParForChunking::kAuto),
       [&blendWeights, &character, &transformations, &outputMesh](

--- a/momentum/character/blend_shape_skinning.h
+++ b/momentum/character/blend_shape_skinning.h
@@ -27,8 +27,7 @@ namespace momentum {
 ///
 /// 2. Weight extraction functions:
 ///    - extractBlendWeights(): Use to get blend shape weights from model parameters for
-///    identity/shape
-///      blend shapes (e.g., body shape variations).
+///      identity/shape blend shapes (e.g., body shape variations).
 ///    - extractFaceExpressionBlendWeights(): Use to get blend shape weights specifically for facial
 ///      expressions, which are stored separately from regular blend shapes.
 
@@ -36,12 +35,12 @@ namespace momentum {
 ///
 /// Computes the final vertex positions by applying blend shape offsets to the base mesh,
 /// then transforming the resulting vertices using linear blend skinning based on the
-/// skeleton state. Use this version when you already have pre-calculated blend weights.
+/// skeleton state. Use this overload when you already have pre-calculated blend weights.
 ///
 /// @param character Character containing mesh, blend shapes, and skinning data
 /// @param state Current pose of the skeleton
 /// @param blendWeights Weights for each blend shape
-/// @param outputMesh Mesh to store the resulting deformed vertices
+/// @param[out] outputMesh Resulting deformed mesh
 template <typename T>
 void skinWithBlendShapes(
     const Character& character,
@@ -51,14 +50,13 @@ void skinWithBlendShapes(
 
 /// Applies blend shape deformations and skeletal transformations to a mesh.
 ///
-/// Overload that extracts blend shape weights from model parameters before skinning.
-/// Use this version when working with high-level character animation where you have
-/// model parameters rather than direct blend weights.
+/// Overload that extracts blend shape weights from `modelParams` via the character's
+/// parameter transform before skinning.
 ///
 /// @param character Character containing mesh, blend shapes, and skinning data
 /// @param state Current pose of the skeleton
-/// @param modelParams Model parameters containing blend shape weights
-/// @param outputMesh Mesh to store the resulting deformed vertices
+/// @param modelParams Model parameters; blend shape weights are extracted from these
+/// @param[out] outputMesh Resulting deformed mesh
 template <typename T>
 void skinWithBlendShapes(
     const Character& character,

--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -52,29 +52,25 @@ CharacterT<T>::CharacterT(
       metadata(metadataIn) {
   if (m) {
     mesh = std::make_unique<Mesh>(*m);
-    // create skinweights copy only if both mesh and skinweights exist
+    // Skin weights are only meaningful in the presence of a mesh; drop them otherwise.
     if (sw) {
       skinWeights = std::make_unique<SkinWeights>(*sw);
     }
   }
 
-  // copy pose blendshapes if present
   if (bs) {
     poseShapes = std::make_unique<PoseShape>(*bs);
   }
 
-  // initialize bindpose inverse list
   if (inverseBindPose.empty()) {
     initInverseBindPose();
   }
   MT_CHECK(this->inverseBindPose.size() == skeleton.joints.size());
 
-  // copy collision geometry if it exists
   if (cg) {
     collision = std::make_unique<CollisionGeometry>(*cg);
   }
 
-  // fill jointMap with identity
   resetJointMap();
 }
 
@@ -93,18 +89,16 @@ CharacterT<T>::CharacterT(const CharacterT& c)
       metadata(c.metadata) {
   if (c.mesh) {
     mesh = std::make_unique<Mesh>(*c.mesh);
-    // create skinweights copy only if both mesh and skinweights exist
+    // Skin weights are only meaningful in the presence of a mesh; drop them otherwise.
     if (c.skinWeights) {
       skinWeights = std::make_unique<SkinWeights>(*c.skinWeights);
     }
   }
 
-  // copy pose blendshapes if present
   if (c.poseShapes) {
     poseShapes = std::make_unique<PoseShape>(*c.poseShapes);
   }
 
-  // copy collision geometry if it exists
   if (c.collision) {
     collision = std::make_unique<CollisionGeometry>(*c.collision);
   }
@@ -121,10 +115,9 @@ CharacterT<T>::~CharacterT() = default;
 
 template <typename T>
 CharacterT<T>& CharacterT<T>::operator=(const CharacterT& rhs) {
-  // create copy
+  // Copy-and-swap: build a temporary copy, then swap members in for strong exception safety.
   CharacterT<T> tmp(rhs);
 
-  // now swap out
   std::swap(skeleton, tmp.skeleton);
   std::swap(parameterTransform, tmp.parameterTransform);
   std::swap(parameterLimits, tmp.parameterLimits);
@@ -149,21 +142,19 @@ CharacterT<T>& CharacterT<T>::operator=(CharacterT&& rhs) noexcept = default;
 
 template <typename T>
 std::vector<bool> CharacterT<T>::parametersToActiveJoints(const ParameterSet& parameterSet) const {
-  // create a list of joints that are currently enabled
   const auto nJoints = skeleton.joints.size();
   std::vector<bool> result(nJoints, false);
   for (int k = 0; k < parameterTransform.transform.outerSize(); ++k) {
     for (SparseRowMatrixf::InnerIterator it(parameterTransform.transform, k); it; ++it) {
-      // row is influenced joint, col is parameter
+      // Row index encodes (jointIndex * kParametersPerJoint + jointParamSlot); col is the model
+      // parameter that drives it.
       const auto& row = it.row();
       const auto& col = it.col();
 
-      // disable any joints that are not set
       if (!parameterSet.test(col)) {
         continue;
       }
 
-      // set joint as enabled
       const auto jointIndex = row / kParametersPerJoint;
       MT_CHECK(jointIndex < nJoints, "{} vs {}", jointIndex, nJoints);
       result[jointIndex] = true;
@@ -183,7 +174,6 @@ ParameterSet CharacterT<T>::activeJointsToParameters(const std::vector<bool>& ac
 
   ParameterSet result;
 
-  // iterate over all non-zero entries of the matrix
   for (int k = 0; k < parameterTransform.transform.outerSize(); ++k) {
     for (SparseRowMatrixf::InnerIterator it(parameterTransform.transform, k); it; ++it) {
       const auto globalParam = it.row();
@@ -204,7 +194,6 @@ ParameterSet CharacterT<T>::activeJointsToParameters(const std::vector<bool>& ac
   return result;
 }
 
-// create simplified skeleton for enabled parameters
 template <typename T>
 CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoints) const {
   MT_CHECK(
@@ -222,14 +211,16 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
   //  start by remapping the skeleton and parameter transform
   // -------------------------------------------------------------------
 
-  // remember parameter mapping from skeleton to anim skeleton
+  // Running count of joints kept in the simplified skeleton.
   size_t jointCount = 0;
 
-  // create a parameter transform with the correct offsets
+  // Build a parameter transform whose offsets are zero for active joints but preserved for
+  // inactive ones, so the reference state below "bakes" the inactive offsets in.
   auto zeroTransform = parameterTransform;
 
   for (size_t jointIndex = 0; jointIndex < activeJoints.size(); ++jointIndex) {
-    // zero out all offsets related to joints that are enabled, keep the disabled ones set
+    // Zero the offsets for active joints; inactive joints keep their offsets so their effect is
+    // captured in the reference state's world transforms below.
     if (activeJoints[jointIndex]) {
       for (size_t o = 0; o < kParametersPerJoint; o++) {
         zeroTransform.offsets(jointIndex * kParametersPerJoint + o) = 0.0f;
@@ -237,29 +228,33 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
     }
   }
 
-  // some state for mapping joints to new joints
+  // Maps each original joint index to its position in `simplifiedSkeleton.joints` (or
+  // kInvalidIndex if the joint is dropped). Populated below as we iterate.
   std::vector<size_t> intermediateJointMap(skeleton.joints.size(), kInvalidIndex);
 
-  // create a reference state for the model where all disabled joints keep their offset influence
+  // Reference state where disabled joints contribute their offsets but enabled joints sit at
+  // their bind values. Used to bake inactive joint offsets into active children.
   const SkeletonState referenceState(
       zeroTransform.apply(ModelParameters::Zero(zeroTransform.numAllModelParameters())),
       skeleton,
       false);
 
-  // create map from anim skeleton to new joints
+  // For each original joint index, the last simplified-joint index seen at-or-above it in the
+  // hierarchy. Used to find the new parent for an active joint after intermediate parents are
+  // pruned.
   std::vector<size_t> lastJoint(skeleton.joints.size(), kInvalidIndex);
 
-  // go over the anim skeleton, check which joints are active and convert them
   std::vector<size_t> simplifiedJointMap(skeleton.joints.size(), kInvalidIndex);
   for (size_t aIndex = 0; aIndex < skeleton.joints.size(); aIndex++) {
     const Joint& j = skeleton.joints[aIndex];
 
-    // find the parent joint that belongs here
+    // Walk up the original hierarchy to find the nearest active ancestor; that becomes this
+    // joint's parent in the simplified skeleton, with the offset re-expressed in the new
+    // parent's local frame.
     Vector3f offset = j.translationOffset;
     size_t currentParent = kInvalidIndex;
     size_t sIndex = aIndex;
     if (j.parent != kInvalidIndex) {
-      // find the last not disabled parent joint
       while (currentParent == kInvalidIndex && sIndex != kInvalidIndex) {
         sIndex = skeleton.joints[sIndex].parent;
         if (sIndex == kInvalidIndex) {
@@ -267,7 +262,8 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
         }
         currentParent = lastJoint[sIndex];
       }
-      // calculate the new offset of the joint in the new parent space
+      // Re-express the joint's translation in the (new) parent's local frame; if no parent
+      // remains, the translation is in world space (root joint case).
       if (sIndex != kInvalidIndex) {
         offset = referenceState.jointState[sIndex].transform.inverse() *
             referenceState.jointState[aIndex].translation();
@@ -276,40 +272,36 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
       }
     }
 
-    // is joint enabled?
     if (activeJoints[aIndex]) {
-      // create copy
       Joint jt = j;
 
-      // set new parent
       jt.parent = currentParent;
 
-      // set updated offset
       jt.translationOffset = offset;
 
-      // update prerotation for the new parent joint by summing up
+      // Compose pre-rotations from every dropped intermediate ancestor into this joint, so the
+      // pruned hierarchy still produces the same orientation chain.
       size_t parent = j.parent;
       while (parent != sIndex && parent != kInvalidIndex) {
         jt.preRotation = skeleton.joints[parent].preRotation * jt.preRotation;
         parent = skeleton.joints[parent].parent;
       }
 
-      // add it
       simplifiedSkeleton.joints.push_back(jt);
 
-      // add jointmap entry
       intermediateJointMap[aIndex] = jointCount;
       jointCount++;
       lastJoint[aIndex] = simplifiedSkeleton.joints.size() - 1;
 
-      // add joint to joint mapping
       simplifiedJointMap[aIndex] = jointCount - 1;
     } else {
+      // Inactive joints are not added to the simplified skeleton; instead, point their entry in
+      // simplifiedJointMap at the nearest active ancestor so consumers (locators, skin weights,
+      // etc.) can still resolve them.
       size_t index = aIndex;
       while (index != kInvalidIndex && intermediateJointMap[index] == kInvalidIndex) {
         index = skeleton.joints[index].parent;
       }
-      // Find the valid joint above this one in the hierarchy:
       MT_THROW_IF(
           index == kInvalidIndex,
           "During skeleton simplification, inactive joint '{}' has no valid parent joint.  "
@@ -325,7 +317,6 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
   const ParameterTransform simplifiedTransform = mapParameterTransformJoints(
       parameterTransform, simplifiedSkeleton.joints.size(), intermediateJointMap);
 
-  // create character result
   CharacterT<T> result(simplifiedSkeleton, simplifiedTransform);
   result.name = name;
   result.metadata = metadata;
@@ -347,7 +338,8 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
   //  remap the mesh and skinning if present
   // -------------------------------------------------------------------
 
-  // create bind states for both source and target skeleton
+  // Bind states for source and target skeleton — used by the collision-remap block below to
+  // transport collision shapes between the two joint frames.
   const SkeletonState sourceBindState(parameterTransform.bindPose(), skeleton, false);
   const SkeletonState targetBindState(result.parameterTransform.bindPose(), result.skeleton, false);
 
@@ -365,13 +357,14 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
     for (auto&& c : *result.collision) {
       const auto oldParent = c.parent;
       c.parent = result.jointMap[c.parent];
+      // Re-express the collision shape's local transform in the new parent's frame:
+      //   newLocal = targetParentBind^-1 * sourceParentBind * oldLocal
       c.transformation =
           (targetBindState.jointState[c.parent].transform.inverse() *
            sourceBindState.jointState[oldParent].transform * c.transformation);
     }
   }
 
-  // return the map
   return result;
 }
 
@@ -432,18 +425,17 @@ SkinWeights CharacterT<T>::remapSkinWeights(
 
   SkinWeights result = inSkinWeights;
 
-  // go over all vertices
   for (int v = 0; v < result.index.rows(); v++) {
-    // remap the parent bones according to the map
+    // Translate each joint index from the original character to the simplified character.
     for (int i = 0; i < gsl::narrow_cast<int>(kMaxSkinJoints); i++) {
       result.index(v, i) = static_cast<uint32_t>(jointMap[result.index(v, i)]);
     }
 
-    // join together all weights with the same parent
+    // Multiple original joints may collapse to the same simplified joint; merge their weights
+    // into the first slot and zero the duplicates.
     for (int i = 0; i < gsl::narrow_cast<int>(kMaxSkinJoints); i++) {
       const auto& joint = result.index(v, i);
       for (int j = i + 1; j < gsl::narrow_cast<int>(kMaxSkinJoints); j++) {
-        // if we have the same joint multiple times, add things up
         if (result.index(v, j) == joint) {
           result.weight(v, i) += result.weight(v, j);
           result.weight(v, j) = 0.0f;
@@ -451,7 +443,8 @@ SkinWeights CharacterT<T>::remapSkinWeights(
       }
     }
 
-    // do a clean up pass, sorting things by weight
+    // Sort influences by weight (descending) so callers that truncate to fewer slots keep the
+    // most significant ones.
     for (int i = 0; i < gsl::narrow_cast<int>(kMaxSkinJoints); i++) {
       for (int j = i + 1; j < gsl::narrow_cast<int>(kMaxSkinJoints); j++) {
         if (result.weight(v, i) < result.weight(v, j)) {
@@ -542,23 +535,25 @@ SkinnedLocatorList CharacterT<T>::remapSkinnedLocators(
 
   SkinnedLocatorList result = locs;
 
-  // create bind states for both source and target skeleton
+  // TODO: sourceBindState and targetBindState are declared but never read in this function.
+  // remapLocators uses them to re-express the locator offset in the new parent frame; the
+  // skinned variant should likely do the equivalent transform on each weighted parent's
+  // contribution, or these declarations should be removed.
   const SkeletonState sourceBindState(
       originalCharacter.parameterTransform.bindPose(), originalCharacter.skeleton, false);
   const SkeletonState targetBindState(parameterTransform.bindPose(), skeleton, false);
 
-  // go over each skinned locator and remap its joint indices
   for (auto& sl : result) {
-    // remap the joint indices according to the map
+    // Translate each parent joint index from the original character to the simplified character.
     for (int i = 0; i < gsl::narrow_cast<int>(kMaxSkinJoints); i++) {
       sl.parents(i) = static_cast<uint32_t>(jointMap[sl.parents(i)]);
     }
 
-    // join together all weights with the same joint
+    // Multiple original joints may collapse to the same simplified joint; merge their weights
+    // into the first slot and zero the duplicates.
     for (int i = 0; i < gsl::narrow_cast<int>(kMaxSkinJoints); i++) {
       const auto& joint = sl.parents(i);
       for (int j = i + 1; j < gsl::narrow_cast<int>(kMaxSkinJoints); j++) {
-        // if we have the same joint multiple times, add weights up
         if (sl.parents(j) == joint) {
           sl.skinWeights(i) += sl.skinWeights(j);
           sl.skinWeights(j) = 0.0f;
@@ -566,7 +561,8 @@ SkinnedLocatorList CharacterT<T>::remapSkinnedLocators(
       }
     }
 
-    // sort by weight, largest first
+    // Sort influences by weight (descending) so callers that truncate to fewer slots keep the
+    // most significant ones.
     for (int i = 0; i < gsl::narrow_cast<int>(kMaxSkinJoints); i++) {
       for (int j = i + 1; j < gsl::narrow_cast<int>(kMaxSkinJoints); j++) {
         if (sl.skinWeights(i) < sl.skinWeights(j)) {
@@ -598,16 +594,17 @@ LocatorList CharacterT<T>::remapLocators(
 
   LocatorList result;
 
-  // create bind states for both source and target skeleton
+  // Bind states for source and target skeletons; used below to re-express each locator's offset
+  // in the new parent joint's local frame.
   const SkeletonState sourceBindState(
       originalCharacter.parameterTransform.bindPose(), originalCharacter.skeleton, false);
   const SkeletonState targetBindState(parameterTransform.bindPose(), skeleton, false);
 
-  // go over each locator and remap it
   for (const auto& sourceLocator : locs) {
     result.emplace_back(sourceLocator);
     auto& loc = result.back();
     loc.parent = jointMap[loc.parent];
+    // newOffset = targetParentBind^-1 * sourceParentBind * oldOffset
     loc.offset = targetBindState.jointState[loc.parent].transform.inverse() *
         sourceBindState.jointState[sourceLocator.parent].transform * sourceLocator.offset;
   }
@@ -631,14 +628,13 @@ void CharacterT<T>::initParameterTransform() {
 
 template <typename T>
 void CharacterT<T>::resetJointMap() {
-  // fill jointMap with identity
+  // Identity map: jointMap[i] = i. Used when no skeleton simplification has been performed.
   jointMap.resize(skeleton.joints.size());
   std::iota(jointMap.begin(), jointMap.end(), 0);
 }
 
 template <typename T>
 void CharacterT<T>::initInverseBindPose() {
-  // initialize bindpose inverse list
   const SkeletonState bindState(parameterTransform.bindPose(), skeleton, false);
   if (!inverseBindPose.empty()) {
     inverseBindPose.clear();
@@ -774,15 +770,16 @@ CharacterT<T> CharacterT<T>::bake(
   CharacterT<T> result = *this;
   MT_CHECK(result.mesh);
 
-  // 2. Blend-shape baking (you already had this, just guarded).
+  // 2. Blend-shape baking: replace the rest-pose vertices with the blend-shape evaluation.
   if (bakeBlendShapes && this->blendShape) {
     const BlendWeights blendWeights = extractBlendWeights(result.parameterTransform, modelParams);
     result.mesh->vertices = this->blendShape->template computeShape<float>(blendWeights);
   }
 
-  // 3. Scale (or any joint transform) baking
+  // 3. Scale (or any joint transform) baking: skin the rest mesh through the posed skeleton so
+  // the resulting vertices already include the joint transforms; then strip those parameters
+  // below.
   if (bakeScales && this->skinWeights) {
-    // Evaluate the posed skeleton with modelParams.
     const SkeletonState posed(
         result.parameterTransform.apply(modelParams),
         result.skeleton,

--- a/momentum/character/character.h
+++ b/momentum/character/character.h
@@ -75,10 +75,8 @@ struct CharacterT {
 
   /// @}
 
-  /// Default constructor
   CharacterT();
 
-  /// Destructor
   ~CharacterT();
 
   /// Constructs a character with the specified components
@@ -113,16 +111,10 @@ struct CharacterT {
       const SkinnedLocatorList& skinnedLocators = {},
       std::string_view metadataIn = "");
 
-  /// Copy constructor
   CharacterT(const CharacterT& c);
-
-  /// Move constructor
   CharacterT(CharacterT&& c) noexcept;
 
-  /// Copy assignment operator
   CharacterT& operator=(const CharacterT& rhs);
-
-  /// Move assignment operator
   CharacterT& operator=(CharacterT&& rhs) noexcept;
 
   /// Creates a simplified character with only joints affected by the specified parameters

--- a/momentum/character/character_state.cpp
+++ b/momentum/character/character_state.cpp
@@ -28,9 +28,7 @@ CharacterStateT<T>::CharacterStateT(const CharacterStateT& other)
       meshState{other.meshState ? std::make_unique<Mesh>(*other.meshState) : nullptr},
       collisionState{
           other.collisionState ? std::make_unique<CollisionGeometryState>(*other.collisionState)
-                               : nullptr} {
-  // Empty
-}
+                               : nullptr} {}
 
 template <typename T>
 CharacterStateT<T>::CharacterStateT(CharacterStateT&& c) noexcept = default;
@@ -89,37 +87,35 @@ void CharacterStateT<T>::set(
       parameters.offsets.size(),
       referenceCharacter.parameterTransform.numJointParameters());
 
-  // create skeleton state first
+  // Skeleton state must be computed first — locator, mesh, and collision updates below
+  // all read from it.
   JointParameters jointParams = referenceCharacter.parameterTransform.apply(parameters);
   if (applyLimits) {
     jointParams = applyPassiveJointParameterLimits(referenceCharacter.parameterLimits, jointParams);
   }
   skeletonState.set(jointParams, referenceCharacter.skeleton);
 
-  // create locator state
   locatorState.update(skeletonState, referenceCharacter.locators);
 
-  // create skinning if we have a mesh
   if (updateMesh && referenceCharacter.mesh && referenceCharacter.skinWeights) {
-    // check if we need to create a mesh
+    // (Re)allocate the cached mesh whenever vertex count diverges from the reference
+    // — covers both first call and switching to a different reference character.
     if (!meshState || meshState->vertices.size() != referenceCharacter.mesh->vertices.size()) {
       meshState = std::make_unique<Mesh>(*referenceCharacter.mesh);
     }
 
-    // check if we have pose blendshapes and use them before skinning if there
+    // Pose blendshapes take precedence: corrective vertex offsets driven by joint pose are
+    // applied before linear skinning so the SSD pass deforms the corrected bind-pose vertices.
     if (referenceCharacter.poseShapes) {
-      // calculate pose shapes
       const auto vs = referenceCharacter.poseShapes->compute(skeletonState);
 
-      // apply skinning
       meshState->vertices = applySSD(
           referenceCharacter.inverseBindPose, *referenceCharacter.skinWeights, vs, skeletonState);
 
-      // update normals
       meshState->updateNormals();
     } else if (referenceCharacter.blendShape) {
-      // For CharacterT<float>, we can cast directly to Character
-      // For CharacterT<double>, we need to cast to Character (CharacterT<float>) first
+      // skinWithBlendShapes() is only defined for `Character` (i.e., CharacterT<float>),
+      // so the double-precision instantiation has to materialize a float Character to call it.
       if constexpr (std::is_same_v<T, float>) {
         skinWithBlendShapes(
             static_cast<const Character&>(referenceCharacter),
@@ -127,8 +123,11 @@ void CharacterStateT<T>::set(
             parameters.pose,
             *meshState);
       } else {
-        // For double, create a temporary Character (CharacterT<float>) object
-        // This is a simplified conversion that may not preserve all properties
+        // TODO: This temporary Character is constructed by shallow-copying member pointers
+        // from a CharacterT<double>. Members that differ between float/double specializations
+        // (e.g., `inverseBindPose`) are passed across without conversion, which can produce
+        // subtly wrong skinning. Consider providing a proper float<->double conversion or
+        // a templated skinWithBlendShapes overload.
         Character tempCharacter(
             referenceCharacter.skeleton,
             referenceCharacter.parameterTransform,
@@ -139,14 +138,13 @@ void CharacterStateT<T>::set(
             referenceCharacter.collision.get(),
             referenceCharacter.poseShapes.get(),
             referenceCharacter.blendShape,
-            nullptr, // No face expression blend shape
+            nullptr, // no face expression blend shape
             referenceCharacter.name,
             referenceCharacter.inverseBindPose);
 
         skinWithBlendShapes(tempCharacter, skeletonState, parameters.pose, *meshState);
       }
     } else {
-      // apply simple skinning
       applySSD(
           referenceCharacter.inverseBindPose,
           *referenceCharacter.skinWeights,
@@ -156,7 +154,6 @@ void CharacterStateT<T>::set(
     }
   }
 
-  // update collision geometry if present
   if (updateCollision && referenceCharacter.collision) {
     if (!collisionState || collisionState->origin.size() != referenceCharacter.collision->size()) {
       collisionState = std::make_unique<CollisionGeometryState>();

--- a/momentum/character/character_state.h
+++ b/momentum/character/character_state.h
@@ -21,56 +21,54 @@ namespace momentum {
 /// character animation and rendering.
 template <typename T>
 struct CharacterStateT {
-  /// Model parameters and joint offsets
+  /// Model parameters (`pose`) and joint parameter offsets driving this state.
   CharacterParameters parameters;
 
-  /// Joint transformations
   SkeletonState skeletonState;
 
-  /// Locator positions and orientations
   LocatorState locatorState;
 
-  /// Skinned mesh (may be null if updateMesh=false)
+  /// Skinned mesh; null when constructed/updated with `updateMesh=false` or
+  /// when the reference character has no mesh or skin weights.
   Mesh_u meshState;
 
-  /// Collision geometry state (may be null if updateCollision=false)
+  /// Collision geometry state; null when constructed/updated with
+  /// `updateCollision=false` or when the reference character has no collision
+  /// geometry.
   CollisionGeometryState_u collisionState;
 
-  /// Creates an empty character state
   CharacterStateT();
 
-  /// Creates a deep copy of another character state
+  /// Creates a deep copy of another character state, including owned
+  /// `meshState` and `collisionState`.
   explicit CharacterStateT(const CharacterStateT& other);
 
-  /// Move constructor
   CharacterStateT(CharacterStateT&& c) noexcept;
 
-  /// Copy assignment is disabled
+  /// Copy assignment is deleted; use the explicit copy constructor instead.
   CharacterStateT& operator=(const CharacterStateT& rhs) = delete;
 
-  /// Move assignment operator
   CharacterStateT& operator=(CharacterStateT&& rhs) noexcept;
 
-  /// Destructor
   ~CharacterStateT();
 
-  /// Creates a character state in bind pose
+  /// Creates a character state in `referenceCharacter`'s bind pose.
   ///
-  /// @param referenceCharacter The character to use as reference
-  /// @param updateMesh Whether to compute the skinned mesh
-  /// @param updateCollision Whether to update collision geometry
+  /// @param updateMesh If true, allocate and populate `meshState` by skinning
+  ///   `referenceCharacter.mesh` (requires non-null mesh and skin weights).
+  /// @param updateCollision If true, allocate and populate `collisionState`
+  ///   from `referenceCharacter.collision` (requires non-null collision).
   explicit CharacterStateT(
       const CharacterT<T>& referenceCharacter,
       bool updateMesh = true,
       bool updateCollision = true);
 
-  /// Creates a character state with specific parameters
+  /// Creates a character state by applying `parameters` to `referenceCharacter`.
   ///
-  /// @param parameters The character parameters to use
-  /// @param referenceCharacter The character to use as reference
-  /// @param updateMesh Whether to compute the skinned mesh
-  /// @param updateCollision Whether to update collision geometry
-  /// @param applyLimits Whether to apply joint parameter limits
+  /// @param applyLimits If true, clamp passive joint parameters to the
+  ///   character's `parameterLimits` after applying the parameter transform.
+  /// @see set() for the meaning of `updateMesh` and `updateCollision` and
+  ///   for the requirements on `parameters.pose` and `parameters.offsets`.
   CharacterStateT(
       const CharacterParameters& parameters,
       const CharacterT<T>& referenceCharacter,
@@ -78,15 +76,21 @@ struct CharacterStateT {
       bool updateCollision = true,
       bool applyLimits = true);
 
-  /// Updates the character state with specific parameters
+  /// Updates the character state by applying `parameters` to `referenceCharacter`.
   ///
-  /// If parameters.offsets is empty, it will be initialized with zeros.
+  /// @pre `parameters.pose.size() == referenceCharacter.parameterTransform.numAllModelParameters()`
+  /// @pre `parameters.offsets` is either empty or has size
+  ///   `referenceCharacter.parameterTransform.numJointParameters()`. When
+  ///   empty, it is initialized to zeros.
   ///
-  /// @param parameters The character parameters to use
-  /// @param referenceCharacter The character to use as reference
-  /// @param updateMesh Whether to compute the skinned mesh
-  /// @param updateCollision Whether to update collision geometry
-  /// @param applyLimits Whether to apply joint parameter limits
+  /// @param updateMesh If true, allocate and populate `meshState` by skinning
+  ///   `referenceCharacter.mesh` (no-op if mesh or skin weights are null).
+  ///   When pose blend shapes or blend shapes are present on the character,
+  ///   they are applied before linear skinning.
+  /// @param updateCollision If true, allocate and populate `collisionState`
+  ///   from `referenceCharacter.collision` (no-op if collision is null).
+  /// @param applyLimits If true, clamp passive joint parameters to the
+  ///   character's `parameterLimits` after applying the parameter transform.
   void set(
       const CharacterParameters& parameters,
       const CharacterT<T>& referenceCharacter,
@@ -94,11 +98,9 @@ struct CharacterStateT {
       bool updateCollision = true,
       bool applyLimits = true);
 
-  /// Sets the character state to the bind pose
+  /// Sets the character state to `referenceCharacter`'s bind pose.
   ///
-  /// @param referenceCharacter The character to use as reference
-  /// @param updateMesh Whether to compute the skinned mesh
-  /// @param updateCollision Whether to update collision geometry
+  /// @see set() for the meaning of `updateMesh` and `updateCollision`.
   void setBindPose(
       const CharacterT<T>& referenceCharacter,
       bool updateMesh = true,

--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -223,7 +223,9 @@ std::vector<size_t> addMappedParameters(
       continue;
     }
 
-    // Invalid joint index, so any model parameters are invalid too:
+    // TODO: Comment is inverted/stale — code marks params VALID for kept joints (the
+    // invalid-joint case is filtered above by the `continue`). Rewrite or remove.
+    // Mark every model parameter that drives this kept joint as valid.
     for (SparseRowMatrixf::InnerIterator it(paramTransformOrig.transform, kJointParam); it; ++it) {
       // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)
       validParamsOrig[it.col()] = true;
@@ -828,12 +830,8 @@ JointParameters mapIdentityToCharacter(
 
 namespace {
 
-/// Reduces base shape vertices based on active vertex selection
-///
-/// @param baseVertices Original base shape vertices
-/// @param activeVertices Boolean vector indicating which vertices to keep
-/// @param newVertexCount Number of vertices in the reduced mesh
-/// @return Reduced base shape vertices
+// Selects the entries of `baseVertices` flagged true in `activeVertices`,
+// reserving capacity for `newVertexCount` results.
 std::vector<Vector3f> reduceBaseShapeVertices(
     const std::vector<Vector3f>& baseVertices,
     const std::vector<bool>& activeVertices,
@@ -850,12 +848,8 @@ std::vector<Vector3f> reduceBaseShapeVertices(
   return newBaseVertices;
 }
 
-/// Reduces blend shape vectors based on active vertex selection
-///
-/// @param shapeVectors Original shape vectors matrix [vertexCount*3 x numShapes]
-/// @param activeVertices Boolean vector indicating which vertices to keep
-/// @param newVertexCount Number of vertices in the reduced mesh
-/// @return Reduced shape vectors matrix [newVertexCount*3 x numShapes]
+// Compacts a [vertexCount*3 x numShapes] shape-vector matrix down to
+// [newVertexCount*3 x numShapes] by keeping the rows for active vertices.
 MatrixXf reduceBlendShapeVectors(
     const MatrixXf& shapeVectors,
     const std::vector<bool>& activeVertices,
@@ -1155,18 +1149,14 @@ MeshT<T> reduceMeshInternal(
     newMesh.texcoord_lines = remapLines(mesh.texcoord_lines, reverseTextureVertexMapping);
   }
 
-  // Remap polygon face data
   remapPolyFaces(newMesh, mesh, activeVertices, reverseVertexMapping, reverseTextureVertexMapping);
 
   return newMesh;
 }
 
-/// Reduces mesh components based on active vertices and faces
-///
-/// @param character Character to be reduced
-/// @param activeVertices Boolean vector indicating which vertices to keep
-/// @param activeFaces Boolean vector indicating which faces to keep
-/// @return A new character with all components reduced accordingly
+// Builds a new character whose mesh, skin weights, pose shapes, and blend shapes
+// are restricted to the given active vertices/faces. Skeleton, parameter transform,
+// limits, locators, collision, and inverseBindPose are passed through unchanged.
 template <typename T>
 CharacterT<T> reduceMeshComponents(
     const CharacterT<T>& character,
@@ -1184,14 +1174,11 @@ CharacterT<T> reduceMeshComponents(
       activeFaces.size(),
       character.mesh->faces.size());
 
-  // Create a mapping from old vertex indices to new vertex indices using generic function
   const auto [forwardVertexMapping, reverseVertexMapping] = createIndexMapping(activeVertices);
 
-  // Reduce the mesh using the standalone mesh-level function
   auto newMesh = std::make_unique<Mesh>(
       reduceMeshInternal<float>(*character.mesh, activeVertices, activeFaces));
 
-  // Create new skin weights if they exist
   std::unique_ptr<SkinWeights> newSkinWeights;
   if (character.skinWeights) {
     newSkinWeights = std::make_unique<SkinWeights>();
@@ -1205,7 +1192,6 @@ CharacterT<T> reduceMeshComponents(
     }
   }
 
-  // Create new pose shapes if they exist
   std::unique_ptr<PoseShape> newPoseShapes;
   if (character.poseShapes) {
     newPoseShapes = std::make_unique<PoseShape>(*character.poseShapes);
@@ -1222,7 +1208,6 @@ CharacterT<T> reduceMeshComponents(
     }
     newPoseShapes->baseShape = std::move(newBaseShape);
 
-    // Reduce the shape vectors matrix
     MatrixXf newShapeVectors(
         forwardVertexMapping.size() * 3, character.poseShapes->shapeVectors.cols());
     newIdx = 0;
@@ -1237,17 +1222,14 @@ CharacterT<T> reduceMeshComponents(
     newPoseShapes->shapeVectors = std::move(newShapeVectors);
   }
 
-  // Create new blend shapes if they exist
   BlendShape_const_p newBlendShape;
   if (character.blendShape) {
     auto blendShape = std::make_shared<BlendShape>();
 
-    // Reduce base shape vertices
     std::vector<Vector3f> newBaseVertices = reduceBaseShapeVertices(
         character.blendShape->getBaseShape(), activeVertices, forwardVertexMapping.size());
     blendShape->setBaseShape(newBaseVertices);
 
-    // Reduce shape vectors using shared function
     MatrixXf newShapeVectors = reduceBlendShapeVectors(
         character.blendShape->getShapeVectors(), activeVertices, forwardVertexMapping.size());
     blendShape->setShapeVectors(newShapeVectors);
@@ -1255,13 +1237,11 @@ CharacterT<T> reduceMeshComponents(
     newBlendShape = blendShape;
   }
 
-  // Create new face expression blend shapes if they exist
   BlendShapeBase_const_p newFaceExpressionBlendShape;
   if (character.faceExpressionBlendShape) {
     auto faceBlendShape = std::make_shared<BlendShapeBase>(
         forwardVertexMapping.size(), character.faceExpressionBlendShape->shapeSize());
 
-    // Reduce shape vectors using shared function
     MatrixXf newShapeVectors = reduceBlendShapeVectors(
         character.faceExpressionBlendShape->getShapeVectors(),
         activeVertices,
@@ -1271,7 +1251,6 @@ CharacterT<T> reduceMeshComponents(
     newFaceExpressionBlendShape = faceBlendShape;
   }
 
-  // Construct and return the new character with all updated components
   return CharacterT<T>(
       character.skeleton,
       character.parameterTransform,
@@ -1300,7 +1279,6 @@ CharacterT<T> reduceMeshByVertices(
       activeVertices.size(),
       character.mesh->vertices.size());
 
-  // Convert vertex selection to face selection
   const auto activeFaces = verticesToFaces(*character.mesh, activeVertices);
 
   return reduceMeshComponents(character, activeVertices, activeFaces);
@@ -1317,7 +1295,6 @@ CharacterT<T> reduceMeshByFaces(
       activeFaces.size(),
       character.mesh->faces.size());
 
-  // Convert face selection to vertex selection
   const auto activeVertices = facesToVertices(*character.mesh, activeFaces);
 
   return reduceMeshComponents(character, activeVertices, activeFaces);
@@ -1331,7 +1308,6 @@ MeshT<T> reduceMeshByVertices(const MeshT<T>& mesh, const std::vector<bool>& act
       activeVertices.size(),
       mesh.vertices.size());
 
-  // Convert vertex selection to face selection
   const auto activeFaces = verticesToFaces(mesh, activeVertices);
 
   return reduceMeshInternal(mesh, activeVertices, activeFaces);
@@ -1345,7 +1321,6 @@ MeshT<T> reduceMeshByFaces(const MeshT<T>& mesh, const std::vector<bool>& active
       activeFaces.size(),
       mesh.faces.size());
 
-  // Convert face selection to vertex selection
   const auto activeVertices = facesToVertices(mesh, activeFaces);
 
   return reduceMeshInternal(mesh, activeVertices, activeFaces);
@@ -1403,7 +1378,6 @@ MeshT<T> reduceMeshByPolys(const MeshT<T>& mesh, const std::vector<bool>& active
       activePolys.size(),
       mesh.polyFaceSizes.size());
 
-  // Convert polygon selection to vertex selection, then to face selection
   const auto activeVertices = polysToVertices(mesh, activePolys);
   const auto activeFaces = verticesToFaces(mesh, activeVertices);
 
@@ -1421,14 +1395,12 @@ CharacterT<T> reduceMeshByPolys(
       activePolys.size(),
       character.mesh->polyFaceSizes.size());
 
-  // Convert polygon selection to vertex selection, then to face selection
   const auto activeVertices = polysToVertices(*character.mesh, activePolys);
   const auto activeFaces = verticesToFaces(*character.mesh, activeVertices);
 
   return reduceMeshComponents(character, activeVertices, activeFaces);
 }
 
-// Explicit instantiations for commonly used types
 template CharacterT<float> reduceMeshByVertices<float>(
     const CharacterT<float>& character,
     const std::vector<bool>& activeVertices);

--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -16,33 +16,22 @@ namespace momentum {
 /// Note that this should primarily be used when transforming the character into different units. If
 /// you simply want to apply an identity-specific scale to the character, you should use the
 /// 'scale_global' parameter in the ParameterTransform class.
-///
-/// @param[in] character Character to be scaled
-/// @param[in] scale Scale factor to apply
-/// @return A new Character object that has been scaled
 [[nodiscard]] Character scaleCharacter(const Character& character, float scale);
 
-/// Transforms the character (mesh and skeleton) by the desired transformation matrix.  The
-/// transformation matrix should not have any scale or shear.
+/// Transforms the character (mesh and skeleton) by the desired transformation matrix.
+///
+/// @pre `xform` must be a rigid transform (no scale or shear).
 ///
 /// Note that this should primarily be used for transforming models between different coordinate
 /// spaces (e.g. y-up vs. z-up). If you want to move a character around the scene, you should
 /// preferably use the model parameters.
-///
-/// @param[in] character Character to be transformed
-/// @param[in] xform Transformation to apply
-/// @return A new Character object that has been transformed
 [[nodiscard]] Character transformCharacter(const Character& character, const Affine3f& xform);
 
-/// Replaces the part of target_character's skeleton rooted at target_root with the part of
-/// source_character's skeleton rooted at source_root.
+/// Replaces the subtree of `tgtCharacter`'s skeleton rooted at `tgtRootJoint` with the subtree of
+/// `srcCharacter`'s skeleton rooted at `srcRootJoint`.
 ///
 /// This function is typically used to swap one character's hand skeleton with another, for example.
 ///
-/// @param[in] srcCharacter The source character whose skeleton will be copied.
-/// @param[in] tgtCharacter The target character whose skeleton will be replaced.
-/// @param[in] srcRootJoint Root of the source skeleton hierarchy to be copied.
-/// @param[in] tgtRootJoint Root of the target skeleton hierarchy to be replaced.
 /// @return A new Character that is identical to tgtCharacter except that the skeleton under
 /// tgtRootJoint has been replaced by the part of srcCharacter's skeleton rooted at srcRootJoint.
 [[nodiscard]] Character replaceSkeletonHierarchy(
@@ -55,11 +44,6 @@ namespace momentum {
 ///
 /// Currently, it is necessary to remove child joints to prevent dangling joints. Mesh points
 /// skinned to the removed joints are re-skinned to their parent joint in the hierarchy.
-///
-/// @param[in] character The character from which joints will be removed.
-/// @param[in] jointsToRemove A vector of joint indices to be removed.
-/// @return A new Character object that is identical to the original except for the removal of
-/// specified joints.
 [[nodiscard]] Character removeJoints(
     const Character& character,
     momentum::span<const size_t> jointsToRemove);
@@ -67,9 +51,7 @@ namespace momentum {
 /// Maps the input ModelParameter motion to a target character by matching model parameter names.
 /// Mismatched names will be discarded (source) or set to zero (target).
 ///
-/// @param[in] inputMotion Input ModelParameter motion with names.
-/// @param[in] targetCharacter Target character that defines its own ModelParameters.
-/// @return A matrix of model parameters for the target character.
+/// @return A matrix of model parameters for the target character (one column per frame).
 MatrixXf mapMotionToCharacter(
     const MotionParameters& inputMotion,
     const Character& targetCharacter);
@@ -77,29 +59,21 @@ MatrixXf mapMotionToCharacter(
 /// Maps the input JointParameter vector to a target character by matching joint names. Mismatched
 /// names will be discarded (source) or set to zero (target). For every matched joint, all 7
 /// parameters will be copied over.
-///
-/// @param[in] inputIdentity Input JointParameter vector with joint names.
-/// @param[in] targetCharacter Target character that defines its own Joints.
-/// @return A vector of joint parameters for the target character.
 JointParameters mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter);
 
-/// Reduces the mesh to only include the specified vertices and associated faces
+/// Reduces the character's mesh to only include the specified vertices and associated faces.
 ///
-/// @param[in] character Character to be reduced
-/// @param[in] activeVertices Boolean vector indicating which vertices to keep
-/// @return A new character with mesh reduced to the specified vertices
+/// @pre `activeVertices.size() == character.mesh->vertices.size()`
 template <typename T>
 [[nodiscard]] CharacterT<T> reduceMeshByVertices(
     const CharacterT<T>& character,
     const std::vector<bool>& activeVertices);
 
-/// Reduces the mesh to only include the specified faces and associated vertices
+/// Reduces the character's mesh to only include the specified faces and associated vertices.
 ///
-/// @param[in] character Character to be reduced
-/// @param[in] activeFaces Boolean vector indicating which faces to keep
-/// @return A new character with mesh reduced to the specified faces
+/// @pre `activeFaces.size() == character.mesh->faces.size()`
 template <typename T>
 [[nodiscard]] CharacterT<T> reduceMeshByFaces(
     const CharacterT<T>& character,
@@ -111,9 +85,7 @@ template <typename T>
 /// It handles vertices, normals, colors, confidence, faces, lines, texcoords, texcoord_faces,
 /// and texcoord_lines with proper index remapping and compaction.
 ///
-/// @param[in] mesh The mesh to reduce
-/// @param[in] activeVertices Boolean vector indicating which vertices to keep
-/// @return A new mesh containing only the specified vertices and their associated faces
+/// @pre `activeVertices.size() == mesh.vertices.size()`
 template <typename T>
 [[nodiscard]] MeshT<T> reduceMeshByVertices(
     const MeshT<T>& mesh,
@@ -125,51 +97,35 @@ template <typename T>
 /// It handles vertices, normals, colors, confidence, faces, lines, texcoords, texcoord_faces,
 /// and texcoord_lines with proper index remapping and compaction.
 ///
-/// @param[in] mesh The mesh to reduce
-/// @param[in] activeFaces Boolean vector indicating which faces to keep
-/// @return A new mesh containing only the specified faces and their referenced vertices
+/// @pre `activeFaces.size() == mesh.faces.size()`
 template <typename T>
 [[nodiscard]] MeshT<T> reduceMeshByFaces(
     const MeshT<T>& mesh,
     const std::vector<bool>& activeFaces);
 
-/// Converts vertex selection to face selection
-///
-/// @param[in] character Character containing the mesh
-/// @param[in] activeVertices Boolean vector indicating which vertices are active
-/// @return Boolean vector indicating which faces only contain active vertices
+/// Converts a vertex selection to a face selection. A face is marked active only if every one of
+/// its vertices is active.
 template <typename T>
 [[nodiscard]] std::vector<bool> verticesToFaces(
     const MeshT<T>& mesh,
     const std::vector<bool>& activeVertices);
 
-/// Converts face selection to vertex selection
-///
-/// @param[in] mesh The mesh containing the faces
-/// @param[in] activeFaces Boolean vector indicating which faces are active
-/// @return Boolean vector indicating which vertices are used by active faces
+/// Converts a face selection to a vertex selection. A vertex is marked active if it is referenced
+/// by any active face.
 template <typename T>
 [[nodiscard]] std::vector<bool> facesToVertices(
     const MeshT<T>& mesh,
     const std::vector<bool>& activeFaces);
 
-/// Converts vertex selection to polygon selection
-///
-/// A polygon is active if all its vertices are active.
-///
-/// @param[in] mesh The mesh containing the polygon data
-/// @param[in] activeVertices Boolean vector indicating which vertices are active
-/// @return Boolean vector indicating which polygons only contain active vertices
+/// Converts a vertex selection to a polygon selection. A polygon is marked active only if every
+/// one of its vertices is active.
 template <typename T>
 [[nodiscard]] std::vector<bool> verticesToPolys(
     const MeshT<T>& mesh,
     const std::vector<bool>& activeVertices);
 
-/// Converts polygon selection to vertex selection
-///
-/// @param[in] mesh The mesh containing the polygon data
-/// @param[in] activePolys Boolean vector indicating which polygons are active
-/// @return Boolean vector indicating which vertices are used by active polygons
+/// Converts a polygon selection to a vertex selection. A vertex is marked active if it is
+/// referenced by any active polygon.
 template <typename T>
 [[nodiscard]] std::vector<bool> polysToVertices(
     const MeshT<T>& mesh,
@@ -180,46 +136,39 @@ template <typename T>
 /// Converts polygon selection to vertex selection and face selection, then reduces the mesh.
 /// Both triangulated faces and polygon data are filtered and remapped.
 ///
-/// @param[in] mesh The mesh to reduce
-/// @param[in] activePolys Boolean vector indicating which polygons to keep
-/// @return A new mesh containing only the specified polygons and their referenced vertices
+/// @pre `activePolys.size() == mesh.polygons.size()`
 template <typename T>
 [[nodiscard]] MeshT<T> reduceMeshByPolys(
     const MeshT<T>& mesh,
     const std::vector<bool>& activePolys);
 
-/// Reduces the mesh to only include the specified polygons and associated vertices
+/// Reduces the character's mesh to only include the specified polygons and associated vertices.
 ///
 /// Converts polygon selection to vertex selection and face selection, then reduces the mesh.
 /// Both triangulated faces and polygon data are filtered and remapped.
 ///
-/// @param[in] character Character to be reduced
-/// @param[in] activePolys Boolean vector indicating which polygons to keep
-/// @return A new character with mesh reduced to the specified polygons
+/// @pre `activePolys.size() == character.mesh->polygons.size()`
 template <typename T>
 [[nodiscard]] CharacterT<T> reduceMeshByPolys(
     const CharacterT<T>& character,
     const std::vector<bool>& activePolys);
 
-/// Result of addRigidTransformNode containing the new character and indices of the added bone and
-/// parameters.
+/// Result of addRigidTransformNode containing the new character and indices of the added joint
+/// and model parameters.
+// TODO: Rename `boneIndex` to `jointIndex` to match the rest of the codebase's terminology
+// ("joint" is used throughout; "bone" appears only here).
 struct RigidTransformNodeResult {
   Character character;
   size_t boneIndex;
   size_t parameterStartIndex;
 };
 
-/// Adds a new root-level bone with 6 rigid DOF parameters (tx/ty/tz/rx/ry/rz) to a character.
+/// Adds a new root-level joint with 6 rigid DOF parameters (tx/ty/tz/rx/ry/rz) to a character.
 ///
 /// The new joint is parented to kInvalidIndex (root-level) and gets 6 new model parameters
 /// that map directly to the joint's translation and rotation parameters.
 ///
-/// @param[in] character Character to add the rigid transform node to
-/// @param[in] name Name for the new joint (also used as prefix for parameter names)
-/// @param[in] translationOffset Translation offset for the new joint
-/// @param[in] preRotation Pre-rotation for the new joint
-/// @return A RigidTransformNodeResult containing the new character, the index of the new bone,
-///         and the start index of the new model parameters
+/// @param[in] name Name for the new joint (also used as prefix for parameter names).
 [[nodiscard]] RigidTransformNodeResult addRigidTransformNode(
     const Character& character,
     const std::string& name,

--- a/momentum/character/collision_geometry_state.cpp
+++ b/momentum/character/collision_geometry_state.cpp
@@ -16,14 +16,13 @@ template <typename T>
 void CollisionGeometryStateT<T>::update(
     const SkeletonStateT<T>& skeletonState,
     const CollisionGeometry& collisionGeometry) {
-  // resize all elements
   const size_t numElements = collisionGeometry.size();
   origin.resize(numElements);
   direction.resize(numElements);
   radius.resize(numElements);
   delta.resize(numElements);
 
-  // calculate data from the geometry (can be parallelized)
+  // TODO: This per-capsule loop is independent across iterations and could be parallelized.
   for (size_t i = 0; i < numElements; ++i) {
     const auto& tc = collisionGeometry[i];
     const TransformT<T> parentTransform = (tc.parent == kInvalidIndex)

--- a/momentum/character/collision_geometry_state.h
+++ b/momentum/character/collision_geometry_state.h
@@ -53,17 +53,22 @@ struct CollisionGeometryStateT {
 /// Determines if two tapered capsules overlap.
 ///
 /// @param originA Origin of the first capsule
-/// @param directionA Direction vector of the first capsule
+/// @param directionA Direction vector of the first capsule (length encodes the segment length)
 /// @param radiiA Radii at the endpoints of the first capsule
-/// @param deltaA Difference between radii of the first capsule
+/// @param deltaA Signed difference between radii of the first capsule (radiiA[1] - radiiA[0])
 /// @param originB Origin of the second capsule
-/// @param directionB Direction vector of the second capsule
+/// @param directionB Direction vector of the second capsule (length encodes the segment length)
 /// @param radiiB Radii at the endpoints of the second capsule
-/// @param deltaB Difference between radii of the second capsule
-/// @param outDistance Output parameter for the distance between the closest points
-/// (normalized). No modification on return false.
-/// @param outOverlap Output parameter for the overlap amount (positive if overlapping)
-/// @return True if the capsules overlap, false otherwise
+/// @param deltaB Signed difference between radii of the second capsule (radiiB[1] - radiiB[0])
+/// @param outDistance Output: distance between the closest points on the two centerline
+///   segments. Only written when the closest-point computation succeeds; left unchanged
+///   when the function returns false due to an early exit from `closestPointsOnSegments`.
+/// @param outClosestPoints Output: parametric positions in [0, 1] along each segment of
+///   the closest points (outClosestPoints[0] for capsule A, outClosestPoints[1] for B).
+/// @param outOverlap Output: amount of overlap (positive if overlapping). Only written
+///   when the closest-point computation succeeds.
+/// @return True if the capsules overlap and the closest points are not coincident
+///   (separation >= ~1e-8 for float, ~1e-17 for double).
 template <typename T>
 bool overlaps(
     const Vector3<T>& originA,
@@ -77,10 +82,10 @@ bool overlaps(
     T& outDistance,
     Vector2<T>& outClosestPoints,
     T& outOverlap) {
-  // Sum of the maximum radii of the tapered capsules
+  // Use the sum of max radii as a proximity cutoff so closestPointsOnSegments can early-out
+  // when segments are guaranteed too far apart for the capsules to overlap.
   const T maxRadiiSum = radiiA.maxCoeff() + radiiB.maxCoeff();
 
-  // Determine the closest points on the segments of the tapered capsules
   auto [success, closestDist, closestPoints] =
       closestPointsOnSegments<T>(originA, directionA, originB, directionB, maxRadiiSum);
 
@@ -88,18 +93,18 @@ bool overlaps(
     return false;
   }
 
-  // Store the closest points to the output argument
   outClosestPoints = closestPoints;
 
-  // Calculate the radii at the closest points
+  // Linearly interpolate each tapered radius at the closest-point parameter along its segment,
+  // then sum to get the combined radius the gap must clear for the capsules to be disjoint.
   const T radiusAtClosestPoints =
       radiiA[0] + closestPoints[0] * deltaA + radiiB[0] + closestPoints[1] * deltaB;
 
-  // Determine the overlap and distance between the closest points
   outOverlap = radiusAtClosestPoints - closestDist;
   outDistance = closestDist;
 
-  // Check for overlap and sufficient proximity
+  // Reject coincident centerlines (closestDist below Eps) to avoid degenerate contact normals
+  // downstream when the two segments are effectively the same line.
   return (outOverlap > T(0)) && (closestDist >= Eps<T>(1e-8, 1e-17));
 }
 

--- a/momentum/character/inverse_parameter_transform.cpp
+++ b/momentum/character/inverse_parameter_transform.cpp
@@ -95,7 +95,7 @@ ModelParameters applyModelParameterScales(
             scaleParametersSubset.size());
         modelIdentity[iParam] = scaleParametersSubset(subsetParamIdx);
 
-        // Add the identity parameters into the motion:
+        // Add the identity parameters into the motion.
         if (!hasScaleParametersInMotion) {
           for (Eigen::Index jFrame = 0; jFrame < motion.cols(); ++jFrame) {
             motion(iParam, jFrame) += scaleParametersSubset(subsetParamIdx);

--- a/momentum/character/inverse_parameter_transform.h
+++ b/momentum/character/inverse_parameter_transform.h
@@ -16,38 +16,42 @@
 
 namespace momentum {
 
-// Maps from joint parameters back to the model parameters.  Because the joint
-// parameters have a much higher dimensionality (7*nJoints) than the number of
-// model parameters, in general we can't always find a set of model parameters
-// that reproduce the passed-in joint parameters.  Therefore, the mapping is
-// done in a least squares sense: we find the model parameters that bring use
-// closest to the passed-in joint parameters under L2.
-//
-// Note that this assumes the parameter transform is well-formed, in the sense
-// that it has rank equal to the number of model parameters.  Any sane
-// parameter transform should have this property (if not, it would be possible
-// to generate the same set of joint parameters with two different model
-// parameter vectors).
-
+/// Maps from joint parameters back to the model parameters.
+///
+/// Because the joint parameters have a much higher dimensionality (7*nJoints) than the number of
+/// model parameters, in general we can't always find a set of model parameters that reproduce the
+/// passed-in joint parameters. Therefore, the mapping is done in a least squares sense: we find
+/// the model parameters that bring us closest to the passed-in joint parameters under L2.
+///
+/// @pre The parameter transform must be well-formed, in the sense that it has rank equal to the
+/// number of model parameters. Any sane parameter transform should have this property (if not, it
+/// would be possible to generate the same set of joint parameters with two different model
+/// parameter vectors).
 template <typename T>
 struct InverseParameterTransformT {
  public:
   const SparseRowMatrix<T> transform;
   const Eigen::SparseQR<Eigen::SparseMatrix<T>, Eigen::COLAMDOrdering<int>> inverseTransform;
-  const Eigen::VectorX<T> offsets; // DEPRECATED: constant offset factor for each joint
+  // TODO: `offsets` is unused by the inverse mapping below and is documented as deprecated; remove
+  // it and update all constructors/consumers.
+  /// @deprecated Constant offset factor for each joint; retained for ABI compatibility but no
+  /// longer consulted by `apply()`.
+  const Eigen::VectorX<T> offsets;
 
   explicit InverseParameterTransformT(const ParameterTransformT<T>& paramTransform);
 
-  // map joint parameters to model parameters.  The residual from the fit is
-  // left in the result's offsets vector.
+  /// Map joint parameters to model parameters.
+  ///
+  /// @return The fit model parameters; the residual from the least-squares fit is left in the
+  ///   result's `offsets` vector.
   [[nodiscard]] CharacterParametersT<T> apply(const JointParametersT<T>& parameters) const;
 
-  // Dimension of the output model parameters vector:
+  /// Dimension of the output model parameters vector.
   [[nodiscard]] Eigen::Index numAllModelParameters() const {
     return transform.cols();
   }
 
-  // Dimension of the input joint parameters vector:
+  /// Dimension of the input joint parameters vector.
   [[nodiscard]] Eigen::Index numJointParameters() const {
     return transform.rows();
   }

--- a/momentum/character/joint.h
+++ b/momentum/character/joint.h
@@ -18,19 +18,21 @@ template <typename T>
 struct JointT {
   using Scalar = T;
 
-  /// Joint name
   std::string name{"uninitialized"};
 
-  /// Index of the parent joint in the skeleton hierarchy
+  /// Index of the parent joint in the skeleton hierarchy, or `kInvalidIndex` for the root.
   size_t parent{kInvalidIndex};
 
   // TODO: does it make sense to save its own index too?
 
-  /// Pre-rotation matrix from its parent's axes to its own axes.
-  /// @note: Braces initialization is avoided due to issues with CUDA 11.
+  /// Pre-rotation from the parent joint's axes to this joint's local axes.
+  /// Applied before the joint's own rotation parameters.
+  /// @note Default-initialized via `=` rather than braces due to a CUDA 11
+  /// compiler bug with brace-initialization of Eigen's Quaternion.
   Quaternion<T> preRotation = Quaternion<T>::Identity();
 
-  /// The constant translation offset from the parent joint to this joint's origin.
+  /// Constant translation offset from the parent joint's origin to this joint's
+  /// origin, expressed in the parent's local frame.
   Vector3<T> translationOffset = Vector3<T>::Zero();
 
   /// Checks if the current joint is approximately equal to the provided joint.

--- a/momentum/character/joint_state.cpp
+++ b/momentum/character/joint_state.cpp
@@ -12,10 +12,6 @@
 
 namespace momentum {
 
-// Joint transform is : WorldTransform = ParentWorldTransform * T * Rpre * R * S,
-// with R depending on rotation order.
-// Each joint thus has 7 parameters, 3 translation, 3 rotation, 1 scale.
-
 template <typename T>
 const std::array<Vector3<T>, 3> RotationAxis = {
     Vector3<T>::UnitX(),
@@ -35,7 +31,8 @@ void JointStateT<T>::set(
     parent = parentState->transform;
   }
 
-  // calculate state based on parameters and parent transform
+  // Translation acts in the parent's frame, so the per-axis translation derivative is
+  // the parent's rotated unit axis. Identity when there is no parent.
   if (computeDeriv) {
     if (parentState != nullptr) {
       translationAxis = parentState->transform.toLinear();
@@ -44,13 +41,13 @@ void JointStateT<T>::set(
     }
   }
 
-  // do the translations
   localTransform.translation.noalias() = joint.translationOffset + parameters.template head<3>();
 
-  // apply pre-rotation
   localTransform.rotation = joint.preRotation;
 
-  // do the rotations
+  // Apply rotations in reverse order (Z, Y, X) so the resulting product is Rpre * Rx * Ry * Rz.
+  // The rotation derivative axis for index i is the parent rotation composed with the
+  // partially-accumulated local rotation up to (but not including) axis i.
   for (int index = 2; index >= 0; --index) {
     if (computeDeriv) {
       rotationAxis.col(index).noalias() =
@@ -60,10 +57,10 @@ void JointStateT<T>::set(
         Quaternion<T>(AngleAxis<T>((T)parameters[3 + index], RotationAxis<T>[index]));
   }
 
-  // perform scale if necessary
+  // Scale parameter is stored as a log2 value: scale = exp2(parameters[6]).
+  // Keeps scale strictly positive and makes the parameter space uniform in log-ratio.
   localTransform.scale = std::exp2((T)parameters[6]);
 
-  // set global transformation
   transform = parent * localTransform;
 }
 

--- a/momentum/character/joint_state.h
+++ b/momentum/character/joint_state.h
@@ -26,6 +26,26 @@ namespace momentum {
 /// - S is the uniform scale factor
 ///
 /// Each joint has 7 parameters: 3 translation, 3 rotation, and 1 scale.
+///
+/// The ordering has direct implications for derivative computation:
+///
+/// - **Translation Jacobian**: Because translation is applied in the parent's frame
+///   (before local rotation), the translation derivative for axis `i` is simply
+///   `translationAxis.col(i)` — the parent's rotated axis direction. It does NOT
+///   depend on the joint's own rotation.
+///
+/// - **Rotation Jacobian**: Because rotation is applied after translation and
+///   pre-rotation, the rotation derivative for a point `p` is
+///   `rotationAxis.col(i).cross(p - jointPosition)`. The pre-rotation (`Rpre`) is
+///   baked into `rotationAxis` and is not a free parameter.
+///
+/// - **Scale Jacobian**: Because scale is applied last (innermost), it scales the
+///   offset from the joint position: `(p - jointPosition) * ln(2)` (since scale
+///   is stored as `exp2(parameter[6])`).
+///
+/// Swapping the order (e.g., applying rotation before translation) would change
+/// which frame the translation operates in, producing incorrect Jacobians in all
+/// error functions.
 template <typename T>
 struct JointStateT {
   /// Local transformation relative to parent joint
@@ -61,7 +81,14 @@ struct JointStateT {
   /// @param joint The joint definition containing offset and pre-rotation
   /// @param parameters The 7 joint parameters [tx, ty, tz, rx, ry, rz, scale]
   /// @param parentState Optional parent joint state for hierarchical transformations
-  /// @param computeDeriv Whether to compute derivative information (translation/rotation axes)
+  /// @param computeDeriv If true, computes `translationAxis` and `rotationAxis`
+  ///   matrices needed for Jacobian computation in error functions. Set to false
+  ///   ONLY when the state is used for visualization, FK output inspection, or IO —
+  ///   never when the state will be passed to a solver or error function.
+  ///   Skipping derivatives saves ~30% of per-joint FK cost.
+  ///   When false, `derivDirty` is set to true and derivative accessors
+  ///   (`getRotationDerivative`, `getTranslationDerivative`, `getScaleDerivative`)
+  ///   return invalid results.
   void set(
       const JointT<T>& joint,
       const JointVectorT<T>& parameters,
@@ -117,6 +144,16 @@ struct JointStateT {
   /// Access the joint's local scale factor
   ///
   /// This scale propagates to all descendant joints
+  ///
+  /// The scale parameter is stored as a log2 value and applied as `exp2(parameter[6])`.
+  /// This means:
+  /// - Parameter value 0.0 → scale = 1.0 (no scaling)
+  /// - Parameter value 1.0 → scale = 2.0 (double size)
+  /// - Parameter value -1.0 → scale = 0.5 (half size)
+  /// - The Jacobian of scale involves `exp2(param) * ln(2)`, not 1.0
+  ///
+  /// This encoding keeps scale always positive and makes the parameter space
+  /// more linear for optimization (uniform steps in log-space = uniform ratios).
   [[nodiscard]] const T& localScale() const {
     return localTransform.scale;
   }

--- a/momentum/character/linear_skinning.cpp
+++ b/momentum/character/linear_skinning.cpp
@@ -56,7 +56,6 @@ std::vector<Vector3<T>> applySSD(
 
   std::vector<Vector3<T>> result(points.size(), Vector3<T>::Zero());
 
-  // go over all vertices and perform transformation
   dispenso::ParForOptions options;
   options.minItemsPerChunk = 1024u;
 
@@ -64,14 +63,17 @@ std::vector<Vector3<T>> applySSD(
       dispenso::makeChunkedRange(0, skin.index.rows(), dispenso::ParForChunking::kAuto),
       [&](const size_t rangeBegin, const size_t rangeEnd) {
         for (size_t i = rangeBegin; i != rangeEnd; i++) {
-          // grab vertex
           const Vector3<T>& pos = points[i];
           auto& output = result[i];
           output.setZero();
 
-          // loop over the weights
+          // Unused influence slots are zero-filled (see `SkinWeights`); the first zero
+          // weight terminates the active influences for this vertex.
+          // TODO: This break assumes used slots are packed contiguously at the front
+          // (no zero gaps before non-zero entries). `SkinWeights::set` enforces this
+          // for ragged inputs, but other loaders may not — consider documenting the
+          // invariant on `SkinWeights` or replacing the break with a continue.
           for (size_t j = 0; j < kMaxSkinJoints; j++) {
-            // get pointer to transformation and weight float
             const auto& weight = skin.weight(i, j);
             if (weight == 0.0f) {
               break;
@@ -86,7 +88,8 @@ std::vector<Vector3<T>> applySSD(
                 skinningTransforms.size());
             const auto& transformation = skinningTransforms[skin.index(i, j)];
 
-            // add up transforms: outputp += (transformation * (pos, 1)) * weight
+            // Equivalent to: output += (transformation * (pos, 1)) * weight,
+            // expanded to avoid the homogeneous extension of `pos`.
             Eigen::Vector3<T> temp = transformation.template topRightCorner<3, 1>();
             temp.noalias() += transformation.template topLeftCorner<3, 3>() * pos;
             output.noalias() += temp * weight;
@@ -189,7 +192,6 @@ void applySSD(
       outputMesh.faces.size(),
       mesh.faces.size());
 
-  // go over all vertices and perform transformation
   dispenso::ParForOptions options;
   options.minItemsPerChunk = 1024u;
 
@@ -197,7 +199,6 @@ void applySSD(
       dispenso::makeChunkedRange(0, skin.index.rows(), dispenso::ParForChunking::kAuto),
       [&](const size_t rangeBegin, const size_t rangeEnd) {
         for (size_t i = rangeBegin; i != rangeEnd; i++) {
-          // grab vertex
           const Vector3<T>& pos = mesh.vertices[i];
           const Vector3<T>& nml = mesh.normals[i];
           auto& outputp = outputMesh.vertices[i];
@@ -205,9 +206,13 @@ void applySSD(
           auto& outputn = outputMesh.normals[i];
           outputn.setZero();
 
-          // loop over the weights
+          // Unused influence slots are zero-filled (see `SkinWeights`); the first zero
+          // weight terminates the active influences for this vertex.
+          // TODO: This break assumes used slots are packed contiguously at the front
+          // (no zero gaps before non-zero entries). `SkinWeights::set` enforces this
+          // for ragged inputs, but other loaders may not — consider documenting the
+          // invariant on `SkinWeights` or replacing the break with a continue.
           for (size_t j = 0; j < kMaxSkinJoints; j++) {
-            // get pointer to transformation and weight float
             const auto& weight = skin.weight(i, j);
             if (weight == 0.0f) {
               break;
@@ -222,13 +227,16 @@ void applySSD(
                 skinningTransforms.size());
             const auto& transformation = skinningTransforms[skin.index(i, j)];
 
-            // add up transforms: outputp += (transformation * (pos, 1)) * weight
+            // Equivalent to: outputp += (transformation * (pos, 1)) * weight,
+            // expanded to avoid the homogeneous extension of `pos`.
             const auto& topLeft = transformation.template topLeftCorner<3, 3>();
             Eigen::Vector3<T> temp = transformation.template topRightCorner<3, 1>();
             temp.noalias() += topLeft * pos;
             outputp.noalias() += temp * weight;
 
-            // add up normals
+            // Normals transform with the rotation/scale block only (no translation).
+            // TODO: This is the inverse-transpose only for rigid transforms; for
+            // non-uniform scale the normal direction will be incorrect.
             outputn.noalias() += topLeft * nml * weight;
           }
           outputn.normalize();
@@ -409,7 +417,6 @@ std::vector<Vector3f> applyInverseSSD(
   return res;
 }
 
-// Explicit template instantiations for computeSkinningTransforms
 template std::vector<Eigen::Matrix4f> computeSkinningTransforms<float>(
     momentum::span<const JointStateT<float>> jointState,
     const TransformationListT<float>& inverseBindPose);
@@ -417,7 +424,6 @@ template std::vector<Eigen::Matrix4d> computeSkinningTransforms<double>(
     momentum::span<const JointStateT<double>> jointState,
     const TransformationListT<double>& inverseBindPose);
 
-// Explicit template instantiations for applySSD with skinning transforms (points)
 template std::vector<Vector3f> applySSD<float>(
     const SkinWeights& skin,
     momentum::span<const Vector3f> points,
@@ -427,7 +433,6 @@ template std::vector<Vector3d> applySSD<double>(
     momentum::span<const Vector3d> points,
     momentum::span<const Eigen::Matrix4d> skinningTransforms);
 
-// Explicit template instantiations for applySSD with joint state span (points)
 template std::vector<Vector3f> applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,
@@ -439,7 +444,6 @@ template std::vector<Vector3d> applySSD<double>(
     momentum::span<const Vector3d> points,
     momentum::span<const JointStateT<double>> jointState);
 
-// Explicit template instantiations for applySSD with skeleton state (points)
 template std::vector<Vector3f> applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,
@@ -451,7 +455,6 @@ template std::vector<Vector3d> applySSD<double>(
     momentum::span<const Vector3d> points,
     const SkeletonStateT<double>& state);
 
-// Explicit template instantiations for applySSD with world transforms vector (points)
 template std::vector<Vector3f> applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,
@@ -463,7 +466,6 @@ template std::vector<Vector3d> applySSD<double>(
     momentum::span<const Vector3d> points,
     const TransformationListT<double>& worldTransforms);
 
-// Explicit template instantiations for applySSD with world transforms span (points)
 template std::vector<Vector3f> applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,
@@ -475,7 +477,6 @@ template std::vector<Vector3d> applySSD<double>(
     momentum::span<const Vector3d> points,
     momentum::span<const TransformT<double>> worldTransforms);
 
-// Explicit template instantiations for applySSD with skinning transforms (mesh)
 template void applySSD<float>(
     const SkinWeights& skin,
     const MeshT<float>& mesh,
@@ -487,7 +488,6 @@ template void applySSD<double>(
     momentum::span<const Eigen::Matrix4d> skinningTransforms,
     MeshT<double>& outputMesh);
 
-// Explicit template instantiations for applySSD with joint state span (mesh)
 template void applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,
@@ -501,7 +501,6 @@ template void applySSD<double>(
     momentum::span<const JointStateT<double>> jointState,
     MeshT<double>& outputMesh);
 
-// Explicit template instantiations for applySSD with skeleton state (mesh)
 template void applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,
@@ -515,7 +514,6 @@ template void applySSD<double>(
     const SkeletonStateT<double>& state,
     MeshT<double>& outputMesh);
 
-// Explicit template instantiations for applySSD with world transforms vector (mesh)
 template void applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,
@@ -529,7 +527,6 @@ template void applySSD<double>(
     const TransformationListT<double>& worldTransforms,
     MeshT<double>& outputMesh);
 
-// Explicit template instantiations for applySSD with world transforms span (mesh)
 template void applySSD<float>(
     const TransformationListT<float>& inverseBindPose,
     const SkinWeights& skin,

--- a/momentum/character/linear_skinning.h
+++ b/momentum/character/linear_skinning.h
@@ -38,10 +38,26 @@ namespace momentum {
 /// - Forward skinning: Applying joint transformations to deform the mesh
 /// - Inverse skinning: Reversing the deformation to return to bind pose
 
-/// Computes the skinning transforms from joint states and inverse bind poses
+// clang-format off
+/// @par Overload selection guide
 ///
-/// This is a helper function that computes the combined transformation matrices
-/// used for skinning. Each transform is computed as: jointState.transform * inverseBindPose.
+/// | I have...                        | I want...               | Use this overload                                         |
+/// |----------------------------------|-------------------------|-----------------------------------------------------------|
+/// | `SkeletonState` + `Mesh`         | Skinned mesh            | `applySSD(ibp, skin, mesh, state, outMesh)`               |
+/// | `SkeletonState` + points         | Skinned points          | `applySSD(ibp, skin, points, state)` -> returns vector    |
+/// | Precomputed skinning transforms  | Skinned mesh (batched)  | `computeSkinningTransforms()` once, then `applySSD(skin, mesh, transforms, outMesh)` |
+/// | World transforms (no skel state) | Skinned mesh            | `applySSD(ibp, skin, mesh, worldTransforms, outMesh)`     |
+/// | `SkeletonState` + vertex index   | Inverse skin transform  | `getInverseSSDTransformation(ibp, skin, state, index)`    |
+/// | `SkeletonState` + posed points   | Bind-pose points        | `applyInverseSSD(ibp, skin, points, state)`               |
+///
+/// For multi-frame animation with the same character, precompute skinning transforms
+/// once per frame with `computeSkinningTransforms()` and reuse across mesh/point calls.
+/// `ibp` = `inverseBindPose` throughout.
+// clang-format on
+
+/// Computes the skinning transforms from joint states and inverse bind poses.
+///
+/// Each transform is computed as: `jointState.transform * inverseBindPose`.
 ///
 /// @param jointState Span of joint states containing current transformations
 /// @param inverseBindPose Inverse bind pose transformations for each joint

--- a/momentum/character/locator.h
+++ b/momentum/character/locator.h
@@ -17,44 +17,34 @@ namespace momentum {
 /// Locators can be used for various purposes such as tracking specific points
 /// on a character, defining constraints, or serving as targets for inverse kinematics.
 struct Locator {
-  /// Name identifier for the locator
   std::string name;
 
-  /// Index of the parent joint in the skeleton
+  /// Index of the parent joint in the skeleton.
   size_t parent;
 
-  /// Position relative to the parent joint's coordinate system
+  /// Position in the parent joint's local coordinate frame.
   Vector3f offset;
 
-  /// Specifies which axes (x,y,z) are locked (1) or free (0)
+  /// Per-axis lock flags (x, y, z): 1 = locked, 0 = free.
   Vector3i locked;
 
-  /// Influence weight of this locator when used in constraints
+  /// Influence weight when used as a constraint in error functions.
   float weight;
 
-  /// Reference position for limit constraints, typically equal to offset when loaded
+  /// Reference position for limit constraints; typically equals `offset` when loaded.
   Vector3f limitOrigin;
 
-  /// Controls how strongly the locator should maintain its original position
-  /// Higher values create stronger constraints, zero means completely free
+  /// Per-axis strength pulling the locator back toward `limitOrigin`.
+  /// Zero on an axis disables the limit on that axis.
   Vector3f limitWeight;
 
-  /// Indicates whether the locator is attached to the skin of a person (e.g. as in mocap tracking),
+  /// True if the locator is attached to the skin of a person (e.g. as in mocap tracking);
   /// used to determine whether the locator can safely be converted to a skinned locator.
   bool attachedToSkin = false;
 
-  /// Offset from the skin surface, used when trying to solve for body shape using locators.
+  /// Offset from the skin surface, used when solving for body shape using locators.
   float skinOffset = 0.0f;
 
-  /// Creates a locator with the specified properties
-  ///
-  /// @param name Identifier for the locator
-  /// @param parent Index of the parent joint
-  /// @param offset Position relative to the parent joint
-  /// @param locked Axes that are locked (1) or free (0)
-  /// @param weight Influence weight in constraints
-  /// @param limitOrigin Reference position for limit constraints
-  /// @param limitWeight Strength of position maintenance constraints
   Locator(
       const std::string& name = "uninitialized",
       const size_t parent = kInvalidIndex,
@@ -75,10 +65,7 @@ struct Locator {
         attachedToSkin(attachedToSkin),
         skinOffset(skinOffset) {}
 
-  /// Compares two locators for equality, using approximate comparison for floating-point values
-  ///
-  /// @param locator The locator to compare with
-  /// @return True if all properties are equal (or approximately equal for floating-point values)
+  /// Equality comparison; uses approximate (`isApprox`) comparison for floating-point fields.
   inline bool operator==(const Locator& locator) const {
     return (
         (name == locator.name) && (parent == locator.parent) && offset.isApprox(locator.offset) &&

--- a/momentum/character/locator_state.cpp
+++ b/momentum/character/locator_state.cpp
@@ -11,27 +11,21 @@
 
 namespace momentum {
 
-// functions
 void LocatorState::update(
     const SkeletonState& skeletonState,
     const LocatorList& referenceLocators) noexcept {
   const size_t numLocators = referenceLocators.size();
 
-  // resize output arrays
   position.resize(numLocators);
 
-  // get joint state
   const auto& jointState = skeletonState.jointState;
 
-  // go over all locators
   for (size_t locatorID = 0; locatorID < numLocators; locatorID++) {
-    // reference for quick access
     const Locator& locator = referenceLocators[locatorID];
 
-    // get parent id
     const size_t& parentId = locator.parent;
 
-    // transform each locator by its parents transformation and store it in the locator state
+    // Transform each locator by its parent joint's world transform.
     position[locatorID] = jointState[parentId].transform * locator.offset;
   }
 }

--- a/momentum/character/locator_state.h
+++ b/momentum/character/locator_state.h
@@ -22,7 +22,6 @@ struct LocatorState {
   std::vector<Vector3f> position;
 
  public:
-  /// Creates an empty locator state with no positions
   LocatorState() noexcept = default;
 
   /// Creates a locator state and immediately updates positions based on the given skeleton state

--- a/momentum/character/marker.h
+++ b/momentum/character/marker.h
@@ -14,38 +14,34 @@
 
 namespace momentum {
 
-/// Marker represents a motion capture marker that defines an active marker during motion capture.
+/// A single motion capture marker observation (position, occlusion, confidence).
 struct Marker {
-  /// The name of the marker, default is "Undefined"
+  /// The name of the marker.
   std::string name = "Undefined";
 
-  /// The 3D position of the marker as a Vector3d object, where the unit is assumed to be in
-  /// centimeters.
+  /// The 3D position of the marker, in centimeters.
   Vector3d pos = {0.0, 0.0, 0.0};
 
-  /// The occlusion status of the marker, true if occluded, false otherwise.
+  /// True if the marker is occluded in this frame, false if visible.
   bool occluded = true;
 
-  /// How much to trust this observation, eg. a keypoint. The value should be in [0, 1] but not
-  /// enforced.
+  /// Trust weight for this observation (e.g. a keypoint score). Conventionally in [0, 1],
+  /// but the range is not enforced.
   float confidence = 1.0;
 };
 
-/// MarkerSequence stores all the frames from a single capture sequence for one subject (motion
-/// capture actor).
+/// All frames from a single motion capture sequence for one subject (actor).
 ///
-/// Each frame is a std::vector<Marker> containing the position and occlusion status of
-/// all the markers placed on the subject.
-/// The size of the std::vector<Marker> must be consistent for all frames.
+/// @invariant Every inner `frames[i]` vector must have the same size — markers are
+/// indexed positionally and the marker count is fixed across the sequence.
 struct MarkerSequence {
-  /// Name of the actor sequence (typically a unique subject name or ID)
+  /// Identifier for the actor or subject this sequence belongs to.
   std::string name;
 
-  /// A 2D vector that specifies the Marker (name/position/occlusion) for all markers
-  /// throughout all captured frames. Size: [numFrames][numMarkers]
+  /// All marker observations across the sequence. Layout: `[numFrames][numMarkers]`.
   std::vector<std::vector<Marker>> frames;
 
-  /// The frame rate of the motion capture sequence in frames per second (default is 30.0)
+  /// Frame rate of the capture, in frames per second.
   float fps = 30.0f;
 };
 

--- a/momentum/character/mesh_state.cpp
+++ b/momentum/character/mesh_state.cpp
@@ -56,7 +56,8 @@ void MeshStateT<T>::update(
     const Character& character) {
   MT_PROFILE_FUNCTION();
 
-  // Initialize mesh objects on first call if character has mesh data
+  // Lazily allocate the three mesh buffers on the first update; subsequent calls
+  // reuse them in place.
   if (!restMesh_ && character.mesh) {
     neutralMesh_ = std::make_unique<MeshT<T>>(character.mesh->template cast<T>());
     restMesh_ = std::make_unique<MeshT<T>>(character.mesh->template cast<T>());
@@ -64,13 +65,11 @@ void MeshStateT<T>::update(
   }
 
   if (!restMesh_ || !posedMesh_) {
-    return; // No mesh to update
+    return;
   }
 
-  // Update rest mesh with blend shapes and face expressions
   bool doUpdateNormals = false;
 
-  // Apply blend shapes if available
   if (character.blendShape) {
     const BlendWeightsT<T> blendWeights =
         extractBlendWeights(character.parameterTransform, parameters);
@@ -78,12 +77,11 @@ void MeshStateT<T>::update(
     doUpdateNormals = true;
   }
 
-  // Apply face expression blend shapes if available
   if (character.faceExpressionBlendShape) {
     if (!character.blendShape) {
-      // Set restMesh back to neutral, removing potential previous expressions.
-      // Note that if the character comes with (shape) blendShape, the previous if block already
-      // takes care of this step.
+      // Reset restMesh to neutral so previously applied face expressions don't accumulate.
+      // When a shape blendShape is present, the block above already overwrites restMesh
+      // and this reset is unnecessary.
       Eigen::Map<Eigen::VectorX<T>> outputVec(
           &restMesh_->vertices[0][0], restMesh_->vertices.size() * 3);
       const Eigen::Map<Eigen::VectorX<T>> baseVec(
@@ -97,12 +95,10 @@ void MeshStateT<T>::update(
     doUpdateNormals = true;
   }
 
-  // Update normals if blend shapes were applied
   if (doUpdateNormals) {
     restMesh_->updateNormals();
   }
 
-  // Apply skinning to get the posed mesh
   applySSD(
       cast<T>(character.inverseBindPose), *character.skinWeights, *restMesh_, state, *posedMesh_);
 }

--- a/momentum/character/mesh_state.h
+++ b/momentum/character/mesh_state.h
@@ -22,14 +22,14 @@ namespace momentum {
 /// - posedMesh: Final mesh after skinning is applied
 template <typename T>
 struct MeshStateT {
-  std::unique_ptr<MeshT<T>>
-      neutralMesh_; // Rest mesh without facial expression basis,
-                    // used to restore the neutral shape after facial expressions are applied.
-                    // Not used with there is a shape basis.
-  std::unique_ptr<MeshT<T>> restMesh_; // The rest positions of the mesh after shape basis
-                                       // (and potentially facial expression) has been applied
-  std::unique_ptr<MeshT<T>>
-      posedMesh_; // The posed mesh after the skeleton transforms have been applied.
+  /// Rest mesh without the facial expression basis, used to restore the neutral shape
+  /// after facial expressions are applied. Not used when there is a shape basis.
+  std::unique_ptr<MeshT<T>> neutralMesh_;
+  /// Rest positions of the mesh after the shape basis (and potentially facial
+  /// expression basis) has been applied.
+  std::unique_ptr<MeshT<T>> restMesh_;
+  /// Posed mesh after the skeleton transforms have been applied.
+  std::unique_ptr<MeshT<T>> posedMesh_;
 
   /// Creates an empty mesh state
   MeshStateT() noexcept = default;
@@ -39,16 +39,12 @@ struct MeshStateT {
       const Character& character) noexcept;
   ~MeshStateT() noexcept;
 
-  /// Copy constructor
   MeshStateT(const MeshStateT& other);
 
-  /// Copy assignment operator
   MeshStateT& operator=(const MeshStateT& other);
 
-  /// Move constructor
   MeshStateT(MeshStateT&& other) noexcept = default;
 
-  /// Move assignment operator
   MeshStateT& operator=(MeshStateT&& other) noexcept = default;
 
   /// Updates the mesh state based on model parameters and skeleton state

--- a/momentum/character/parameter_limits.cpp
+++ b/momentum/character/parameter_limits.cpp
@@ -30,7 +30,7 @@ std::string_view toString(const LimitType type) {
     case HalfPlane:
       return "HalfPlane";
     case LimitTypeCount:
-      // This is not a real enum value, just a counter
+      // Sentinel value used to count enum entries; not a real limit type.
       return "LimitTypeCount";
     default:
       return "Unknown";
@@ -103,8 +103,8 @@ bool LimitData::operator==(const LimitData& limitData) const {
 }
 
 bool isInRange(const LimitLinear& limit, float value) {
-  // Default initialized limits have all zeros in their members due to the std::fill_n above
-  // but we want in this case to have the limit apply across the entire range of values:
+  // Treat a zero-zero range as "applies everywhere": LimitData's default constructor
+  // zero-fills rawData (see LimitData::LimitData above), so an unset range is (0, 0).
   if (limit.rangeMin == 0 && limit.rangeMax == 0) {
     return true;
   }
@@ -113,8 +113,8 @@ bool isInRange(const LimitLinear& limit, float value) {
 }
 
 bool isInRange(const LimitLinearJoint& limit, float value) {
-  // Default initialized limits have all zeros in their members due to the std::fill_n above
-  // but we want in this case to have the limit apply across the entire range of values:
+  // Treat a zero-zero range as "applies everywhere": LimitData's default constructor
+  // zero-fills rawData (see LimitData::LimitData above), so an unset range is (0, 0).
   if (limit.rangeMin == 0 && limit.rangeMax == 0) {
     return true;
   }

--- a/momentum/character/parameter_limits.h
+++ b/momentum/character/parameter_limits.h
@@ -72,12 +72,15 @@ struct LimitLinearJoint {
   float rangeMax; ///< Non-inclusive
 };
 
+/// Constrains a point (offset in `parent` joint's frame) to lie on the surface of an
+/// ellipsoid defined in `ellipsoidParent`'s frame.
 struct LimitEllipsoid {
-  alignas(32) Affine3f ellipsoid;
-  alignas(32) Affine3f ellipsoidInv;
-  alignas(32) Vector3f offset;
-  size_t ellipsoidParent;
-  size_t parent;
+  alignas(32) Affine3f
+      ellipsoid; ///< Maps the unit sphere to the constraint ellipsoid (in ellipsoidParent's frame)
+  alignas(32) Affine3f ellipsoidInv; ///< Cached inverse of `ellipsoid`
+  alignas(32) Vector3f offset; ///< Constrained point's offset in `parent` joint's local frame
+  size_t ellipsoidParent; ///< Joint whose frame the ellipsoid is defined in
+  size_t parent; ///< Joint whose frame the constrained point is defined in
 };
 
 /// Constraint: (p1, p2) · (normal) - offset >= 0

--- a/momentum/character/parameter_transform.cpp
+++ b/momentum/character/parameter_transform.cpp
@@ -16,7 +16,8 @@
 namespace momentum {
 
 bool PoseConstraint::operator==(const PoseConstraint& poseConstraint) const {
-  // Compare the parameterIdValue as sets
+  // Compare parameterIdValue as sets — the vector ordering is not semantically
+  // meaningful (see header comment on `parameterIdValue`).
   std::map<size_t, float> paramIdToValue1;
   std::copy(
       parameterIdValue.begin(),
@@ -105,7 +106,6 @@ VectorX<bool> ParameterTransformT<T>::computeActiveJointParams(const ParameterSe
   return result;
 }
 
-// map model parameters to joint parameters using a linear transformation
 template <typename T>
 JointParametersT<T> ParameterTransformT<T>::apply(const ModelParametersT<T>& parameters) const {
   MT_PROFILE_FUNCTION();
@@ -122,7 +122,6 @@ JointParametersT<T> ParameterTransformT<T>::apply(const ModelParametersT<T>& par
   return transform * parameters.v + offsets;
 }
 
-// map model parameters to joint parameters using a linear transformation
 template <typename T>
 JointParametersT<T> ParameterTransformT<T>::apply(const CharacterParametersT<T>& parameters) const {
   MT_PROFILE_FUNCTION();
@@ -143,20 +142,17 @@ JointParametersT<T> ParameterTransformT<T>::apply(const CharacterParametersT<T>&
   return result;
 }
 
-// return rest pose parameters
 template <typename T>
 JointParametersT<T> ParameterTransformT<T>::zero() const {
   MT_CHECK(offsets.size() == transform.rows(), "{} is not {}", offsets.size(), transform.rows());
   return offsets;
 }
 
-// return rest pose parameters
 template <typename T>
 JointParametersT<T> ParameterTransformT<T>::bindPose() const {
   return JointParametersT<T>::Zero(transform.rows());
 }
 
-// get a list of scaling parameters
 template <typename T>
 ParameterSet ParameterTransformT<T>::getScalingParameters() const {
   ParameterSet result;
@@ -170,7 +166,9 @@ ParameterSet ParameterTransformT<T>::getScalingParameters() const {
   return result;
 }
 
-// get a list of root parameters
+// TODO: Header Doxygen and impl name disagree — getRigidParameters() also matches
+// any parameter name containing "hips", not just the "root_" prefix. Either tighten
+// the impl to root_-only or update the header doc to mention the hips fallback.
 template <typename T>
 ParameterSet ParameterTransformT<T>::getRigidParameters() const {
   ParameterSet result;
@@ -234,14 +232,13 @@ ParameterTransformT<T> mapParameterTransformJoints(
     const std::vector<size_t>& jointMapping) {
   ParameterTransformT<T> mappedTransform;
 
-  // No change in the parameters:
+  // Model parameter list is preserved verbatim; only the joint dimension is remapped.
   mappedTransform.name = parameterTransform.name;
 
-  // resize the offset matrix to the right size
   mappedTransform.offsets.setZero(numTargetJoints * kParametersPerJoint);
   mappedTransform.activeJointParams.setConstant(numTargetJoints * kParametersPerJoint, false);
 
-  // map the offset from the anim skel to the new one
+  // Re-index per-joint offsets from the source skeleton into the target skeleton.
   for (size_t i = 0; i < jointMapping.size(); i++) {
     if (jointMapping[i] != kInvalidIndex) {
       for (size_t d = 0; d < kParametersPerJoint; d++) {
@@ -251,11 +248,13 @@ ParameterTransformT<T> mapParameterTransformJoints(
     }
   }
 
-  // map the transform from the anim skel to the new one
+  // Re-index transform rows (joint parameters) from the source skeleton into the
+  // target skeleton; columns (model parameters) are unchanged.
   std::vector<Eigen::Triplet<float>> triplets;
   for (int k = 0; k < parameterTransform.transform.outerSize(); ++k) {
     for (typename SparseRowMatrix<T>::InnerIterator it(parameterTransform.transform, k); it; ++it) {
-      // row is joint + type index, col is parameter
+      // row encodes (joint index * kParametersPerJoint + parameter type); col is the model
+      // parameter.
       const int jIndex = static_cast<int>(it.row()) / kParametersPerJoint;
       const int jOffset = static_cast<int>(it.row()) % kParametersPerJoint;
 
@@ -270,20 +269,18 @@ ParameterTransformT<T> mapParameterTransformJoints(
               static_cast<int>(it.col()),
               it.value()));
 
-      // enable joint channels
+      // Mark this remapped joint parameter row as driven by some model parameter.
       mappedTransform.activeJointParams[mappedJoint * kParametersPerJoint + jOffset] = true;
     }
   }
 
-  // resize the Transform matrix to the correct size
   mappedTransform.transform.resize(
       static_cast<int>(numTargetJoints) * kParametersPerJoint,
       static_cast<int>(mappedTransform.name.size()));
 
-  // create sparse matrix from triplet
   mappedTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
 
-  // copy over the parameterSets
+  // Pass-through metadata: none of these depend on the joint remapping.
   mappedTransform.parameterSets = parameterTransform.parameterSets;
   mappedTransform.poseConstraints = parameterTransform.poseConstraints;
   mappedTransform.blendShapeParameters = parameterTransform.blendShapeParameters;

--- a/momentum/character/parameter_transform.h
+++ b/momentum/character/parameter_transform.h
@@ -18,11 +18,11 @@
 namespace momentum {
 
 struct PoseConstraint {
-  /// A vector of tuple of type: (model parameter index, parameter value).
-  /// The model parameter index must be in [0, numModelParameters.size()).
+  /// A vector of tuples of type: (model parameter index, parameter value).
+  /// The model parameter index must be in [0, numAllModelParameters()).
   /// The value of the model parameters specified here are kept constant (= parameter value) during
   /// optimization. The ordering of elements in the vector doesn't matter (making it an unordered
-  /// map would be more semantically correct) since it stores an index to the model parameters
+  /// map would be more semantically correct) since it stores an index to the model parameters.
   std::vector<std::pair<size_t, float>> parameterIdValue;
 
   bool operator==(const PoseConstraint& poseConstraint) const;
@@ -33,9 +33,31 @@ using PoseConstraints = std::unordered_map<std::string, PoseConstraint>;
 
 /// A parameter transform is an abstraction of the joint parameters that maps a model_parameter
 /// vector to a joint_parameter vector. It allows mapping a single model_parameter to multiple
-/// joints, and a single joint being influenced by multiple model_parameters joint parameters are
-/// calculated from parameters in the following way : <joint_parameters> = <transform> *
-/// <model_parameters> + <offsets>
+/// joints, and a single joint being influenced by multiple model_parameters. Joint parameters are
+/// calculated from model parameters in the following way:
+/// `<joint_parameters> = <transform> * <model_parameters> + <offsets>`
+///
+/// @par Parameter enablement hierarchy
+///
+/// Momentum has three levels of parameter enablement that interact:
+///
+/// 1. **Model parameters** (`ParameterSet`): A bitset over the ~200 model parameters.
+///    The solver's `setEnabledParameters()` operates at this level. A model parameter
+///    being disabled means it won't be optimized.
+///
+/// 2. **Joint parameters** (`activeJointParams`): A boolean vector over all
+///    `numJoints * 7` joint parameters. Computed from the `transform` sparse matrix —
+///    if any model parameter drives joint J's RX column, then `activeJointParams[J*7+3]`
+///    is true. Error functions check this to skip zero Jacobian columns.
+///    Recomputed via `computeActiveJointParams(enabledModelParams)`.
+///
+/// 3. **Solver active set** (`SolverT::activeParameters_`): The solver's internal
+///    copy of the enabled model parameters. Passed to `SolverFunctionT` which
+///    forwards to error functions.
+///
+/// When adding a new error function, you typically check `activeJointParams_` (level 2)
+/// to determine which joint parameter columns to compute Jacobians for. You do NOT
+/// need to check model-level enablement — the solver handles that mapping.
 template <typename T>
 struct ParameterTransformT {
   /// The list of model parameter names.
@@ -147,7 +169,7 @@ struct ParameterTransformT {
   /// Dimension of facial expression parameters.
   [[nodiscard]] Eigen::Index numFaceExpressionParameters() const;
 
-  /// Dimension of facial expression parameters.
+  /// Dimension of skinned locator parameters (3 per skinned locator: x, y, z).
   [[nodiscard]] Eigen::Index numSkinnedLocatorParameters() const;
 
   /// Dimension of skeletal model parameters, including pose parameters,

--- a/momentum/character/pose_shape.cpp
+++ b/momentum/character/pose_shape.cpp
@@ -19,15 +19,16 @@ std::vector<Vector3f> PoseShape::compute(const SkeletonState& state) const {
       baseShape.size(),
       shapeVectors.rows());
 
-  // compute coefficients
   VectorXf coefficients(shapeVectors.cols());
 
-  // calculate base transform
+  // If baseJoint is out of range, fall back to baseRot directly (no relative rotation).
   const Quaternionf base = (baseJoint < state.jointState.size())
       ? baseRot * state.jointState.at(baseJoint).rotation().inverse()
       : baseRot;
 
-  // set up pose shape coefficients
+  // Pack each driving joint's rotation (relative to base) as a 4-vector of quaternion
+  // coefficients (x, y, z, w). Out-of-range joints leave their segment uninitialized.
+  // TODO: zero-initialize `coefficients` so out-of-range joint indices don't read garbage.
   for (size_t i = 0; i < jointMap.size(); i++) {
     const auto& jid = jointMap[i];
     if (jid < state.jointState.size()) {
@@ -35,7 +36,6 @@ std::vector<Vector3f> PoseShape::compute(const SkeletonState& state) const {
     }
   }
 
-  // use the coefficients to calculate the new base shape
   std::vector<Vector3f> output(baseShape.size() / 3);
   if (output.empty()) {
     return output;

--- a/momentum/character/pose_shape.h
+++ b/momentum/character/pose_shape.h
@@ -40,20 +40,14 @@ struct PoseShape {
   /// Each column corresponds to a quaternion component (x,y,z,w) of a joint.
   MatrixXf shapeVectors;
 
-  /// Computes the deformed shape based on the current skeleton state.
+  /// Computes the deformed shape vertices for the given skeleton pose.
   ///
-  /// @param state Current state of the skeleton containing joint rotations
-  /// @return Vector of 3D vertex positions representing the deformed shape
-  /// @throws If baseShape.size() != shapeVectors.rows()
+  /// @return Flattened 3D vertex positions, length `baseShape.size() / 3`.
+  /// @throws If `baseShape.size() != shapeVectors.rows()`.
   [[nodiscard]] std::vector<Vector3f> compute(const SkeletonState& state) const;
 
-  /// Checks if this PoseShape is approximately equal to another.
-  ///
-  /// Two PoseShape objects are considered approximately equal if all their
-  /// corresponding members are approximately equal.
-  ///
-  /// @param poseShape The PoseShape to compare with
-  /// @return True if the PoseShape objects are approximately equal
+  /// Returns true if all members are approximately equal (uses `Eigen::isApprox`
+  /// for floating-point members and exact equality for `baseJoint`/`jointMap`).
   [[nodiscard]] inline bool isApprox(const PoseShape& poseShape) const {
     return (
         (baseJoint == poseShape.baseJoint) && baseRot.isApprox(poseShape.baseRot) &&

--- a/momentum/character/sdf_collision_geometry.h
+++ b/momentum/character/sdf_collision_geometry.h
@@ -23,7 +23,6 @@ namespace momentum {
 /// SDF collision geometry for character collision detection.
 ///
 /// Defined by a transformation, parent joint, and a shared pointer to a SignedDistanceField.
-/// The SDF data is shared to avoid expensive copies of large SDF volumes.
 template <typename S>
 struct SDFColliderT {
   using Scalar = S;
@@ -37,24 +36,23 @@ struct SDFColliderT {
   /// fixed in world space.
   size_t parent = kInvalidIndex;
 
-  /// Shared pointer to the SignedDistanceField data.
-  /// Using shared_ptr to avoid expensive copies of potentially large SDF volumes.
+  /// Shared pointer to the SignedDistanceField data. Uses shared_ptr to avoid
+  /// expensive copies of potentially large SDF volumes.
   std::shared_ptr<const SDFType> sdf;
 
-  SDFColliderT() : transformation(TransformT<S>()), parent(kInvalidIndex), sdf(nullptr) {
-    // Empty
-  }
+  SDFColliderT() : transformation(TransformT<S>()), parent(kInvalidIndex), sdf(nullptr) {}
 
-  /// Constructor with SDF initialization.
   SDFColliderT(
       const TransformT<S>& transform,
       size_t parentJoint,
       std::shared_ptr<const SDFType> sdfPtr)
-      : transformation(transform), parent(parentJoint), sdf(std::move(sdfPtr)) {
-    // Empty
-  }
+      : transformation(transform), parent(parentJoint), sdf(std::move(sdfPtr)) {}
 
   /// Checks if the current SDF collider is approximately equal to another.
+  ///
+  /// SDF data is compared by pointer identity, not by value: two colliders sharing the
+  /// same `SignedDistanceField` instance are considered equal, but two colliders pointing
+  /// to distinct instances with identical contents are not.
   [[nodiscard]] bool isApprox(const SDFColliderT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
       const {
     if (!transformation.isApprox(other.transformation, tol)) {
@@ -65,7 +63,6 @@ struct SDFColliderT {
       return false;
     }
 
-    // Compare SDF pointers - they should point to the same SDF instance
     if (sdf != other.sdf) {
       return false;
     }
@@ -73,7 +70,8 @@ struct SDFColliderT {
     return true;
   }
 
-  /// Checks if the SDF collider is valid (has a valid SDF pointer).
+  /// Returns true when the collider holds a non-null SDF and is therefore usable for
+  /// collision queries.
   [[nodiscard]] bool isValid() const {
     return sdf != nullptr;
   }

--- a/momentum/character/skeleton.cpp
+++ b/momentum/character/skeleton.cpp
@@ -14,7 +14,8 @@ namespace momentum {
 
 template <typename T>
 SkeletonT<T>::SkeletonT(JointList joints_in) : joints(std::move(joints_in)) {
-  // Ensure some invariants of the skeleton:
+  // Invariant: parents must precede children in the joint list. Many algorithms
+  // (e.g. forward kinematics, getChildrenJoints) rely on this topological order.
   for (size_t iJoint = 0; iJoint < joints.size(); ++iJoint) {
     MT_CHECK(joints[iJoint].parent == kInvalidIndex || joints[iJoint].parent < iJoint);
   }
@@ -54,7 +55,8 @@ std::vector<size_t> SkeletonT<T>::getChildrenJoints(const size_t jointId, const 
   std::vector<int> jointDistance(joints.size(), -1);
   jointDistance[jointId] = 0;
 
-  // traversal assuming parentJoint < childJoint
+  // Single forward pass works because the constructor guarantees parent index <
+  // child index, so every descendant of jointId has a higher index.
   for (size_t jointIter = jointId + 1; jointIter < joints.size(); ++jointIter) {
     const auto jointParent = joints[jointIter].parent;
     const int distParent = (jointParent == kInvalidIndex) ? -1 : jointDistance[jointParent];

--- a/momentum/character/skeleton.h
+++ b/momentum/character/skeleton.h
@@ -20,67 +20,50 @@ namespace momentum {
 /// The skeletal structure of a momentum Character.
 template <typename T>
 struct SkeletonT {
-  /// The list of joints in this skeleton.
+  /// The list of joints in this skeleton, ordered such that every joint's parent
+  /// appears earlier in the list (parent index < child index, or kInvalidIndex for roots).
   JointList joints;
 
-  /// Default constructor
   SkeletonT() = default;
 
-  /// Constructor that validates joint hierarchy.
-  /// Ensures parent indices are valid (parent < child index or kInvalidIndex).
+  /// @pre Every joint's parent index is either less than its own index or kInvalidIndex.
+  /// @throws if the hierarchy invariant is violated.
   explicit SkeletonT(JointList joints);
 
-  /// Copy constructor
   SkeletonT(const SkeletonT& other) = default;
-
-  /// Move constructor
   SkeletonT(SkeletonT&& other) noexcept = default;
-
-  /// Copy assignment operator
   SkeletonT& operator=(const SkeletonT& other) = default;
-
-  /// Move assignment operator
   SkeletonT& operator=(SkeletonT&& other) noexcept = default;
-
-  /// Destructor
   ~SkeletonT() = default;
 
   /// Returns the index of a joint with the given name, or kInvalidIndex if not found.
   [[nodiscard]] size_t getJointIdByName(std::string_view name) const;
 
-  /// Returns a vector containing all joint names in the skeleton.
   [[nodiscard]] std::vector<std::string> getJointNames() const;
 
-  /// Returns indices of child joints for the specified joint.
+  /// Returns indices of child joints of the specified joint.
   ///
   /// @param jointId Index of the joint to find children for
   /// @param recursive If true, returns all descendants; if false, only direct children
   /// @throws std::out_of_range if jointId is invalid
   [[nodiscard]] std::vector<size_t> getChildrenJoints(size_t jointId, bool recursive = true) const;
 
-  /// Determines if one joint is an ancestor of another in the hierarchy.
+  /// Returns true if `ancestorJointId` is an ancestor of `jointId`.
   ///
-  /// Returns true if ancestorJointId is an ancestor of jointId.
-  /// A joint is considered to be its own ancestor (isAncestor(id, id) returns true).
+  /// A joint is considered to be its own ancestor (`isAncestor(id, id)` returns true).
   [[nodiscard]] bool isAncestor(size_t jointId, size_t ancestorJointId) const;
 
-  /// Checks if two joints are the same joint or directly adjacent (one is the direct parent
-  /// of the other) in the skeleton hierarchy.
+  /// Returns true if the two joints are the same, or one is the direct parent of the other.
   ///
   /// Returns false if either joint is kInvalidIndex, since world-fixed entities have no
   /// joint ancestry and are never considered adjacent to skeleton joints.
   [[nodiscard]] bool isSameOrAdjacentJoints(size_t joint1, size_t joint2) const;
 
-  /// Finds the closest common ancestor of two joints in the hierarchy.
-  ///
-  /// Returns the index of the joint that is the lowest common ancestor
-  /// in the hierarchy for the two specified joints. Returns kInvalidIndex
+  /// Returns the lowest common ancestor of two joints in the hierarchy, or kInvalidIndex
   /// if either joint is kInvalidIndex.
   [[nodiscard]] size_t commonAncestor(size_t joint1, size_t joint2) const;
 
-  /// Converts the skeleton to use a different scalar type.
-  ///
-  /// Returns a copy of this skeleton with all numeric values converted to type U.
+  /// Returns a copy of this skeleton with all numeric values converted to scalar type `U`.
   template <typename U>
   [[nodiscard]] SkeletonT<U> cast() const {
     if constexpr (std::is_same_v<T, U>) {

--- a/momentum/character/skeleton_state.cpp
+++ b/momentum/character/skeleton_state.cpp
@@ -86,13 +86,9 @@ void SkeletonStateT<T>::set(
 template <typename T>
 void SkeletonStateT<T>::set(const Skeleton& referenceSkeleton, bool computeDeriv) {
   MT_PROFILE_FUNCTION();
-  // get input joints
   const JointListT<T>& joints = ::momentum::cast<T>(referenceSkeleton.joints);
-
-  // initialize array size variables
   const size_t numJoints = joints.size();
 
-  // ensure that all variables are valid
   MT_CHECK(
       jointParameters.size() == static_cast<Eigen::Index>(numJoints * kParametersPerJoint),
       "Unexpected joint parameter size. Expected '{}' (# of joints '{}' X kParametersPerJoint '{}') but got '{}'.",
@@ -101,16 +97,14 @@ void SkeletonStateT<T>::set(const Skeleton& referenceSkeleton, bool computeDeriv
       kParametersPerJoint,
       jointParameters.size());
 
-  // go over all joint elements and calculate Transformation
+  // IMPORTANT: this single forward pass assumes parents always precede their children in the
+  // joint list (i.e. the skeleton is topologically sorted). Each child reads its parent's
+  // already-computed JointState, so violating that ordering will silently propagate stale
+  // parent transforms into children.
   for (size_t jointID = 0; jointID < numJoints; jointID++) {
     const Eigen::Index parameterOffset = jointID * kParametersPerJoint;
-
-    // some reference for quick access
     const JointT<T>& joint = joints[jointID];
 
-    // set joint-state based on parameters
-    // IMPORTANT: this all assumes that parent joints always appear before their children in the
-    // joint list, so their joint state will already be calculated when processing the children
     if (joint.parent == kInvalidIndex) {
       jointState[jointID].set(
           joint, jointParameters.v.template middleRows<7>(parameterOffset), nullptr, computeDeriv);
@@ -123,7 +117,6 @@ void SkeletonStateT<T>::set(const Skeleton& referenceSkeleton, bool computeDeriv
     }
   }
 
-  // ensure arrays are valid
   MT_CHECK(jointState.size() == numJoints, "{} is not {}", jointState.size(), numJoints);
 }
 
@@ -141,7 +134,6 @@ template <typename T>
 StateSimilarity SkeletonStateT<T>::compare(
     const SkeletonStateT<T>& state1,
     const SkeletonStateT<T>& state2) {
-  // check that we're actually good to compare the states
   MT_CHECK(
       state1.jointParameters.size() == state2.jointParameters.size(),
       "{} is not {}",
@@ -157,7 +149,10 @@ StateSimilarity SkeletonStateT<T>::compare(
   result.positionError.resize(state1.jointState.size());
   result.orientationError.resize(state1.jointState.size());
 
-  // calculate position error and orientation error in global coordinates per joint
+  // Per-joint position/orientation error in world space. Quaternion dot is clamped to [-1, 1]
+  // to guard acos against numerical drift just outside the valid domain, and the sign flip on
+  // negative dot picks the shorter of the two equivalent quaternion representations (q and -q
+  // encode the same rotation) so the angular error stays in [0, pi].
   for (size_t i = 0; i < state1.jointState.size(); i++) {
     result.positionError[i] =
         (state1.jointState[i].translation() - state2.jointState[i].translation()).norm();
@@ -171,9 +166,11 @@ StateSimilarity SkeletonStateT<T>::compare(
     result.orientationError[i] = gsl::narrow_cast<float>(T(2) * std::acos(sgn * dot));
   }
 
-  // derive RMSE/max values
   result.positionRMSE = std::sqrt(
       result.positionError.squaredNorm() / static_cast<float>(result.positionError.size()));
+  // TODO: orientationRMSE divides by positionError.size() instead of orientationError.size().
+  // The sizes are identical today (both resized to jointState.size() above), so this is harmless,
+  // but it's a latent bug if the two arrays ever diverge. Use orientationError.size() here.
   result.orientationRMSE = std::sqrt(
       result.orientationError.squaredNorm() / static_cast<float>(result.positionError.size()));
   result.positionMax = result.positionError.maxCoeff();
@@ -182,8 +179,11 @@ StateSimilarity SkeletonStateT<T>::compare(
   return result;
 }
 
-// It turns out because the body is topologically sorted, there is a pretty simple algorithm for
-// computing the common ancestor.
+// Because the skeleton is topologically sorted (parent index < child index), the lowest common
+// ancestor of A and B can be found by repeatedly walking the joint with the larger index up to
+// its parent until both pointers meet. We accumulate the local-transform chain on each side,
+// so the final result composes A->ancestor and ancestor->B without ever inverting world-space
+// transforms.
 template <typename T>
 TransformT<T> transformAtoB(
     size_t jointA,
@@ -197,11 +197,10 @@ TransformT<T> transformAtoB(
   TransformT<T> A_to_ancestorA;
 
   while (true) {
-    // Note that we treat kInvalidIndex as if it is the _lowest_ index, as the world is the
-    // topological ancestor of everything.
+    // kInvalidIndex represents "world" and is treated as the lowest index, since world is the
+    // topological ancestor of every joint.
     if (ancestorB != kInvalidIndex && (ancestorA == kInvalidIndex || ancestorA < ancestorB)) {
-      // parentB can't possible be a parent of parentA, so move parentB up one level in the
-      // hierarchy.
+      // ancestorB has the larger index, so it cannot be an ancestor of ancestorA -- walk B up.
       B_to_ancestorB = skelState.jointState[ancestorB].localTransform * B_to_ancestorB;
       if (ancestorB < referenceSkeleton.joints.size()) {
         ancestorB = referenceSkeleton.joints[ancestorB].parent;
@@ -217,12 +216,11 @@ TransformT<T> transformAtoB(
         break;
       }
     } else {
-      // Reached a common ancestor of A and B so we can stop.
+      // Indices are equal -- we've reached the common ancestor.
       break;
     }
   }
 
-  // At this point, ancestorA == ancestorB.
   MT_CHECK(ancestorA == ancestorB, "{} is not {}", ancestorA, ancestorB);
   return B_to_ancestorB.inverse() * A_to_ancestorA;
 }
@@ -253,13 +251,15 @@ JointParametersT<T> skeletonStateToJointParameters(
   JointParametersT<T> result =
       JointParametersT<T>::Zero(skeleton.joints.size() * kParametersPerJoint);
   for (size_t i = 0; i < skeleton.joints.size(); ++i) {
+    // TODO: parentJoint and parentXF are computed but never used in this overload -- the local
+    // transform is read directly from jointState[i].localTransform. Remove the dead lookup, or
+    // assert it matches parentXF.inverse() * jointState[i].transform.
     const auto parentJoint = skeleton.joints[i].parent;
     TransformT<T> parentXF;
     if (parentJoint != kInvalidIndex) {
       parentXF = state.jointState[parentJoint].transform;
     }
 
-    // parentXF * localXF = jointXF
     const TransformT<T> localXF = state.jointState[i].localTransform;
     result.v.template segment<kParametersPerJoint>(i * kParametersPerJoint) =
         localTransformToJointParameters(skeleton.joints[i], localXF);
@@ -281,7 +281,7 @@ JointParametersT<T> skeletonStateToJointParameters(
       parentXF = state[parentJoint];
     }
 
-    // parentXF * localXF = jointXF
+    // parentXF * localXF = jointXF, so localXF = parentXF^-1 * jointXF.
     const TransformT<T> localXF = parentXF.inverse() * state[i];
     result.v.template segment<kParametersPerJoint>(i * kParametersPerJoint) =
         localTransformToJointParameters(skeleton.joints[i], localXF);
@@ -291,18 +291,10 @@ JointParametersT<T> skeletonStateToJointParameters(
 
 namespace {
 
-/// Helper function to convert a local transform to joint parameters respecting active joint params.
-///
-/// This function replaces the original `localTransformToJointParameters` to respect parameter
-/// constraints. It uses different rotation conversion methods based on how many rotation
-/// axes are active for the joint.
-///
-/// @tparam T The scalar type (float or double)
-/// @param[in] joint The joint definition
-/// @param[in] localTransform The local transform to convert
-/// @param[in] activeJointParams Boolean array indicating which joint parameters are active
-/// @param[in] jointIndex The index of this joint
-/// @return Joint parameter vector for this joint
+// Constrained inverse of localTransformToJointParameters: zero-fill any parameter slot whose
+// activeJointParams entry is false, and pick the rotation extraction that matches how many
+// rotation axes are active. This avoids the Euler-angle ambiguity that the unconstrained 3-axis
+// path suffers from when a joint really only has 1 or 2 free rotation DOFs.
 template <typename T>
 [[nodiscard]] Eigen::Vector<T, kParametersPerJoint>
 localTransformToJointParametersRespectingConstraints(
@@ -314,21 +306,17 @@ localTransformToJointParametersRespectingConstraints(
 
   Eigen::Vector<T, kParametersPerJoint> result = Eigen::Vector<T, kParametersPerJoint>::Zero();
 
-  // Handle translation (same as original)
   for (int k = 0; k < 3; ++k) {
     if (activeJointParams[paramOffset + k]) {
       result(k) = localTransform.translation(k) - static_cast<T>(joint.translationOffset(k));
     }
   }
 
-  // Handle rotation based on active parameters
+  // Strip the joint's pre-rotation so we work in the joint's own rotation frame.
   const Eigen::Quaternion<T> localRotation =
       joint.preRotation.template cast<T>().inverse() * localTransform.rotation;
 
-  // Convert to rotation matrix for the new rotation functions
   const Matrix3<T> rotationMatrix = localRotation.toRotationMatrix();
-
-  // Determine which rotation axes are active
 
   std::array<int, 3> activeAxes{};
   size_t numActiveAxes = 0;
@@ -339,25 +327,22 @@ localTransformToJointParametersRespectingConstraints(
   }
 
   if (numActiveAxes == 1) {
-    // Single axis rotation - use rotationMatrixToOneAxisEuler
     const auto axis = activeAxes[0];
     const T angle = rotationMatrixToOneAxisEuler(rotationMatrix, axis);
     result(3 + axis) = angle;
   } else if (numActiveAxes == 2) {
-    // Two axis rotation - use rotationMatrixToTwoAxisEuler
     const Vector2<T> angles =
         rotationMatrixToTwoAxisEuler(rotationMatrix, activeAxes[0], activeAxes[1]);
     result(3 + activeAxes[0]) = angles[0];
     result(3 + activeAxes[1]) = angles[1];
   } else if (numActiveAxes == 3) {
-    // Three axis rotation - use the existing quaternion to Euler conversion (equivalent to
-    // original)
+    // ZYX-then-reverse matches the (Rx * Ry * Rz) convention used elsewhere in momentum and
+    // produces the same parameters as the unconstrained quaternionToEuler path.
     result.template segment<3>(3) = rotationMatrixToEulerZYX(rotationMatrix).reverse();
   } else {
-    // No active rotation axes, don't convert rotation.
+    // numActiveAxes == 0: leave rotation parameters at zero.
   }
 
-  // Handle scale (same as original)
   if (activeJointParams[paramOffset + 6]) {
     result(6) = std::log2(localTransform.scale);
   }
@@ -384,13 +369,15 @@ JointParametersT<T> skeletonStateToJointParametersRespectingActiveParameters(
       JointParametersT<T>::Zero(skeleton.joints.size() * kParametersPerJoint);
 
   for (size_t i = 0; i < skeleton.joints.size(); ++i) {
+    // TODO: parentJoint and parentXF are computed but never used in this overload -- the local
+    // transform is read directly from jointState[i].localTransform. Remove the dead lookup, or
+    // assert it matches parentXF.inverse() * jointState[i].transform.
     const auto parentJoint = skeleton.joints[i].parent;
     TransformT<T> parentXF;
     if (parentJoint != kInvalidIndex) {
       parentXF = state.jointState[parentJoint].transform;
     }
 
-    // parentXF * localXF = jointXF
     const TransformT<T> localXF = state.jointState[i].localTransform;
     result.v.template segment<kParametersPerJoint>(i * kParametersPerJoint) =
         localTransformToJointParametersRespectingConstraints(
@@ -423,7 +410,7 @@ JointParametersT<T> skeletonStateToJointParametersRespectingActiveParameters(
       parentXF = state[parentJoint];
     }
 
-    // parentXF * localXF = jointXF
+    // parentXF * localXF = jointXF, so localXF = parentXF^-1 * jointXF.
     const TransformT<T> localXF = parentXF.inverse() * state[i];
     result.v.template segment<kParametersPerJoint>(i * kParametersPerJoint) =
         localTransformToJointParametersRespectingConstraints(

--- a/momentum/character/skeleton_state.h
+++ b/momentum/character/skeleton_state.h
@@ -56,7 +56,14 @@ struct SkeletonStateT {
   ///
   /// @param parameters Joint parameters for all joints in the skeleton
   /// @param referenceSkeleton The skeleton structure defining joint hierarchy
-  /// @param computeDeriv Whether to compute derivative information for the joints
+  /// @param computeDeriv If true, computes `translationAxis` and `rotationAxis`
+  ///   matrices needed for Jacobian computation in error functions. Set to false
+  ///   ONLY when the state is used for visualization, FK output inspection, or IO —
+  ///   never when the state will be passed to a solver or error function.
+  ///   Skipping derivatives saves ~30% of per-joint FK cost.
+  ///   When false, `derivDirty` is set to true and derivative accessors
+  ///   (`getRotationDerivative`, `getTranslationDerivative`, `getScaleDerivative`)
+  ///   return invalid results.
   SkeletonStateT(
       const JointParametersT<T>& parameters,
       const Skeleton& referenceSkeleton,
@@ -66,7 +73,14 @@ struct SkeletonStateT {
   ///
   /// @param parameters Joint parameters for all joints in the skeleton (moved from)
   /// @param referenceSkeleton The skeleton structure defining joint hierarchy
-  /// @param computeDeriv Whether to compute derivative information for the joints
+  /// @param computeDeriv If true, computes `translationAxis` and `rotationAxis`
+  ///   matrices needed for Jacobian computation in error functions. Set to false
+  ///   ONLY when the state is used for visualization, FK output inspection, or IO —
+  ///   never when the state will be passed to a solver or error function.
+  ///   Skipping derivatives saves ~30% of per-joint FK cost.
+  ///   When false, `derivDirty` is set to true and derivative accessors
+  ///   (`getRotationDerivative`, `getTranslationDerivative`, `getScaleDerivative`)
+  ///   return invalid results.
   SkeletonStateT(
       JointParametersT<T>&& parameters,
       const Skeleton& referenceSkeleton,
@@ -83,7 +97,14 @@ struct SkeletonStateT {
   ///
   /// @param jointParameters New joint parameters for all joints
   /// @param referenceSkeleton The skeleton structure defining joint hierarchy
-  /// @param computeDeriv Whether to compute derivative information for the joints
+  /// @param computeDeriv If true, computes `translationAxis` and `rotationAxis`
+  ///   matrices needed for Jacobian computation in error functions. Set to false
+  ///   ONLY when the state is used for visualization, FK output inspection, or IO —
+  ///   never when the state will be passed to a solver or error function.
+  ///   Skipping derivatives saves ~30% of per-joint FK cost.
+  ///   When false, `derivDirty` is set to true and derivative accessors
+  ///   (`getRotationDerivative`, `getTranslationDerivative`, `getScaleDerivative`)
+  ///   return invalid results.
   void set(
       const JointParametersT<T>& jointParameters,
       const Skeleton& referenceSkeleton,
@@ -93,7 +114,14 @@ struct SkeletonStateT {
   ///
   /// @param jointParameters New joint parameters for all joints (moved from)
   /// @param referenceSkeleton The skeleton structure defining joint hierarchy
-  /// @param computeDeriv Whether to compute derivative information for the joints
+  /// @param computeDeriv If true, computes `translationAxis` and `rotationAxis`
+  ///   matrices needed for Jacobian computation in error functions. Set to false
+  ///   ONLY when the state is used for visualization, FK output inspection, or IO —
+  ///   never when the state will be passed to a solver or error function.
+  ///   Skipping derivatives saves ~30% of per-joint FK cost.
+  ///   When false, `derivDirty` is set to true and derivative accessors
+  ///   (`getRotationDerivative`, `getTranslationDerivative`, `getScaleDerivative`)
+  ///   return invalid results.
   void set(
       JointParametersT<T>&& jointParameters,
       const Skeleton& referenceSkeleton,
@@ -135,7 +163,14 @@ struct SkeletonStateT {
   /// Updates the joint states based on the current joint parameters
   ///
   /// @param referenceSkeleton The skeleton structure defining joint hierarchy
-  /// @param computeDeriv Whether to compute derivative information for the joints
+  /// @param computeDeriv If true, computes `translationAxis` and `rotationAxis`
+  ///   matrices needed for Jacobian computation in error functions. Set to false
+  ///   ONLY when the state is used for visualization, FK output inspection, or IO —
+  ///   never when the state will be passed to a solver or error function.
+  ///   Skipping derivatives saves ~30% of per-joint FK cost.
+  ///   When false, `derivDirty` is set to true and derivative accessors
+  ///   (`getRotationDerivative`, `getTranslationDerivative`, `getScaleDerivative`)
+  ///   return invalid results.
   void set(const Skeleton& referenceSkeleton, bool computeDeriv);
 
   /// Copies joint states from another skeleton state with a different scalar type
@@ -165,9 +200,37 @@ TransformT<T> transformAtoB(
     const Skeleton& referenceSkeleton,
     const SkeletonStateT<T>& skelState);
 
+/// @name Inverse FK: Skeleton State → Joint Parameters
+///
+/// Four variants exist for converting skeleton state back to joint parameters:
+///
+// clang-format off
+/// | Scenario                          | Function                                              |
+/// |-----------------------------------|-------------------------------------------------------|
+/// | General 3-axis joints             | `skeletonStateToJointParameters(state, skeleton)`     |
+/// | Joints with <3 rotation DOF       | `skeletonStateToJointParametersRespectingActiveParameters(state, skeleton, activeJointParams)` |
+/// | Starting from transforms          | `skeletonStateToJointParameters(transforms, skeleton)` |
+/// | Transforms + constrained DOF      | `skeletonStateToJointParametersRespectingActiveParameters(transforms, skeleton, activeJointParams)` |
+// clang-format on
+///
+/// The "RespectingActiveParameters" variants use `rotationMatrixToOneAxisEuler` or
+/// `rotationMatrixToTwoAxisEuler` for joints with restricted DOF, avoiding Euler
+/// angle ambiguity that the standard 3-axis extraction suffers from.
+/// @{
+
 /// Invert the skeleton state (global transforms in world space) back to joint parameters (Euler
 /// angles in local space).  Note that this conversion is not unique due to the non-uniqueness of
 /// Euler angle conversion.
+///
+/// @warning Euler angle extraction is numerically unstable near gimbal lock
+/// (±90° pitch / Y-axis rotation). Near these configurations:
+/// - Float precision: round-trip FK → inverse FK can shift angles by ~1e-3 radians
+/// - Double precision: ~1e-10 radians
+/// - The extracted angles may "flip" to an equivalent but numerically different representation
+///
+/// For joints with fewer than 3 rotation DOF, prefer
+/// `skeletonStateToJointParametersRespectingActiveParameters()` which uses
+/// constrained Euler extraction and avoids the ambiguity entirely.
 template <typename T>
 [[nodiscard]] JointParametersT<T> skeletonStateToJointParameters(
     const SkeletonStateT<T>& state,
@@ -223,5 +286,7 @@ template <typename T>
     const TransformListT<T>& state,
     const Skeleton& skeleton,
     const VectorX<bool>& activeJointParams);
+
+/// @}
 
 } // namespace momentum

--- a/momentum/character/skeleton_utility.cpp
+++ b/momentum/character/skeleton_utility.cpp
@@ -16,12 +16,10 @@ ModelParameters extrapolateModelParameters(
     const float factor,
     const float maxDelta) {
   MT_PROFILE_FUNCTION();
-  // check if we have any reasonable data
   if (current.size() != previous.size()) {
     return current;
   }
 
-  // yes, perform extrapolation
   ModelParameters result =
       current.v + (current.v - previous.v).cwiseMin(maxDelta).cwiseMax(-maxDelta) * factor;
 
@@ -39,9 +37,8 @@ ModelParameters extrapolateModelParameters(
     return current;
   }
 
-  // yes, perform extrapolation
-  // Cap the maximum extrapolation angle to avoid issues where the extrapolation grows over time.
-
+  // Clamp the per-parameter delta to maxDelta so repeated extrapolation cannot
+  // accumulate unbounded growth across frames.
   const auto sz = current.size();
   ModelParameters result = current;
   for (Eigen::Index i = 0; i < sz; ++i) {

--- a/momentum/character/skeleton_utility.h
+++ b/momentum/character/skeleton_utility.h
@@ -27,7 +27,8 @@ inline constexpr float kDefaultExtrapolateMaxDelta = 0.4f; // ~23 degrees
 /// Extrapolates model parameters considering active parameters. The extrapolation is done by first
 /// clamping the difference between current and previous parameters to the range [-maxDelta,
 /// maxDelta] for each active parameter, and then scaling this clamped difference by `factor`.
-/// Returns the current parameters when sizes mismatch.
+/// Inactive parameters (those for which `activeParams.test(i)` is false) are passed through
+/// unchanged from `current`. Returns the current parameters when sizes mismatch.
 [[nodiscard]] ModelParameters extrapolateModelParameters(
     const ModelParameters& previous,
     const ModelParameters& current,

--- a/momentum/character/skin_weights.cpp
+++ b/momentum/character/skin_weights.cpp
@@ -20,6 +20,8 @@ void SkinWeights::set(
   index = IndexMatrix::Zero(ind.size(), kMaxSkinJoints);
   weight = WeightMatrix::Zero(ind.size(), kMaxSkinJoints);
 
+  // TODO: silently truncates per-vertex influences beyond kMaxSkinJoints; consider
+  // warning or renormalizing the kept weights when ind[i].size() > kMaxSkinJoints.
   for (size_t i = 0; i < ind.size(); i++) {
     for (size_t j = 0; j < std::min(ind[i].size(), size_t(kMaxSkinJoints)); j++) {
       index(i, j) = gsl::narrow_cast<uint32_t>(ind[i][j]);

--- a/momentum/character/skin_weights.h
+++ b/momentum/character/skin_weights.h
@@ -18,49 +18,40 @@ namespace momentum {
 /// Maximum number of joints that can influence a single vertex
 inline constexpr uint32_t kMaxSkinJoints = 8;
 
-/// Matrix type for storing joint indices that influence each vertex
-///
-/// Each row represents a vertex, and each column represents a joint influence.
-/// The matrix has a fixed number of columns (kMaxSkinJoints) and a dynamic number of rows.
+/// Joint indices that influence each vertex. Row = vertex, column = influence slot
+/// (fixed at kMaxSkinJoints). Row-major to keep per-vertex influences contiguous.
 using IndexMatrix =
     Eigen::Matrix<uint32_t, Eigen::Dynamic, kMaxSkinJoints, Eigen::AutoAlign | Eigen::RowMajor>;
 
-/// Matrix type for storing weights of joint influences on each vertex
-///
-/// Each row represents a vertex, and each column represents the weight of a joint influence.
-/// The matrix has a fixed number of columns (kMaxSkinJoints) and a dynamic number of rows.
+/// Skinning weights for each joint influence. Row = vertex, column = influence slot
+/// (fixed at kMaxSkinJoints). Row-major to keep per-vertex influences contiguous.
 using WeightMatrix =
     Eigen::Matrix<float, Eigen::Dynamic, kMaxSkinJoints, Eigen::AutoAlign | Eigen::RowMajor>;
 
-/// Stores skinning weights and joint indices for character mesh deformation
+/// Linear blend skinning weights for a character mesh: per-vertex joint indices
+/// and influence weights. `index` and `weight` always have the same row count
+/// (one row per vertex) and matching unused-slot conventions.
 struct SkinWeights {
-  /// Joint indices that influence each vertex
-  ///
-  /// Each row corresponds to a vertex, and each column contains the index of a joint
-  /// that influences that vertex. Unused influences are set to 0.
+  /// Joint indices influencing each vertex. Unused slots are set to 0.
+  /// Read in conjunction with `weight` — index 0 only contributes when its
+  /// matching weight is non-zero.
   IndexMatrix index;
 
-  /// Weight of each joint's influence on each vertex
-  ///
-  /// Each row corresponds to a vertex, and each column contains the weight of a joint's
-  /// influence on that vertex. Weights for a vertex typically sum to 1.0. Unused influences
-  /// are set to 0.0.
+  /// Joint influence weights per vertex. Weights for a vertex are expected to
+  /// sum to 1.0; unused slots are set to 0.0. Loaders/setters do not enforce
+  /// normalization — callers are responsible for normalized input.
   WeightMatrix weight;
 
-  /// Sets the skin weights from vectors of joint indices and weights
+  /// Populates `index` and `weight` from ragged per-vertex influence lists.
+  /// Each entry of `ind`/`wgt` is one vertex's joints/weights; influences beyond
+  /// `kMaxSkinJoints` are silently dropped, and unused slots are zero-filled.
   ///
-  /// @param ind Vector of vectors containing joint indices for each vertex
-  /// @param wgt Vector of vectors containing weights for each vertex
-  /// @throws If ind.size() != wgt.size() (via MT_CHECK)
+  /// @pre `ind.size() == wgt.size()` (checked via MT_CHECK).
+  /// @pre For each vertex i, `wgt[i].size() >= min(ind[i].size(), kMaxSkinJoints)`;
+  ///   shorter weight rows produce out-of-bounds reads.
   void set(const std::vector<std::vector<size_t>>& ind, const std::vector<std::vector<float>>& wgt);
 
-  /// Compares two SkinWeights objects for equality
-  ///
-  /// Two SkinWeights objects are considered equal if their index and weight matrices
-  /// are approximately equal (using Eigen's isApprox method).
-  ///
-  /// @param skinWeights The SkinWeights object to compare with
-  /// @return True if the objects are equal, false otherwise
+  /// Approximate equality on `index` and `weight` using Eigen's `isApprox`.
   bool operator==(const SkinWeights& skinWeights) const;
 };
 

--- a/momentum/character/skinned_locator.h
+++ b/momentum/character/skinned_locator.h
@@ -13,46 +13,35 @@
 
 namespace momentum {
 
-/// A skinned locator is a locator which can be attached to multiple bones.
-/// The locator's position is defined relative to the rest pose of the character (and not
-/// local to a single parent bone as with a regular Locator) and its position at runtime is
-/// determined by blending the skinning transforms (using LBS).
+/// A locator attached to multiple joints, with its runtime position determined by
+/// blending the skinning transforms (LBS) of those joints.
 ///
-/// The purpose of the SkinnedLocator is to model mocap markers attached to the actor's skin:
-/// the location of points on e.g. the shoulder is more accurately modeled by blending
-/// multiple transforms.  In addition, the locator can be constrained to slide along the
-/// surface of the mesh using e.g. the SkinnedLocatorTriangleErrorFunction.
-///
-/// Locators can be used for various purposes such as tracking specific points
-/// on a character, defining constraints, or serving as targets for inverse kinematics.
+/// Unlike a regular `Locator` (which is local to a single parent joint), a
+/// `SkinnedLocator`'s position is defined relative to the character's rest pose.
+/// This is intended to model mocap markers attached to the actor's skin: points on
+/// e.g. the shoulder are more accurately modeled by blending multiple joint
+/// transforms. The locator can also be constrained to slide along the mesh surface
+/// using e.g. `SkinnedLocatorTriangleErrorFunction`.
 struct SkinnedLocator {
-  /// Name identifier for the locator
   std::string name;
 
-  /// Index of the parent joints in the skeleton.  The final position of the locator
-  /// is determined by blending the transforms from each (valid) parent.
+  /// Indices of the parent joints used for skinning. The final position is the
+  /// `skinWeights`-weighted blend of transforms from each (valid) parent.
   Eigen::Matrix<uint32_t, kMaxSkinJoints, 1> parents;
 
-  /// Skinning weight for each parent joint.
+  /// Skinning weight for each entry in `parents`. Typically sums to 1.0.
   Eigen::Matrix<float, kMaxSkinJoints, 1> skinWeights;
 
-  /// Position relative to rest pose of the character
+  /// Position in the character's rest-pose coordinate frame.
   Vector3f position = Vector3f::Zero();
 
-  /// Influence weight of this locator when used in constraints
+  /// Influence weight when used as a constraint in error functions.
   float weight = 1.0f;
 
   /// Offset from the skin surface in centimeters, used when solving for body shape.
   /// Accounts for physical marker thickness (e.g. half the marker diameter).
   float skinOffset = 0.0f;
 
-  /// Creates a locator with the specified properties
-  ///
-  /// @param name Identifier for the locator
-  /// @param parents Indices of the parent joints
-  /// @param weights Skinning weights for the parent joints
-  /// @param weight Influence weight in constraints
-  /// @param skinOffset Offset from the skin surface in centimeters
   SkinnedLocator(
       const std::string& name = "uninitialized",
       const Eigen::Matrix<uint32_t, kMaxSkinJoints, 1>& parents =
@@ -69,10 +58,7 @@ struct SkinnedLocator {
         weight(weight),
         skinOffset(skinOffset) {}
 
-  /// Compares two locators for equality, using approximate comparison for floating-point values
-  ///
-  /// @param locator The locator to compare with
-  /// @return True if all properties are equal (or approximately equal for floating-point values)
+  /// Equality comparison; uses approximate (`isApprox`) comparison for floating-point fields.
   inline bool operator==(const SkinnedLocator& locator) const {
     return (
         (name == locator.name) && (parents == locator.parents) &&

--- a/momentum/character/texture_classification.cpp
+++ b/momentum/character/texture_classification.cpp
@@ -27,6 +27,7 @@ struct BarycentricCoord {
 };
 
 std::vector<BarycentricCoord> getSamplePoints(int32_t numSamples) {
+  // The three triangle corners.
   constexpr BarycentricCoord v0{1.0f, 0.0f, 0.0f};
   constexpr BarycentricCoord v1{0.0f, 1.0f, 0.0f};
   constexpr BarycentricCoord v2{0.0f, 0.0f, 1.0f};
@@ -34,10 +35,13 @@ std::vector<BarycentricCoord> getSamplePoints(int32_t numSamples) {
   constexpr float third = 1.0f / 3.0f;
   constexpr BarycentricCoord centroid{third, third, third};
 
+  // Edge midpoints.
   constexpr BarycentricCoord mid01{0.5f, 0.5f, 0.0f};
   constexpr BarycentricCoord mid12{0.0f, 0.5f, 0.5f};
   constexpr BarycentricCoord mid02{0.5f, 0.0f, 0.5f};
 
+  // Interior points biased 75% toward each corner (the other two coords each get 12.5%).
+  // Note: `quarter * 0.5f` = 0.125, so each interior point sums to 1.0 (0.75 + 0.125 + 0.125).
   constexpr float quarter = 0.25f;
   constexpr float threeQuarters = 0.75f;
   constexpr BarycentricCoord int0{threeQuarters, quarter * 0.5f, quarter * 0.5f};
@@ -61,6 +65,8 @@ std::vector<BarycentricCoord> getSamplePoints(int32_t numSamples) {
   MT_THROW("Invalid num_samples value {}. Must be one of: 1, 3, 4, 6, 7, 10.", numSamples);
 }
 
+// Packs an RGB triple into a single integer key (R in bits 0-7, G in 8-15, B in 16-23) so it
+// can be used as the key in unordered_map / unordered_set lookups against region colors.
 inline size_t packRgb(uint8_t r, uint8_t g, uint8_t b) {
   return static_cast<size_t>(r) | (static_cast<size_t>(g) << 8) | (static_cast<size_t>(b) << 16);
 }
@@ -104,6 +110,8 @@ std::vector<std::vector<int32_t>> classifyTrianglesByTexture(
   const auto nTriangles = static_cast<int64_t>(mesh.faces.size());
   const auto nRegions = regionColors.nRegions;
 
+  // threshold == 0 is treated as "any single sample is enough"; otherwise we ceil so a fractional
+  // threshold like 0.5 with 3 samples requires 2 (not 1) matching samples.
   const int32_t minSamplesNeeded = (threshold == 0.0f)
       ? 1
       : static_cast<int32_t>(std::ceil(threshold * static_cast<float>(nSamples)));
@@ -172,6 +180,9 @@ struct TextureSampler {
                packRgb(pixel[0 * tex.stride2], pixel[1 * tex.stride2], pixel[2 * tex.stride2])) > 0;
   }
 
+  // Binary search along the UV segment uvA->uvB for the parameter t at which the sample
+  // transitions from inside (lo) to outside (hi). Caller must pass a segment where uvA is
+  // inside and uvB is outside; otherwise the returned t is meaningless.
   float findCrossingT(const Eigen::Vector2f& uvA, const Eigen::Vector2f& uvB, int32_t numSteps)
       const {
     float lo = 0.0f, hi = 1.0f;
@@ -188,6 +199,7 @@ struct TextureSampler {
   }
 };
 
+// Undirected edge represented by (smaller, larger) vertex index so {a,b} and {b,a} hash equally.
 using Edge = std::pair<int, int>;
 
 Edge makeEdge(int v1, int v2) {
@@ -196,6 +208,7 @@ Edge makeEdge(int v1, int v2) {
 
 struct HashEdge {
   std::size_t operator()(const Edge& e) const {
+    // boost::hash_combine recipe: 0x9e3779b9 is the golden-ratio constant chosen to spread bits.
     std::size_t h1 = std::hash<int>{}(e.first);
     std::size_t h2 = std::hash<int>{}(e.second);
     return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
@@ -207,6 +220,11 @@ struct GeomCacheEntry {
   float t;
 };
 
+// Returns the crossing parameter t in [0, 1] along the edge (geomV0 -> geomV1) such that
+// uv0 + t*(uv1 - uv0) lies on the region boundary. The cached t is always stored with respect to
+// the canonical orientation (smaller-index -> larger-index); we flip to (1 - t) when the caller's
+// orientation is reversed. If the cache misses, we orient the binary search so it always runs
+// inside -> outside (the precondition findCrossingT requires).
 float findEdgeCrossingT(
     const TextureSampler& sampler,
     const Eigen::Vector2f& uv0,
@@ -242,6 +260,9 @@ void processMixedFace(
     GetOrCreateTexVertexFn& getOrCreateTexVertex,
     std::vector<Eigen::Vector3i>& newFaces,
     std::vector<Eigen::Vector3i>& newTexcoordFaces) {
+  // Find the "solo" corner -- the lone inside vertex when nInside==1, or the lone outside vertex
+  // when nInside==2. We then re-index the triangle so k0=solo, k1/k2=the other two corners,
+  // making the two edges to clip always (k0->k1) and (k0->k2).
   int solo = -1;
   for (int k = 0; k < 3; ++k) {
     if ((nInside == 1 && inside[k]) || (nInside == 2 && !inside[k])) {
@@ -254,6 +275,7 @@ void processMixedFace(
   const int gV0 = face[k0], gV1 = face[k1], gV2 = face[k2];
   const int tV0 = texFace[k0], tV1 = texFace[k1], tV2 = texFace[k2];
 
+  // After reindexing, V0 is inside iff there was exactly one inside vertex (the solo case).
   const bool v0IsInside = (nInside == 1);
   const float t01 = findEdgeCrossingT(
       sampler,
@@ -280,9 +302,12 @@ void processMixedFace(
   const int tM02 = getOrCreateTexVertex(tV0, tV2, t02);
 
   if (nInside == 1) {
+    // One inside corner: emit the single inside sub-triangle (V0, M01, M02).
     newFaces.emplace_back(gV0, gM01, gM02);
     newTexcoordFaces.emplace_back(tV0, tM01, tM02);
   } else {
+    // Two inside corners: emit the inside quadrilateral as two triangles. The diagonal goes
+    // from V2 to M01 to keep both sub-triangles consistently wound with the original face.
     newFaces.emplace_back(gV1, gV2, gM01);
     newTexcoordFaces.emplace_back(tV1, tV2, tM01);
     newFaces.emplace_back(gV2, gM02, gM01);
@@ -329,6 +354,10 @@ Mesh splitMeshByTextureRegion(
   const bool hasColors = !colors.empty();
   const bool hasConfidence = !confidence.empty();
 
+  // Lazily mints (or reuses) a vertex along edge (geomA, geomB) at parameter t. The cached
+  // tOriented is always relative to the canonical (smaller -> larger) edge direction so the same
+  // boundary vertex is shared between the two faces incident to the edge, preserving a watertight
+  // split mesh.
   auto getOrCreateGeomVertex = [&](int geomA, int geomB, float t) -> int {
     const auto edge = makeEdge(geomA, geomB);
     auto it = geomCache.find(edge);

--- a/momentum/character/types.h
+++ b/momentum/character/types.h
@@ -7,10 +7,6 @@
 
 #pragma once
 
-//------------------------------------------------------------------------------
-// Momentum specific Eigen defines
-//------------------------------------------------------------------------------
-
 #include <momentum/character/fwd.h>
 
 #include <Eigen/Dense>
@@ -98,7 +94,7 @@ struct EigenStrongType {
   }
 };
 
-// a vector describing model parameters
+/// A vector of size numModelParams holding the values of all model parameters for a character.
 template <typename T>
 struct ModelParametersT : public EigenStrongType<ModelParametersT, ::Eigen::VectorX<T>> {
   using t = ::Eigen::VectorX<T>;
@@ -126,9 +122,9 @@ static_assert(
     sizeof(BlendWeightsd) == sizeof(Eigen::VectorXd),
     "Missing Empty Base Class Optimization");
 
-// A vector describing joint parameters, the vector has size numSkeletonJoints * kParametersPerJoint
-// e.g. in case of a character body model with 159 joints, the joint parameters vector will have the
-// size 159 * 7 = 1113
+/// A vector describing joint parameters, of size `numSkeletonJoints * kParametersPerJoint`.
+/// E.g. for a character body model with 159 joints, the joint parameters vector has size
+/// 159 * 7 = 1113. The 7 parameters per joint are ordered [tx, ty, tz, rx, ry, rz, sc].
 template <typename T>
 struct JointParametersT : public EigenStrongType<JointParametersT, ::Eigen::VectorX<T>> {
   using t = ::Eigen::VectorX<T>;
@@ -183,20 +179,17 @@ struct CharacterParametersT {
 using CharacterParameters = CharacterParametersT<float>;
 using CharacterParametersd = CharacterParametersT<double>;
 
-// The tuple of model parameter names and corresponding matrix representing the pose in a sequence
-// of frames The poses are ordered in columns and the expected shape of motion matrix is
-// (numModelParams, numFrames)
-
+/// A tuple of model parameter names and a matrix of poses across a sequence of frames.
+/// Poses are stored column-major: the matrix has shape (numModelParams, numFrames).
 using MotionParameters = std::tuple<std::vector<std::string>, Eigen::MatrixXf>;
 
-// The tuple containing the skeleton joint names and identity parameters. The identity parameters
-// represent bone offsets and bone scales that are added to the joint states (local transform for
-// each joint wrt parent joint) during FK step The identity parameters are expressed as a vector of
-// size (numSkeletonJoints * momentum::kParametersPerJoint)
-
+/// A tuple of skeleton joint names and identity parameters. The identity parameters represent
+/// bone offsets and bone scales that are added to the joint states (the local transform for each
+/// joint relative to its parent) during the FK step. The identity parameter vector has size
+/// `numSkeletonJoints * kParametersPerJoint`.
 using IdentityParameters = std::tuple<std::vector<std::string>, JointParameters>;
 
-// define static kInvalidIndex for size_t
+/// Sentinel value indicating an invalid or unset `size_t` index.
 inline constexpr size_t kInvalidIndex = std::numeric_limits<size_t>::max();
 
 } // namespace momentum

--- a/momentum/docs/superpowers/specs/2026-03-21-comment-audit-pipeline-design.md
+++ b/momentum/docs/superpowers/specs/2026-03-21-comment-audit-pipeline-design.md
@@ -1,0 +1,301 @@
+# Comment Audit Pipeline for AI Readability
+
+**Date:** 2026-03-21
+**Goal:** Optimize code comments across momentum/ and pymomentum/ for AI agent consumption.
+
+## Problem
+
+A 44-commit stack auditing comments across 44 folders exists but cannot be landed efficiently:
+
+- **Stack structure** forces sequential landing — a conflict in commit N blocks N+1 through 44
+- **Staleness** — many commits have conflicts with upstream changes
+- **No parallelism** — single eden worktree limits concurrent work
+- **Context drift** — Claude stops following audit rules on large/complex files (leaves filler comments it should remove)
+- **Original generation script was lost** — the prompt cannot be re-run as-is
+
+The commits are independent (no cross-folder dependencies), so the stack structure is unnecessary.
+
+## Audit Rules
+
+The audit rules — fix outdated comments, remove filler, add documentation for high-value locations (contracts, units, algorithms, side effects, edge cases, data formats, dependencies), flag code issues with TODOs, and consistency principles — live in **`arvr/libraries/momentum/.llms/rules/comment_style.md`**. That file is the source of truth and is auto-loaded for any C++ file edit; consult it for the full rule text and examples. The original inline rules in this spec have moved there to avoid duplication.
+
+Doxygen format conventions (use `///` over `/** */`, `@param`/`@return`, no `@brief`) live in `arvr/libraries/momentum/.llms/rules/cpp_style.md` Documentation section.
+
+**Scope constraint:** Comment-only changes. No functional code modifications (except adding TODO comments for issues found). pymomentum bindings are not affected by comment-only changes in momentum/ — each folder is audited independently.
+
+## Design
+
+### Architecture
+
+```
+                    +------------------+
+                    |     Tracker      |
+                    | (tracker.md)     |
+                    +--------+---------+
+                             |
+              +--------------+--------------+
+              |                             |
+     +--------v--------+          +--------v--------+
+     |  Triage Phase   |          |  Audit Phase    |
+     |  (sequential)   |          |  (parallel via  |
+     |                 |          |   background    |
+     |                 |          |   Agent tool)   |
+     +--------+--------+          +--------+--------+
+              |                             |
+              v                             v
+     existing-clean/stale          edit plans on disk
+              |                             |
+              +-------------+---------------+
+                            |
+                   +--------v--------+
+                   | Verification    |
+                   | (parallel via   |
+                   |  background     |
+                   |  Agent tool)    |
+                   +--------+--------+
+                            |
+                   +--------v--------+
+                   | Commit & Submit |
+                   | (sequential,    |
+                   |  sl goto trunk  |
+                   |  between each)  |
+                   +--------+--------+
+                            |
+                   +--------v--------+
+                   | Land            |
+                   | (after review)  |
+                   +-----------------+
+```
+
+### Component 1: Tracker
+
+File: `arvr/libraries/momentum/.llms/comment-tasks/tracker.md`
+
+The tracker lives **in the repo** so progress survives when the long-lived audit-infrastructure commit is rebased onto trunk. It belongs to the same local commit as this design spec; amend updates into that commit rather than committing them separately.
+
+A manifest tracking every folder's status:
+
+```markdown
+| Folder | Status | Diff | Notes |
+|--------|--------|------|-------|
+| common/ | existing-clean | D96091113 | Rebases cleanly, needs verification |
+| math/ | existing-stale | — | Conflicts in quaternion.h |
+| solver/ | pending | — | Not yet audited |
+```
+
+**Statuses:**
+
+| Status | Meaning | Next action |
+|--------|---------|-------------|
+| `existing-clean` | Existing commit rebases cleanly onto trunk | Run verification |
+| `existing-stale` | Existing commit has rebase conflicts | Fresh audit |
+| `pending` | No existing work | Fresh audit |
+| `audited` | Edit plan produced and saved to disk | Run verification |
+| `needs-rework` | Verification failed; issues documented in plan file | Re-audit with issues as input |
+| `verified` | Verification pass confirmed edit plan quality | Commit and submit |
+| `submitted` | Diff submitted as independent draft | Wait for review / check status |
+| `landed` | Diff has landed | Done |
+
+A folder can cycle `audited → needs-rework → audited` at most 2 times. After 2 failed verification cycles, escalate to the user for manual review of the edit plan.
+
+### Component 2: Triage (one-time, sequential)
+
+For each of the 44 existing commits:
+
+1. Attempt to rebase the commit onto trunk independently (cherry-pick style, not stack rebase)
+2. If clean → status `existing-clean`
+3. If conflicts → status `existing-stale`, record which files conflict
+4. Undo the rebase attempt (restore worktree to trunk)
+
+`existing-clean` folders still go through verification (Component 4) because the original audit had known context drift issues. Verification for these operates on the commit diff (`sl diff -c <commit>`) rather than an edit plan file. If verification passes, the commit is used as-is (no re-audit needed). If verification fails, the folder transitions to `pending` for a fresh audit from scratch — no attempt to patch the existing commit.
+
+`existing-stale` folders are treated the same as `pending` — fresh audit from scratch.
+
+This must be sequential because it modifies the worktree.
+
+### Component 3: Audit (parallelizable)
+
+Dispatch Claude subagents via the `Agent` tool with `run_in_background: true`. Each subagent:
+
+1. Reads all files in the folder (read-only — no worktree modifications)
+2. Applies the 5 audit rules
+3. Produces a structured edit plan saved to `~/.claude/projects/-home-yutingye-fbsource-scratch-arvr-libraries-momentum/comment-audit/plans/<folder-name>.md`
+
+Multiple background agents can run concurrently since they only read files.
+
+#### Edit Plan Format
+
+Edit plans use **semantic descriptions anchored by code context**, not line numbers. This makes them robust to upstream trunk changes.
+
+```markdown
+# Edit Plan: common/
+
+## File: common/types.h
+
+### Edit 1: Remove filler comment
+- **Location:** Above `struct Foo`, inside namespace `momentum`
+- **Action:** Remove
+- **Current comment:**
+  ```cpp
+  // Foo struct
+  ```
+- **Reason:** Restates the struct name; no information added
+
+### Edit 2: Add documentation
+- **Location:** Method `Bar::compute()` in class `Bar`
+- **Action:** Add above function
+- **New comment:**
+  ```cpp
+  /// Computes the weighted average of joint positions, skipping
+  /// joints with zero weight. Returns identity if all weights are zero.
+  ```
+- **Reason:** Non-obvious fallback behavior undocumented
+
+### Edit 3: Fix inaccurate comment
+- **Location:** Above `calculateBlendWeights()`, comment mentioning "linear interpolation"
+- **Action:** Replace
+- **Current comment:**
+  ```cpp
+  // Uses linear interpolation between keyframes
+  ```
+- **New comment:**
+  ```cpp
+  // Uses spherical linear interpolation (slerp) for rotations,
+  // linear interpolation for translations.
+  ```
+- **Reason:** Comment says linear but code uses slerp for rotations
+```
+
+**Anchoring convention:** Locations are described by function/class/struct name and namespace context — never by line number alone. Include enough surrounding context (e.g., "above `Bar::compute()` in class `Bar`") that the location is unambiguous even after upstream changes.
+
+**Staleness tracking:** Each edit plan file records the trunk revision it was generated against in its header:
+
+```markdown
+# Edit Plan: common/
+**Trunk revision:** abc123def456
+```
+
+#### Chunking for Large Files
+
+Files over ~300 lines are processed in chunks of ~200-300 lines. The chunking threshold should be calibrated empirically — start at 300 and adjust if drift is still observed. The subagent:
+
+1. Reads the full file to understand structure
+2. Processes chunks sequentially, keeping the audit rules in the prompt throughout
+3. Produces a single unified edit plan for the file
+
+### Component 4: Verification (parallelizable)
+
+A separate Claude session (fresh context, not the audit session) reads:
+
+1. The edit plan from `plans/<folder-name>.md`
+2. The original source files
+
+**Verification checklist:**
+
+- [ ] Were all filler comments identified and removed? (Scan for remaining constructor labels, restatements, section banners — see Rule 2 patterns)
+- [ ] Are added comments accurate — do they match what the code actually does?
+- [ ] Do added comments target high-value locations? (Contracts, units, algorithms, side effects — see Rule 3 priority list)
+- [ ] Were any non-comment changes introduced? (Only comment changes and TODO additions are allowed)
+- [ ] Are TODO comments actionable and correctly flagging real issues? (Not style opinions or wishlists — see Rule 4)
+- [ ] Doxygen format: uses `///` not `/** */`, uses `@param`/`@return` not `\param`/`\return`, no `@brief`
+- [ ] No substantive comments were incorrectly flagged as filler (false-positive removal check — see Rule 2 "keep these")
+- [ ] Terminology matches the codebase (no synonym drift — see Consistency principles)
+- [ ] Comment density matches surrounding code style
+
+**On pass:** Status → `verified`.
+**On fail:** Status → `needs-rework`. Issues are documented in the edit plan file itself as a `## Verification Issues` section at the top, so the next audit session sees them.
+
+Verification agents are dispatched via `Agent` tool with `run_in_background: true`, same as audit agents.
+
+### Component 5: Commit & Submit (sequential, user-approved)
+
+For each `verified` folder:
+
+1. `sl goto trunk` — ensure we're on a clean trunk
+2. Apply the edit plan to the worktree (Claude reads the plan and makes the edits)
+3. `sl commit` with the standard commit message format
+4. `jf submit --draft` as an independent diff
+5. `sl goto trunk` — reset to trunk for the next folder
+6. Update tracker with diff number, status → `submitted`
+
+This creates independent commits, each rooted on trunk, avoiding an accidental stack.
+
+This is sequential (single worktree) and requires user approval for each `jf submit`.
+
+**Submission cadence:** Submit in waves of 5-8 diffs. Adjust wave size based on reviewer throughput after the first wave.
+
+**Staleness check before applying:** Before applying an edit plan, verify that the target files haven't changed since the plan was created. If files have changed, re-run verification on the plan against the current file contents. If verification fails, re-audit.
+
+### Component 6: Landing & Status Checks
+
+- Claude checks diff status via `jf status` or Phab queries
+- After reviewer approval, land the diff
+- Update tracker status → `landed`
+- Individual diffs can be reverted independently since they are not stacked
+
+## Session Workflow
+
+### Simplified workflow (current)
+
+This is the workflow actually used today. The triage / edit-plan / verification phases above are preserved as design reference but not exercised in this mode.
+
+1. User asks: "audit the next N folders" (or names specific folders).
+2. Claude opens `arvr/libraries/momentum/.llms/comment-tasks/tracker.md` and picks the next N rows with status `pending`.
+3. For each folder, dispatch a background `Agent` (rooted on master) that:
+   - Reads `arvr/libraries/momentum/.llms/rules/comment_style.md` (auto-loaded for C++ files).
+   - Reads any per-folder hints in `.llms/comment-tasks/<folder>.md`.
+   - Edits comments in that folder per the rules.
+   - Commits the change as one diff (`[Momentum] Comment audit: <folder>`) and runs `jf submit --draft`.
+4. Claude updates each row in the tracker to `submitted` with the diff number.
+5. Claude amends the tracker change into this local audit-infrastructure commit so progress survives the next rebase. Do not create a separate commit for tracker updates.
+6. After review and landing, the user (or a follow-up session) flips rows to `landed`.
+
+Folders are independent — different sessions can pick different rows in any order. Subagents work in parallel safely as long as no two pick the same row.
+
+### Full pipeline workflow (design reference)
+
+When auditing the entire backlog at once with verification gates:
+
+1. User starts a session: "continue the comment audit"
+2. Claude reads the tracker file
+3. Claude picks the next action based on current state:
+   - If triage hasn't been done → run triage (sequential)
+   - If folders need auditing → dispatch background audit agents (parallel)
+   - If edit plans need verification → dispatch background verification agents (parallel)
+   - If verified folders are ready → commit and submit (sequential, user approves)
+   - If submitted diffs need status checks → check and update tracker
+4. Claude updates the tracker before session ends
+
+## File Structure
+
+In-repo (committed to the long-lived audit-infrastructure commit):
+
+```
+arvr/libraries/momentum/
+  .llms/
+    rules/
+      comment_style.md            # Audit rules (source of truth)
+    comment-tasks/
+      tracker.md                  # Status manifest (this is what to update each session)
+      character.md                # Per-folder hints (only some folders have these)
+      character_solver.md
+      marker_tracking.md
+      math.md
+      simd.md
+      solver.md
+  docs/superpowers/specs/
+    2026-03-21-comment-audit-pipeline-design.md  # This file
+```
+
+Edit plans (Component 3) are only used in the full pipeline; the simplified per-session workflow audits and submits in one session without persisting plans.
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Edit plans go stale | Semantic anchoring (not line numbers); staleness check before applying |
+| Verification misses drift issues | Verification agent gets fresh context with rules front-loaded; explicit checklist |
+| Verification loops forever | Max 2 rework cycles per folder, then escalate to user |
+| Accidental commit stacking | Explicit `sl goto trunk` between each commit |
+| Large review backlog | Submit in waves; adjust wave size based on reviewer throughput |
+| Landed diff causes incorrect docs | Each diff is independent and can be reverted individually |


### PR DESCRIPTION
Summary:
- `joint_state.h` — added Jacobian-implications block on `JointStateT`'s transform-composition note, expanded `computeDeriv` `param` doc with the warn-on-skipping wording, added log2 scale-encoding block on `localScale()`.
- `skeleton_state.h` — applied the same `computeDeriv` rewrite to all 5 occurrences, added Euler-singularity `warning` on `skeletonStateToJointParameters()`, wrapped the four-overload family with an `name` group + selection table (clang-format-guarded).
- `parameter_transform.h` — added `EntilZha Parameter enablement hierarchy` block on `ParameterTransformT` describing the model/joint/solver three-level system.
- `linear_skinning.h` — added `EntilZha Overload selection guide` table at the file level (clang-format-guarded).

For all other files: removed restatement, constructor-label, and section-banner filler; converted `//` member docs to `///` Doxygen on headers; removed duplicate Doxygen blocks from `.cpp` files (keeping the .h as source of truth); added `pre`/`invariant`/`warning` for non-obvious contracts; tightened terminology (e.g. "bone" → "joint", "mesh" instead of "Character containing the mesh").

Substantive `// TODO:` markers added (filed as follow-up tasks per file with bug-class issues):

- `blend_shape.cpp` — `regularization` silently ignored on the unweighted SVD branch.
- `character.cpp` — `remapSkinnedLocators` declares `sourceBindState`/`targetBindState` but never reads them (asymmetric with `remapLocators`, dead).
- `character_state.cpp` — temporary `Character` constructed by shallow-copying member pointers may not preserve all properties (existing smell, now flagged).
- `character_utility.cpp` — comment inversion: text says "Invalid joint index, so any model parameters are invalid too" but code marks params valid for kept joints.
- `inverse_parameter_transform.h` — `offsets` field unused by the inverse mapping and documented deprecated; safe to remove.
- `linear_skinning.cpp` — three TODOs: (1) per-vertex `break` assumes packed-contiguous influence slots without enforcement, (2) repeated for the second variant, (3) `inverseTransposed` is only the inverse-transpose for rigid transforms — wrong for non-uniform scale.
- `parameter_transform.cpp` — header Doxygen for `getRigidParameters()` only mentions `root_` prefix but impl also matches `hips`.
- `pose_shape.cpp` — `coefficients` is not zero-initialized; out-of-range joint indices read garbage into the matrix multiply.
- `skeleton_state.cpp` — three TODOs: (1) `orientationRMSE` divides by `positionError.size()` instead of `orientationError.size()` (latent — usually equal), (2) and (3) `parentJoint`/`parentXF` computed but never used in two `SkeletonStateT&` overloads (dead).
- `skin_weights.cpp` — `set()` silently truncates per-vertex influences beyond `kMaxSkinJoints`.

Differential Revision: D102721452
