### PR TITLE
Use SVD with stable custom backward for quaternion blending (#1354)

### DIFF
--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -70,6 +70,53 @@ import torch
 # pyre-strict
 
 
+class _TopRightSingularVector(torch.autograd.Function):
+    """First right singular vector of A via SVD, with stable custom backward.
+
+    The backward only differentiates through the top singular triplet.
+    The 1/(sigma_1^2 - sigma_k^2) terms are well-conditioned when sigma_1 dominates.
+
+    The forward pass sign-stabilizes the result: the component with the
+    largest absolute value is forced positive so the output is continuous
+    under small input perturbations.
+    """
+
+    @staticmethod
+    # pyre-ignore[14]: Pyre doesn't model torch.autograd.Function signatures
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx, A: torch.Tensor
+    ) -> torch.Tensor:
+        U, S, Vh = torch.linalg.svd(A, full_matrices=False)
+        v1 = Vh[..., 0, :]
+        idx = v1.abs().argmax(dim=-1, keepdim=True)
+        sign = v1.gather(-1, idx).sign()
+        ctx.save_for_backward(U, S, Vh, sign)
+        return v1 * sign
+
+    @staticmethod
+    # pyre-ignore[14]: Pyre doesn't model torch.autograd.Function signatures
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx, grad_v: torch.Tensor
+    ) -> torch.Tensor:
+        U, S, Vh, sign = ctx.saved_tensors  # pyre-ignore[16]
+        grad_v = grad_v * sign
+        u1 = U[..., :, 0]
+        v1 = Vh[..., 0, :]
+        s1 = S[..., :1]
+        Uk = U[..., :, 1:]
+        Vk = Vh[..., 1:, :]
+        Sk = S[..., 1:]
+
+        proj = torch.einsum("...n,...kn->...k", grad_v, Vk)
+        coeffs = proj / (s1 * s1 - Sk * Sk)
+
+        wv = torch.einsum("...k,...kn->...n", coeffs, Vk)
+        wu = Uk @ (coeffs * Sk).unsqueeze(-1)
+        return s1[..., None] * u1.unsqueeze(-1) @ wv.unsqueeze(-2) + wu @ v1.unsqueeze(
+            -2
+        )
+
+
 def check(q: torch.Tensor) -> None:
     """
     Check if a tensor represents a quaternion.
@@ -510,21 +557,18 @@ def blend(
     https://stackoverflow.com/questions/12374087/average-of-multiple-quaternions
     and http://www.acsu.buffalo.edu/~johnc/ave_quat07.pdf.
 
+    Uses SVD with a custom backward pass that only differentiates through the
+    top singular triplet, providing stable gradients for training.
+
     :parameter quaternions: A tensor of shape (..., k, 4) representing the quaternions to blend.
     :parameter weights_in: An optional tensor of shape (..., k) representing the weights for each quaternion.
                        If not provided, all quaternions will be weighted equally.
     :return: A tensor of shape (..., 4) representing the blended quaternion.
     """
-    # If no weights, then assume evenly weighted:
     weights = check_and_normalize_weights(quaternions, weights_in)
-
-    # Find average rotation by means described in the references above
     check(quaternions)
-    outer_prod = torch.einsum("...i,...k->...ik", [quaternions, quaternions])
-    QtQ = (weights.unsqueeze(-1).unsqueeze(-1) * outer_prod).sum(dim=-3)
-    _, eigenvectors = torch.linalg.eigh(QtQ)
-    result = eigenvectors.select(dim=-1, index=3)
-    return result
+    wq = torch.sqrt(weights).unsqueeze(-1) * quaternions
+    return _TopRightSingularVector.apply(wq)
 
 
 def slerp(q0: torch.Tensor, q1: torch.Tensor, t: torch.Tensor) -> torch.Tensor:

--- a/pymomentum/test/test_quaternion.py
+++ b/pymomentum/test/test_quaternion.py
@@ -787,6 +787,104 @@ class TestQuaternion(unittest.TestCase):
             raise_exception=True,
         )
 
+    def test_blend_gradient_check(self) -> None:
+        """Verify analytical SVD backward matches finite differences for blend."""
+        torch.manual_seed(42)
+        quats = generateRandomQuats(5)
+
+        def _blend_to_matrix(q: torch.Tensor) -> torch.Tensor:
+            return quaternion.to_rotation_matrix(quaternion.blend(q))
+
+        self.assertTrue(
+            torch.autograd.gradcheck(_blend_to_matrix, (quats.unsqueeze(0),), eps=1e-6),
+        )
+
+    def test_blend_weighted_gradient_check(self) -> None:
+        """Verify SVD backward with explicit weights matches finite differences."""
+        torch.manual_seed(42)
+        quats = generateRandomQuats(4).unsqueeze(0)
+        weights = torch.tensor(
+            [[0.6, 0.2, 0.1, 0.1]], dtype=torch.float64, requires_grad=True
+        )
+
+        def _blend_weighted_to_matrix(q: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+            return quaternion.to_rotation_matrix(quaternion.blend(q, w))
+
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                _blend_weighted_to_matrix, (quats, weights), eps=1e-6
+            ),
+        )
+
+    def test_blend_gradient_flows(self) -> None:
+        """Verify gradients flow through blend to both quaternions and weights."""
+        torch.manual_seed(42)
+        raw = torch.randn(1, 4, 4, dtype=torch.float64)
+        quats = quaternion.normalize(raw).detach().requires_grad_(True)
+        weights = torch.tensor(
+            [[0.7, 0.1, 0.1, 0.1]], dtype=torch.float64, requires_grad=True
+        )
+
+        result = quaternion.blend(quats, weights)
+        loss = result.sum()
+        loss.backward()
+
+        self.assertIsNotNone(quats.grad)
+        self.assertFalse(torch.all(quats.grad == 0))
+        self.assertIsNotNone(weights.grad)
+        self.assertFalse(torch.all(weights.grad == 0))
+
+    def test_blend_batch_gradient_check(self) -> None:
+        """Verify SVD backward is correct with batched inputs via rotation matrices.
+
+        Uses weights concentrated on one quaternion so the top singular value
+        of the weighted quaternion matrix dominates, keeping the custom backward
+        well-conditioned.
+        """
+        torch.manual_seed(7)
+        quats = (
+            quaternion.normalize(torch.randn(4, 5, 4, dtype=torch.float64))
+            .detach()
+            .requires_grad_(True)
+        )
+        weights = torch.tensor(
+            [[0.7, 0.1, 0.1, 0.05, 0.05]] * 4,
+            dtype=torch.float64,
+            requires_grad=True,
+        )
+
+        def _blend_to_matrix(q: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+            return quaternion.to_rotation_matrix(quaternion.blend(q, w))
+
+        self.assertTrue(
+            torch.autograd.gradcheck(_blend_to_matrix, (quats, weights), eps=1e-6),
+        )
+
+    def test_blend_raw_quaternion_gradient_check(self) -> None:
+        """Verify sign-stabilized SVD backward works directly on quaternion output."""
+        torch.manual_seed(42)
+        quats = generateRandomQuats(5)
+
+        self.assertTrue(
+            torch.autograd.gradcheck(quaternion.blend, (quats.unsqueeze(0),), eps=1e-6),
+        )
+
+    def test_blend_dominant_weight(self) -> None:
+        """With one dominant weight, blended result should be close to that quaternion."""
+        torch.manual_seed(42)
+        quats = generateRandomQuats(4)
+        weights = torch.tensor([0.97, 0.01, 0.01, 0.01], dtype=torch.float64)
+
+        result = quaternion.blend(quats, weights)
+
+        diff_pos = torch.norm(result - quats[0])
+        diff_neg = torch.norm(result + quats[0])
+        self.assertLess(
+            min(diff_pos.item(), diff_neg.item()),
+            0.05,
+            "Dominant weight should produce result close to the dominant quaternion",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pymomentum/test/test_skel_state_autograd.py
+++ b/pymomentum/test/test_skel_state_autograd.py
@@ -27,6 +27,8 @@ _AUTOGRAD_TESTS = frozenset(
         "test_skel_state_to_transforms",
         "test_bulk_multiplication_backward",
         "test_multiply_backprop",
+        "test_blend_gradient_check",
+        "test_blend_gradient_flows",
     }
 )
 
@@ -141,6 +143,48 @@ class TestSkelStateAutograd(unittest.TestCase):
         # Compare gradients - use appropriate tolerance for numerical differences
         self.assertTrue(torch.allclose(ds1_autograd, ds1_custom, atol=1e-4, rtol=1e-4))
         self.assertTrue(torch.allclose(ds2_autograd, ds2_custom, atol=1e-4, rtol=1e-4))
+
+    @staticmethod
+    def _make_random_skel_states(n: int) -> torch.Tensor:
+        states = []
+        for _ in range(n):
+            t = torch.randn(3, dtype=torch.float64)
+            q = pym_quaternion.normalize(torch.randn(4, dtype=torch.float64))
+            s = torch.rand(1, dtype=torch.float64) + 0.5
+            states.append(torch.cat([t, q, s]))
+        return torch.stack(states)
+
+    def test_blend_gradient_check(self) -> None:
+        """Verify gradcheck passes for skel_state.blend via the SVD backward."""
+        torch.manual_seed(42)
+        skel_states = self._make_random_skel_states(4).requires_grad_(True)
+        weights = torch.tensor(
+            [0.6, 0.2, 0.1, 0.1], dtype=torch.float64, requires_grad=True
+        )
+
+        def _blend_to_matrix(ss: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+            return pym_skel_state.to_matrix(pym_skel_state.blend(ss, w))
+
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                _blend_to_matrix, (skel_states, weights), eps=1e-6
+            ),
+        )
+
+    def test_blend_gradient_flows(self) -> None:
+        """Verify gradients flow through skel_state.blend to inputs."""
+        torch.manual_seed(42)
+        skel_states = self._make_random_skel_states(3).requires_grad_(True)
+        weights = torch.tensor([0.5, 0.3, 0.2], dtype=torch.float64, requires_grad=True)
+
+        result = pym_skel_state.blend(skel_states, weights)
+        loss = result.sum()
+        loss.backward()
+
+        self.assertIsNotNone(skel_states.grad)
+        self.assertFalse(torch.all(skel_states.grad == 0))
+        self.assertIsNotNone(weights.grad)
+        self.assertFalse(torch.all(weights.grad == 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

Replace the eigendecomposition-based quaternion blending in `quaternion.blend()` with an SVD-based approach that has a custom backward pass providing much more stable gradients for training.

The new `_TopRightSingularVector` autograd function computes the dominant right singular vector of the weighted quaternion matrix via `torch.linalg.svd`, with a custom backward that only differentiates through the top singular triplet. The `1/(sigma_1^2 - sigma_k^2)` terms in the backward are well-conditioned when the first singular value dominates (i.e., when blend weights are concentrated on one joint), which is the typical use case.

The forward pass also sign-stabilizes the output by forcing the component with the largest absolute value positive, preventing sign flips under small input perturbations during training.

Mathematically equivalent to the previous eigendecomposition approach (the right singular vector of `sqrt(W)*Q` equals the eigenvector of `Q^T*W*Q` with the largest eigenvalue), but the custom backward avoids the numerical instabilities of PyTorch built-in SVD/eigh backward when singular/eigenvalues are close.

Reviewed By: cstollmeta

Differential Revision: D103231178


