### PR TITLE
Clarify CharacterT<double> tempCharacter workaround in character_state

### DIFF
--- a/momentum/character/character_state.cpp
+++ b/momentum/character/character_state.cpp
@@ -114,8 +114,14 @@ void CharacterStateT<T>::set(
 
       meshState->updateNormals();
     } else if (referenceCharacter.blendShape) {
-      // skinWithBlendShapes() is only defined for `Character` (i.e., CharacterT<float>),
-      // so the double-precision instantiation has to materialize a float Character to call it.
+      // skinWithBlendShapes() is only defined for `Character` (i.e., CharacterT<float>), so the
+      // double-precision instantiation must materialize a float Character to call it. Every
+      // CharacterT<T> member is itself non-templated (skeleton, parameterTransform, mesh,
+      // skinWeights, inverseBindPose are all stored as float types regardless of T), so the
+      // temporary built below is bit-equivalent to the source — no float<->double conversion is
+      // needed. The cost is the per-call deep copies the constructor performs for `mesh`,
+      // `skinWeights`, `collision`, and `poseShapes`; that overhead could be avoided by
+      // templating `skinWithBlendShapes` on the character type if it ever shows up in profiles.
       if constexpr (std::is_same_v<T, float>) {
         skinWithBlendShapes(
             static_cast<const Character&>(referenceCharacter),
@@ -123,11 +129,6 @@ void CharacterStateT<T>::set(
             parameters.pose,
             *meshState);
       } else {
-        // TODO: This temporary Character is constructed by shallow-copying member pointers
-        // from a CharacterT<double>. Members that differ between float/double specializations
-        // (e.g., `inverseBindPose`) are passed across without conversion, which can produce
-        // subtly wrong skinning. Consider providing a proper float<->double conversion or
-        // a templated skinWithBlendShapes overload.
         Character tempCharacter(
             referenceCharacter.skeleton,
             referenceCharacter.parameterTransform,


### PR DESCRIPTION
Summary:
The audit comment claimed the temporary `Character` constructed for the `T = double` branch could "produce subtly wrong skinning" because members "differ between float/double specializations (e.g., `inverseBindPose`)". That isn't accurate today: every `CharacterT<T>` member is non-templated — `mesh`, `skinWeights`, `inverseBindPose` (which is `TransformationList = std::vector<Affine3f>`), and friends are all stored as float regardless of `T`. The temporary built from a `CharacterT<double>` is therefore bit-equivalent to its source; no float/double conversion is needed and there is no skinning-correctness bug here.

Replace the misleading TODO with a comment that documents the actual situation: why the workaround is correct, and the only real cost (per-call deep copies in the `Character` constructor for the unique_ptr-owned members) — which could be eliminated by templating `skinWithBlendShapes` on the character type if the overhead ever shows up in profiles.

Removes the corresponding `// TODO:` comment flagged in the recent comment audit.

Differential Revision: D103897481


