### PR TITLE
Fix dangling-else hazard in MT_THROW_IF_T macro

### DIFF
--- a/momentum/common/exception.h
+++ b/momentum/common/exception.h
@@ -39,12 +39,12 @@
 ///   MT_THROW_IF_T(x > y, std::out_of_range, "x ({}) is greater than y ({})", x, y);
 ///   MT_THROW_IF_T(x > y, std::bad_array_new_length); // No message
 /// @endcode
-// TODO: Wrap macro body in `do { ... } while (0)` to avoid dangling-else bugs when used
-// inside an `if`/`else` without braces.
 #define MT_THROW_IF_T(Condition, Exception, ...) \
-  if (Condition) {                               \
-    MT_THROW_T(Exception, ##__VA_ARGS__);        \
-  }
+  do {                                           \
+    if (Condition) {                             \
+      MT_THROW_T(Exception, ##__VA_ARGS__);      \
+    }                                            \
+  } while (0)
 
 /// Conditionally throws a std::runtime_error with a formatted message if the condition is true.
 /// @param Condition The condition to evaluate.

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -47,7 +47,7 @@ mm::Character withBlendShapeImpl(
     return c.withBlendShape({}, 0);
   }
 
-  MT_THROW_IF(!c.mesh, "Character has no mesh, cannot apply blend shapes.")
+  MT_THROW_IF(!c.mesh, "Character has no mesh, cannot apply blend shapes.");
 
   auto blendShapePtr = blendShape.value();
   MT_THROW_IF(

--- a/pymomentum/python_utility/python_utility.cpp
+++ b/pymomentum/python_utility/python_utility.cpp
@@ -96,7 +96,7 @@ nlohmann::json from_msgpack(const pybind11::bytes& bytes) {
   const auto* data = reinterpret_cast<const uint8_t*>(info.ptr);
   const auto length = static_cast<size_t>(info.size);
 
-  MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.")
+  MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.");
 
   return nlohmann::json::from_msgpack(data, data + length);
 }
@@ -118,7 +118,7 @@ PyBytesStreamBuffer::PyBytesStreamBuffer(const pybind11::bytes& bytes) {
   char* data = const_cast<char*>(reinterpret_cast<const char*>(info.ptr));
   const auto length = static_cast<size_t>(info.size);
 
-  MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.")
+  MT_THROW_IF(data == nullptr, "Unable to extract contents from bytes.");
 
   this->setg(data, data, data + length);
 }

--- a/pymomentum/solver/momentum_ik_autograd.cpp
+++ b/pymomentum/solver/momentum_ik_autograd.cpp
@@ -142,7 +142,7 @@ std::pair<std::vector<std::unique_ptr<TensorErrorFunction<T>>>, std::vector<int>
     // Check whether we have duplicated error function types here:
     MT_THROW_IF(
         errorFunctionMap[typeIndex] != -1,
-        "solveBodyIKProblem(): active_error_functions have duplicate types")
+        "solveBodyIKProblem(): active_error_functions have duplicate types");
     errorFunctionMap[typeIndex] = static_cast<int>(iErr);
   }
 
@@ -557,7 +557,7 @@ variable_list IKProblemAutogradFunction<T, IKFunction>::backward(
     variable_list dLoss_dResults) {
   MT_THROW_IF(
       dLoss_dResults.size() != IKFunction<T>::N_RESULTS,
-      "Invalid grad_outputs in IKProblemAutogradFunction::backward.")
+      "Invalid grad_outputs in IKProblemAutogradFunction::backward.");
 
   const momentum::Mppca* mppca = nullptr;
 #ifndef PYMOMENTUM_LIMITED_TORCH_API
@@ -846,7 +846,7 @@ std::tuple<at::Tensor, at::Tensor, std::vector<at::Tensor>> GradientFunction<T>:
     const std::vector<int>& weightsMap) {
   MT_THROW_IF(
       results.size() != 1 || dLoss_dResults.size() != 1,
-      "Mismatch in length of results list in IKSolveFunction::backward.")
+      "Mismatch in length of results list in IKSolveFunction::backward.");
 
   const at::Tensor& dLoss_dGradient = dLoss_dResults[0];
   return d_computeGradient<T>(


### PR DESCRIPTION
Summary:
Wrap the macro body in `do { ... } while (0)` so that the macro behaves as a single statement and does not bind unexpectedly to a following `else`. Previously the macro expanded to a bare `if (cond) { ... }`, which would silently consume an `else` from an enclosing unbraced `if`/`else` chain at the call site.

Removes the corresponding `// TODO:` comment flagged in the recent comment audit.

Differential Revision: D103888516


