### PR TITLE
Remove stale TODO above kept-joint validity loop in addMappedParameters

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -223,8 +223,6 @@ std::vector<size_t> addMappedParameters(
       continue;
     }
 
-    // TODO: Comment is inverted/stale — code marks params VALID for kept joints (the
-    // invalid-joint case is filtered above by the `continue`). Rewrite or remove.
     // Mark every model parameter that drives this kept joint as valid.
     for (SparseRowMatrixf::InnerIterator it(paramTransformOrig.transform, kJointParam); it; ++it) {
       // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)


### PR DESCRIPTION
Summary:
The loop in `addMappedParameters` marks every model parameter that drives a kept joint as valid; the inverse-joint case is already filtered out by the `continue` above. The pre-existing one-line comment ("Mark every model parameter that drives this kept joint as valid.") already describes this correctly, so the audit's TODO note about the comment being "inverted/stale" was itself stale once we keep that one line. Drop the TODO, leave the accurate comment.

Removes the corresponding `// TODO:` comment flagged in the recent comment audit.

Differential Revision: D103897838


