### PR TITLE
Enforce keyword-only arguments for config constructors in Python bindings (#1358)

### DIFF
--- a/momentum/examples/process_markers_app/process_markers_app.cpp
+++ b/momentum/examples/process_markers_app/process_markers_app.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
 
     CLI11_PARSE(app, argc, argv);
     if (calibConfig->debug || trackingConfig->debug) {
-      setLogLevel(LogLevel::Debug);
+      setLogLevel(momentum::LogLevel::Debug);
     }
     processMarkerFile(
         ioOpt->inputFile,

--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -7,6 +7,7 @@
 
 #include "momentum/marker_tracking/marker_tracker.h"
 
+#include "momentum/camera/projection_utils.h"
 #include "momentum/character/blend_shape_skinning.h"
 #include "momentum/character/character.h"
 #include "momentum/character/linear_skinning.h"
@@ -24,6 +25,7 @@
 #include "momentum/character_solver/model_parameters_error_function.h"
 #include "momentum/character_solver/plane_error_function.h"
 #include "momentum/character_solver/position_error_function.h"
+#include "momentum/character_solver/projection_error_function.h"
 #include "momentum/character_solver/skeleton_solver_function.h"
 #include "momentum/character_solver/skinned_locator_error_function.h"
 #include "momentum/character_solver/skinned_locator_triangle_error_function.h"
@@ -41,6 +43,19 @@ using namespace momentum;
 namespace momentum {
 
 namespace {
+
+void validateCameraKeypointFrameCount(
+    std::span<const CameraKeypointData> cameraKeypointData,
+    size_t numFrames) {
+  for (size_t cam = 0; cam < cameraKeypointData.size(); ++cam) {
+    MT_THROW_IF(
+        cameraKeypointData[cam].frameData.size() != numFrames,
+        "Camera keypoint data[{}] has {} frames but marker data has {} frames",
+        cam,
+        cameraKeypointData[cam].frameData.size(),
+        numFrames);
+  }
+}
 
 /// Compute a frame stride for sampling numFrames down to ~targetFrames.
 /// Always returns at least 1 to avoid division-by-zero or infinite loops.
@@ -221,11 +236,27 @@ Eigen::MatrixXf trackSequence(
     float targetHeightCm,
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
-    const std::optional<GloveConfig>& gloveConfig) {
+    const std::optional<GloveConfig>& gloveConfig,
+    std::span<const CameraKeypointData> cameraKeypointData) {
   // sanity checks
   const size_t numFrames = markerData.size();
   MT_CHECK(numFrames > 0, "Input marker data is empty.");
   MT_CHECK(frameStride > 0, "frameStride must be > 0.");
+  validateCameraKeypointFrameCount(cameraKeypointData, numFrames);
+  if (!leftGloveData.empty()) {
+    MT_CHECK(
+        leftGloveData.size() == numFrames,
+        "trackSequence: left glove data has {} frames but marker data has {} frames",
+        leftGloveData.size(),
+        numFrames);
+  }
+  if (!rightGloveData.empty()) {
+    MT_CHECK(
+        rightGloveData.size() == numFrames,
+        "trackSequence: right glove data has {} frames but marker data has {} frames",
+        rightGloveData.size(),
+        numFrames);
+  }
   std::vector<size_t> frames;
   for (size_t fi = 0; fi < numFrames; fi += frameStride) {
     frames.emplace_back(fi);
@@ -244,7 +275,8 @@ Eigen::MatrixXf trackSequence(
       targetHeightCm,
       leftGloveData,
       rightGloveData,
-      gloveConfig);
+      gloveConfig,
+      cameraKeypointData);
 }
 
 /// Add a blend shape regularizer that penalizes deviations from zero for all
@@ -271,6 +303,66 @@ void addBlendShapeRegularizer(
   solverFunc.addErrorFunction(solverFrame, blendShapeConstrFunc);
 }
 
+/// Add 2D keypoint projection constraints from outside-in cameras for one solver frame.
+/// Uses ProjectionErrorFunctionT with projectionMatrixRadians() so the residual is in
+/// radians (tangent-of-angle), making the weight pixel-independent and naturally scaled
+/// relative to marker constraints (in cm).
+void addKeypointProjectionConstraints(
+    SequenceSolverFunctionT<float>& solverFunc,
+    size_t solverFrame,
+    size_t iFrame,
+    const Character& character,
+    float projectionWeight,
+    std::span<const CameraKeypointData> cameraKeypointData) {
+  if (projectionWeight <= 0.0f) {
+    return;
+  }
+  size_t totalProjectionConstraints = 0;
+  size_t totalInvalidProj = 0;
+  for (const auto& camData : cameraKeypointData) {
+    if (iFrame >= camData.frameData.size() || camData.frameData[iFrame].empty()) {
+      continue;
+    }
+    auto projFunc = std::make_shared<ProjectionErrorFunctionT<float>>(
+        character.skeleton, character.parameterTransform);
+    for (const auto& obs : camData.frameData[iFrame]) {
+      if (obs.confidence <= 0.0f || obs.locatorIndex >= character.locators.size()) {
+        continue;
+      }
+      const auto& locator = character.locators[obs.locatorIndex];
+      if (locator.parent >= character.skeleton.joints.size()) {
+        continue;
+      }
+      const auto [M, valid] = projectionMatrixRadians(camData.camera, obs.target);
+      if (!valid) {
+        totalInvalidProj++;
+        continue;
+      }
+      ProjectionConstraintDataT<float> constr;
+      constr.projection = M;
+      constr.target = Eigen::Vector2f::Zero();
+      constr.parent = locator.parent;
+      constr.offset = locator.offset;
+      constr.weight = obs.confidence;
+      projFunc->addConstraint(constr);
+    }
+    if (!projFunc->empty()) {
+      totalProjectionConstraints += projFunc->getNumConstraints();
+      projFunc->setWeight(projectionWeight);
+      solverFunc.addErrorFunction(solverFrame, projFunc);
+    }
+  }
+  if (iFrame == 0) {
+    MT_LOGI(
+        "Frame 0: added {} projection constraints (radians, weight={}), "
+        "{} cameras, {} invalid projections",
+        totalProjectionConstraints,
+        projectionWeight,
+        cameraKeypointData.size(),
+        totalInvalidProj);
+  }
+}
+
 /// Add per-frame marker, floor, and glove constraints for one frame of the
 /// sequence solver.  Extracted from trackSequence to reduce cyclomatic complexity.
 void addSequenceFrameConstraints(
@@ -291,7 +383,8 @@ void addSequenceFrameConstraints(
     const std::vector<std::vector<JointToJointPositionDataT<float>>>& leftGlovePosData,
     const std::vector<std::vector<JointToJointOrientationDataT<float>>>& leftGloveOriData,
     const std::vector<std::vector<JointToJointPositionDataT<float>>>& rightGlovePosData,
-    const std::vector<std::vector<JointToJointOrientationDataT<float>>>& rightGloveOriData) {
+    const std::vector<std::vector<JointToJointOrientationDataT<float>>>& rightGloveOriData,
+    std::span<const CameraKeypointData> cameraKeypointData = {}) {
   auto posConstrWeight = PositionErrorFunction::kLegacyWeight * config.markerWeight;
   if (solverFrame == 0 && (enforceFloorInFirstFrame || !firstFramePoseConstraintSet.empty())) {
     posConstrWeight *= solvedFrames;
@@ -376,6 +469,9 @@ void addSequenceFrameConstraints(
         gloveConfig->positionWeight,
         gloveConfig->orientationWeight);
   }
+
+  addKeypointProjectionConstraints(
+      solverFunc, solverFrame, iFrame, character, config.projectionWeight, cameraKeypointData);
 }
 
 /// Track motion across multiple frames simultaneously for specific frame indices.
@@ -408,7 +504,8 @@ Eigen::MatrixXf trackSequence(
     float targetHeightCm,
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
-    const std::optional<GloveConfig>& gloveConfig) {
+    const std::optional<GloveConfig>& gloveConfig,
+    std::span<const CameraKeypointData> cameraKeypointData) {
   // sanity checks
   const size_t numFrames = markerData.size();
   MT_CHECK(numFrames > 0, "Input marker data is empty.");
@@ -432,6 +529,7 @@ Eigen::MatrixXf trackSequence(
       "Right glove data has {} frames but marker data has {} frames",
       rightGloveData.size(),
       numFrames);
+  validateCameraKeypointFrameCount(cameraKeypointData, numFrames);
 
   const ParameterTransform& pt = character.parameterTransform;
 
@@ -522,7 +620,8 @@ Eigen::MatrixXf trackSequence(
           leftGlovePosData,
           leftGloveOriData,
           rightGlovePosData,
-          rightGloveOriData);
+          rightGloveOriData,
+          cameraKeypointData);
     }
     // Set per-frame initial value
     solverFunc.setFrameParameters(solverFrame, initialMotion.col(iFrame));
@@ -1020,6 +1119,96 @@ void logSkinnedLocatorMeshDistances(const Character& character, const std::strin
   }
 }
 
+void logKeypointObservationSummary(
+    std::span<const CameraKeypointData> cameraKeypointData,
+    float projectionWeight) {
+  if (cameraKeypointData.empty() || projectionWeight <= 0.0f) {
+    return;
+  }
+  size_t totalObs = 0;
+  for (const auto& camData : cameraKeypointData) {
+    for (const auto& frame : camData.frameData) {
+      totalObs += frame.size();
+    }
+  }
+  MT_LOGI(
+      "2D keypoint constraints: {} cameras, {} total observations, "
+      "projectionWeight={}",
+      cameraKeypointData.size(),
+      totalObs,
+      projectionWeight);
+}
+
+void logKeypointReprojectionDiagnostic(
+    const Character& character,
+    std::span<const CameraKeypointData> cameraKeypointData,
+    const Eigen::MatrixXf& motion,
+    const ParameterTransform& transform,
+    const CalibrationConfig& config) {
+  if (!config.debug || cameraKeypointData.empty() || config.projectionWeight <= 0.0f) {
+    return;
+  }
+  const size_t diagFrame = 0;
+  SkeletonState skelState;
+  skelState.set(
+      character.parameterTransform.apply(
+          ModelParameters(motion.col(diagFrame).head(transform.numAllModelParameters()))),
+      character.skeleton);
+
+  MT_LOGI("=== Keypoint reprojection diagnostic (frame {}, after Stage 0) ===", diagFrame);
+  for (size_t iCam = 0; iCam < cameraKeypointData.size(); ++iCam) {
+    const auto& camData = cameraKeypointData[iCam];
+    if (diagFrame >= camData.frameData.size() || camData.frameData[diagFrame].empty()) {
+      continue;
+    }
+    size_t nObs = 0, nSkipped = 0;
+    float sumPxErr = 0, maxPxErr = 0;
+    float sumRadErr = 0, maxRadErr = 0;
+    for (const auto& obs : camData.frameData[diagFrame]) {
+      if (obs.confidence <= 0.0f || obs.locatorIndex >= character.locators.size()) {
+        nSkipped++;
+        continue;
+      }
+      const auto& locator = character.locators[obs.locatorIndex];
+      if (locator.parent >= skelState.jointState.size()) {
+        nSkipped++;
+        continue;
+      }
+      const Eigen::Vector3f p_world =
+          skelState.jointState[locator.parent].transform * locator.offset;
+      const auto [projected, valid] = camData.camera.project(p_world);
+      if (!valid) {
+        nSkipped++;
+        continue;
+      }
+      const float pxErr = (projected.head<2>() - obs.target).norm();
+      sumPxErr += pxErr;
+      maxPxErr = std::max(maxPxErr, pxErr);
+      const auto [M, mValid] = projectionMatrixRadians(camData.camera, obs.target);
+      float radErr = 0;
+      if (mValid) {
+        const Eigen::Vector4f ph(p_world[0], p_world[1], p_world[2], 1.0f);
+        const Eigen::Vector3f h = M * ph;
+        if (std::abs(h[2]) > 1e-6f) {
+          radErr = Eigen::Vector2f(h[0] / h[2], h[1] / h[2]).norm();
+        }
+      }
+      sumRadErr += radErr;
+      maxRadErr = std::max(maxRadErr, radErr);
+      nObs++;
+    }
+    MT_LOGI(
+        "cam[{}]: {} obs, {} skip, mean={:.1f}px/{:.4f}rad, max={:.1f}px/{:.4f}rad",
+        iCam,
+        nObs,
+        nSkipped,
+        nObs > 0 ? sumPxErr / nObs : 0.0f,
+        nObs > 0 ? sumRadErr / nObs : 0.0f,
+        maxPxErr,
+        maxRadErr);
+  }
+}
+
 } // namespace
 
 Character addSkinnedLocatorParametersToTransform(Character character) {
@@ -1045,7 +1234,8 @@ void calibrateModel(
     const std::array<float, 3>& regularizerWeights,
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
-    const std::optional<GloveConfig>& gloveConfig) {
+    const std::optional<GloveConfig>& gloveConfig,
+    std::span<const CameraKeypointData> cameraKeypointData) {
   const size_t numFrames = markerData.size();
   MT_THROW_IF(numFrames < 2, "Calibration requires at least 2 frames, got {}.", numFrames);
   MT_THROW_IF(
@@ -1063,6 +1253,7 @@ void calibrateModel(
       "Right glove data has {} frames but marker data has {} frames",
       rightGloveData.size(),
       numFrames);
+  validateCameraKeypointFrameCount(cameraKeypointData, numFrames);
 
   MT_THROW_IF(config.calibFrames == 0, "calibFrames must be > 0.");
   if (numFrames < config.calibFrames) {
@@ -1071,6 +1262,19 @@ void calibrateModel(
         numFrames,
         config.calibFrames);
   }
+
+  logKeypointObservationSummary(cameraKeypointData, config.projectionWeight);
+
+  MT_LOGI(
+      "calibrateModel: {} frames, {} locators, {} skinnedLocators, {} joints, "
+      "leftGlove={}, rightGlove={}, keypoints={} cameras",
+      numFrames,
+      character.locators.size(),
+      character.skinnedLocators.size(),
+      character.skeleton.joints.size(),
+      leftGloveData.size(),
+      rightGloveData.size(),
+      cameraKeypointData.size());
 
   // uniformly sample frames for calibration
   const size_t frameStride = computeSampleStride(numFrames, config.calibFrames);
@@ -1117,15 +1321,14 @@ void calibrateModel(
   }
 
   // special trackingConfig for initialization: zero out smoothness and collision
-  TrackingConfig trackingConfig{
-      {config.minVisPercent, config.lossAlpha, config.maxIter, config.regularization, config.debug},
-      0.0,
-      0.0,
-      1.0f,
-      {},
-      std::nullopt,
-      config.meshConstraintWeight,
-      {}};
+  TrackingConfig trackingConfig;
+  trackingConfig.minVisPercent = config.minVisPercent;
+  trackingConfig.lossAlpha = config.lossAlpha;
+  trackingConfig.maxIter = config.maxIter;
+  trackingConfig.regularization = config.regularization;
+  trackingConfig.debug = config.debug;
+  trackingConfig.meshConstraintWeight = config.meshConstraintWeight;
+  trackingConfig.projectionWeight = config.projectionWeight;
 
   // only keep one motion; no need to duplicate.
   // identity information will be initialized and updated in the motion matrix throughout all the
@@ -1223,6 +1426,8 @@ void calibrateModel(
     }
   }
 
+  logKeypointReprojectionDiagnostic(character, cameraKeypointData, motion, transform, config);
+
   // Solve everything together for a few iterations
   for (size_t iIter = 0; iIter < config.majorIter; ++iIter) {
     MT_LOGI_IF(config.debug, "Iteration {} of calibration", iIter);
@@ -1242,7 +1447,8 @@ void calibrateModel(
           config.targetHeightCm,
           leftGloveData,
           rightGloveData,
-          gloveConfig); // still solving a subset
+          gloveConfig,
+          cameraKeypointData);
     } else {
       motion = trackSequence(
           markerData,
@@ -1258,7 +1464,8 @@ void calibrateModel(
           config.targetHeightCm,
           leftGloveData,
           rightGloveData,
-          gloveConfig); // still solving a subset
+          gloveConfig,
+          cameraKeypointData);
     }
     // extract solving results to identity and character so we can pass them to trackPosesPerframe
     // below.
@@ -1314,7 +1521,8 @@ void calibrateModel(
         config.targetHeightCm,
         leftGloveData,
         rightGloveData,
-        gloveConfig);
+        gloveConfig,
+        cameraKeypointData);
   } else {
     motion = trackSequence(
         markerData,
@@ -1330,7 +1538,8 @@ void calibrateModel(
         config.targetHeightCm,
         leftGloveData,
         rightGloveData,
-        gloveConfig);
+        gloveConfig,
+        cameraKeypointData);
   }
   std::tie(identity.v, character.locators, character.skinnedLocators) =
       extractIdAndLocatorsFromParams(motion.col(0), solvingCharacter, character);
@@ -1394,15 +1603,13 @@ void calibrateLocators(
   ParameterSet locatorSet = transformExtended.parameterSets.find("locators")->second;
 
   // special trackingConfig for initialization: zero out smoothness and collision
-  TrackingConfig trackingConfig{
-      {config.minVisPercent, config.lossAlpha, config.maxIter, config.regularization, config.debug},
-      0.0,
-      0.0,
-      1.0f,
-      {},
-      std::nullopt,
-      config.meshConstraintWeight,
-      {}};
+  TrackingConfig trackingConfig;
+  trackingConfig.minVisPercent = config.minVisPercent;
+  trackingConfig.lossAlpha = config.lossAlpha;
+  trackingConfig.maxIter = config.maxIter;
+  trackingConfig.regularization = config.regularization;
+  trackingConfig.debug = config.debug;
+  trackingConfig.meshConstraintWeight = config.meshConstraintWeight;
 
   // only keep one motion for both character and solvingCharacter; no need to duplicate.
   // identity information will be initialized and updated in the motion matrix throughout all the

--- a/momentum/marker_tracking/marker_tracker.h
+++ b/momentum/marker_tracking/marker_tracker.h
@@ -7,12 +7,35 @@
 
 #pragma once
 
+#include <momentum/camera/camera.h>
 #include <momentum/character/character.h>
 #include <momentum/character/marker.h>
 #include <momentum/marker_tracking/glove_utils.h>
 #include <momentum/marker_tracking/marker_gap_fill.h>
 
 namespace momentum {
+
+/// A single 2D keypoint observation from a camera view.
+///
+/// Each observation maps a detected 2D pixel location to a specific locator on the character
+/// skeleton (identified by index into the character's locator list). The confidence score
+/// from the keypoint detector is used as a weight multiplier.
+struct KeypointObservation {
+  size_t locatorIndex{}; ///< Index into the character's locator list
+  Eigen::Vector2f target = Eigen::Vector2f::Zero(); ///< Target 2D pixel coordinates
+  float confidence = 1.0f; ///< Detection confidence, used as weight multiplier
+};
+
+/// Per-camera 2D keypoint data for all frames.
+///
+/// Groups a camera (with intrinsics and extrinsics) together with the 2D keypoint
+/// observations detected in that camera's image stream. The outer vector is indexed
+/// by frame number (matching the marker data indexing), and the inner vector contains
+/// all keypoint observations visible in that frame for this camera.
+struct CameraKeypointData {
+  Camera camera; ///< Camera intrinsics and extrinsics (world-space)
+  std::vector<std::vector<KeypointObservation>> frameData; ///< Per-frame keypoint observations
+};
 
 /// Common configuration for a tracking problem
 struct BaseConfig {
@@ -54,6 +77,8 @@ struct CalibrationConfig : public BaseConfig {
   /// Multiplier for the mesh surface constraint weight on skinned locators during shape
   /// calibration. Higher values pull markers more tightly to the mesh surface. Default 1.0.
   float meshConstraintWeight = 1.0f;
+  /// Base weight for 2D keypoint projection constraints. Set to 0 to disable.
+  float projectionWeight = 0.0f;
 };
 
 /// Configuration for pose tracking given a calibrated body and locators
@@ -76,6 +101,8 @@ struct TrackingConfig : public BaseConfig {
   /// Multiplier for the mesh surface constraint weight on skinned locators. Higher values pull
   /// skinned locators closer to the mesh surface during the solve. Default 1.0.
   float meshConstraintWeight = 1.0f;
+  /// Base weight for 2D keypoint projection constraints. Default 0 (disabled).
+  float projectionWeight = 0.0f;
   /// Configuration for pre-processing marker gaps before constraint creation.
   /// Fills temporary gaps via cubic Hermite interpolation and blends off permanent
   /// dropouts via linear velocity extrapolation with cosine weight ramp.
@@ -125,7 +152,8 @@ Eigen::MatrixXf trackSequence(
     float targetHeightCm = 0.0f,
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
-    const std::optional<GloveConfig>& gloveConfig = std::nullopt);
+    const std::optional<GloveConfig>& gloveConfig = std::nullopt,
+    std::span<const CameraKeypointData> cameraKeypointData = {});
 
 /// Use multiple frames to solve for global parameters such as body proportions and/or marker
 /// offsets together with the motion.
@@ -157,7 +185,8 @@ Eigen::MatrixXf trackSequence(
     float targetHeightCm = 0.0f,
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
-    const std::optional<GloveConfig>& gloveConfig = std::nullopt);
+    const std::optional<GloveConfig>& gloveConfig = std::nullopt,
+    std::span<const CameraKeypointData> cameraKeypointData = {});
 
 /// Track poses per-frame given a calibrated character.
 ///
@@ -225,7 +254,8 @@ void calibrateModel(
     const std::array<float, 3>& regularizerWeights = {0.0f, 0.0f, 0.0f},
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
-    const std::optional<GloveConfig>& gloveConfig = std::nullopt);
+    const std::optional<GloveConfig>& gloveConfig = std::nullopt,
+    std::span<const CameraKeypointData> cameraKeypointData = {});
 
 /// Calibrate locator offsets of a character from input identity and marker data.
 ///

--- a/momentum/marker_tracking/process_markers.cpp
+++ b/momentum/marker_tracking/process_markers.cpp
@@ -42,6 +42,32 @@ std::span<const GloveFrameData> validateAndSliceGloveData(
   return gloveData.subspan(firstFrame, lastFrame - firstFrame);
 }
 
+/// Slice camera keypoint data to match the [firstFrame, lastFrame) range.
+/// Each CameraKeypointData has per-frame observations, so we create sliced
+/// copies with frameData adjusted to the same range as the marker data.
+std::vector<CameraKeypointData> sliceCameraKeypointData(
+    std::span<const CameraKeypointData> data,
+    size_t firstFrame,
+    size_t lastFrame) {
+  std::vector<CameraKeypointData> result;
+  if (data.empty()) {
+    return result;
+  }
+  result.reserve(data.size());
+  for (const auto& camData : data) {
+    CameraKeypointData sliced;
+    sliced.camera = camData.camera;
+    if (camData.frameData.size() >= lastFrame) {
+      sliced.frameData.assign(
+          camData.frameData.begin() + firstFrame, camData.frameData.begin() + lastFrame);
+    } else if (camData.frameData.size() > firstFrame) {
+      sliced.frameData.assign(camData.frameData.begin() + firstFrame, camData.frameData.end());
+    }
+    result.push_back(std::move(sliced));
+  }
+  return result;
+}
+
 } // namespace
 
 void calibrateMarkers(
@@ -53,7 +79,8 @@ void calibrateMarkers(
     size_t maxFrames,
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
-    const std::optional<GloveConfig>& gloveConfig) {
+    const std::optional<GloveConfig>& gloveConfig,
+    std::span<const CameraKeypointData> cameraKeypointData) {
   MT_THROW_IF(
       firstFrame > markerData.size(),
       "First frame {} can't exceed total frames {}",
@@ -80,6 +107,9 @@ void calibrateMarkers(
       !(calibrationConfig.globalScaleOnly & calibrationConfig.locatorsOnly),
       "globalScaleOnly and locatorsOnly are exclusive; they cannot both be true.");
 
+  const auto slicedKeypointData =
+      sliceCameraKeypointData(cameraKeypointData, firstFrame, lastFrame);
+
   if (calibrationConfig.locatorsOnly) {
     // The output locators will be written to character.
     calibrateLocators(inputData, calibrationConfig, identity, character);
@@ -94,7 +124,8 @@ void calibrateMarkers(
         {0.0f, 0.0f, 0.0f},
         leftGloveSlice,
         rightGloveSlice,
-        gloveConfig);
+        gloveConfig,
+        slicedKeypointData);
   }
 }
 
@@ -109,7 +140,8 @@ Eigen::MatrixXf processMarkers(
     size_t maxFrames,
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
-    const std::optional<GloveConfig>& gloveConfig) {
+    const std::optional<GloveConfig>& gloveConfig,
+    std::span<const CameraKeypointData> cameraKeypointData) {
   MT_THROW_IF(
       firstFrame > markerData.size(),
       "First frame {} can't exceed total frames {}",
@@ -129,6 +161,9 @@ Eigen::MatrixXf processMarkers(
       validateAndSliceGloveData(leftGloveData, markerData.size(), firstFrame, lastFrame, "Left");
   const auto rightGloveSlice =
       validateAndSliceGloveData(rightGloveData, markerData.size(), firstFrame, lastFrame, "Right");
+
+  const auto slicedKeypointData =
+      sliceCameraKeypointData(cameraKeypointData, firstFrame, lastFrame);
 
   // calibrate model and locators
   if (calibrate) {
@@ -150,7 +185,8 @@ Eigen::MatrixXf processMarkers(
           {0.0f, 0.0f, 0.0f},
           leftGloveSlice,
           rightGloveSlice,
-          gloveConfig);
+          gloveConfig,
+          slicedKeypointData);
     }
   }
 

--- a/momentum/marker_tracking/process_markers.h
+++ b/momentum/marker_tracking/process_markers.h
@@ -41,7 +41,8 @@ void calibrateMarkers(
     size_t maxFrames = 0,
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
-    const std::optional<GloveConfig>& gloveConfig = std::nullopt);
+    const std::optional<GloveConfig>& gloveConfig = std::nullopt,
+    std::span<const CameraKeypointData> cameraKeypointData = {});
 
 /// Processes marker data for a character model.
 ///
@@ -72,7 +73,8 @@ Eigen::MatrixXf processMarkers(
     size_t maxFrames = 0,
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
-    const std::optional<GloveConfig>& gloveConfig = std::nullopt);
+    const std::optional<GloveConfig>& gloveConfig = std::nullopt,
+    std::span<const CameraKeypointData> cameraKeypointData = {});
 
 /// Runs marker tracking on an input marker file (e.g. c3d) and writes the output motion (e.g. glb)
 /// to outputFile

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -218,7 +218,11 @@ PYBIND11_MODULE(marker_tracking, m) {
       .def_readwrite(
           "mesh_constraint_weight",
           &momentum::CalibrationConfig::meshConstraintWeight,
-          "Weight multiplier for mesh surface constraints during calibration");
+          "Weight multiplier for mesh surface constraints during calibration")
+      .def_readwrite(
+          "projection_weight",
+          &momentum::CalibrationConfig::projectionWeight,
+          "Base weight for 2D keypoint projection constraints. Set to 0 to disable.");
 
   auto gapFillConfig = py::class_<momentum::GapFillConfig>(
       m, "GapFillConfig", "Config for marker gap filling and dropout blending");
@@ -590,6 +594,68 @@ and orientation of a finger joint in the glove's local coordinate frame.)");
           &momentum::GloveSensorObservation::valid,
           "Whether this observation is valid (False if sensor data is missing/occluded).");
 
+  // Bindings for 2D keypoint projection constraint types
+  auto keypointObservation = py::class_<momentum::KeypointObservation>(
+      m,
+      "KeypointObservation",
+      R"(A single 2D keypoint observation from a camera view.
+
+Each observation maps a detected 2D pixel location to a specific locator on the
+character skeleton. The confidence score is used as a weight multiplier.)");
+
+  keypointObservation.def(py::init<>())
+      .def(
+          py::init([](size_t locatorIndex, const Eigen::Vector2f& target, float confidence) {
+            momentum::KeypointObservation obs;
+            obs.locatorIndex = locatorIndex;
+            obs.target = target;
+            obs.confidence = confidence;
+            return obs;
+          }),
+          py::arg("locator_index"),
+          py::arg("target"),
+          py::arg("confidence") = 1.0f)
+      .def_readwrite(
+          "locator_index",
+          &momentum::KeypointObservation::locatorIndex,
+          "Index into the character's locator list")
+      .def_readwrite(
+          "target", &momentum::KeypointObservation::target, "Target 2D pixel coordinates")
+      .def_readwrite(
+          "confidence",
+          &momentum::KeypointObservation::confidence,
+          "Detection confidence, used as weight multiplier");
+
+  pybind11::module_::import("pymomentum.camera"); // @dep=fbsource//arvr/libraries/pymomentum:camera
+
+  auto cameraKeypointData = py::class_<momentum::CameraKeypointData>(
+      m,
+      "CameraKeypointData",
+      R"(Per-camera 2D keypoint data for all frames.
+
+Groups a camera (with intrinsics and extrinsics) together with per-frame 2D keypoint
+observations detected in that camera's image stream.)");
+
+  cameraKeypointData.def(py::init<>())
+      .def(
+          py::init([](const momentum::Camera& camera,
+                      const std::vector<std::vector<momentum::KeypointObservation>>& frameData) {
+            momentum::CameraKeypointData data;
+            data.camera = camera;
+            data.frameData = frameData;
+            return data;
+          }),
+          py::arg("camera"),
+          py::arg("frame_data"))
+      .def_readwrite(
+          "camera",
+          &momentum::CameraKeypointData::camera,
+          "Camera intrinsics and extrinsics (world-space)")
+      .def_readwrite(
+          "frame_data",
+          &momentum::CameraKeypointData::frameData,
+          "Per-frame keypoint observations: list of list of KeypointObservation");
+
   m.def(
       "process_marker_file",
       &momentum::processMarkerFile,
@@ -612,7 +678,8 @@ and orientation of a finger joint in the glove's local coordinate frame.)");
          size_t maxFrames,
          const std::vector<momentum::GloveFrameData>& leftGloveData,
          const std::vector<momentum::GloveFrameData>& rightGloveData,
-         const std::optional<momentum::GloveConfig>& gloveConfig) {
+         const std::optional<momentum::GloveConfig>& gloveConfig,
+         const std::vector<momentum::CameraKeypointData>& cameraKeypointData) {
         momentum::ModelParameters params(identity);
 
         if (params.size() == 0) { // If no identity is passed in, use default
@@ -628,7 +695,8 @@ and orientation of a finger joint in the glove's local coordinate frame.)");
             maxFrames,
             leftGloveData,
             rightGloveData,
-            gloveConfig);
+            gloveConfig,
+            cameraKeypointData);
 
         // Return the identity parameters (scaling params only)
         // Use .v to get the underlying Eigen::VectorXf from ModelParameters
@@ -650,6 +718,11 @@ When glove data is provided via ``left_glove_data`` / ``right_glove_data`` and a
 This improves locator calibration by providing additional constraint information from the
 data glove sensors.
 
+When ``camera_keypoint_data`` is provided and ``calibration_config.projection_weight > 0``,
+the solver adds 2D reprojection constraints from outside-in cameras. These constraints
+project 3D skeleton locator positions through the camera model and penalize the error
+against detected 2D keypoints.
+
 :param character: Character to be calibrated. Will be modified in-place if locator
     calibration is enabled.
 :param identity: Identity parameters, pass in empty array for default identity.
@@ -662,6 +735,9 @@ data glove sensors.
 :param right_glove_data: Per-frame glove sensor observations for the right hand.
 :param glove_config: Optional :class:`GloveConfig` controlling constraint weights and
     wrist joint names. Must be provided if glove data is non-empty.
+:param camera_keypoint_data: Per-camera 2D keypoint observations for projection constraints.
+    Each element is a :class:`CameraKeypointData` with camera parameters and per-frame
+    keypoint detections.
 :return: Calibrated identity parameters (scaling parameters).)",
       py::arg("character"),
       py::arg("identity"),
@@ -671,7 +747,8 @@ data glove sensors.
       py::arg("max_frames") = 0,
       py::arg("left_glove_data") = std::vector<momentum::GloveFrameData>{},
       py::arg("right_glove_data") = std::vector<momentum::GloveFrameData>{},
-      py::arg("glove_config") = std::nullopt);
+      py::arg("glove_config") = std::nullopt,
+      py::arg("camera_keypoint_data") = std::vector<momentum::CameraKeypointData>{});
 
   m.def(
       "process_markers",

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -72,7 +72,7 @@ PYBIND11_MODULE(marker_tracking, m) {
   auto baseConfig =
       py::class_<momentum::BaseConfig>(m, "BaseConfig", "Represents base config class");
 
-  baseConfig.def(py::init<>())
+  baseConfig
       .def(
           "__repr__",
           [](const momentum::BaseConfig& self) {
@@ -85,14 +85,28 @@ PYBIND11_MODULE(marker_tracking, m) {
                 boolToString(self.debug));
           })
       .def(
-          py::init<float, float, size_t, float, bool>(),
+          py::init([](float minVisPercent,
+                      float lossAlpha,
+                      size_t maxIter,
+                      float regularization,
+                      bool debug) {
+            momentum::BaseConfig cfg;
+            cfg.minVisPercent = minVisPercent;
+            cfg.lossAlpha = lossAlpha;
+            cfg.maxIter = maxIter;
+            cfg.regularization = regularization;
+            cfg.debug = debug;
+            return cfg;
+          }),
           R"(Create a BaseConfig with specified parameters.
 
           :param min_vis_percent: Minimum percentage of visible markers to be used
           :param loss_alpha: Parameter to control the loss function
           :param max_iter: Maximum number of iterations
+          :param regularization: Regularization parameter (lambda) for solver
           :param debug: Whether to output debugging info
           )",
+          py::kw_only(),
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
@@ -111,7 +125,7 @@ PYBIND11_MODULE(marker_tracking, m) {
       m, "CalibrationConfig", "Config for the body scale calibration step");
 
   // Default values are set from the configured values in marker_tracker.h
-  calibrationConfig.def(py::init<>())
+  calibrationConfig
       .def(
           "__repr__",
           [](const momentum::CalibrationConfig& self) {
@@ -134,27 +148,47 @@ PYBIND11_MODULE(marker_tracking, m) {
                 self.meshConstraintWeight);
           })
       .def(
-          py::init<
-              float,
-              float,
-              size_t,
-              float,
-              bool,
-              size_t,
-              size_t,
-              bool,
-              bool,
-              size_t,
-              bool,
-              std::string,
-              bool,
-              float,
-              float>(),
+          py::init([](float minVisPercent,
+                      float lossAlpha,
+                      size_t maxIter,
+                      float regularization,
+                      bool debug,
+                      size_t calibFrames,
+                      size_t majorIter,
+                      bool globalScaleOnly,
+                      bool locatorsOnly,
+                      size_t greedySampling,
+                      bool enforceFloorInFirstFrame,
+                      std::string firstFramePoseConstraintSet,
+                      bool calibShape,
+                      float targetHeightCm,
+                      float meshConstraintWeight,
+                      float projectionWeight) {
+            momentum::CalibrationConfig cfg;
+            cfg.minVisPercent = minVisPercent;
+            cfg.lossAlpha = lossAlpha;
+            cfg.maxIter = maxIter;
+            cfg.regularization = regularization;
+            cfg.debug = debug;
+            cfg.calibFrames = calibFrames;
+            cfg.majorIter = majorIter;
+            cfg.globalScaleOnly = globalScaleOnly;
+            cfg.locatorsOnly = locatorsOnly;
+            cfg.greedySampling = greedySampling;
+            cfg.enforceFloorInFirstFrame = enforceFloorInFirstFrame;
+            cfg.firstFramePoseConstraintSet = std::move(firstFramePoseConstraintSet);
+            cfg.calibShape = calibShape;
+            cfg.targetHeightCm = targetHeightCm;
+            cfg.meshConstraintWeight = meshConstraintWeight;
+            cfg.projectionWeight = projectionWeight;
+            return cfg;
+          }),
           R"(Create a CalibrationConfig with specified parameters.
 
           :param min_vis_percent: Minimum percentage of visible markers to be used
           :param loss_alpha: Parameter to control the loss function
           :param max_iter: Maximum number of iterations
+          :param regularization: Regularization parameter (lambda) for solver
           :param debug: Whether to output debugging info
           :param calib_frames: Number of frames used for model calibration
           :param major_iter: Number of calibration loops to run
@@ -163,9 +197,12 @@ PYBIND11_MODULE(marker_tracking, m) {
           :param greedy_sampling: Enable greedy frame sampling with the given stride
           :param enforce_floor_in_first_frame: Force floor contact in first frame
           :param first_frame_pose_constraint_set: Name of pose constraint set to use in first frame
+          :param calib_shape: Calibrate shape parameters
           :param target_height_cm: Target height for character in cm.  Defaults to 0 (unspecified).
           :param mesh_constraint_weight: Weight multiplier for mesh surface constraints during calibration.
+          :param projection_weight: Base weight for 2D keypoint projection constraints. Set to 0 to disable.
           )",
+          py::kw_only(),
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
@@ -180,7 +217,8 @@ PYBIND11_MODULE(marker_tracking, m) {
           py::arg("first_frame_pose_constraint_set") = "",
           py::arg("calib_shape") = false,
           py::arg("target_height_cm") = 0.0,
-          py::arg("mesh_constraint_weight") = 1.0f)
+          py::arg("mesh_constraint_weight") = 1.0f,
+          py::arg("projection_weight") = 0.0f)
       .def_readwrite(
           "calib_frames",
           &momentum::CalibrationConfig::calibFrames,
@@ -275,7 +313,7 @@ PYBIND11_MODULE(marker_tracking, m) {
   auto trackingConfig = py::class_<momentum::TrackingConfig, momentum::BaseConfig>(
       m, "TrackingConfig", "Config for the tracking optimization step");
 
-  trackingConfig.def(py::init<>())
+  trackingConfig
       .def(
           "__repr__",
           [](const momentum::TrackingConfig& self) {
@@ -293,7 +331,31 @@ PYBIND11_MODULE(marker_tracking, m) {
                 self.activeParams ? "set" : "None");
           })
       .def(
-          py::init<float, float, size_t, float, bool, float, float, float, Eigen::VectorXf>(),
+          py::init([](float minVisPercent,
+                      float lossAlpha,
+                      size_t maxIter,
+                      float regularization,
+                      bool debug,
+                      float smoothing,
+                      float collisionErrorWeight,
+                      float markerWeight,
+                      Eigen::VectorXf smoothingWeights,
+                      float meshConstraintWeight,
+                      float projectionWeight) {
+            momentum::TrackingConfig cfg;
+            cfg.minVisPercent = minVisPercent;
+            cfg.lossAlpha = lossAlpha;
+            cfg.maxIter = maxIter;
+            cfg.regularization = regularization;
+            cfg.debug = debug;
+            cfg.smoothing = smoothing;
+            cfg.collisionErrorWeight = collisionErrorWeight;
+            cfg.markerWeight = markerWeight;
+            cfg.smoothingWeights = std::move(smoothingWeights);
+            cfg.meshConstraintWeight = meshConstraintWeight;
+            cfg.projectionWeight = projectionWeight;
+            return cfg;
+          }),
           R"(Create a TrackingConfig with specified parameters.
 
           :param min_vis_percent: Minimum percentage of visible markers to be used
@@ -305,7 +367,10 @@ PYBIND11_MODULE(marker_tracking, m) {
           :param collision_error_weight: Collision error weight; 0 to disable
           :param marker_weight: Multiplier for marker position constraint weight; 0 to disable markers
           :param smoothing_weights: Smoothing weights per model parameter
+          :param mesh_constraint_weight: Weight multiplier for mesh surface constraints
+          :param projection_weight: Base weight for 2D keypoint projection constraints. Set to 0 to disable.
           )",
+          py::kw_only(),
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,
@@ -314,7 +379,9 @@ PYBIND11_MODULE(marker_tracking, m) {
           py::arg("smoothing") = 0.0,
           py::arg("collision_error_weight") = 0.0,
           py::arg("marker_weight") = 1.0f,
-          py::arg("smoothing_weights") = Eigen::VectorXf())
+          py::arg("smoothing_weights") = Eigen::VectorXf(),
+          py::arg("mesh_constraint_weight") = 1.0f,
+          py::arg("projection_weight") = 0.0f)
       .def_readwrite(
           "smoothing", &momentum::TrackingConfig::smoothing, "Smoothing weight; 0 to disable")
       .def_readwrite(
@@ -383,7 +450,7 @@ Set to None (default) to use the solver's default parameter set.)")
   auto refineConfig = py::class_<momentum::RefineConfig, momentum::TrackingConfig>(
       m, "RefineConfig", "Config for refining a tracked motion.");
 
-  refineConfig.def(py::init<>())
+  refineConfig
       .def(
           "__repr__",
           [](const momentum::RefineConfig& self) {
@@ -444,6 +511,7 @@ Set to None (default) to use the solver's default parameter set.)")
           :param calib_id: Calibrate identity parameters
           :param calib_locators: Calibrate locator offsets
           )",
+          py::kw_only(),
           py::arg("min_vis_percent") = 0.0,
           py::arg("loss_alpha") = 2.0,
           py::arg("max_iter") = 30,


### PR DESCRIPTION
Summary:

The pybind11 constructors for BaseConfig, CalibrationConfig, TrackingConfig, and RefineConfig previously used positional `py::init<...>()` which allowed callers to pass arguments by position. This is error-prone: if a field is added or reordered in the C++ struct, existing Python callers silently get wrong values.

This diff converts all four config constructors to lambda-based `py::init` with `py::kw_only()`, requiring all arguments to be passed by name. This also adds the previously missing `projection_weight` parameter to CalibrationConfig and TrackingConfig constructors, and `mesh_constraint_weight` and `projection_weight` to TrackingConfig.

The C++ TrackingConfig brace initializers in marker_tracker.cpp are also converted from positional aggregate initialization to named field assignment, which is similarly resilient to field reordering.

Reviewed By: cstollmeta

Differential Revision: D103504304


