### PR TITLE
Fix docstring parameter name mismatches in pymomentum (#1351)

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -92,6 +92,18 @@ jobs:
       run: |
         cp -R build/python_api_doc momentum/website/build/python_api_doc
 
+    # 4.5) Preserve existing Python API docs from gh-pages (when not rebuilt)
+    - name: Preserve existing Python API docs from gh-pages
+      if: steps.check_pymomentum.outputs.changed != 'true'
+      run: |
+        git fetch origin gh-pages --depth=1 || true
+        if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+          git checkout origin/gh-pages -- python_api_doc/ 2>/dev/null || true
+          if [ -d python_api_doc ]; then
+            cp -R python_api_doc momentum/website/build/python_api_doc
+          fi
+        fi
+
     # 5) Upload the built website as an artifact
     - name: Upload Built Website
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -288,7 +288,7 @@ def identity(
     """
     Create a quaternion identity tensor.
 
-    :parameter sizes: A tuple of integers representing the size of the quaternion tensor.
+    :parameter size: A tuple of integers representing the size of the quaternion tensor.
     :parameter device: The device on which to create the tensor.
     :return: A quaternion identity tensor with the specified sizes and device.
     """

--- a/pymomentum/skel_state.py
+++ b/pymomentum/skel_state.py
@@ -181,7 +181,6 @@ def to_matrix(skeleton_state: torch.Tensor) -> torch.Tensor:
     check(skeleton_state)
     t, q, s = split(skeleton_state)
 
-    # Assuming quaternionToRotationMatrix is implemented elsewhere
     rot_mat = quaternion.to_rotation_matrix(q)
     linear = rot_mat * s.unsqueeze(-2).expand_as(rot_mat)
     affine = torch.cat((linear, t.unsqueeze(-1)), -1)
@@ -365,8 +364,8 @@ def identity(
     """
     Returns a skeleton state representing the identity transform.
 
-    :parameter sizes: The size of each dimension in the output tensor. Defaults to None, which means the output will be a 1D tensor with 8 elements.
-    :type sizes: list[int], optional
+    :parameter size: The size of each dimension in the output tensor. Defaults to None, which means the output will be a 1D tensor with 8 elements.
+    :type size: list[int], optional
     :parameter device: The device on which to create the tensor. Defaults to None, which means the tensor will be created on the default device.
     :type device: torch.device, optional
     :return: The identity skeleton state.


### PR DESCRIPTION
Summary:

Fix Sphinx documentation parameter names that do not match the actual function signatures:
- `quaternion.identity()`: docstring says `sizes` but parameter is `size`
- `skel_state.identity()`: docstring says `sizes` (both `:parameter` and `:type`) but parameter is `size`

Also remove a stale comment in `skel_state.to_matrix()` that says "Assuming quaternionToRotationMatrix is implemented elsewhere" — the function is clearly implemented and called on the next line.

These mismatches cause Sphinx to document a nonexistent `sizes` parameter while leaving the real `size` parameter undocumented in the generated Python API docs.

Reviewed By: yutingye

Differential Revision: D102874808


