### PR TITLE
Fix Python API docs being wiped on website-only deployments

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -92,6 +92,18 @@ jobs:
       run: |
         cp -R build/python_api_doc momentum/website/build/python_api_doc
 
+    # 4.5) Preserve existing Python API docs from gh-pages (when not rebuilt)
+    - name: Preserve existing Python API docs from gh-pages
+      if: steps.check_pymomentum.outputs.changed != 'true'
+      run: |
+        git fetch origin gh-pages --depth=1 || true
+        if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+          git checkout origin/gh-pages -- python_api_doc/ 2>/dev/null || true
+          if [ -d python_api_doc ]; then
+            cp -R python_api_doc momentum/website/build/python_api_doc
+          fi
+        fi
+
     # 5) Upload the built website as an artifact
     - name: Upload Built Website
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
Summary:
The publish_website workflow conditionally builds Python API docs only when pymomentum/ source changes, but the GitHub Pages deploy action replaces the entire gh-pages branch on every deployment. This means any push that triggers the workflow without pymomentum/ changes (e.g., website content or Doxyfile edits) wipes the previously-deployed Python API docs, causing a 404.

Fix this by adding a step that fetches the existing python_api_doc/ directory from the gh-pages branch and includes it in the deployment folder when the docs are not rebuilt. The step handles edge cases gracefully: if gh-pages does not exist yet or has no python_api_doc directory, nothing is copied.

Reviewed By: yutingye

Differential Revision: D102862140


