### PR TITLE
Reject integer T in uniformAffine3 to prevent silent default truncation

### DIFF
--- a/momentum/math/random-inl.h
+++ b/momentum/math/random-inl.h
@@ -250,12 +250,13 @@ Affine3<T> Random<Generator>::uniformAffine3(
     T scaleMax,
     const Vector3<T>& min,
     const Vector3<T>& max) {
+  static_assert(
+      std::is_floating_point_v<T>,
+      "uniformAffine3 requires a floating-point T; integer T would silently truncate the "
+      "default scale range and the rotation factor.");
   Affine3<T> out = Affine3<T>::Identity();
   // Linear part is rotation * isotropic_scale; this samples a single scale
   // factor applied to all three axes, not a full anisotropic affine.
-  // TODO: the public name `uniformAffine3` is misleading — it does not
-  // sample uniformly over the space of affine transforms (which would need
-  // anisotropic scale and shear); consider renaming or extending.
   out.linear() = uniformRotationMatrix<T>() * uniform<T>(scaleMin, scaleMax);
   out.translation().noalias() = uniform<Vector3<T>>(min, max);
   return out;
@@ -361,6 +362,10 @@ Isometry3<T> uniformIsometry3(const Vector3<T>& min, const Vector3<T>& max) {
 
 template <typename T>
 Affine3<T> uniformAffine3(T scaleMin, T scaleMax, const Vector3<T>& min, const Vector3<T>& max) {
+  static_assert(
+      std::is_floating_point_v<T>,
+      "uniformAffine3 requires a floating-point T; integer T would silently truncate the "
+      "default scale range and the rotation factor.");
   auto& rand = Random<>::GetSingleton();
   return rand.uniformAffine3<T>(scaleMin, scaleMax, min, max);
 }

--- a/momentum/math/random.h
+++ b/momentum/math/random.h
@@ -179,18 +179,18 @@ class Random final {
   /// scale drawn from `[scaleMin, scaleMax]`, and translation drawn uniformly from the box
   /// `[min, max]`.
   ///
-  /// @tparam T Scalar type of the affine components, typically `float` or `double`.
+  /// @tparam T Floating-point scalar type of the affine components (`float` or `double`). The
+  ///   defaults below are floating-point literals, so instantiation with an integer T is rejected
+  ///   by a `static_assert` in the implementation rather than silently truncating the defaults.
   /// @param scaleMin Inclusive lower bound on the uniform scale factor.
   /// @param scaleMax Inclusive upper bound on the uniform scale factor.
   /// @param min Inclusive lower bound on the translation component (per axis).
   /// @param max Inclusive upper bound on the translation component (per axis).
   /// @return A random Affine3<T>.
-  // TODO: The default `scaleMin = 0.1` / `scaleMax = 10.0` only makes sense when T is a floating
-  // type; instantiation with an integer T would silently truncate the defaults.
   template <typename T>
   [[nodiscard]] Affine3<T> uniformAffine3(
-      T scaleMin = 0.1,
-      T scaleMax = 10.0,
+      T scaleMin = T(0.1),
+      T scaleMax = T(10.0),
       const Vector3<T>& min = Vector3<T>::Zero(),
       const Vector3<T>& max = Vector3<T>::Ones());
 
@@ -313,11 +313,12 @@ template <typename T>
     const Vector3<T>& max = Vector3<T>::Ones());
 
 /// Random affine transformation via the global `Random` singleton (uniform rotation, uniform
-/// scale in `[scaleMin, scaleMax]`, uniform translation in `[min, max]`).
+/// scale in `[scaleMin, scaleMax]`, uniform translation in `[min, max]`). Requires a
+/// floating-point T; integer T is rejected by `static_assert` in the implementation.
 template <typename T>
 [[nodiscard]] Affine3<T> uniformAffine3(
-    T scaleMin = 0.1,
-    T scaleMax = 10.0,
+    T scaleMin = T(0.1),
+    T scaleMax = T(10.0),
     const Vector3<T>& min = Vector3<T>::Zero(),
     const Vector3<T>& max = Vector3<T>::Ones());
 


### PR DESCRIPTION
Summary:
`uniformAffine3<T>` declared its scale defaults as `0.1` / `10.0` (untyped floating-point literals). Instantiating with an integer T silently truncated those defaults to 0 and 10, producing a zero-or-trivial scale and a degenerate output. The function also calls `uniformRotationMatrix<T>()`, which is not meaningful for integer T either.

Make the default values explicitly `T(0.1)` / `T(10.0)` so the conversion is at least visible at the declaration, and add a `static_assert(std::is_floating_point_v<T>)` in both implementations (member and free function) so misuse fails at compile time rather than producing a degenerate transform at runtime.

Removes the corresponding `// TODO:` comment flagged in the recent comment audit.

Differential Revision: D103892654


