### PR TITLE
Return selected calibration frame indices from calibrate_markers (#1368)

### DIFF
--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -1139,15 +1139,34 @@ void logKeypointObservationSummary(
       projectionWeight);
 }
 
+} // namespace
+
+Character addSkinnedLocatorParametersToTransform(Character character) {
+  if (character.skinnedLocators.empty()) {
+    return character;
+  }
+
+  std::vector<bool> activeSkinnedLocators(character.skinnedLocators.size(), true);
+  std::vector<std::string> locatorNames;
+  for (const auto& sl : character.skinnedLocators) {
+    locatorNames.push_back(sl.name);
+  }
+  std::tie(character.parameterTransform, character.parameterLimits) = addSkinnedLocatorParameters(
+      character.parameterTransform, character.parameterLimits, activeSkinnedLocators, locatorNames);
+  return character;
+}
+
 void logKeypointReprojectionDiagnostic(
     const Character& character,
-    std::span<const CameraKeypointData> cameraKeypointData,
-    const Eigen::MatrixXf& motion,
     const ParameterTransform& transform,
-    const CalibrationConfig& config) {
+    const Eigen::MatrixXf& motion,
+    std::span<const CameraKeypointData> cameraKeypointData,
+    const CalibrationConfig& config,
+    const std::string& label) {
   if (!config.debug || cameraKeypointData.empty() || config.projectionWeight <= 0.0f) {
     return;
   }
+
   const size_t diagFrame = 0;
   SkeletonState skelState;
   skelState.set(
@@ -1155,7 +1174,7 @@ void logKeypointReprojectionDiagnostic(
           ModelParameters(motion.col(diagFrame).head(transform.numAllModelParameters()))),
       character.skeleton);
 
-  MT_LOGI("=== Keypoint reprojection diagnostic (frame {}, after Stage 0) ===", diagFrame);
+  MT_LOGI("=== Keypoint reprojection diagnostic (frame {}, {}) ===", diagFrame, label);
   for (size_t iCam = 0; iCam < cameraKeypointData.size(); ++iCam) {
     const auto& camData = cameraKeypointData[iCam];
     if (diagFrame >= camData.frameData.size() || camData.frameData[diagFrame].empty()) {
@@ -1209,23 +1228,6 @@ void logKeypointReprojectionDiagnostic(
   }
 }
 
-} // namespace
-
-Character addSkinnedLocatorParametersToTransform(Character character) {
-  if (character.skinnedLocators.empty()) {
-    return character;
-  }
-
-  std::vector<bool> activeSkinnedLocators(character.skinnedLocators.size(), true);
-  std::vector<std::string> locatorNames;
-  for (const auto& sl : character.skinnedLocators) {
-    locatorNames.push_back(sl.name);
-  }
-  std::tie(character.parameterTransform, character.parameterLimits) = addSkinnedLocatorParameters(
-      character.parameterTransform, character.parameterLimits, activeSkinnedLocators, locatorNames);
-  return character;
-}
-
 void calibrateModel(
     const std::span<const std::vector<Marker>> markerData,
     const CalibrationConfig& config,
@@ -1235,7 +1237,9 @@ void calibrateModel(
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
     const std::optional<GloveConfig>& gloveConfig,
-    std::span<const CameraKeypointData> cameraKeypointData) {
+    std::span<const CameraKeypointData> cameraKeypointData,
+    std::vector<size_t>* selectedFrameIndices,
+    Eigen::MatrixXf* selectedFrameMotion) {
   const size_t numFrames = markerData.size();
   MT_THROW_IF(numFrames < 2, "Calibration requires at least 2 frames, got {}.", numFrames);
   MT_THROW_IF(
@@ -1389,84 +1393,58 @@ void calibrateModel(
           sampleStride,
           config.calibFrames);
 
-      // then solve for identity and poses with fixed locators, initialized with solved poses
-      // this works using "character" because additional parameters for the locators are appended at
-      // the end, so the indices work out using topRows() without special treatment.
-      motion.topRows(transform.numAllModelParameters()) = trackSequence(
-          markerData,
-          character,
-          calibBodySet, // only solve for identity and not markers
-          motion.topRows(transform.numAllModelParameters()),
-          trackingConfig,
-          frameIndices,
-          regularizerWeights.at(0), // note: ideally allow large change at initialization with 0
-                                    // or low regularization weight
-          config.enforceFloorInFirstFrame,
-          config.firstFramePoseConstraintSet,
-          config.targetHeightCm);
     } else {
       motion.topRows(transform.numAllModelParameters()) =
           trackPosesPerframe(markerData, character, identity, trackingConfig, frameStride);
 
-      // then solve for identity and poses with fixed locators, initialized with solved poses
-      // this works using "character" because additional parameters for the locators are appended at
-      // the end, so the indices work out using topRows() without special treatment.
-      motion.topRows(transform.numAllModelParameters()) = trackSequence(
-          markerData,
-          character,
-          calibBodySet, // only solve for identity and not markers
-          motion.topRows(transform.numAllModelParameters()),
-          trackingConfig,
-          regularizerWeights.at(0), // note: ideally allow large change at initialization with 0
-                                    // or low regularization weight
-          frameStride,
-          config.enforceFloorInFirstFrame,
-          config.firstFramePoseConstraintSet,
-          config.targetHeightCm);
+      // Build uniform-stride frame indices.
+      for (size_t i = 0; i < numFrames; i += frameStride) {
+        frameIndices.push_back(i);
+      }
     }
+
+    // Solve for identity and poses with fixed locators, initialized with solved poses.
+    // This works using "character" because additional parameters for the locators are appended at
+    // the end, so the indices work out using topRows() without special treatment.
+    motion.topRows(transform.numAllModelParameters()) = trackSequence(
+        markerData,
+        character,
+        calibBodySet,
+        motion.topRows(transform.numAllModelParameters()),
+        trackingConfig,
+        frameIndices,
+        regularizerWeights.at(0),
+        config.enforceFloorInFirstFrame,
+        config.firstFramePoseConstraintSet,
+        config.targetHeightCm);
   }
 
-  logKeypointReprojectionDiagnostic(character, cameraKeypointData, motion, transform, config);
+  if (selectedFrameIndices != nullptr) {
+    *selectedFrameIndices = frameIndices;
+  }
+
+  logKeypointReprojectionDiagnostic(
+      character, transform, motion, cameraKeypointData, config, "after Stage 0");
 
   // Solve everything together for a few iterations
   for (size_t iIter = 0; iIter < config.majorIter; ++iIter) {
     MT_LOGI_IF(config.debug, "Iteration {} of calibration", iIter);
 
-    if (config.greedySampling > 0) {
-      motion = trackSequence(
-          markerData,
-          solvingCharacter,
-          locatorSet | calibBodySetExtended | gloveSet,
-          motion,
-          trackingConfig,
-          frameIndices,
-          regularizerWeights.at(
-              1), // note: ideally use a small regularization to prevent too large a change
-          config.enforceFloorInFirstFrame,
-          config.firstFramePoseConstraintSet,
-          config.targetHeightCm,
-          leftGloveData,
-          rightGloveData,
-          gloveConfig,
-          cameraKeypointData);
-    } else {
-      motion = trackSequence(
-          markerData,
-          solvingCharacter,
-          locatorSet | calibBodySetExtended | gloveSet,
-          motion,
-          trackingConfig,
-          regularizerWeights.at(
-              1), // note: ideally use a small regularization to prevent too large a change
-          frameStride,
-          config.enforceFloorInFirstFrame,
-          config.firstFramePoseConstraintSet,
-          config.targetHeightCm,
-          leftGloveData,
-          rightGloveData,
-          gloveConfig,
-          cameraKeypointData);
-    }
+    motion = trackSequence(
+        markerData,
+        solvingCharacter,
+        locatorSet | calibBodySetExtended | gloveSet,
+        motion,
+        trackingConfig,
+        frameIndices,
+        regularizerWeights.at(1),
+        config.enforceFloorInFirstFrame,
+        config.firstFramePoseConstraintSet,
+        config.targetHeightCm,
+        leftGloveData,
+        rightGloveData,
+        gloveConfig,
+        cameraKeypointData);
     // extract solving results to identity and character so we can pass them to trackPosesPerframe
     // below.
     std::tie(identity.v, character.locators, character.skinnedLocators) =
@@ -1484,63 +1462,37 @@ void calibrateModel(
     // The sequence solve above could get stuck with euler singularity but per-frame solve could get
     // it out. Pass in the first frame from previous solve as a better initial guess than the zero
     // pose.
-    if (config.greedySampling > 0) {
-      motion.topRows(transform.numAllModelParameters()) = trackPosesForFrames(
-          markerData,
-          character,
-          motion.topRows(transform.numAllModelParameters()),
-          trackingConfig,
-          frameIndices,
-          false, // Not continuous for calibration keyframes
-          {},
-          {},
-          std::nullopt,
-          "Calibrating per-frame");
-    } else {
-      const VectorXf initPose = motion.col(0).head(transform.numAllModelParameters());
-      motion.topRows(transform.numAllModelParameters()) =
-          trackPosesPerframe(markerData, character, initPose, trackingConfig, frameStride);
-    }
+    motion.topRows(transform.numAllModelParameters()) = trackPosesForFrames(
+        markerData,
+        character,
+        motion.topRows(transform.numAllModelParameters()),
+        trackingConfig,
+        frameIndices,
+        false, // Not continuous for calibration keyframes
+        {},
+        {},
+        std::nullopt,
+        "Calibrating per-frame");
   }
 
   // Finally, fine tune marker offsets with fix identity.
   MT_LOGI_IF(config.debug, "Fine-tune marker offsets");
 
-  if (config.greedySampling > 0) {
-    motion = trackSequence(
-        markerData,
-        solvingCharacter,
-        locatorSet | gloveSet,
-        motion,
-        trackingConfig,
-        frameIndices,
-        regularizerWeights.at(
-            2), // note: ideally use a higher regularizer weight to prevent too large a change
-        config.enforceFloorInFirstFrame,
-        config.firstFramePoseConstraintSet,
-        config.targetHeightCm,
-        leftGloveData,
-        rightGloveData,
-        gloveConfig,
-        cameraKeypointData);
-  } else {
-    motion = trackSequence(
-        markerData,
-        solvingCharacter,
-        locatorSet | gloveSet,
-        motion,
-        trackingConfig,
-        regularizerWeights.at(
-            2), // note: ideally use a higher regularizer weight to prevent too large a change
-        frameStride,
-        config.enforceFloorInFirstFrame,
-        config.firstFramePoseConstraintSet,
-        config.targetHeightCm,
-        leftGloveData,
-        rightGloveData,
-        gloveConfig,
-        cameraKeypointData);
-  }
+  motion = trackSequence(
+      markerData,
+      solvingCharacter,
+      locatorSet | gloveSet,
+      motion,
+      trackingConfig,
+      frameIndices,
+      regularizerWeights.at(2),
+      config.enforceFloorInFirstFrame,
+      config.firstFramePoseConstraintSet,
+      config.targetHeightCm,
+      leftGloveData,
+      rightGloveData,
+      gloveConfig,
+      cameraKeypointData);
   std::tie(identity.v, character.locators, character.skinnedLocators) =
       extractIdAndLocatorsFromParams(motion.col(0), solvingCharacter, character);
 
@@ -1551,6 +1503,15 @@ void calibrateModel(
 
   // TODO: A hack to return the solved first frame as initialization for tracking later.
   identity.v = motion.col(0).head(transform.numAllModelParameters());
+
+  // Extract solved motion for the selected calibration frames.
+  if (selectedFrameMotion != nullptr && !frameIndices.empty()) {
+    const auto nParams = transform.numAllModelParameters();
+    selectedFrameMotion->resize(nParams, frameIndices.size());
+    for (size_t i = 0; i < frameIndices.size(); ++i) {
+      selectedFrameMotion->col(i) = motion.col(frameIndices[i]).head(nParams);
+    }
+  }
 
   // Log final per-locator mesh distances
   logSkinnedLocatorMeshDistances(character, "Final");

--- a/momentum/marker_tracking/marker_tracker.h
+++ b/momentum/marker_tracking/marker_tracker.h
@@ -246,6 +246,10 @@ Eigen::MatrixXf trackPosesForFrames(
 /// stage 0, 0 or low regularization weight to allow a large change; in stage 1, a small
 /// regularization weight to prevent too large of a change; in stage 2, a higher regularization
 /// weight to prevent large changes.
+/// @param[out] selectedFrameIndices If non-null, receives the frame indices selected by greedy
+/// sampling for calibration.
+/// @param[out] selectedFrameMotion If non-null, receives the solved motion parameters for the
+/// selected calibration frames. Each column corresponds to an entry in selectedFrameIndices.
 void calibrateModel(
     std::span<const std::vector<momentum::Marker>> markerData,
     const CalibrationConfig& config,
@@ -255,7 +259,9 @@ void calibrateModel(
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
     const std::optional<GloveConfig>& gloveConfig = std::nullopt,
-    std::span<const CameraKeypointData> cameraKeypointData = {});
+    std::span<const CameraKeypointData> cameraKeypointData = {},
+    std::vector<size_t>* selectedFrameIndices = nullptr,
+    Eigen::MatrixXf* selectedFrameMotion = nullptr);
 
 /// Calibrate locator offsets of a character from input identity and marker data.
 ///

--- a/momentum/marker_tracking/process_markers.cpp
+++ b/momentum/marker_tracking/process_markers.cpp
@@ -80,7 +80,9 @@ void calibrateMarkers(
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
     const std::optional<GloveConfig>& gloveConfig,
-    std::span<const CameraKeypointData> cameraKeypointData) {
+    std::span<const CameraKeypointData> cameraKeypointData,
+    std::vector<size_t>* selectedFrameIndices,
+    Eigen::MatrixXf* selectedFrameMotion) {
   MT_THROW_IF(
       firstFrame > markerData.size(),
       "First frame {} can't exceed total frames {}",
@@ -125,7 +127,9 @@ void calibrateMarkers(
         leftGloveSlice,
         rightGloveSlice,
         gloveConfig,
-        slicedKeypointData);
+        slicedKeypointData,
+        selectedFrameIndices,
+        selectedFrameMotion);
   }
 }
 

--- a/momentum/marker_tracking/process_markers.h
+++ b/momentum/marker_tracking/process_markers.h
@@ -32,6 +32,8 @@ namespace momentum {
 /// of trimming markerData to avoid data copy.
 /// @param[in] maxFrames The maximum number of frames to use for calibration starting from
 /// firstFrame.
+/// @param[out] selectedFrameIndices If non-null, receives the frame indices selected by greedy
+/// sampling for calibration (relative to the firstFrame-trimmed input).
 void calibrateMarkers(
     momentum::Character& character,
     momentum::ModelParameters& identity,
@@ -42,7 +44,9 @@ void calibrateMarkers(
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
     const std::optional<GloveConfig>& gloveConfig = std::nullopt,
-    std::span<const CameraKeypointData> cameraKeypointData = {});
+    std::span<const CameraKeypointData> cameraKeypointData = {},
+    std::vector<size_t>* selectedFrameIndices = nullptr,
+    Eigen::MatrixXf* selectedFrameMotion = nullptr);
 
 /// Processes marker data for a character model.
 ///

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -747,13 +747,16 @@ observations detected in that camera's image stream.)");
          const std::vector<momentum::GloveFrameData>& leftGloveData,
          const std::vector<momentum::GloveFrameData>& rightGloveData,
          const std::optional<momentum::GloveConfig>& gloveConfig,
-         const std::vector<momentum::CameraKeypointData>& cameraKeypointData) {
+         const std::vector<momentum::CameraKeypointData>& cameraKeypointData)
+          -> std::tuple<Eigen::VectorXf, std::vector<size_t>, Eigen::MatrixXf> {
         momentum::ModelParameters params(identity);
 
         if (params.size() == 0) { // If no identity is passed in, use default
           params = momentum::ModelParameters::Zero(character.parameterTransform.name.size());
         }
 
+        std::vector<size_t> selectedFrames;
+        Eigen::MatrixXf selectedMotion;
         momentum::calibrateMarkers(
             character,
             params,
@@ -764,11 +767,11 @@ observations detected in that camera's image stream.)");
             leftGloveData,
             rightGloveData,
             gloveConfig,
-            cameraKeypointData);
+            cameraKeypointData,
+            &selectedFrames,
+            &selectedMotion);
 
-        // Return the identity parameters (scaling params only)
-        // Use .v to get the underlying Eigen::VectorXf from ModelParameters
-        return params.v;
+        return {params.v, selectedFrames, selectedMotion};
       },
       R"(Calibrate a character model using marker data without running full tracking.
 
@@ -806,7 +809,12 @@ against detected 2D keypoints.
 :param camera_keypoint_data: Per-camera 2D keypoint observations for projection constraints.
     Each element is a :class:`CameraKeypointData` with camera parameters and per-frame
     keypoint detections.
-:return: Calibrated identity parameters (scaling parameters).)",
+:return: A tuple of ``(identity_params, selected_frame_indices, selected_frame_motion)`` where
+    ``identity_params`` is the calibrated identity parameter vector,
+    ``selected_frame_indices`` is a list of frame indices that were selected
+    by greedy sampling for calibration, and ``selected_frame_motion`` is a
+    matrix of shape ``(num_params, num_selected_frames)`` with the solved
+    model parameters for each selected frame.)",
       py::arg("character"),
       py::arg("identity"),
       py::arg("marker_data"),

--- a/pymomentum/test/test_process_markers.py
+++ b/pymomentum/test/test_process_markers.py
@@ -190,7 +190,7 @@ class TestMarkerTracker(unittest.TestCase):
             marker_data.append(markers)
 
         # Run calibration only (no tracking)
-        calibrated_identity = calibrate_markers(
+        calibrated_identity, selected_frames, selected_motion = calibrate_markers(
             character, identity, marker_data, calibration_config
         )
 
@@ -198,6 +198,12 @@ class TestMarkerTracker(unittest.TestCase):
         self.assertEqual(
             calibrated_identity.shape[0], character.parameter_transform.size
         )
+
+        # Check that selected frame indices and motion are valid
+        self.assertGreater(len(selected_frames), 0)
+        self.assertTrue(all(f < num_frames for f in selected_frames))
+        self.assertEqual(selected_motion.shape[1], len(selected_frames))
+        self.assertEqual(selected_motion.shape[0], character.parameter_transform.size)
 
         # Verify we can use the calibrated identity with process_markers
         tracking_config = TrackingConfig()


### PR DESCRIPTION
Summary:

calibrateModel() now populates frameIndices in both the greedy sampling and uniform stride paths, and exposes them via a new output parameter. The Python binding returns a tuple of (identity_params, selected_frame_indices) instead of just identity_params.

Reviewed By: cstollmeta

Differential Revision: D101400173


