### PR TITLE
Honor column remap in ColumnIndexedMatrix::transpose_times (#1371)

### DIFF
--- a/momentum/math/online_householder_qr.h
+++ b/momentum/math/online_householder_qr.h
@@ -75,14 +75,11 @@ class ColumnIndexedMatrix {
   /// Computes `this->transpose() * b`, returning a vector of length `cols()`.
   /// @param b Vector with `rows()` entries.
   /// @return Vector with `cols()` entries; entry @c i equals `view.col(i).dot(b)`.
-  // TODO: When `useColumnIndices_` is true, the loop reads `mat_.col(iCol)` instead of
-  //   `mat_.col(columnIndices_[iCol])`. This silently ignores the remap and returns the
-  //   wrong values whenever `colIndices` is a non-identity permutation/subset.
   [[nodiscard]] VectorType transpose_times(Eigen::Ref<VectorType> b) const {
     if (useColumnIndices_) {
       VectorType result(columnIndices_.size());
       for (Eigen::Index iCol = 0; iCol < (Eigen::Index)columnIndices_.size(); ++iCol) {
-        result[iCol] = mat_.col(iCol).dot(b);
+        result[iCol] = mat_.col(columnIndices_[iCol]).dot(b);
       }
       return result;
     } else {

--- a/momentum/test/math/online_qr_test.cpp
+++ b/momentum/test/math/online_qr_test.cpp
@@ -1251,10 +1251,13 @@ TEST(ColumnIndexedMatrix, WithColumnIndices) {
     EXPECT_EQ(returnedIndices[i], colIndices[i]);
   }
 
-  // Instead of testing transpose_times which seems to have implementation differences,
-  // let's just test the basic functionality of column access
+  Eigen::VectorXd b(3);
+  b << 1, 2, 3;
+  Eigen::VectorXd expected(3);
+  expected << A.col(2).dot(b), A.col(0).dot(b), A.col(3).dot(b);
+  Eigen::VectorXd result = mat.transpose_times(b);
+  EXPECT_TRUE(result.isApprox(expected));
 
-  // Also test the basic functionality of column access
   for (size_t i = 0; i < colIndices.size(); i++) {
     EXPECT_TRUE(mat.col(i).isApprox(A.col(colIndices[i])));
   }


### PR DESCRIPTION
Summary:

When `ColumnIndexedMatrix` was constructed with a `colIndices` span, `transpose_times` was reading `mat_.col(iCol)` instead of `mat_.col(columnIndices_[iCol])`, silently ignoring the remap and returning wrong values whenever `colIndices` was a non-identity permutation/subset.

Use the remapped index inside the loop so the dot product is taken against the column the caller asked for. The non-remapped branch is unchanged.

Removes the corresponding `// TODO:` comment flagged in the recent comment audit.

Differential Revision: D103891939


