### PR TITLE
Transpose calibrate_markers output to match Python convention (#1375)

### DIFF
--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -771,7 +771,8 @@ observations detected in that camera's image stream.)");
             &selectedFrames,
             &selectedMotion);
 
-        return {params.v, selectedFrames, selectedMotion};
+        // python (#frames, #params) vs. cpp (#params, #frames)
+        return {params.v, selectedFrames, selectedMotion.transpose().eval()};
       },
       R"(Calibrate a character model using marker data without running full tracking.
 
@@ -813,7 +814,7 @@ against detected 2D keypoints.
     ``identity_params`` is the calibrated identity parameter vector,
     ``selected_frame_indices`` is a list of frame indices that were selected
     by greedy sampling for calibration, and ``selected_frame_motion`` is a
-    matrix of shape ``(num_params, num_selected_frames)`` with the solved
+    matrix of shape ``(num_selected_frames, num_params)`` with the solved
     model parameters for each selected frame.)",
       py::arg("character"),
       py::arg("identity"),

--- a/pymomentum/test/test_process_markers.py
+++ b/pymomentum/test/test_process_markers.py
@@ -202,8 +202,8 @@ class TestMarkerTracker(unittest.TestCase):
         # Check that selected frame indices and motion are valid
         self.assertGreater(len(selected_frames), 0)
         self.assertTrue(all(f < num_frames for f in selected_frames))
-        self.assertEqual(selected_motion.shape[1], len(selected_frames))
-        self.assertEqual(selected_motion.shape[0], character.parameter_transform.size)
+        self.assertEqual(selected_motion.shape[0], len(selected_frames))
+        self.assertEqual(selected_motion.shape[1], character.parameter_transform.size)
 
         # Verify we can use the calibrated identity with process_markers
         tracking_config = TrackingConfig()


### PR DESCRIPTION
Summary:

Every other motion-returning function in pymomentum (`process_markers`, `refine_motion`, `load_gltf_with_motion`, `save_motion`, etc.) transposes at the C++/Python boundary so Python always sees `(num_frames, num_params)`. `calibrate_markers` was the sole exception, returning raw C++ layout `(num_params, num_frames)` and forcing Python callers to transpose manually.

Fix the inconsistency by adding `.transpose().eval()` in the pybind11 binding, matching the pattern used by `process_markers`. Update the docstring, test assertions

Differential Revision: D103428145


