### PR TITLE
Add adaptive floor contact constraints for calibration

### DIFF
--- a/momentum/marker_tracking/app_utils.cpp
+++ b/momentum/marker_tracking/app_utils.cpp
@@ -84,11 +84,17 @@ void addCalibrationOptions(CLI::App& app, std::shared_ptr<CalibrationConfig> con
       "Use greedy sampling to select calibration frames");
   greedySamplingOption->default_val(config->greedySampling)->check(CLI::NonNegativeNumber);
 
-  auto* firstFrameFloorContactOption = app.add_flag(
-      "--init-floor-contact",
+  auto* enforceFloorOption = app.add_flag(
+      "--enforce-floor-in-first-frame",
       config->enforceFloorInFirstFrame,
-      "Enforce floor contact constraints in first frame");
-  firstFrameFloorContactOption->default_val(config->enforceFloorInFirstFrame);
+      "Force all floor locators to y=0 on frame 0 with high weight");
+  enforceFloorOption->default_val(config->enforceFloorInFirstFrame);
+
+  auto* adaptiveFloorContactOption = app.add_flag(
+      "--adaptive-floor-contact",
+      config->adaptiveFloorContact,
+      "Enable adaptive per-locator floor contact detection during calibration");
+  adaptiveFloorContactOption->default_val(config->adaptiveFloorContact);
 
   auto* poseOption = app.add_option(
       "--init-pose",

--- a/momentum/marker_tracking/marker_tracker.cpp
+++ b/momentum/marker_tracking/marker_tracker.cpp
@@ -220,7 +220,6 @@ std::vector<size_t> sampleFrames(
 /// @param config Tracking configuration settings
 /// @param regularizer Weight for regularizing changes to global parameters
 /// @param frameStride Process every frameStride-th frame (1 = all frames)
-/// @param enforceFloorInFirstFrame Force floor contact constraints in first frame
 /// @param firstFramePoseConstraintSet Name of pose constraint set for first frame
 /// @return Solved motion parameters matrix (parameters x frames)
 Eigen::MatrixXf trackSequence(
@@ -384,7 +383,8 @@ void addSequenceFrameConstraints(
     const std::vector<std::vector<JointToJointOrientationDataT<float>>>& leftGloveOriData,
     const std::vector<std::vector<JointToJointPositionDataT<float>>>& rightGlovePosData,
     const std::vector<std::vector<JointToJointOrientationDataT<float>>>& rightGloveOriData,
-    std::span<const CameraKeypointData> cameraKeypointData = {}) {
+    std::span<const CameraKeypointData> cameraKeypointData = {},
+    std::span<const std::vector<PlaneDataT<float>>> perFrameFloorContacts = {}) {
   auto posConstrWeight = PositionErrorFunction::kLegacyWeight * config.markerWeight;
   if (solverFrame == 0 && (enforceFloorInFirstFrame || !firstFramePoseConstraintSet.empty())) {
     posConstrWeight *= solvedFrames;
@@ -423,19 +423,29 @@ void addSequenceFrameConstraints(
     solverFunc.addErrorFunction(solverFrame, heightConstrFunc);
   }
 
-  // prepare floor constraints
+  // Floor constraints
   if (!floorConstraints.empty()) {
-    bool halfPlane = true;
-    float weightMultiplier = 1.0f;
     if (enforceFloorInFirstFrame && solverFrame == 0) {
-      halfPlane = false;
-      weightMultiplier = solvedFrames;
+      // Legacy: full equality constraint on frame 0 with high weight
+      auto eqConstrFunc = std::make_shared<PlaneErrorFunction>(character, /*half plane*/ false);
+      eqConstrFunc->setConstraints(floorConstraints);
+      eqConstrFunc->setWeight(PlaneErrorFunction::kLegacyWeight * solvedFrames);
+      solverFunc.addErrorFunction(solverFrame, eqConstrFunc);
+    } else {
+      // Half-plane floor constraint (non-penetration) on all frames
+      auto halfPlaneConstrFunc =
+          std::make_shared<PlaneErrorFunction>(character, /*half plane*/ true);
+      halfPlaneConstrFunc->setConstraints(floorConstraints);
+      halfPlaneConstrFunc->setWeight(PlaneErrorFunction::kLegacyWeight);
+      solverFunc.addErrorFunction(solverFrame, halfPlaneConstrFunc);
     }
-    auto halfPlaneConstrFunc =
-        std::make_shared<PlaneErrorFunction>(character, /*half plane*/ halfPlane);
-    halfPlaneConstrFunc->setConstraints(floorConstraints);
-    halfPlaneConstrFunc->setWeight(PlaneErrorFunction::kLegacyWeight * weightMultiplier);
-    solverFunc.addErrorFunction(solverFrame, halfPlaneConstrFunc);
+  }
+  // Soft equality floor constraint on detected contact frames (per-locator)
+  if (solverFrame < perFrameFloorContacts.size() && !perFrameFloorContacts[solverFrame].empty()) {
+    auto eqFunc = std::make_shared<PlaneErrorFunction>(character, /*half plane*/ false);
+    eqFunc->setConstraints(perFrameFloorContacts[solverFrame]);
+    eqFunc->setWeight(PlaneErrorFunction::kLegacyWeight * 3.0f);
+    solverFunc.addErrorFunction(solverFrame, eqFunc);
   }
 
   if (!firstFramePoseConstraintSet.empty() && solverFrame == 0) {
@@ -488,7 +498,6 @@ void addSequenceFrameConstraints(
 /// @param config Tracking configuration settings
 /// @param frames Vector of specific frame indices to solve
 /// @param regularizer Weight for regularizing changes to global parameters
-/// @param enforceFloorInFirstFrame Force floor contact constraints in first frame
 /// @param firstFramePoseConstraintSet Name of pose constraint set for first frame
 /// @return Solved motion parameters matrix (parameters x frames)
 Eigen::MatrixXf trackSequence(
@@ -505,7 +514,8 @@ Eigen::MatrixXf trackSequence(
     std::span<const GloveFrameData> leftGloveData,
     std::span<const GloveFrameData> rightGloveData,
     const std::optional<GloveConfig>& gloveConfig,
-    std::span<const CameraKeypointData> cameraKeypointData) {
+    std::span<const CameraKeypointData> cameraKeypointData,
+    std::span<const std::vector<PlaneDataT<float>>> perFrameFloorContacts) {
   // sanity checks
   const size_t numFrames = markerData.size();
   MT_CHECK(numFrames > 0, "Input marker data is empty.");
@@ -621,7 +631,8 @@ Eigen::MatrixXf trackSequence(
           leftGloveOriData,
           rightGlovePosData,
           rightGloveOriData,
-          cameraKeypointData);
+          cameraKeypointData,
+          perFrameFloorContacts);
     }
     // Set per-frame initial value
     solverFunc.setFrameParameters(solverFrame, initialMotion.col(iFrame));
@@ -1228,6 +1239,33 @@ void logKeypointReprojectionDiagnostic(
   }
 }
 
+// Build the parameter sets controlling which body parameters are calibrated.
+std::pair<ParameterSet, ParameterSet> buildCalibBodySets(
+    const CalibrationConfig& config,
+    const ParameterTransform& transform,
+    const ParameterTransform& transformExtended) {
+  if (config.globalScaleOnly) {
+    const size_t paramIndex = transform.getParameterIdByName("scale_global");
+    const size_t paramIndexExt = transformExtended.getParameterIdByName("scale_global");
+    MT_THROW_IF(
+        paramIndex == kInvalidIndex || paramIndexExt == kInvalidIndex,
+        "Can't calibrate global scale since it is not defined in the parameter list!");
+    ParameterSet calibBodySet;
+    ParameterSet calibBodySetExtended;
+    calibBodySet.set(paramIndex);
+    calibBodySetExtended.set(paramIndexExt);
+    return {calibBodySet, calibBodySetExtended};
+  }
+
+  ParameterSet calibBodySet = transform.getScalingParameters();
+  ParameterSet calibBodySetExtended = transformExtended.getScalingParameters();
+  if (config.calibShape) {
+    calibBodySet |= transform.getBlendShapeParameters();
+    calibBodySetExtended |= transformExtended.getBlendShapeParameters();
+  }
+  return {calibBodySet, calibBodySetExtended};
+}
+
 void calibrateModel(
     const std::span<const std::vector<Marker>> markerData,
     const CalibrationConfig& config,
@@ -1259,6 +1297,9 @@ void calibrateModel(
       numFrames);
   validateCameraKeypointFrameCount(cameraKeypointData, numFrames);
 
+  MT_THROW_IF(
+      config.enforceFloorInFirstFrame && config.adaptiveFloorContact,
+      "enforceFloorInFirstFrame and adaptiveFloorContact are mutually exclusive.");
   MT_THROW_IF(config.calibFrames == 0, "calibFrames must be > 0.");
   if (numFrames < config.calibFrames) {
     MT_LOGW(
@@ -1303,26 +1344,8 @@ void calibrateModel(
   ParameterSet locatorSet = transformExtended.getParameterSet("locators", true) |
       transformExtended.getParameterSet("skinnedLocators", true);
   ParameterSet gloveSet = transformExtended.getParameterSet("gloves", true);
-  ParameterSet calibBodySetExtended;
-  ParameterSet calibBodySet;
-  if (config.globalScaleOnly) {
-    const size_t paramIndex = transform.getParameterIdByName("scale_global");
-    const size_t paramIndexExt = transformExtended.getParameterIdByName("scale_global");
-    MT_THROW_IF(
-        paramIndex == kInvalidIndex || paramIndexExt == kInvalidIndex,
-        "Can't calibrate global scale since it is not defined in the parameter list!");
-
-    calibBodySetExtended.set(paramIndexExt);
-    calibBodySet.set(paramIndex);
-  } else {
-    calibBodySetExtended = transformExtended.getScalingParameters();
-    calibBodySet = transform.getScalingParameters();
-
-    if (config.calibShape) {
-      calibBodySetExtended |= transformExtended.getBlendShapeParameters();
-      calibBodySet |= transform.getBlendShapeParameters();
-    }
-  }
+  const auto [calibBodySet, calibBodySetExtended] =
+      buildCalibBodySets(config, transform, transformExtended);
 
   // special trackingConfig for initialization: zero out smoothness and collision
   TrackingConfig trackingConfig;
@@ -1427,6 +1450,10 @@ void calibrateModel(
       character, transform, motion, cameraKeypointData, config, "after Stage 0");
 
   // Solve everything together for a few iterations
+  const auto calibFloorConstraints =
+      createFloorConstraints<float>("Floor_", character.locators, Vector3f::UnitY(), 0.0f, 5.0f);
+  std::vector<std::vector<PlaneDataT<float>>> perFrameFloorContacts;
+
   for (size_t iIter = 0; iIter < config.majorIter; ++iIter) {
     MT_LOGI_IF(config.debug, "Iteration {} of calibration", iIter);
 
@@ -1444,11 +1471,22 @@ void calibrateModel(
         leftGloveData,
         rightGloveData,
         gloveConfig,
-        cameraKeypointData);
+        cameraKeypointData,
+        perFrameFloorContacts);
     // extract solving results to identity and character so we can pass them to trackPosesPerframe
     // below.
     std::tie(identity.v, character.locators, character.skinnedLocators) =
         extractIdAndLocatorsFromParams(motion.col(0), solvingCharacter, character);
+
+    // Update per-locator floor contact constraints for the next iteration
+    if (config.adaptiveFloorContact && !calibFloorConstraints.empty()) {
+      perFrameFloorContacts = computeFloorContactConstraints(
+          solvingCharacter,
+          motion,
+          calibFloorConstraints,
+          frameIndices,
+          config.floorContactPercentile);
+    }
     if (config.calibShape && solvingCharacter.blendShape) {
       auto blendShapeParams =
           extractBlendWeights(solvingCharacter.parameterTransform, ModelParameters(motion.col(0)));
@@ -1545,6 +1583,9 @@ void calibrateLocators(
       identity.v.size(),
       character.parameterTransform.numAllModelParameters());
 
+  MT_THROW_IF(
+      config.enforceFloorInFirstFrame && config.adaptiveFloorContact,
+      "enforceFloorInFirstFrame and adaptiveFloorContact are mutually exclusive.");
   MT_THROW_IF(config.calibFrames == 0, "calibFrames must be > 0.");
   if (numFrames < config.calibFrames) {
     MT_LOGW(

--- a/momentum/marker_tracking/marker_tracker.h
+++ b/momentum/marker_tracking/marker_tracker.h
@@ -10,6 +10,7 @@
 #include <momentum/camera/camera.h>
 #include <momentum/character/character.h>
 #include <momentum/character/marker.h>
+#include <momentum/character_solver/plane_error_function.h>
 #include <momentum/marker_tracking/glove_utils.h>
 #include <momentum/marker_tracking/marker_gap_fill.h>
 
@@ -66,8 +67,13 @@ struct CalibrationConfig : public BaseConfig {
   bool locatorsOnly = false;
   /// Sample uniformly or do a greedy importance sampling
   size_t greedySampling = 0;
-  /// True to lock the floor constraints to the floor in the first frame
+  /// Force all floor locators to y=0 on frame 0 with high weight.
+  /// Mutually exclusive with adaptiveFloorContact.
   bool enforceFloorInFirstFrame = false;
+  /// Enable adaptive floor contact detection during calibration. When true, the
+  /// solver detects per-locator contact frames using floorContactPercentile and
+  /// applies soft equality floor constraints on those frames.
+  bool adaptiveFloorContact = false;
   /// Name of a pose constraint set to use for the first frame
   std::string firstFramePoseConstraintSet;
   /// Calibrate the character's shape
@@ -79,6 +85,10 @@ struct CalibrationConfig : public BaseConfig {
   float meshConstraintWeight = 1.0f;
   /// Base weight for 2D keypoint projection constraints. Set to 0 to disable.
   float projectionWeight = 0.0f;
+  /// Percentile threshold for adaptive floor contact detection (0-1).
+  /// For each floor locator, frames at or below this percentile of Y heights
+  /// receive a soft equality floor constraint. Higher values = more frames constrained.
+  float floorContactPercentile = 1.0f / 3.0f;
 };
 
 /// Configuration for pose tracking given a calibrated body and locators
@@ -134,7 +144,6 @@ struct RefineConfig : public TrackingConfig {
 /// Number of parameters should be the same as defined in character.
 /// @param[in] config Solving options.
 /// @param[in] frameStride Frame stride to select solver frames (ie. uniform sample).
-/// @param[in] enforceFloorInFirstFrame Flag to enforce the floor contact constraints in first frame
 /// @param[in] firstFramePoseConstraintSet Name of a pose constraint set to use for the first frame
 ///
 /// @return The solved motion. It has the same length as markerData. It repeats the same solved pose
@@ -167,7 +176,6 @@ Eigen::MatrixXf trackSequence(
 /// Number of parameters should be the same as defined in character.
 /// @param[in] config Solving options.
 /// @param[in] frames List of frames to solve for.
-/// @param[in] enforceFloorInFirstFrame Flag to enforce the floor contact constraints in first frame
 /// @param[in] firstFramePoseConstraintSet Name of a pose constraint set to use for the first frame
 ///
 /// @return The solved motion. It has the same length as markerData. It repeats the same solved pose
@@ -186,7 +194,8 @@ Eigen::MatrixXf trackSequence(
     std::span<const GloveFrameData> leftGloveData = {},
     std::span<const GloveFrameData> rightGloveData = {},
     const std::optional<GloveConfig>& gloveConfig = std::nullopt,
-    std::span<const CameraKeypointData> cameraKeypointData = {});
+    std::span<const CameraKeypointData> cameraKeypointData = {},
+    std::span<const std::vector<PlaneDataT<float>>> perFrameFloorContacts = {});
 
 /// Track poses per-frame given a calibrated character.
 ///

--- a/momentum/marker_tracking/tracker_utils.cpp
+++ b/momentum/marker_tracking/tracker_utils.cpp
@@ -941,4 +941,63 @@ std::vector<std::pair<std::string, float>> computeSkinnedLocatorMeshDistances(
   return result;
 }
 
+std::vector<std::vector<PlaneDataT<float>>> computeFloorContactConstraints(
+    const Character& character,
+    const MatrixXf& motion,
+    const std::vector<PlaneDataT<float>>& floorConstraints,
+    const std::vector<size_t>& frameIndices,
+    float percentile) {
+  const size_t nFrames = frameIndices.size();
+  std::vector<std::vector<PlaneDataT<float>>> result(nFrames);
+  if (floorConstraints.empty() || nFrames == 0) {
+    return result;
+  }
+
+  const auto& pt = character.parameterTransform;
+  const size_t nParams = pt.numAllModelParameters();
+  const size_t nLocators = floorConstraints.size();
+
+  // heights[locator][frame] = signed distance to floor plane
+  std::vector<std::vector<float>> heights(nLocators, std::vector<float>(nFrames));
+  for (size_t fi = 0; fi < nFrames; ++fi) {
+    const size_t iFrame = frameIndices[fi];
+    SkeletonState skelState;
+    skelState.set(
+        pt.apply(ModelParameters(motion.col(iFrame).head(nParams))), character.skeleton, false);
+    for (size_t li = 0; li < nLocators; ++li) {
+      const auto& constr = floorConstraints[li];
+      const auto worldPos = skelState.jointState[constr.parent].transform * constr.offset;
+      heights[li][fi] = worldPos.dot(constr.normal) - constr.d;
+    }
+  }
+
+  // For each locator independently, find the percentile threshold and mark
+  // frames where that locator is in contact
+  size_t totalContactPairs = 0;
+  for (size_t li = 0; li < nLocators; ++li) {
+    auto sorted = heights[li];
+    std::sort(sorted.begin(), sorted.end());
+    const size_t pIdx = std::min(static_cast<size_t>(percentile * nFrames), nFrames - 1);
+    const float threshold = sorted[pIdx];
+    for (size_t fi = 0; fi < nFrames; ++fi) {
+      if (heights[li][fi] <= threshold) {
+        result[fi].push_back(floorConstraints[li]);
+        ++totalContactPairs;
+      }
+    }
+  }
+
+  const size_t framesWithContact =
+      std::count_if(result.begin(), result.end(), [](const auto& v) { return !v.empty(); });
+  MT_LOGI(
+      "Floor contact: {}/{} frames have contact ({} locator-frame pairs, {} locators, percentile={})",
+      framesWithContact,
+      nFrames,
+      totalContactPairs,
+      nLocators,
+      percentile);
+
+  return result;
+}
+
 } // namespace momentum

--- a/momentum/marker_tracking/tracker_utils.h
+++ b/momentum/marker_tracking/tracker_utils.h
@@ -11,6 +11,7 @@
 #include <momentum/character/locator.h>
 #include <momentum/character/marker.h>
 #include <momentum/character_solver/fwd.h>
+#include <momentum/character_solver/plane_error_function.h>
 #include <momentum/character_solver/skinned_locator_triangle_error_function.h>
 
 namespace momentum {
@@ -106,6 +107,27 @@ std::vector<momentum::CandidateTriangle> findCandidateTrianglesDfs(
 momentum::LocatorList extractLocatorsFromCharacter(
     const momentum::Character& locatorCharacter,
     const momentum::CharacterParameters& calibParams);
+
+/// Compute per-frame floor contact constraints based on solved locator heights.
+///
+/// For each floor locator independently, computes the Nth percentile of its Y
+/// position across all solved frames. Locators at or below their threshold on a
+/// given frame are included in that frame's equality constraint set. This allows
+/// different feet/regions to be in contact on different frames.
+///
+/// @param character Character with skeleton and floor locators
+/// @param motion Solved motion matrix (numAllModelParams x numFrames)
+/// @param floorConstraints Floor constraint data (from createFloorConstraints)
+/// @param frameIndices Which frames in the motion matrix to evaluate
+/// @param percentile Percentile threshold for contact detection (0-1, e.g. 0.25)
+/// @return Per-frame constraint lists (same length as frameIndices, each entry is
+///         the subset of floorConstraints that are in contact for that frame)
+std::vector<std::vector<momentum::PlaneDataT<float>>> computeFloorContactConstraints(
+    const momentum::Character& character,
+    const Eigen::MatrixXf& motion,
+    const std::vector<momentum::PlaneDataT<float>>& floorConstraints,
+    const std::vector<size_t>& frameIndices,
+    float percentile);
 
 // TODO: move to momentum proper
 momentum::ModelParameters extractParameters(

--- a/pymomentum/marker_tracking/marker_tracking_pybind.cpp
+++ b/pymomentum/marker_tracking/marker_tracking_pybind.cpp
@@ -130,7 +130,7 @@ PYBIND11_MODULE(marker_tracking, m) {
           "__repr__",
           [](const momentum::CalibrationConfig& self) {
             return fmt::format(
-                "CalibrationConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, regularization={}, debug={}, calib_frames={}, major_iter={}, global_scale_only={}, locators_only={}, greedy_sampling={}, enforce_floor_in_first_frame={}, first_frame_pose_constraint_set=\"{}\", calib_shape={}, target_height_cm={}, mesh_constraint_weight={})",
+                "CalibrationConfig(min_vis_percent={}, loss_alpha={}, max_iter={}, regularization={}, debug={}, calib_frames={}, major_iter={}, global_scale_only={}, locators_only={}, greedy_sampling={}, enforce_floor_in_first_frame={}, adaptive_floor_contact={}, first_frame_pose_constraint_set=\"{}\", calib_shape={}, target_height_cm={}, mesh_constraint_weight={}, floor_contact_percentile={})",
                 self.minVisPercent,
                 self.lossAlpha,
                 self.maxIter,
@@ -142,10 +142,12 @@ PYBIND11_MODULE(marker_tracking, m) {
                 boolToString(self.locatorsOnly),
                 self.greedySampling,
                 boolToString(self.enforceFloorInFirstFrame),
+                boolToString(self.adaptiveFloorContact),
                 self.firstFramePoseConstraintSet,
                 boolToString(self.calibShape),
                 self.targetHeightCm,
-                self.meshConstraintWeight);
+                self.meshConstraintWeight,
+                self.floorContactPercentile);
           })
       .def(
           py::init([](float minVisPercent,
@@ -159,11 +161,13 @@ PYBIND11_MODULE(marker_tracking, m) {
                       bool locatorsOnly,
                       size_t greedySampling,
                       bool enforceFloorInFirstFrame,
+                      bool adaptiveFloorContact,
                       std::string firstFramePoseConstraintSet,
                       bool calibShape,
                       float targetHeightCm,
                       float meshConstraintWeight,
-                      float projectionWeight) {
+                      float projectionWeight,
+                      float floorContactPercentile) {
             momentum::CalibrationConfig cfg;
             cfg.minVisPercent = minVisPercent;
             cfg.lossAlpha = lossAlpha;
@@ -176,11 +180,13 @@ PYBIND11_MODULE(marker_tracking, m) {
             cfg.locatorsOnly = locatorsOnly;
             cfg.greedySampling = greedySampling;
             cfg.enforceFloorInFirstFrame = enforceFloorInFirstFrame;
+            cfg.adaptiveFloorContact = adaptiveFloorContact;
             cfg.firstFramePoseConstraintSet = std::move(firstFramePoseConstraintSet);
             cfg.calibShape = calibShape;
             cfg.targetHeightCm = targetHeightCm;
             cfg.meshConstraintWeight = meshConstraintWeight;
             cfg.projectionWeight = projectionWeight;
+            cfg.floorContactPercentile = floorContactPercentile;
             return cfg;
           }),
           R"(Create a CalibrationConfig with specified parameters.
@@ -195,12 +201,14 @@ PYBIND11_MODULE(marker_tracking, m) {
           :param global_scale_only: Calibrate only the global scale and not all proportions
           :param locators_only: Calibrate only the locator offsets
           :param greedy_sampling: Enable greedy frame sampling with the given stride
-          :param enforce_floor_in_first_frame: Force floor contact in first frame
+          :param enforce_floor_in_first_frame: Force all floor locators to y=0 on frame 0
+          :param adaptive_floor_contact: Enable adaptive per-locator floor contact detection
           :param first_frame_pose_constraint_set: Name of pose constraint set to use in first frame
           :param calib_shape: Calibrate shape parameters
           :param target_height_cm: Target height for character in cm.  Defaults to 0 (unspecified).
           :param mesh_constraint_weight: Weight multiplier for mesh surface constraints during calibration.
           :param projection_weight: Base weight for 2D keypoint projection constraints. Set to 0 to disable.
+          :param floor_contact_percentile: Percentile threshold for adaptive floor contact detection (0-1).
           )",
           py::kw_only(),
           py::arg("min_vis_percent") = 0.0,
@@ -214,11 +222,13 @@ PYBIND11_MODULE(marker_tracking, m) {
           py::arg("locators_only") = false,
           py::arg("greedy_sampling") = 0,
           py::arg("enforce_floor_in_first_frame") = false,
+          py::arg("adaptive_floor_contact") = false,
           py::arg("first_frame_pose_constraint_set") = "",
           py::arg("calib_shape") = false,
           py::arg("target_height_cm") = 0.0,
           py::arg("mesh_constraint_weight") = 1.0f,
-          py::arg("projection_weight") = 0.0f)
+          py::arg("projection_weight") = 0.0f,
+          py::arg("floor_contact_percentile") = 1.0f / 3.0f)
       .def_readwrite(
           "calib_frames",
           &momentum::CalibrationConfig::calibFrames,
@@ -242,7 +252,11 @@ PYBIND11_MODULE(marker_tracking, m) {
       .def_readwrite(
           "enforce_floor_in_first_frame",
           &momentum::CalibrationConfig::enforceFloorInFirstFrame,
-          "Force floor contact in first frame")
+          "Force all floor locators to y=0 on frame 0 with high weight")
+      .def_readwrite(
+          "adaptive_floor_contact",
+          &momentum::CalibrationConfig::adaptiveFloorContact,
+          "Enable adaptive per-locator floor contact detection")
       .def_readwrite(
           "first_frame_pose_constraint_set",
           &momentum::CalibrationConfig::firstFramePoseConstraintSet,
@@ -260,7 +274,13 @@ PYBIND11_MODULE(marker_tracking, m) {
       .def_readwrite(
           "projection_weight",
           &momentum::CalibrationConfig::projectionWeight,
-          "Base weight for 2D keypoint projection constraints. Set to 0 to disable.");
+          "Base weight for 2D keypoint projection constraints. Set to 0 to disable.")
+      .def_readwrite(
+          "floor_contact_percentile",
+          &momentum::CalibrationConfig::floorContactPercentile,
+          "Percentile threshold for adaptive floor contact detection (0-1). "
+          "For each floor locator, frames at or below this percentile of Y heights "
+          "receive a soft equality floor constraint.");
 
   auto gapFillConfig = py::class_<momentum::GapFillConfig>(
       m, "GapFillConfig", "Config for marker gap filling and dropout blending");


### PR DESCRIPTION
Summary:
Replace the first-frame floor equality constraint with adaptive per-frame floor contact detection. Instead of forcing all 12 floor locators to y=0 on frame 0 with a massive weight, the solver now:

1. Runs the first major iteration with half-plane (non-penetration) floor constraints only.
2. After each iteration, evaluates all floor locator Y positions across all solved frames.
3. For each locator independently, computes the 33rd percentile of its height distribution.
4. Frames where a locator is at or below its percentile threshold get a soft equality floor constraint for that locator only.
5. Non-contact frames keep only the half-plane constraint.

This discovers floor contact from the data rather than hardcoding frame 0, handles asymmetric contact (e.g., one foot lifted during ROM), and uses a soft weight (5x kLegacyWeight) that balances against markers rather than overwhelming them.

New config field `CalibrationConfig::floorContactPercentile` (default 1/3) controls the contact threshold. Gated behind `enforceFloorInFirstFrame` so disabling floor constraints still works.

New helper `computeFloorContactConstraints()` in tracker_utils computes per-frame per-locator contact constraint lists.

Reviewed By: cstollmeta

Differential Revision: D103428146


