### PR TITLE
De-template Character (drop CharacterT<T>)

### DIFF
--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -24,8 +24,7 @@
 
 namespace momentum {
 
-template <typename T>
-CharacterT<T>::CharacterT(
+Character::Character(
     const Skeleton& s,
     const ParameterTransform& pt,
     const ParameterLimits& pl,
@@ -74,8 +73,7 @@ CharacterT<T>::CharacterT(
   resetJointMap();
 }
 
-template <typename T>
-CharacterT<T>::CharacterT(const CharacterT& c)
+Character::Character(const Character& c)
     : skeleton(c.skeleton),
       parameterTransform(c.parameterTransform),
       parameterLimits(c.parameterLimits),
@@ -104,19 +102,15 @@ CharacterT<T>::CharacterT(const CharacterT& c)
   }
 }
 
-template <typename T>
-CharacterT<T>::CharacterT(CharacterT&& c) noexcept = default;
+Character::Character(Character&& c) noexcept = default;
 
-template <typename T>
-CharacterT<T>::CharacterT() = default;
+Character::Character() = default;
 
-template <typename T>
-CharacterT<T>::~CharacterT() = default;
+Character::~Character() = default;
 
-template <typename T>
-CharacterT<T>& CharacterT<T>::operator=(const CharacterT& rhs) {
+Character& Character::operator=(const Character& rhs) {
   // Copy-and-swap: build a temporary copy, then swap members in for strong exception safety.
-  CharacterT<T> tmp(rhs);
+  Character tmp(rhs);
 
   std::swap(skeleton, tmp.skeleton);
   std::swap(parameterTransform, tmp.parameterTransform);
@@ -137,11 +131,9 @@ CharacterT<T>& CharacterT<T>::operator=(const CharacterT& rhs) {
   return *this;
 }
 
-template <typename T>
-CharacterT<T>& CharacterT<T>::operator=(CharacterT&& rhs) noexcept = default;
+Character& Character::operator=(Character&& rhs) noexcept = default;
 
-template <typename T>
-std::vector<bool> CharacterT<T>::parametersToActiveJoints(const ParameterSet& parameterSet) const {
+std::vector<bool> Character::parametersToActiveJoints(const ParameterSet& parameterSet) const {
   const auto nJoints = skeleton.joints.size();
   std::vector<bool> result(nJoints, false);
   for (int k = 0; k < parameterTransform.transform.outerSize(); ++k) {
@@ -164,8 +156,7 @@ std::vector<bool> CharacterT<T>::parametersToActiveJoints(const ParameterSet& pa
   return result;
 }
 
-template <typename T>
-ParameterSet CharacterT<T>::activeJointsToParameters(const std::vector<bool>& activeJoints) const {
+ParameterSet Character::activeJointsToParameters(const std::vector<bool>& activeJoints) const {
   MT_CHECK(
       activeJoints.size() == skeleton.joints.size(),
       "{} is not {}",
@@ -194,8 +185,7 @@ ParameterSet CharacterT<T>::activeJointsToParameters(const std::vector<bool>& ac
   return result;
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoints) const {
+Character Character::simplifySkeleton(const std::vector<bool>& activeJoints) const {
   MT_CHECK(
       activeJoints.size() == skeleton.joints.size(),
       "{} is not {}",
@@ -260,7 +250,7 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
         if (sIndex == kInvalidIndex) {
           break;
         }
-        currentParent = lastJoint[sIndex];
+        currentParent = lastJoint.at(sIndex);
       }
       // Re-express the joint's translation in the (new) parent's local frame; if no parent
       // remains, the translation is in world space (root joint case).
@@ -289,17 +279,17 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
 
       simplifiedSkeleton.joints.push_back(jt);
 
-      intermediateJointMap[aIndex] = jointCount;
+      intermediateJointMap.at(aIndex) = jointCount;
       jointCount++;
-      lastJoint[aIndex] = simplifiedSkeleton.joints.size() - 1;
+      lastJoint.at(aIndex) = simplifiedSkeleton.joints.size() - 1;
 
-      simplifiedJointMap[aIndex] = jointCount - 1;
+      simplifiedJointMap.at(aIndex) = jointCount - 1;
     } else {
       // Inactive joints are not added to the simplified skeleton; instead, point their entry in
       // simplifiedJointMap at the nearest active ancestor so consumers (locators, skin weights,
       // etc.) can still resolve them.
       size_t index = aIndex;
-      while (index != kInvalidIndex && intermediateJointMap[index] == kInvalidIndex) {
+      while (index != kInvalidIndex && intermediateJointMap.at(index) == kInvalidIndex) {
         index = skeleton.joints[index].parent;
       }
       MT_THROW_IF(
@@ -307,7 +297,7 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
           "During skeleton simplification, inactive joint '{}' has no valid parent joint.  "
           "Every joint in the simplified skeleton must have at least one parent joint that is not disabled.",
           skeleton.joints.at(aIndex).name);
-      simplifiedJointMap[aIndex] = intermediateJointMap[index];
+      simplifiedJointMap.at(aIndex) = intermediateJointMap.at(index);
     }
   }
   MT_THROW_IF(
@@ -317,7 +307,7 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
   const ParameterTransform simplifiedTransform = mapParameterTransformJoints(
       parameterTransform, simplifiedSkeleton.joints.size(), intermediateJointMap);
 
-  CharacterT<T> result(simplifiedSkeleton, simplifiedTransform);
+  Character result(simplifiedSkeleton, simplifiedTransform);
   result.name = name;
   result.metadata = metadata;
 
@@ -356,7 +346,7 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
     result.collision = std::make_unique<CollisionGeometry>(*collision);
     for (auto&& c : *result.collision) {
       const auto oldParent = c.parent;
-      c.parent = result.jointMap[c.parent];
+      c.parent = result.jointMap.at(c.parent);
       // Re-express the collision shape's local transform in the new parent's frame:
       //   newLocal = targetParentBind^-1 * sourceParentBind * oldLocal
       c.transformation =
@@ -368,15 +358,14 @@ CharacterT<T> CharacterT<T>::simplifySkeleton(const std::vector<bool>& activeJoi
   return result;
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::simplifyParameterTransform(const ParameterSet& parameterSet) const {
+Character Character::simplifyParameterTransform(const ParameterSet& parameterSet) const {
   MT_CHECK(
       parameterSet.count() > 0, "No active parameters in the input to simplifyParameterTransform.");
 
   auto [subsetParamTransform, subsetParamLimits] =
       subsetParameterTransform(parameterTransform, parameterLimits, parameterSet);
 
-  return CharacterT(
+  return {
       skeleton,
       subsetParamTransform,
       subsetParamLimits,
@@ -390,11 +379,10 @@ CharacterT<T> CharacterT<T>::simplifyParameterTransform(const ParameterSet& para
       name,
       inverseBindPose,
       skinnedLocators,
-      metadata);
+      metadata};
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::simplify(const ParameterSet& activeParams) const {
+Character Character::simplify(const ParameterSet& activeParams) const {
   auto activeJoints = parametersToActiveJoints(activeParams);
   // always keep the root joint to ensure valid simplification.
   // This is needed because while previously we generally parametrized the root joint with
@@ -407,10 +395,9 @@ CharacterT<T> CharacterT<T>::simplify(const ParameterSet& activeParams) const {
   return simplifySkeleton(activeJoints);
 }
 
-template <typename T>
-SkinWeights CharacterT<T>::remapSkinWeights(
+SkinWeights Character::remapSkinWeights(
     const SkinWeights& inSkinWeights,
-    const CharacterT& originalCharacter) const {
+    const Character& originalCharacter) const {
   MT_CHECK(
       originalCharacter.parameterTransform.numAllModelParameters() ==
           parameterTransform.numAllModelParameters(),
@@ -458,10 +445,9 @@ SkinWeights CharacterT<T>::remapSkinWeights(
   return result;
 }
 
-template <typename T>
-ParameterLimits CharacterT<T>::remapParameterLimits(
+ParameterLimits Character::remapParameterLimits(
     const ParameterLimits& limits,
-    const CharacterT& originalCharacter) const {
+    const Character& originalCharacter) const {
   MT_CHECK(
       originalCharacter.parameterTransform.numAllModelParameters() ==
           parameterTransform.numAllModelParameters(),
@@ -517,10 +503,9 @@ ParameterLimits CharacterT<T>::remapParameterLimits(
   return result;
 }
 
-template <typename T>
-SkinnedLocatorList CharacterT<T>::remapSkinnedLocators(
+SkinnedLocatorList Character::remapSkinnedLocators(
     const SkinnedLocatorList& locs,
-    const CharacterT& originalCharacter) const {
+    const Character& originalCharacter) const {
   MT_CHECK(
       originalCharacter.parameterTransform.numAllModelParameters() ==
           parameterTransform.numAllModelParameters(),
@@ -575,10 +560,8 @@ SkinnedLocatorList CharacterT<T>::remapSkinnedLocators(
   return result;
 }
 
-template <typename T>
-LocatorList CharacterT<T>::remapLocators(
-    const LocatorList& locs,
-    const CharacterT& originalCharacter) const {
+LocatorList Character::remapLocators(const LocatorList& locs, const Character& originalCharacter)
+    const {
   MT_CHECK(
       originalCharacter.parameterTransform.numAllModelParameters() ==
           parameterTransform.numAllModelParameters(),
@@ -611,29 +594,25 @@ LocatorList CharacterT<T>::remapLocators(
   return result;
 }
 
-template <typename T>
-CharacterParameters CharacterT<T>::bindPose() const {
+CharacterParameters Character::bindPose() const {
   CharacterParameters result;
   result.pose = VectorXf::Zero(parameterTransform.numAllModelParameters());
   result.offsets = VectorXf::Zero(skeleton.joints.size() * kParametersPerJoint);
   return result;
 }
 
-template <typename T>
-void CharacterT<T>::initParameterTransform() {
+void Character::initParameterTransform() {
   size_t nParams = skeleton.joints.size() * kParametersPerJoint;
   parameterTransform = ParameterTransform::empty(nParams);
 }
 
-template <typename T>
-void CharacterT<T>::resetJointMap() {
+void Character::resetJointMap() {
   // Identity map: jointMap[i] = i. Used when no skeleton simplification has been performed.
   jointMap.resize(skeleton.joints.size());
   std::iota(jointMap.begin(), jointMap.end(), 0);
 }
 
-template <typename T>
-void CharacterT<T>::initInverseBindPose() {
+void Character::initInverseBindPose() {
   const SkeletonState bindState(parameterTransform.bindPose(), skeleton, false);
   if (!inverseBindPose.empty()) {
     inverseBindPose.clear();
@@ -644,9 +623,8 @@ void CharacterT<T>::initInverseBindPose() {
   }
 }
 
-template <typename T>
-CharacterParameters CharacterT<T>::splitParameters(
-    const CharacterT& character,
+CharacterParameters Character::splitParameters(
+    const Character& character,
     const CharacterParameters& parameters,
     const ParameterSet& parameterSet) {
   auto parameterSplit = parameters;
@@ -662,17 +640,15 @@ CharacterParameters CharacterT<T>::splitParameters(
   return parameterSplit;
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::withBlendShape(
-    BlendShape_const_p blendShape_in,
+Character Character::withBlendShape(
+    const BlendShape_const_p& blendShape_in,
     Eigen::Index maxBlendShapes) const {
-  CharacterT<T> result = *this;
+  Character result = *this;
   result.addBlendShape(blendShape_in, maxBlendShapes);
   return result;
 }
 
-template <typename T>
-void CharacterT<T>::addBlendShape(
+void Character::addBlendShape(
     const BlendShape_const_p& blendShape_in,
     Eigen::Index maxBlendShapes) {
   MT_CHECK(this->mesh);
@@ -698,17 +674,15 @@ void CharacterT<T>::addBlendShape(
       parameterTransform, parameterLimits, std::min(maxBlendShapes, blendShape_in->shapeSize()));
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::withFaceExpressionBlendShape(
-    BlendShapeBase_const_p blendShape_in,
+Character Character::withFaceExpressionBlendShape(
+    const BlendShapeBase_const_p& blendShape_in,
     Eigen::Index maxBlendShapes) const {
-  CharacterT<T> res = *this;
+  Character res = *this;
   res.addFaceExpressionBlendShape(blendShape_in, maxBlendShapes);
   return res;
 }
 
-template <typename T>
-void CharacterT<T>::addFaceExpressionBlendShape(
+void Character::addFaceExpressionBlendShape(
     const BlendShapeBase_const_p& blendShape_in,
     Eigen::Index maxBlendShapes) {
   MT_CHECK(mesh);
@@ -738,9 +712,8 @@ void CharacterT<T>::addFaceExpressionBlendShape(
       addFaceExpressionParameters(parameterTransform, parameterLimits, nBlendShapes);
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::bakeBlendShape(const BlendWeights& blendWeights) const {
-  CharacterT<T> result = *this;
+Character Character::bakeBlendShape(const BlendWeights& blendWeights) const {
+  Character result = *this;
   MT_CHECK(result.mesh);
   if (this->blendShape) {
     result.mesh->vertices = this->blendShape->template computeShape<float>(blendWeights);
@@ -755,18 +728,14 @@ CharacterT<T> CharacterT<T>::bakeBlendShape(const BlendWeights& blendWeights) co
   return result;
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::bakeBlendShape(const ModelParameters& modelParams) const {
+Character Character::bakeBlendShape(const ModelParameters& modelParams) const {
   return bakeBlendShape(extractBlendWeights(this->parameterTransform, modelParams));
 }
 
-template <typename T>
-CharacterT<T> CharacterT<T>::bake(
-    const ModelParameters& modelParams,
-    bool bakeBlendShapes,
-    bool bakeScales) const {
+Character Character::bake(const ModelParameters& modelParams, bool bakeBlendShapes, bool bakeScales)
+    const {
   // 1. Clone the character so we don't mutate the original.
-  CharacterT<T> result = *this;
+  Character result = *this;
   MT_CHECK(result.mesh);
 
   // 2. Blend-shape baking: replace the rest-pose vertices with the blend-shape evaluation.
@@ -805,8 +774,5 @@ CharacterT<T> CharacterT<T>::bake(
 
   return result;
 }
-
-template struct CharacterT<float>;
-template struct CharacterT<double>;
 
 } // namespace momentum

--- a/momentum/character/character.h
+++ b/momentum/character/character.h
@@ -20,8 +20,14 @@
 namespace momentum {
 
 /// A character model with skeletal structure, mesh, and optional components.
-template <typename T>
-struct CharacterT {
+///
+/// `Character` is intentionally **not** templated on a scalar type: every member
+/// (skeleton, parameter transform, mesh, inverse bind pose, etc.) is stored as
+/// float. Double-precision callers convert to/from float at API boundaries via
+/// `cast<T>()` on the inner types (e.g. `MeshT<T>`, `SkeletonStateT<T>`). This
+/// reflects the reality that the previous `CharacterT<T>` template parameter was
+/// never wired through to any member; see T270138855 for the audit.
+struct Character {
   /// @{ @name Required components
 
   /// Skeletal structure defining the character's joints and hierarchy
@@ -75,9 +81,9 @@ struct CharacterT {
 
   /// @}
 
-  CharacterT();
+  Character();
 
-  ~CharacterT();
+  ~Character();
 
   /// Constructs a character with the specified components
   ///
@@ -95,7 +101,7 @@ struct CharacterT {
   /// @param inverseBindPose Optional inverse bind pose transformations
   /// @param skinnedLocators Optional points of interest attached to joints, with skinning weights
   /// @param metadataIn Optional metadata
-  CharacterT(
+  Character(
       const Skeleton& s,
       const ParameterTransform& pt,
       const ParameterLimits& pl = ParameterLimits(),
@@ -111,29 +117,29 @@ struct CharacterT {
       const SkinnedLocatorList& skinnedLocators = {},
       std::string_view metadataIn = "");
 
-  CharacterT(const CharacterT& c);
-  CharacterT(CharacterT&& c) noexcept;
+  Character(const Character& c);
+  Character(Character&& c) noexcept;
 
-  CharacterT& operator=(const CharacterT& rhs);
-  CharacterT& operator=(CharacterT&& rhs) noexcept;
+  Character& operator=(const Character& rhs);
+  Character& operator=(Character&& rhs) noexcept;
 
   /// Creates a simplified character with only joints affected by the specified parameters
   ///
   /// @param activeParams Parameters to keep (defaults to all parameters)
   /// @return A new character with simplified skeleton and parameter transform
-  [[nodiscard]] CharacterT simplify(const ParameterSet& activeParams = ParameterSet().flip()) const;
+  [[nodiscard]] Character simplify(const ParameterSet& activeParams = ParameterSet().flip()) const;
 
   /// Creates a simplified character with only the specified joints
   ///
   /// @param activeJoints Boolean vector indicating which joints to keep
   /// @return A new character with only the requested joints
-  [[nodiscard]] CharacterT simplifySkeleton(const std::vector<bool>& activeJoints) const;
+  [[nodiscard]] Character simplifySkeleton(const std::vector<bool>& activeJoints) const;
 
   /// Creates a simplified character with only the specified parameters
   ///
   /// @param parameterSet Set of parameters to keep
   /// @return A new character with only the requested parameters
-  [[nodiscard]] CharacterT simplifyParameterTransform(const ParameterSet& parameterSet) const;
+  [[nodiscard]] Character simplifyParameterTransform(const ParameterSet& parameterSet) const;
 
   /// Remaps skin weights from original character to simplified version
   ///
@@ -142,7 +148,7 @@ struct CharacterT {
   /// @return Remapped skin weights for the simplified character
   [[nodiscard]] SkinWeights remapSkinWeights(
       const SkinWeights& skinWeights,
-      const CharacterT& originalCharacter) const;
+      const Character& originalCharacter) const;
 
   /// Remaps parameter limits from original character to simplified version
   ///
@@ -151,7 +157,7 @@ struct CharacterT {
   /// @return Remapped parameter limits for the simplified character
   [[nodiscard]] ParameterLimits remapParameterLimits(
       const ParameterLimits& limits,
-      const CharacterT& originalCharacter) const;
+      const Character& originalCharacter) const;
 
   /// Remaps locators from original character to simplified version
   ///
@@ -160,11 +166,11 @@ struct CharacterT {
   /// @return Remapped locators for the simplified character
   [[nodiscard]] LocatorList remapLocators(
       const LocatorList& locs,
-      const CharacterT& originalCharacter) const;
+      const Character& originalCharacter) const;
 
   [[nodiscard]] SkinnedLocatorList remapSkinnedLocators(
       const SkinnedLocatorList& locs,
-      const CharacterT& originalCharacter) const;
+      const Character& originalCharacter) const;
 
   /// Determines which joints are affected by the specified parameters
   ///
@@ -203,7 +209,7 @@ struct CharacterT {
   /// @param parameterSet Set indicating which parameters are active
   /// @return Parameters with active parameters zeroed in pose and applied to offsets
   [[nodiscard]] static CharacterParameters splitParameters(
-      const CharacterT& character,
+      const Character& character,
       const CharacterParameters& parameters,
       const ParameterSet& parameterSet);
 
@@ -212,8 +218,8 @@ struct CharacterT {
   /// @param blendShape_in Blend shapes to add to the character
   /// @param maxBlendShapes Maximum number of blend shape parameters to add (use all if <= 0)
   /// @return A new character with the specified blend shapes
-  [[nodiscard]] CharacterT withBlendShape(
-      BlendShape_const_p blendShape_in,
+  [[nodiscard]] Character withBlendShape(
+      const BlendShape_const_p& blendShape_in,
       Eigen::Index maxBlendShapes) const;
 
   /// Creates a new character with the specified face expression blend shapes
@@ -221,8 +227,8 @@ struct CharacterT {
   /// @param blendShape_in Face expression blend shapes to add to the character
   /// @param maxBlendShapes Maximum number of blend shape parameters to add (use all if <= 0)
   /// @return A new character with the specified face expression blend shapes
-  [[nodiscard]] CharacterT withFaceExpressionBlendShape(
-      BlendShapeBase_const_p blendShape_in,
+  [[nodiscard]] Character withFaceExpressionBlendShape(
+      const BlendShapeBase_const_p& blendShape_in,
       Eigen::Index maxBlendShapes = -1) const;
 
   /// Adds blend shapes to this character
@@ -243,13 +249,13 @@ struct CharacterT {
   ///
   /// @param modelParams Model parameters containing blend shape weights
   /// @return A new character with blend shapes baked into the mesh
-  [[nodiscard]] CharacterT bakeBlendShape(const ModelParameters& modelParams) const;
+  [[nodiscard]] Character bakeBlendShape(const ModelParameters& modelParams) const;
 
   /// Creates a new character with blend shapes baked into the mesh
   ///
   /// @param blendWeights Blend shape weights to apply
   /// @return A new character with blend shapes baked into the mesh
-  [[nodiscard]] CharacterT bakeBlendShape(const BlendWeights& blendWeights) const;
+  [[nodiscard]] Character bakeBlendShape(const BlendWeights& blendWeights) const;
 
   /// Generic "bake-out" for turning a character into self-contained geometry.
   ///
@@ -261,7 +267,7 @@ struct CharacterT {
   ///
   /// The returned character contains a static mesh with all requested deformations baked in, while
   /// still supporting any parameters you elected to keep.
-  [[nodiscard]] CharacterT bake(
+  [[nodiscard]] Character bake(
       const ModelParameters& modelParams,
       bool bakeBlendShapes = true,
       bool bakeScales = true) const;

--- a/momentum/character/character_state.cpp
+++ b/momentum/character/character_state.cpp
@@ -41,7 +41,7 @@ CharacterStateT<T>::~CharacterStateT() = default;
 
 template <typename T>
 CharacterStateT<T>::CharacterStateT(
-    const CharacterT<T>& referenceCharacter,
+    const Character& referenceCharacter,
     bool updateMesh,
     bool updateCollision) {
   setBindPose(referenceCharacter, updateMesh, updateCollision);
@@ -50,7 +50,7 @@ CharacterStateT<T>::CharacterStateT(
 template <typename T>
 CharacterStateT<T>::CharacterStateT(
     const CharacterParameters& parameters,
-    const CharacterT<T>& referenceCharacter,
+    const Character& referenceCharacter,
     bool updateMesh,
     bool updateCollision,
     bool applyLimits) {
@@ -59,7 +59,7 @@ CharacterStateT<T>::CharacterStateT(
 
 template <typename T>
 void CharacterStateT<T>::setBindPose(
-    const CharacterT<T>& referenceCharacter,
+    const Character& referenceCharacter,
     bool updateMesh,
     bool updateCollision) {
   set(referenceCharacter.bindPose(), referenceCharacter, updateMesh, updateCollision);
@@ -68,7 +68,7 @@ void CharacterStateT<T>::setBindPose(
 template <typename T>
 void CharacterStateT<T>::set(
     const CharacterParameters& inParameters,
-    const CharacterT<T>& referenceCharacter,
+    const Character& referenceCharacter,
     bool updateMesh,
     bool updateCollision,
     bool applyLimits) {
@@ -114,36 +114,9 @@ void CharacterStateT<T>::set(
 
       meshState->updateNormals();
     } else if (referenceCharacter.blendShape) {
-      // skinWithBlendShapes() is only defined for `Character` (i.e., CharacterT<float>),
-      // so the double-precision instantiation has to materialize a float Character to call it.
-      if constexpr (std::is_same_v<T, float>) {
-        skinWithBlendShapes(
-            static_cast<const Character&>(referenceCharacter),
-            skeletonState,
-            parameters.pose,
-            *meshState);
-      } else {
-        // TODO: This temporary Character is constructed by shallow-copying member pointers
-        // from a CharacterT<double>. Members that differ between float/double specializations
-        // (e.g., `inverseBindPose`) are passed across without conversion, which can produce
-        // subtly wrong skinning. Consider providing a proper float<->double conversion or
-        // a templated skinWithBlendShapes overload.
-        Character tempCharacter(
-            referenceCharacter.skeleton,
-            referenceCharacter.parameterTransform,
-            referenceCharacter.parameterLimits,
-            referenceCharacter.locators,
-            referenceCharacter.mesh.get(),
-            referenceCharacter.skinWeights.get(),
-            referenceCharacter.collision.get(),
-            referenceCharacter.poseShapes.get(),
-            referenceCharacter.blendShape,
-            nullptr, // no face expression blend shape
-            referenceCharacter.name,
-            referenceCharacter.inverseBindPose);
-
-        skinWithBlendShapes(tempCharacter, skeletonState, parameters.pose, *meshState);
-      }
+      // `Character` is now non-templated (T270138855), so this branch no longer needs the
+      // float-vs-double specialization workaround.
+      skinWithBlendShapes(referenceCharacter, skeletonState, parameters.pose, *meshState);
     } else {
       applySSD(
           referenceCharacter.inverseBindPose,

--- a/momentum/character/character_state.h
+++ b/momentum/character/character_state.h
@@ -59,7 +59,7 @@ struct CharacterStateT {
   /// @param updateCollision If true, allocate and populate `collisionState`
   ///   from `referenceCharacter.collision` (requires non-null collision).
   explicit CharacterStateT(
-      const CharacterT<T>& referenceCharacter,
+      const Character& referenceCharacter,
       bool updateMesh = true,
       bool updateCollision = true);
 
@@ -71,7 +71,7 @@ struct CharacterStateT {
   ///   for the requirements on `parameters.pose` and `parameters.offsets`.
   CharacterStateT(
       const CharacterParameters& parameters,
-      const CharacterT<T>& referenceCharacter,
+      const Character& referenceCharacter,
       bool updateMesh = true,
       bool updateCollision = true,
       bool applyLimits = true);
@@ -93,7 +93,7 @@ struct CharacterStateT {
   ///   character's `parameterLimits` after applying the parameter transform.
   void set(
       const CharacterParameters& parameters,
-      const CharacterT<T>& referenceCharacter,
+      const Character& referenceCharacter,
       bool updateMesh = true,
       bool updateCollision = true,
       bool applyLimits = true);
@@ -102,7 +102,7 @@ struct CharacterStateT {
   ///
   /// @see set() for the meaning of `updateMesh` and `updateCollision`.
   void setBindPose(
-      const CharacterT<T>& referenceCharacter,
+      const Character& referenceCharacter,
       bool updateMesh = true,
       bool updateCollision = true);
 };

--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -1155,9 +1155,8 @@ MeshT<T> reduceMeshInternal(
 // Builds a new character whose mesh, skin weights, pose shapes, and blend shapes
 // are restricted to the given active vertices/faces. Skeleton, parameter transform,
 // limits, locators, collision, and inverseBindPose are passed through unchanged.
-template <typename T>
-CharacterT<T> reduceMeshComponents(
-    const CharacterT<T>& character,
+Character reduceMeshComponents(
+    const Character& character,
     const std::vector<bool>& activeVertices,
     const std::vector<bool>& activeFaces) {
   MT_CHECK(character.mesh, "Cannot reduce mesh: character has no mesh");
@@ -1249,7 +1248,7 @@ CharacterT<T> reduceMeshComponents(
     newFaceExpressionBlendShape = faceBlendShape;
   }
 
-  return CharacterT<T>(
+  return {
       character.skeleton,
       character.parameterTransform,
       character.parameterLimits,
@@ -1261,14 +1260,13 @@ CharacterT<T> reduceMeshComponents(
       std::move(newBlendShape),
       std::move(newFaceExpressionBlendShape),
       character.name,
-      character.inverseBindPose);
+      character.inverseBindPose};
 }
 
 } // namespace
 
-template <typename T>
-CharacterT<T> reduceMeshByVertices(
-    const CharacterT<T>& character,
+Character reduceMeshByVertices(
+    const Character& character,
     const std::vector<bool>& activeVertices) {
   MT_CHECK(character.mesh, "Cannot reduce mesh: character has no mesh");
   MT_CHECK(
@@ -1282,10 +1280,7 @@ CharacterT<T> reduceMeshByVertices(
   return reduceMeshComponents(character, activeVertices, activeFaces);
 }
 
-template <typename T>
-CharacterT<T> reduceMeshByFaces(
-    const CharacterT<T>& character,
-    const std::vector<bool>& activeFaces) {
+Character reduceMeshByFaces(const Character& character, const std::vector<bool>& activeFaces) {
   MT_CHECK(character.mesh, "Cannot reduce mesh: character has no mesh");
   MT_CHECK(
       activeFaces.size() == character.mesh->faces.size(),
@@ -1382,10 +1377,7 @@ MeshT<T> reduceMeshByPolys(const MeshT<T>& mesh, const std::vector<bool>& active
   return reduceMeshInternal(mesh, activeVertices, activeFaces);
 }
 
-template <typename T>
-CharacterT<T> reduceMeshByPolys(
-    const CharacterT<T>& character,
-    const std::vector<bool>& activePolys) {
+Character reduceMeshByPolys(const Character& character, const std::vector<bool>& activePolys) {
   MT_CHECK(character.mesh, "Cannot reduce mesh: character has no mesh");
   MT_CHECK(
       activePolys.size() == character.mesh->polyFaceSizes.size(),
@@ -1398,22 +1390,6 @@ CharacterT<T> reduceMeshByPolys(
 
   return reduceMeshComponents(character, activeVertices, activeFaces);
 }
-
-template CharacterT<float> reduceMeshByVertices<float>(
-    const CharacterT<float>& character,
-    const std::vector<bool>& activeVertices);
-
-template CharacterT<double> reduceMeshByVertices<double>(
-    const CharacterT<double>& character,
-    const std::vector<bool>& activeVertices);
-
-template CharacterT<float> reduceMeshByFaces<float>(
-    const CharacterT<float>& character,
-    const std::vector<bool>& activeFaces);
-
-template CharacterT<double> reduceMeshByFaces<double>(
-    const CharacterT<double>& character,
-    const std::vector<bool>& activeFaces);
 
 template MeshT<float> reduceMeshByVertices<float>(
     const MeshT<float>& mesh,
@@ -1469,14 +1445,6 @@ template MeshT<float> reduceMeshByPolys<float>(
 
 template MeshT<double> reduceMeshByPolys<double>(
     const MeshT<double>& mesh,
-    const std::vector<bool>& activePolys);
-
-template CharacterT<float> reduceMeshByPolys<float>(
-    const CharacterT<float>& character,
-    const std::vector<bool>& activePolys);
-
-template CharacterT<double> reduceMeshByPolys<double>(
-    const CharacterT<double>& character,
     const std::vector<bool>& activePolys);
 
 } // namespace momentum

--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -66,17 +66,15 @@ JointParameters mapIdentityToCharacter(
 /// Reduces the character's mesh to only include the specified vertices and associated faces.
 ///
 /// @pre `activeVertices.size() == character.mesh->vertices.size()`
-template <typename T>
-[[nodiscard]] CharacterT<T> reduceMeshByVertices(
-    const CharacterT<T>& character,
+[[nodiscard]] Character reduceMeshByVertices(
+    const Character& character,
     const std::vector<bool>& activeVertices);
 
 /// Reduces the character's mesh to only include the specified faces and associated vertices.
 ///
 /// @pre `activeFaces.size() == character.mesh->faces.size()`
-template <typename T>
-[[nodiscard]] CharacterT<T> reduceMeshByFaces(
-    const CharacterT<T>& character,
+[[nodiscard]] Character reduceMeshByFaces(
+    const Character& character,
     const std::vector<bool>& activeFaces);
 
 /// Reduces a standalone mesh to only include the specified vertices and associated faces.
@@ -148,9 +146,8 @@ template <typename T>
 /// Both triangulated faces and polygon data are filtered and remapped.
 ///
 /// @pre `activePolys.size() == character.mesh->polygons.size()`
-template <typename T>
-[[nodiscard]] CharacterT<T> reduceMeshByPolys(
-    const CharacterT<T>& character,
+[[nodiscard]] Character reduceMeshByPolys(
+    const Character& character,
     const std::vector<bool>& activePolys);
 
 /// Result of addRigidTransformNode containing the new character and indices of the added joint

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -33,6 +33,15 @@ using BlendShapeBase_const_p = ::std::shared_ptr<const BlendShapeBase>;
 using BlendShapeBase_const_u = ::std::unique_ptr<const BlendShapeBase>;
 using BlendShapeBase_const_w = ::std::weak_ptr<const BlendShapeBase>;
 
+struct Character;
+
+using Character_p = ::std::shared_ptr<Character>;
+using Character_u = ::std::unique_ptr<Character>;
+using Character_w = ::std::weak_ptr<Character>;
+using Character_const_p = ::std::shared_ptr<const Character>;
+using Character_const_u = ::std::unique_ptr<const Character>;
+using Character_const_w = ::std::weak_ptr<const Character>;
+
 struct Locator;
 
 using Locator_p = ::std::shared_ptr<Locator>;
@@ -68,25 +77,6 @@ using SkinnedLocator_w = ::std::weak_ptr<SkinnedLocator>;
 using SkinnedLocator_const_p = ::std::shared_ptr<const SkinnedLocator>;
 using SkinnedLocator_const_u = ::std::unique_ptr<const SkinnedLocator>;
 using SkinnedLocator_const_w = ::std::weak_ptr<const SkinnedLocator>;
-
-template <typename T>
-struct CharacterT;
-using Character = CharacterT<float>;
-using Characterd = CharacterT<double>;
-
-using Character_p = ::std::shared_ptr<Character>;
-using Character_u = ::std::unique_ptr<Character>;
-using Character_w = ::std::weak_ptr<Character>;
-using Character_const_p = ::std::shared_ptr<const Character>;
-using Character_const_u = ::std::unique_ptr<const Character>;
-using Character_const_w = ::std::weak_ptr<const Character>;
-
-using Characterd_p = ::std::shared_ptr<Characterd>;
-using Characterd_u = ::std::unique_ptr<Characterd>;
-using Characterd_w = ::std::weak_ptr<Characterd>;
-using Characterd_const_p = ::std::shared_ptr<const Characterd>;
-using Characterd_const_u = ::std::unique_ptr<const Characterd>;
-using Characterd_const_w = ::std::weak_ptr<const Characterd>;
 
 template <typename T>
 struct CharacterStateT;

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -22,13 +22,13 @@ subdirectory = "character"
 structs = [
     "BlendShape",
     "BlendShapeBase",
+    "Character",
     "Locator",
     "PoseShape",
     "SkinWeights",
     "SkinnedLocator"
 ]
 template_structs = [
-    "Character",
     "CharacterState",
     "CollisionGeometryState",
     "Joint",

--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -40,7 +40,6 @@ struct MimicData {
   bool isRotation{}; // true for revolute/continuous, false for prismatic
 };
 
-template <typename T>
 struct ParsingData {
   Skeleton skeleton;
   ParameterTransform parameterTransform;
@@ -201,9 +200,8 @@ std::optional<Mesh> loadVisualMesh(
 constexpr std::array<const char*, 3> kTranslationNames = {"tx", "ty", "tz"};
 constexpr std::array<const char*, 3> kRotationNames = {"rx", "ry", "rz"};
 
-template <typename T>
 bool loadUrdfSkeletonRecursive(
-    ParsingData<T>& data,
+    ParsingData& data,
     size_t parentJointId,
     const urdf::ModelInterface* urdfModel,
     const urdf::Link* urdfLink) {
@@ -421,8 +419,7 @@ bool loadUrdfSkeletonRecursive(
 
 /// Resolves mimic joints by mapping each mimic joint's DOF to the mimicked joint's model
 /// parameter via the parameter transform.
-template <typename T>
-void resolveMimicJoints(ParsingData<T>& data) {
+void resolveMimicJoints(ParsingData& data) {
   for (const auto& mimic : data.mimicJoints) {
     auto it = data.urdfJointNameToModelParamIdx.find(mimic.mimickedJointName);
     if (it == data.urdfJointNameToModelParamIdx.end()) {
@@ -464,9 +461,8 @@ Eigen::Vector3b extractVertexColor(const urdf::Visual& visual, bool& hasColor) {
 
 /// Builds a combined mesh and skin weights from per-link visual data.
 /// Returns nullopt if no visual meshes were loaded.
-template <typename T>
 std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
-    const ParsingData<T>& data,
+    const ParsingData& data,
     const filesystem::path& urdfDir) {
   if (data.linkVisuals.empty()) {
     return std::nullopt;
@@ -512,8 +508,8 @@ std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
       combinedMesh.vertices.insert(
           combinedMesh.vertices.end(), meshOpt->vertices.begin(), meshOpt->vertices.end());
       for (const auto& face : meshOpt->faces) {
-        combinedMesh.faces.push_back(
-            {face[0] + vertexOffset, face[1] + vertexOffset, face[2] + vertexOffset});
+        combinedMesh.faces.emplace_back(
+            face[0] + vertexOffset, face[1] + vertexOffset, face[2] + vertexOffset);
       }
       combinedMesh.colors.resize(combinedMesh.vertices.size(), vertexColor);
 
@@ -544,14 +540,13 @@ std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
   return std::make_pair(std::move(combinedMesh), std::move(skinWeights));
 }
 
-template <typename T>
-CharacterT<T> loadUrdfCharacterFromUrdfModel(
+Character loadUrdfCharacterFromUrdfModel(
     urdf::ModelInterfaceSharedPtr urdfModel,
     const filesystem::path& urdfDir) {
   const urdf::Link* root = urdfModel->getRoot().get();
   MT_THROW_IF(!root, "Failed to parse URDF file from. No root link found.");
 
-  ParsingData<T> data;
+  ParsingData data;
 
   // Special Case: If the root link is named "world", it is treated as a world link. In this case,
   // the actual root link is the first child link. Otherwise, the root link itself is considered the
@@ -589,7 +584,7 @@ CharacterT<T> loadUrdfCharacterFromUrdfModel(
   auto meshResult = buildCombinedMesh(data, urdfDir);
   if (meshResult) {
     auto& [mesh, skinWeights] = *meshResult;
-    return CharacterT<T>(
+    return {
         data.skeleton,
         data.parameterTransform,
         data.limits,
@@ -600,10 +595,10 @@ CharacterT<T> loadUrdfCharacterFromUrdfModel(
         nullptr, // poseShapes
         {}, // blendShapes
         {}, // faceExpressionBlendShapes
-        robotName);
+        robotName};
   }
 
-  return CharacterT<T>(
+  return {
       data.skeleton,
       data.parameterTransform,
       data.limits,
@@ -614,13 +609,12 @@ CharacterT<T> loadUrdfCharacterFromUrdfModel(
       nullptr, // poseShapes
       {}, // blendShapes
       {}, // faceExpressionBlendShapes
-      robotName);
+      robotName};
 }
 
 } // namespace
 
-template <typename T>
-CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath) {
+Character loadUrdfCharacter(const filesystem::path& filepath) {
   urdf::ModelInterfaceSharedPtr urdfModel;
 
   try {
@@ -632,7 +626,7 @@ CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath) {
   }
 
   try {
-    return loadUrdfCharacterFromUrdfModel<T>(urdfModel, filepath.parent_path());
+    return loadUrdfCharacterFromUrdfModel(urdfModel, filepath.parent_path());
   } catch (const std::exception& e) {
     MT_THROW(
         "Failed to create Character from URDF file: {}. Error: {}", filepath.string(), e.what());
@@ -641,11 +635,7 @@ CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath) {
   }
 }
 
-template CharacterT<float> loadUrdfCharacter(const filesystem::path& filepath);
-template CharacterT<double> loadUrdfCharacter(const filesystem::path& filepath);
-
-template <typename T>
-CharacterT<T> loadUrdfCharacter(std::span<const std::byte> bytes) {
+Character loadUrdfCharacter(std::span<const std::byte> bytes) {
   urdf::ModelInterfaceSharedPtr urdfModel;
 
   try {
@@ -660,7 +650,7 @@ CharacterT<T> loadUrdfCharacter(std::span<const std::byte> bytes) {
   }
 
   try {
-    return loadUrdfCharacterFromUrdfModel<T>(urdfModel, {});
+    return loadUrdfCharacterFromUrdfModel(urdfModel, {});
   } catch (const std::exception& e) {
     MT_THROW("Failed to create Character from URDF bytes. Error: {}", e.what());
   } catch (...) {
@@ -668,11 +658,7 @@ CharacterT<T> loadUrdfCharacter(std::span<const std::byte> bytes) {
   }
 }
 
-template CharacterT<float> loadUrdfCharacter(std::span<const std::byte> bytes);
-template CharacterT<double> loadUrdfCharacter(std::span<const std::byte> bytes);
-
-template <typename T>
-CharacterT<T> loadUrdfCharacter(
+Character loadUrdfCharacter(
     std::span<const std::byte> bytes,
     const filesystem::path& meshBasePath) {
   urdf::ModelInterfaceSharedPtr urdfModel;
@@ -687,19 +673,12 @@ CharacterT<T> loadUrdfCharacter(
   }
 
   try {
-    return loadUrdfCharacterFromUrdfModel<T>(urdfModel, meshBasePath);
+    return loadUrdfCharacterFromUrdfModel(urdfModel, meshBasePath);
   } catch (const std::exception& e) {
     MT_THROW("Failed to create Character from URDF bytes. Error: {}", e.what());
   } catch (...) {
     MT_THROW("Failed to create Character from URDF bytes");
   }
 }
-
-template CharacterT<float> loadUrdfCharacter(
-    std::span<const std::byte> bytes,
-    const filesystem::path& meshBasePath);
-template CharacterT<double> loadUrdfCharacter(
-    std::span<const std::byte> bytes,
-    const filesystem::path& meshBasePath);
 
 } // namespace momentum

--- a/momentum/io/urdf/urdf_io.h
+++ b/momentum/io/urdf/urdf_io.h
@@ -73,24 +73,21 @@ namespace momentum {
 /// @param filepath Path to the URDF file.
 /// @return The loaded character with skeleton, parameter transform, limits, and optionally
 ///   mesh with skin weights.
-template <typename T = float>
-CharacterT<T> loadUrdfCharacter(const filesystem::path& filepath);
+Character loadUrdfCharacter(const filesystem::path& filepath);
 
 /// Loads a character from a URDF file using the provided byte data.
 ///
 /// Mesh loading is not supported when loading from bytes because there is no
 /// file path to resolve relative mesh references. Use the overload with
 /// meshBasePath to enable mesh loading.
-template <typename T = float>
-[[nodiscard]] CharacterT<T> loadUrdfCharacter(std::span<const std::byte> bytes);
+[[nodiscard]] Character loadUrdfCharacter(std::span<const std::byte> bytes);
 
 /// Loads a character from a URDF file using the provided byte data, with a base
 /// path for resolving mesh file references.
 ///
 /// @param bytes The raw URDF file contents.
 /// @param meshBasePath The directory to use for resolving relative mesh file paths.
-template <typename T = float>
-[[nodiscard]] CharacterT<T> loadUrdfCharacter(
+[[nodiscard]] Character loadUrdfCharacter(
     std::span<const std::byte> bytes,
     const filesystem::path& meshBasePath);
 

--- a/momentum/test/character/character_blend_shape_test.cpp
+++ b/momentum/test/character/character_blend_shape_test.cpp
@@ -29,13 +29,13 @@ using namespace momentum;
 template <typename T>
 class CharacterBlendShapeTest : public testing::Test {
  protected:
-  using CharacterType = CharacterT<T>;
+  using CharacterType = Character;
   using Vector3Type = Vector3<T>;
   using QuaternionType = Quaternion<T>;
 
   void SetUp() override {
     // Create a test character with 5 joints
-    character = createTestCharacter<T>(5);
+    character = createTestCharacter(5);
 
     // Create a character with blend shapes
     characterWithBlendShapes = withTestBlendShapes(character);

--- a/momentum/test/character/character_helpers.cpp
+++ b/momentum/test/character/character_helpers.cpp
@@ -219,13 +219,12 @@ ParameterLimits createDefaultParameterLimits() {
 
 } // namespace
 
-template <typename T>
-CharacterT<T> createTestCharacter(size_t numJoints) {
+Character createTestCharacter(size_t numJoints) {
   MT_CHECK(numJoints >= 3, "The number of joints '{}' should be equal to 3 or greater.", numJoints);
   auto [mesh, skin] = createDefaultMesh(static_cast<int>(numJoints));
   auto collisionGeometry = createDefaultCollisionGeometry(numJoints);
   const auto skeleton = createDefaultSkeleton(numJoints);
-  return CharacterT<T>(
+  return {
       skeleton,
       createDefaultParameterTransform(numJoints),
       createDefaultParameterLimits(),
@@ -239,14 +238,10 @@ CharacterT<T> createTestCharacter(size_t numJoints) {
       std::string("test character"),
       momentum::TransformationList{},
       createDefaultSkinnedLocatorList(skeleton),
-      std::string(R"({"name":"testCharacterV1","version":1})"));
+      std::string(R"({"name":"testCharacterV1","version":1})")};
 }
 
-template CharacterT<float> createTestCharacter(size_t numJoints);
-template CharacterT<double> createTestCharacter(size_t numJoints);
-
-template <typename T>
-CharacterT<T> withTestBlendShapes(const CharacterT<T>& character) {
+Character withTestBlendShapes(const Character& character) {
   MT_CHECK(character.mesh);
 
   const int nShapes = 5;
@@ -255,11 +250,7 @@ CharacterT<T> withTestBlendShapes(const CharacterT<T>& character) {
   return character.withBlendShape(blendShapes, nShapes);
 }
 
-template CharacterT<float> withTestBlendShapes(const CharacterT<float>& character);
-template CharacterT<double> withTestBlendShapes(const CharacterT<double>& character);
-
-template <typename T>
-CharacterT<T> withTestFaceExpressionBlendShapes(const CharacterT<T>& character) {
+Character withTestFaceExpressionBlendShapes(const Character& character) {
   MT_CHECK(character.mesh);
 
   const int nShapes = 5;
@@ -268,9 +259,6 @@ CharacterT<T> withTestFaceExpressionBlendShapes(const CharacterT<T>& character) 
 
   return character.withFaceExpressionBlendShape(blendShapes, nShapes);
 }
-
-template CharacterT<float> withTestFaceExpressionBlendShapes(const CharacterT<float>& character);
-template CharacterT<double> withTestFaceExpressionBlendShapes(const CharacterT<double>& character);
 
 template <typename T>
 std::shared_ptr<const MppcaT<T>> createDefaultPosePrior() {

--- a/momentum/test/character/character_helpers.h
+++ b/momentum/test/character/character_helpers.h
@@ -16,18 +16,15 @@ namespace momentum {
 ///
 /// @param numJoints The number of joints in the resulting character.
 /// @note: The `numJoints` parameter should be equal to 3 or greater.
-template <typename T = float>
-[[nodiscard]] CharacterT<T> createTestCharacter(size_t numJoints = 3);
+[[nodiscard]] Character createTestCharacter(size_t numJoints = 3);
 // TODO: Currently, the number of parameters is fixed to 10, affecting only the first 3 joints.
 // Additional work is needed to scale the number of parameters with the number of joints.
 
 template <typename T>
 [[nodiscard]] std::shared_ptr<const MppcaT<T>> createDefaultPosePrior();
 
-template <typename T>
-[[nodiscard]] CharacterT<T> withTestBlendShapes(const CharacterT<T>& character);
+[[nodiscard]] Character withTestBlendShapes(const Character& character);
 
-template <typename T>
-[[nodiscard]] CharacterT<T> withTestFaceExpressionBlendShapes(const CharacterT<T>& character);
+[[nodiscard]] Character withTestFaceExpressionBlendShapes(const Character& character);
 
 } // namespace momentum

--- a/momentum/test/character/character_mesh_test.cpp
+++ b/momentum/test/character/character_mesh_test.cpp
@@ -29,13 +29,13 @@ using namespace momentum;
 template <typename T>
 class CharacterMeshTest : public testing::Test {
  protected:
-  using CharacterType = CharacterT<T>;
+  using CharacterType = Character;
   using Vector3Type = Vector3<T>;
   using QuaternionType = Quaternion<T>;
 
   void SetUp() override {
     // Create a test character with 5 joints
-    character = createTestCharacter<T>(5);
+    character = createTestCharacter(5);
 
     // Create a character with blend shapes
     characterWithBlendShapes = withTestBlendShapes(character);

--- a/momentum/test/character/character_state_test.cpp
+++ b/momentum/test/character/character_state_test.cpp
@@ -32,14 +32,14 @@ template <typename T>
 class CharacterStateTest : public testing::Test {
  protected:
   using Type = T;
-  using CharacterType = CharacterT<T>;
+  using CharacterType = Character;
   using CharacterStateType = CharacterStateT<T>;
   using Vector3Type = Vector3<T>;
   using QuaternionType = Quaternion<T>;
 
   void SetUp() override {
     // Create a test character with 5 joints
-    character = createTestCharacter<T>(5);
+    character = createTestCharacter(5);
 
     // Create a character with blend shapes
     characterWithBlendShapes = withTestBlendShapes(character);
@@ -56,7 +56,7 @@ TYPED_TEST_SUITE(CharacterStateTest, Types);
 template <typename T>
 void expectStateHasCorrectComponents(
     const CharacterStateT<T>& state,
-    const CharacterT<T>& character,
+    const Character& character,
     bool expectMesh = true,
     bool expectCollision = true) {
   EXPECT_EQ(state.parameters.pose.size(), character.parameterTransform.numAllModelParameters());

--- a/momentum/test/character/character_test.cpp
+++ b/momentum/test/character/character_test.cpp
@@ -27,13 +27,13 @@ using namespace momentum;
 template <typename T>
 class CharacterTest : public testing::Test {
  protected:
-  using CharacterType = CharacterT<T>;
+  using CharacterType = Character;
   using Vector3Type = Vector3<T>;
   using QuaternionType = Quaternion<T>;
 
   void SetUp() override {
     // Create a test character with 5 joints
-    character = createTestCharacter<T>(5);
+    character = createTestCharacter(5);
 
     // Create a character with blend shapes
     characterWithBlendShapes = withTestBlendShapes(character);
@@ -273,7 +273,7 @@ TYPED_TEST(CharacterTest, MoveAssignment) {
 
   // Create two characters
   CharacterType originalCharacter = this->character;
-  CharacterType targetCharacter = createTestCharacter<TypeParam>(3); // Different size
+  CharacterType targetCharacter = createTestCharacter(3); // Different size
 
   // Store original data for comparison
   const size_t originalJointCount = originalCharacter.skeleton.joints.size();

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -33,8 +33,8 @@ class CharacterUtilityTest : public ::testing::Test {
     Random<>::GetSingleton().setSeed(42);
 
     // Create test characters with different numbers of joints
-    character = createTestCharacter<float>(5);
-    smallCharacter = createTestCharacter<float>(3);
+    character = createTestCharacter(5);
+    smallCharacter = createTestCharacter(3);
     characterWithBlendShapes = withTestBlendShapes(character);
   }
 
@@ -380,10 +380,10 @@ TEST_F(CharacterUtilityTest, MapIdentityToCharacter) {
 // Test replaceSkeletonHierarchy error cases
 TEST_F(CharacterUtilityTest, ReplaceSkeletonHierarchyErrors) {
   // Create a simple source character
-  Character sourceCharacter = createTestCharacter<float>(3);
+  Character sourceCharacter = createTestCharacter(3);
 
   // Create a simple target character
-  Character targetCharacter = createTestCharacter<float>(3);
+  Character targetCharacter = createTestCharacter(3);
 
   // Test with non-existent source root joint
   EXPECT_THROW(
@@ -423,8 +423,8 @@ TEST_F(CharacterUtilityTest, ReplaceSkeletonHierarchyErrors) {
 // Test replaceSkeletonHierarchy basic functionality
 TEST_F(CharacterUtilityTest, ReplaceSkeletonHierarchyBasic) {
   // Create source and target characters with unique parameter names
-  Character sourceCharacter = createTestCharacter<float>(3);
-  Character targetCharacter = createTestCharacter<float>(3);
+  Character sourceCharacter = createTestCharacter(3);
+  Character targetCharacter = createTestCharacter(3);
 
   // Ensure parameter names don't conflict by renaming source parameters
   for (auto& name : sourceCharacter.parameterTransform.name) {
@@ -803,8 +803,8 @@ TEST_F(CharacterUtilityTest, ParentMappingInReplaceSkeletonHierarchy) {
 // Test parameter sets and other remaining code paths
 TEST_F(CharacterUtilityTest, ParameterSetsAndRemainingCodePaths) {
   // Create source and target characters for replaceSkeletonHierarchy
-  Character sourceCharacter = createTestCharacter<float>(3);
-  Character targetCharacter = createTestCharacter<float>(3);
+  Character sourceCharacter = createTestCharacter(3);
+  Character targetCharacter = createTestCharacter(3);
 
   // Ensure parameter names don't conflict
   for (auto& name : sourceCharacter.parameterTransform.name) {
@@ -1106,7 +1106,7 @@ TYPED_TEST(
   using JointParametersType = typename TestFixture::JointParametersType;
 
   // Create a test character where all joints have all rotations active (3D joints)
-  auto testCharacter = createTestCharacter<T>();
+  auto testCharacter = createTestCharacter();
 
   // Create joint parameters
   Random<> rng(98765);

--- a/momentum/test/character/mesh_reduction_test.cpp
+++ b/momentum/test/character/mesh_reduction_test.cpp
@@ -19,10 +19,10 @@ using namespace momentum;
 template <typename T>
 class MeshReductionTest : public testing::Test {
  protected:
-  using CharacterType = CharacterT<T>;
+  using CharacterType = Character;
 
   void SetUp() override {
-    character = createTestCharacter<T>(5);
+    character = createTestCharacter(5);
   }
 
   CharacterType character;

--- a/momentum/test/io/io_fbx_builder_test.cpp
+++ b/momentum/test/io/io_fbx_builder_test.cpp
@@ -18,7 +18,7 @@
 using namespace momentum;
 
 TEST(FbxBuilderTest, AddCharacter_RoundTripsNameAndMetadata) {
-  Character character = createTestCharacter<float>(5);
+  Character character = createTestCharacter(5);
 
   const auto outFile = temporaryFile("builder_char", "fbx");
   {
@@ -60,7 +60,7 @@ TEST(FbxBuilderTest, AddCharacter_MatchesSaveFbxModel) {
 }
 
 TEST(FbxBuilderTest, AddCharacterWithMotion) {
-  Character character = createTestCharacter<float>(5);
+  Character character = createTestCharacter(5);
 
   const auto nModelParams = character.parameterTransform.numAllModelParameters();
   const Eigen::Index nFrames = 10;
@@ -83,7 +83,7 @@ TEST(FbxBuilderTest, AddCharacterWithMotion) {
 }
 
 TEST(FbxBuilderTest, AddRigidBody_HasCorrectJointCount) {
-  Character character = createTestCharacter<float>(3);
+  Character character = createTestCharacter(3);
 
   const auto outFile = temporaryFile("builder_rigid", "fbx");
   {
@@ -98,7 +98,7 @@ TEST(FbxBuilderTest, AddRigidBody_HasCorrectJointCount) {
 }
 
 TEST(FbxBuilderTest, AddRigidBody_NonRootParentJoint) {
-  Character character = createTestCharacter<float>(3);
+  Character character = createTestCharacter(3);
 
   const auto outFile = temporaryFile("builder_rigid_joint1", "fbx");
   {
@@ -113,7 +113,7 @@ TEST(FbxBuilderTest, AddRigidBody_NonRootParentJoint) {
 }
 
 TEST(FbxBuilderTest, AddRigidBodyWithMotion) {
-  Character character = createTestCharacter<float>(3);
+  Character character = createTestCharacter(3);
 
   const auto nJointParams =
       static_cast<Eigen::Index>(character.parameterTransform.numJointParameters());
@@ -142,9 +142,9 @@ TEST(FbxBuilderTest, AddRigidBodyWithMotion) {
 }
 
 TEST(FbxBuilderTest, MultipleCharacters) {
-  Character body = createTestCharacter<float>(5);
+  Character body = createTestCharacter(5);
   body.name = "body";
-  Character prop = createTestCharacter<float>(3);
+  Character prop = createTestCharacter(3);
   prop.name = "prop";
 
   const auto outFile = temporaryFile("builder_multi", "fbx");
@@ -161,7 +161,7 @@ TEST(FbxBuilderTest, MultipleCharacters) {
 }
 
 TEST(FbxBuilderTest, MarkerSequence) {
-  Character character = createTestCharacter<float>(3);
+  Character character = createTestCharacter(3);
 
   std::vector<std::vector<Marker>> markerSeq(5);
   for (size_t f = 0; f < markerSeq.size(); f++) {
@@ -185,7 +185,7 @@ TEST(FbxBuilderTest, MarkerSequence) {
 }
 
 TEST(FbxBuilderTest, SaveConsumesBuilder) {
-  Character character = createTestCharacter<float>(3);
+  Character character = createTestCharacter(3);
 
   FbxBuilder builder;
   builder.addCharacter(character);

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -211,11 +211,11 @@ void saveLocatorsToFile(
 }
 
 momentum::Character loadURDFCharacterFromFile(const std::string& urdfPath) {
-  return momentum::loadUrdfCharacter<float>(urdfPath);
+  return momentum::loadUrdfCharacter(urdfPath);
 }
 
 momentum::Character loadURDFCharacterFromBytes(const pybind11::bytes& urdfBytes) {
-  return momentum::loadUrdfCharacter<float>(toSpan<std::byte>(urdfBytes));
+  return momentum::loadUrdfCharacter(toSpan<std::byte>(urdfBytes));
 }
 
 std::shared_ptr<const momentum::Mppca> loadPosePriorFromFile(const std::string& path) {

--- a/pymomentum/geometry_test_utils/geometry_test_utils_pybind.cpp
+++ b/pymomentum/geometry_test_utils/geometry_test_utils_pybind.cpp
@@ -16,7 +16,7 @@ namespace mm = momentum;
 
 namespace {
 mm::Character createTestCharacter(int num_joints, bool with_blendshapes) {
-  auto character = momentum::createTestCharacter<float>(num_joints);
+  auto character = momentum::createTestCharacter(num_joints);
   if (with_blendshapes) {
     character = momentum::withTestBlendShapes(character);
   }


### PR DESCRIPTION
Summary:
`CharacterT<T>` was templated on a scalar type, but the parameter `T` was never wired through to any member: `skeleton`, `parameterTransform`, `mesh`, `inverseBindPose`, and every other member is stored as float regardless of `T`. As a result, `CharacterT<float>` and `CharacterT<double>` were bit-identical structures with bit-identical method bodies, doubling object code for no behavioral benefit.

This change removes the template parameter and renames the type to plain `Character`. The previous `Characterd` typedef ( = `CharacterT<double>`) is dropped entirely. All in-momentum and downstream consumers are migrated to take/return `Character` directly. A docstring on the new `Character` declaration documents the float-only design choice so future readers don't relitigate it.

The `if constexpr (std::is_same_v<T, float>)` workaround in `CharacterStateT<T>::set` (which previously had to materialize a temporary float `Character` from a `CharacterT<double>` via shallow member copy in order to call `skinWithBlendShapes`) collapses to a single direct call. The accompanying `// TODO` describing a phantom skinning bug is deleted — the workaround compiled correctly precisely because the members were bit-identical, which the audit confirmed.

Functions whose `T` template parameter only existed to forward to a `CharacterT<T>` argument lose their `T` parameter as well. Functions that legitimately use `T` for math (e.g. `MeshT<T>` overloads, `MeshCollisionErrorFunctionT<T>`) keep their `T`; they just take `Character` instead of `CharacterT<T>` and `cast<T>()` internally where they need a typed mesh.

`gen_fwd_input.toml` moves `Character` from the `template_structs` section to `structs`; the regenerated `character/fwd.h` no longer declares `CharacterT` or `Characterd`.

Reviewed By: cdtwigg

Differential Revision: D104327355


