### PR TITLE
Add CollisionDebugEntryT and getCollisionDebugInfo() to CollisionErrorFunction

### DIFF
--- a/momentum/character_solver/collision_error_function.cpp
+++ b/momentum/character_solver/collision_error_function.cpp
@@ -432,6 +432,26 @@ double CollisionErrorFunctionT<T>::getJacobian(
 }
 
 template <typename T>
+std::vector<CollisionDebugEntryT<T>> CollisionErrorFunctionT<T>::getCollisionDebugInfo() const {
+  std::vector<CollisionDebugEntryT<T>> entries;
+  for (const auto& pair : validPairs_) {
+    T distance;
+    Vector2<T> cp;
+    T overlap;
+    if (checkCollision(collisionState_, pair.indexA, pair.indexB, distance, cp, overlap)) {
+      entries.push_back(
+          {pair.indexA,
+           pair.indexB,
+           collisionGeometry_[pair.indexA].parent,
+           collisionGeometry_[pair.indexB].parent,
+           overlap,
+           distance});
+    }
+  }
+  return entries;
+}
+
+template <typename T>
 size_t CollisionErrorFunctionT<T>::getJacobianSize() const {
   return validPairs_.size();
 }

--- a/momentum/character_solver/collision_error_function.h
+++ b/momentum/character_solver/collision_error_function.h
@@ -18,6 +18,20 @@
 
 namespace momentum {
 
+/// Per-pair collision debug information returned by getCollisionDebugInfo().
+template <typename T>
+struct CollisionDebugEntryT {
+  size_t capsuleIndexA;
+  size_t capsuleIndexB;
+  size_t parentJointA;
+  size_t parentJointB;
+  T overlap;
+  T distance;
+};
+
+using CollisionDebugEntry = CollisionDebugEntryT<float>;
+using CollisionDebugEntryd = CollisionDebugEntryT<double>;
+
 template <typename T>
 class CollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
  public:
@@ -55,6 +69,13 @@ class CollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   [[nodiscard]] size_t getJacobianSize() const final;
 
   [[nodiscard]] std::vector<Vector2i> getCollisionPairs() const;
+
+  /// Query detailed collision state for all currently-colliding pairs.
+  ///
+  /// Returns overlap, distance, capsule indices, and parent joint indices for
+  /// each colliding pair. Uses the collision state from the most recent solver
+  /// iteration (computed during getJacobian/getError/getGradient).
+  [[nodiscard]] std::vector<CollisionDebugEntryT<T>> getCollisionDebugInfo() const;
 
  protected:
   void updateCollisionPairs(bool filterRestPoseOverlaps = true);

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -1371,7 +1371,42 @@ tangent space of the rotation group, which is invariant to the choice of coordin
             }
             return result;
           },
-          R"(Returns the pairs of colliding elements.)");
+          R"(Returns the pairs of colliding elements.)")
+      .def(
+          "get_collision_debug_info",
+          [](const mm::CollisionErrorFunction& self) {
+            const auto entries = self.getCollisionDebugInfo();
+            const auto n = static_cast<py::ssize_t>(entries.size());
+            py::array_t<int64_t> capsuleIndices({n, py::ssize_t{2}});
+            py::array_t<int64_t> parentJoints({n, py::ssize_t{2}});
+            py::array_t<float> overlaps(n);
+            py::array_t<float> distances(n);
+            auto capAcc = capsuleIndices.mutable_unchecked<2>();
+            auto jointAcc = parentJoints.mutable_unchecked<2>();
+            auto overlapAcc = overlaps.mutable_unchecked<1>();
+            auto distAcc = distances.mutable_unchecked<1>();
+            for (py::ssize_t i = 0; i < n; ++i) {
+              capAcc(i, 0) = static_cast<int64_t>(entries[i].capsuleIndexA);
+              capAcc(i, 1) = static_cast<int64_t>(entries[i].capsuleIndexB);
+              jointAcc(i, 0) = static_cast<int64_t>(entries[i].parentJointA);
+              jointAcc(i, 1) = static_cast<int64_t>(entries[i].parentJointB);
+              overlapAcc(i) = entries[i].overlap;
+              distAcc(i) = entries[i].distance;
+            }
+            py::dict result;
+            result["capsule_indices"] = capsuleIndices;
+            result["parent_joints"] = parentJoints;
+            result["overlaps"] = overlaps;
+            result["distances"] = distances;
+            return result;
+          },
+          R"(Returns detailed collision debug info for all currently-colliding pairs.
+
+        Returns a dict with keys:
+            capsule_indices: (N, 2) int64 array of capsule index pairs
+            parent_joints: (N, 2) int64 array of parent joint index pairs
+            overlaps: (N,) float array of penetration depths in meters
+            distances: (N,) float array of center-to-center distances in meters)");
 
   // Call sub-registration functions
   addAimAxisErrorFunctions(m);


### PR DESCRIPTION
Summary:
Adds a debug query API to CollisionErrorFunction for inspecting per-pair collision state after solving. This enables downstream consumers (pipeline, Python scripts) to log or visualize which capsules are colliding, how much they overlap, and which joints they belong to.

- Added `CollisionDebugEntryT<T>` struct with capsule indices, parent joint indices, overlap, and distance, plus `CollisionDebugEntry`/`CollisionDebugEntryd` type aliases
- Added `getCollisionDebugInfo()` method that returns detailed collision entries for all currently-colliding pairs (richer than existing `getCollisionPairs()` which only returns index pairs)
- Added pymomentum binding `get_collision_debug_info()` returning a dict with `capsule_indices`, `parent_joints`, `overlaps`, `distances` numpy arrays

Differential Revision: D102555020


