### PR TITLE
Check all components in MeshT::updateNormals NaN guard

### DIFF
--- a/momentum/math/mesh.cpp
+++ b/momentum/math/mesh.cpp
@@ -33,8 +33,8 @@ void MeshT<T>::updateNormals() {
         (vertices[face[1]] - vertices[face[0]]).cross(vertices[face[2]] - vertices[face[0]]);
     // Skip degenerate faces that produced NaN (e.g., from non-finite vertex coordinates).
     // Collinear/zero-area triangles produce a zero vector, which contributes nothing and is safe.
-    // TODO: only checking normal[0] misses NaNs that appear only in y or z components.
-    if (IsNanNoOpt(normal[0])) {
+    // Inspect all components so a NaN limited to y or z is also caught.
+    if (IsNanNoOpt(normal[0]) || IsNanNoOpt(normal[1]) || IsNanNoOpt(normal[2])) {
       continue;
     }
     for (const auto& faceIdx : face) {


### PR DESCRIPTION
Summary:
`updateNormals` was only inspecting `normal[0]` to decide whether to skip a degenerate face. A NaN that appears only in the y or z component (which can happen when a single vertex coordinate is non-finite, since the cross product distributes the NaN unevenly) would bypass the guard and corrupt the accumulated vertex normals.

Inspect all three components instead.

Removes the corresponding `// TODO:` comment flagged in the recent comment audit.

Differential Revision: D103890847


