### PR TITLE
Preserve URDF visual colors in meshes (#1384)

### DIFF
--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -144,6 +144,12 @@ size_t addMeshToModel(fx::gltf::Document& model, const Mesh& mesh, const bool ad
     setBufferView(model, def["texfaces"], fx::gltf::BufferView::TargetType::ArrayBuffer);
   }
 
+  if (addColor && !mesh.colors.empty() && mesh.colors.size() != mesh.vertices.size()) {
+    MT_LOGW(
+        "Skipping vertex colors because color count ({}) does not match vertex count ({})",
+        mesh.colors.size(),
+        mesh.vertices.size());
+  }
   if (mesh.colors.size() == mesh.vertices.size() && addColor) {
     prim.attributes["COLOR_0"] =
         createAccessorBuffer<const Vector3b>(model, mesh.colors, true, true);
@@ -433,7 +439,7 @@ size_t addMeshToModel(
 
     // create model mesh
     const auto& mesh = *character.mesh;
-    auto newMeshIdx = addMeshToModel(model, mesh);
+    auto newMeshIdx = addMeshToModel(model, mesh, !mesh.colors.empty());
     if (newMeshIdx >= model.meshes.size()) {
       // Mesh not valid, skip
       return kInvalidIndex;

--- a/momentum/io/gltf/gltf_mesh_io.cpp
+++ b/momentum/io/gltf/gltf_mesh_io.cpp
@@ -119,17 +119,27 @@ addMesh(const fx::gltf::Document& model, const fx::gltf::Primitive& primitive, M
   }
   MT_LOGT_IF(texcoord.empty(), "no texture coords found");
 
+  const bool hadColors = !mesh->colors.empty();
+  const bool hasColors = !col.empty();
+  const size_t vertexOffset = mesh->vertices.size();
+
   // append new faces
   mesh->faces.insert(mesh->faces.end(), idx.begin(), idx.end());
   mesh->vertices.insert(mesh->vertices.end(), pos.begin(), pos.end());
   mesh->normals.insert(mesh->normals.end(), nml.begin(), nml.end());
-  mesh->colors.insert(mesh->colors.end(), col.begin(), col.end());
+  if (hasColors) {
+    if (!hadColors && vertexOffset > 0) {
+      mesh->colors.resize(vertexOffset, Vector3b::Constant(255));
+    }
+    mesh->colors.insert(mesh->colors.end(), col.begin(), col.end());
+  } else if (hadColors) {
+    mesh->colors.resize(mesh->vertices.size(), Vector3b::Constant(255));
+  }
   mesh->texcoords.insert(mesh->texcoords.end(), texcoord.begin(), texcoord.end());
   mesh->texcoord_faces.insert(mesh->texcoord_faces.end(), texfaces.begin(), texfaces.end());
 
-  // make sure we have enough normals and colors
+  // make sure we have enough normals
   mesh->normals.resize(mesh->vertices.size(), Vector3f::Zero());
-  mesh->colors.resize(mesh->vertices.size(), Vector3b::Zero());
   mesh->confidence.resize(mesh->vertices.size(), 1.0f);
   return pos.size();
 }

--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -17,6 +17,8 @@
 #include <urdf_model/pose.h>
 #include <urdf_parser/urdf_parser.h>
 
+#include <algorithm>
+#include <optional>
 #include <unordered_map>
 
 namespace momentum {
@@ -443,20 +445,28 @@ void resolveMimicJoints(ParsingData& data) {
   }
 }
 
-/// Extracts per-vertex color from a URDF visual's material, returning white if no color is set.
-/// Sets hasColor to true if the material has a non-black color.
-Eigen::Vector3b extractVertexColor(const urdf::Visual& visual, bool& hasColor) {
-  if (visual.material &&
-      (visual.material->color.r > 0 || visual.material->color.g > 0 ||
-       visual.material->color.b > 0)) {
-    const auto& c = visual.material->color;
-    hasColor = true;
-    return {
-        static_cast<uint8_t>(std::clamp(c.r, 0.0f, 1.0f) * 255.0f),
-        static_cast<uint8_t>(std::clamp(c.g, 0.0f, 1.0f) * 255.0f),
-        static_cast<uint8_t>(std::clamp(c.b, 0.0f, 1.0f) * 255.0f)};
+[[nodiscard]] Eigen::Vector3b toVertexColor(const urdf::Color& color) {
+  return {
+      static_cast<uint8_t>(std::clamp(color.r, 0.0f, 1.0f) * 255.0f),
+      static_cast<uint8_t>(std::clamp(color.g, 0.0f, 1.0f) * 255.0f),
+      static_cast<uint8_t>(std::clamp(color.b, 0.0f, 1.0f) * 255.0f)};
+}
+
+/// Extracts per-vertex color from a URDF visual's material.
+std::optional<Eigen::Vector3b> extractVertexColor(const urdf::Visual& visual) {
+  if (!visual.material) {
+    return std::nullopt;
   }
-  return {255, 255, 255};
+
+  const auto& material = *visual.material;
+  const bool looksLikeTextureOnlyMaterial = !material.texture_filename.empty() &&
+      material.color.r == 0.0f && material.color.g == 0.0f && material.color.b == 0.0f &&
+      material.color.a == 1.0f;
+  if (looksLikeTextureOnlyMaterial) {
+    return std::nullopt;
+  }
+
+  return toVertexColor(material.color);
 }
 
 /// Builds a combined mesh and skin weights from per-link visual data.
@@ -501,7 +511,8 @@ std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
         v = jointWorldTransform.rotation * v + jointWorldTransform.translation;
       }
 
-      const Eigen::Vector3b vertexColor = extractVertexColor(*visual, hasAnyColor);
+      const auto vertexColor = extractVertexColor(*visual);
+      hasAnyColor = hasAnyColor || vertexColor.has_value();
 
       // Merge into the combined mesh
       const auto vertexOffset = static_cast<int32_t>(combinedMesh.vertices.size());
@@ -511,7 +522,8 @@ std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
         combinedMesh.faces.emplace_back(
             face[0] + vertexOffset, face[1] + vertexOffset, face[2] + vertexOffset);
       }
-      combinedMesh.colors.resize(combinedMesh.vertices.size(), vertexColor);
+      combinedMesh.colors.resize(
+          combinedMesh.vertices.size(), vertexColor.value_or(Eigen::Vector3b{255, 255, 255}));
 
       // Extend skin weights: all new vertices are rigidly bound to this joint
       const auto prevVertexCount = skinWeights.index.rows();

--- a/momentum/io/usd/usd_mesh_io.cpp
+++ b/momentum/io/usd/usd_mesh_io.cpp
@@ -306,7 +306,12 @@ void saveMeshToUsd(const Mesh& mesh, UsdGeomMesh& meshPrim) {
   }
 
   // Write vertex colors
-  if (!mesh.colors.empty()) {
+  if (!mesh.colors.empty() && mesh.colors.size() != mesh.vertices.size()) {
+    MT_LOGW(
+        "Skipping vertex colors because color count ({}) does not match vertex count ({})",
+        mesh.colors.size(),
+        mesh.vertices.size());
+  } else if (!mesh.colors.empty()) {
     UsdGeomPrimvarsAPI primvarsAPI(meshPrim);
     auto colorPrimvar = primvarsAPI.CreatePrimvar(
         _tokens->displayColor, SdfValueTypeNames->Color3fArray, UsdGeomTokens->vertex);

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -28,6 +28,12 @@ std::optional<filesystem::path> getTestFilePath(const std::string& filename) {
   return filesystem::path(envVar.value()) / filename;
 }
 
+void expectColorEq(const Eigen::Vector3b& actual, const Eigen::Vector3b& expected) {
+  EXPECT_EQ(static_cast<int>(actual.x()), static_cast<int>(expected.x()));
+  EXPECT_EQ(static_cast<int>(actual.y()), static_cast<int>(expected.y()));
+  EXPECT_EQ(static_cast<int>(actual.z()), static_cast<int>(expected.z()));
+}
+
 TEST(IoUrdfTest, LoadCharacter) {
   auto urdfPath = getTestFilePath("character.urdf");
   if (!urdfPath.has_value()) {
@@ -111,7 +117,7 @@ TEST(IoUrdfTest, GenerateSphereMesh) {
 }
 
 TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
-  // Create a simple URDF with primitive visual geometries
+  // Create a simple URDF with primitive visual geometries and material colors.
   const std::string urdfContent = R"(
     <?xml version="1.0"?>
     <robot name="test_robot">
@@ -121,6 +127,9 @@ TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
           <geometry>
             <box size="0.1 0.2 0.3"/>
           </geometry>
+          <material name="base_red">
+            <color rgba="1 0 0 1"/>
+          </material>
         </visual>
       </link>
       <link name="child_link">
@@ -129,6 +138,9 @@ TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
           <geometry>
             <cylinder radius="0.05" length="0.2"/>
           </geometry>
+          <material name="child_black">
+            <color rgba="0 0 0 1"/>
+          </material>
         </visual>
       </link>
       <joint name="joint1" type="revolute">
@@ -162,6 +174,9 @@ TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
   const size_t boxVertices = 8;
   const size_t cylinderVertices = 2 + 2 * 32; // 2 centers + 2 rings of 32
   EXPECT_EQ(character.mesh->vertices.size(), boxVertices + cylinderVertices);
+  ASSERT_EQ(character.mesh->colors.size(), character.mesh->vertices.size());
+  expectColorEq(character.mesh->colors.at(0), Eigen::Vector3b(255, 0, 0));
+  expectColorEq(character.mesh->colors.at(boxVertices), Eigen::Vector3b(0, 0, 0));
 
   // Verify skin weights: first 8 vertices should be bound to joint 0 (base_link),
   // remaining to joint 1 (child_link)

--- a/momentum/test/io/io_usd_gltf_roundtrip_test.cpp
+++ b/momentum/test/io/io_usd_gltf_roundtrip_test.cpp
@@ -84,6 +84,16 @@ void compareMeshesCrossFormat(const Mesh_u& a, const Mesh_u& b) {
   // NOTE: polyFaces/polyFaceSizes/polyTexcoordFaces are skipped — GLTF doesn't populate them.
 }
 
+void expectMeshColorsEq(const Mesh& mesh, const std::vector<Vector3b>& expectedColors) {
+  ASSERT_EQ(mesh.colors.size(), expectedColors.size());
+  for (size_t i = 0; i < expectedColors.size(); ++i) {
+    for (int c = 0; c < 3; ++c) {
+      EXPECT_EQ(static_cast<int>(mesh.colors[i][c]), static_cast<int>(expectedColors[i][c]))
+          << "Color mismatch at vertex " << i << ", channel " << c;
+    }
+  }
+}
+
 /// Compares skin weights using order-independent per-vertex comparison of nonzero influences.
 void compareSkinWeightsData(const SkinWeights& a, const SkinWeights& b) {
   ASSERT_EQ(a.index.rows(), b.index.rows());
@@ -177,6 +187,32 @@ TEST_F(IoUsdGltfRoundtripTest, BasicCharacter_IndependentSave) {
   ASSERT_TRUE(gltfChar.skinWeights);
   ASSERT_TRUE(usdChar.skinWeights);
   compareSkinWeightsData(*gltfChar.skinWeights, *usdChar.skinWeights);
+}
+
+TEST_F(IoUsdGltfRoundtripTest, MixedVertexColors_GltfAndUsdRoundTrip) {
+  ASSERT_TRUE(testCharacter.mesh);
+  ASSERT_GE(testCharacter.mesh->vertices.size(), 3);
+
+  std::vector<Vector3b> expectedColors(
+      testCharacter.mesh->vertices.size(), Vector3b::Constant(255));
+  expectedColors.front() = Vector3b(255, 0, 0);
+  expectedColors[expectedColors.size() / 2] = Vector3b(0, 0, 0);
+  expectedColors.back() = Vector3b(0, 0, 255);
+  testCharacter.mesh->colors = expectedColors;
+
+  auto gltfFile = temporaryFile("roundtrip_mixed_colors", "glb");
+  saveGltfCharacter(gltfFile.path(), testCharacter);
+  auto gltfChar = loadGltfCharacter(gltfFile.path());
+
+  auto usdFile = temporaryFile("roundtrip_mixed_colors", "usda");
+  saveUsd(usdFile.path(), testCharacter);
+  auto usdChar = loadUsdCharacter(usdFile.path());
+
+  ASSERT_TRUE(gltfChar.mesh);
+  ASSERT_TRUE(usdChar.mesh);
+  expectMeshColorsEq(*gltfChar.mesh, expectedColors);
+  expectMeshColorsEq(*usdChar.mesh, expectedColors);
+  compareMeshesCrossFormat(gltfChar.mesh, usdChar.mesh);
 }
 
 TEST_F(IoUsdGltfRoundtripTest, CharacterWithSkeletonStates) {

--- a/pymomentum/test/test_viser_vis.py
+++ b/pymomentum/test/test_viser_vis.py
@@ -27,19 +27,23 @@ except ImportError:
 # still letting BUCK exercise the suite normally (viser is a hard dep there).
 if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suite
     from pymomentum.viser_vis import (
+        _max_nonzero_skin_influences,
         _normalize_param_limit,
+        _normalize_skin_weights,
         _xyzw_to_wxyz,
         add_character,
         add_character_param_sliders,
         add_joints,
         add_log_panel,
         add_mesh,
+        add_skinned_mesh,
         add_wireframe_toggle,
         CharacterHandles,
         remove_character,
         update_character,
         update_joints,
         update_mesh,
+        update_skinned_mesh,
     )
 
     class TestViserVis(unittest.TestCase):
@@ -114,6 +118,26 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             solid_handle.remove()
             wireframe_handle.remove()
 
+        def test_add_and_update_skinned_mesh(self) -> None:
+            character, skel_state = self._make_character_and_skel_state()
+            skinned_handle = add_skinned_mesh(
+                self.server, "test_skinned_mesh", character, skel_state
+            )
+            self.assertGreaterEqual(len(skinned_handle.bones), character.skeleton.size)
+
+            moved = skel_state.copy()
+            moved[:, 0] += 1.0
+            scale = 2.0
+            update_skinned_mesh(skinned_handle, moved, scale=scale)
+            for i, bone in enumerate(skinned_handle.bones[: character.skeleton.size]):
+                np.testing.assert_allclose(
+                    np.asarray(bone.position),
+                    moved[i, :3] * scale,
+                    atol=1e-5,
+                )
+
+            skinned_handle.remove()
+
         def test_add_character_with_and_without_mesh(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
             posed_mesh = self._posed_mesh(character)
@@ -152,6 +176,32 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             self.assertGreater(len(no_mesh.joint_frames), 0)
             remove_character(no_mesh)
 
+            # Skinned mesh: no secondary wireframe handle is needed because the
+            # skinned mesh handle exposes a wireframe property directly.
+            skinned = add_character(
+                self.server,
+                "test_char_skinned",
+                character,
+                skel_state,
+                use_skinned_mesh=True,
+            )
+            self.assertIsNotNone(skinned.mesh_handle)
+            self.assertIsNone(skinned.wireframe_handle)
+            self.assertGreaterEqual(
+                len(skinned.mesh_handle.bones), character.skeleton.size
+            )
+            moved[:, 1] += 0.25
+            update_character(self.server, skinned, character, moved)
+            for i, bone in enumerate(
+                skinned.mesh_handle.bones[: character.skeleton.size]
+            ):
+                np.testing.assert_allclose(
+                    np.asarray(bone.position),
+                    moved[i, :3] * 0.01,
+                    atol=1e-5,
+                )
+            remove_character(skinned)
+
         def test_xyzw_to_wxyz(self) -> None:
             # xyzw [0.1, 0.2, 0.3, 0.9] -> wxyz [0.9, 0.1, 0.2, 0.3]
             q_xyzw = np.array([0.1, 0.2, 0.3, 0.9])
@@ -172,6 +222,21 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             lo, hi = _normalize_param_limit("hip_rx", -1e35, 1e35)
             self.assertAlmostEqual(lo, -math.pi)
             self.assertAlmostEqual(hi, math.pi)
+
+        def test_skin_weight_influence_helpers(self) -> None:
+            weights = np.array(
+                [
+                    [0.40, 0.30, 0.20, 0.05, 0.05],
+                    [0.00, 0.00, 0.00, 0.00, 0.00],
+                ],
+                dtype=np.float32,
+            )
+            result = _normalize_skin_weights(weights)
+
+            self.assertEqual(_max_nonzero_skin_influences(weights), 5)
+            np.testing.assert_allclose(result[0], weights[0], atol=1e-6)
+            np.testing.assert_allclose(result[0].sum(), 1.0, atol=1e-6)
+            np.testing.assert_allclose(result[1], np.zeros(5, dtype=np.float32))
 
         def test_add_character_param_sliders(self) -> None:
             character, _ = self._make_character_and_skel_state()
@@ -211,6 +276,27 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
 
             cb.remove()
             remove_character(handles)
+
+            skinned = add_character(
+                self.server,
+                "test_wf_skinned",
+                character,
+                skel_state,
+                use_skinned_mesh=True,
+            )
+            self.assertIsNotNone(skinned.mesh_handle)
+            self.assertIsNone(skinned.wireframe_handle)
+
+            skinned_cb = add_wireframe_toggle(self.server, skinned)
+            self.assertTrue(skinned.mesh_handle.visible)
+            self.assertFalse(skinned.mesh_handle.wireframe)
+
+            skinned_cb.value = True
+            self.assertTrue(skinned.mesh_handle.visible)
+            self.assertTrue(skinned.mesh_handle.wireframe)
+
+            skinned_cb.remove()
+            remove_character(skinned)
 
         def test_add_log_panel(self) -> None:
             panel = add_log_panel(self.server, echo_to_stdout=False)

--- a/pymomentum/viser_vis.py
+++ b/pymomentum/viser_vis.py
@@ -35,6 +35,8 @@ frame.  The typical usage pattern is::
 Individual functions are also available:
 
 - :func:`add_mesh` / :func:`update_mesh` — manage a :class:`~pymomentum.geometry.Mesh`
+- :func:`add_skinned_mesh` / :func:`update_skinned_mesh` — upload mesh data once
+  and update only bone transforms
 - :func:`add_joints` / :func:`update_joints` — manage skeleton joint frames
 - :func:`add_character` / :func:`update_character` / :func:`remove_character` —
   manage a complete character
@@ -53,6 +55,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, TYPE_CHECKING
 
 import numpy as np
+from pymomentum.quaternion_np import from_rotation_matrix
 
 if TYPE_CHECKING:
     import viser
@@ -79,7 +82,8 @@ CM_TO_M: float = 0.01
 
 def _xyzw_to_wxyz(q: np.ndarray) -> np.ndarray:
     """Convert quaternion from ``[x, y, z, w]`` (pymomentum) to ``[w, x, y, z]`` (viser)."""
-    return np.array([q[3], q[0], q[1], q[2]], dtype=np.float64)
+    q_arr = np.asarray(q, dtype=np.float64)
+    return np.concatenate((q_arr[..., 3:4], q_arr[..., :3]), axis=-1)
 
 
 def add_mesh(
@@ -185,6 +189,176 @@ def update_mesh(
     mesh_handle.vertices = vertices
     if wireframe_handle is not None:
         wireframe_handle.vertices = vertices
+
+
+def _max_nonzero_skin_influences(
+    skin_weights: np.ndarray,
+    *,
+    weight_threshold: float = 1e-8,
+) -> int:
+    """Return the maximum number of nonzero skinning influences on any vertex."""
+    if skin_weights.shape[0] == 0:
+        return 0
+    return int(
+        np.max(np.count_nonzero(np.abs(skin_weights) > weight_threshold, axis=1))
+    )
+
+
+def _normalize_skin_weights(skin_weights: np.ndarray) -> np.ndarray:
+    """Renormalize skin weights without dropping any nonzero influences."""
+    result = skin_weights.copy()
+    row_sums = np.sum(result, axis=1, keepdims=True)
+    return np.divide(
+        result,
+        row_sums,
+        out=np.zeros_like(result),
+        where=row_sums > 0.0,
+    )
+
+
+def max_skin_influences(character: Character) -> int:
+    """Return the maximum nonzero skinning influences per vertex for *character*.
+
+    :param character: Character to inspect.
+    :return: The largest number of nonzero skin weights on any mesh vertex, or
+        zero if the character has no skinned mesh.
+    """
+    if not character.has_mesh:
+        return 0
+    skin_weights = np.asarray(
+        character.skin_weights.to_dense(character.skeleton.size), dtype=np.float32
+    )
+    return _max_nonzero_skin_influences(skin_weights)
+
+
+def can_use_skinned_mesh(character: Character) -> bool:
+    """Return whether Viser client-side skinning can represent *character*.
+
+    Viser uses at most four skinning influences per vertex. Characters with
+    more influences should use the posed-vertex mesh path to preserve the
+    original deformation.
+
+    :param character: Character to inspect.
+    :return: ``True`` if the character has a mesh and no vertex has more than
+        four nonzero skin weights.
+    """
+    return character.has_mesh and max_skin_influences(character) <= 4
+
+
+def add_skinned_mesh(
+    server: viser.ViserServer,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    color: tuple[int, int, int] = (200, 200, 200),
+    scale: float = CM_TO_M,
+) -> Any:
+    """Add a client-side skinned mesh to the viser scene.
+
+    Unlike :func:`add_mesh`, this sends rest vertices, faces, skin weights, and
+    bind-pose bones once. Subsequent animation only needs
+    :func:`update_skinned_mesh`, which updates per-joint bone transforms rather
+    than re-uploading all posed vertex positions.
+
+    :param server: The viser server instance.
+    :param entity_path: Scene-graph path for the mesh node.
+    :param character: Character with a mesh, skin weights, and bind pose.
+    :param skel_state: Initial skeleton state array of shape ``(n_joints, 8)``.
+    :param color: RGB color tuple ``(r, g, b)`` in 0–255.
+    :param scale: Unit conversion factor applied to vertices and bone
+        translations. Defaults to :data:`CM_TO_M`.
+    :return: The viser skinned mesh handle.
+    """
+    if not character.has_mesh:
+        raise ValueError("add_skinned_mesh() requires a character with mesh skinning")
+
+    skeleton_size = character.skeleton.size
+    mesh = character.mesh
+    vertices = np.asarray(mesh.vertices, dtype=np.float32) * scale
+    faces = np.asarray(mesh.faces, dtype=np.int32)
+    skin_weights = np.asarray(
+        character.skin_weights.to_dense(skeleton_size), dtype=np.float32
+    )
+    if skin_weights.shape != (vertices.shape[0], skeleton_size):
+        raise ValueError(
+            "Expected dense skin weights with shape "
+            f"({vertices.shape[0]}, {skeleton_size}); got {skin_weights.shape}"
+        )
+    max_influences = _max_nonzero_skin_influences(skin_weights)
+    if max_influences > 4:
+        raise ValueError(
+            "Viser skinned meshes support at most 4 skinning influences per "
+            f"vertex; this character has {max_influences}"
+        )
+    skin_weights = _normalize_skin_weights(skin_weights)
+
+    bind_pose = np.asarray(character.bind_pose, dtype=np.float32)
+    expected_bind_pose_shape = (skeleton_size, 4, 4)
+    if bind_pose.shape != expected_bind_pose_shape:
+        raise ValueError(
+            f"Expected bind pose shape {expected_bind_pose_shape}; got {bind_pose.shape}"
+        )
+
+    bone_positions = bind_pose[:, :3, 3].astype(np.float32) * scale
+    bone_wxyzs = _xyzw_to_wxyz(from_rotation_matrix(bind_pose[:, :3, :3])).astype(
+        np.float32
+    )
+    if skeleton_size < 4:
+        # Viser's skinned mesh path always extracts four influences per vertex,
+        # so characters with fewer than four joints need zero-weight padding.
+        pad_count = 4 - skeleton_size
+        skin_weights = np.pad(skin_weights, ((0, 0), (0, pad_count)))
+        bone_positions = np.concatenate(
+            (bone_positions, np.zeros((pad_count, 3), dtype=np.float32)), axis=0
+        )
+        bone_wxyzs = np.concatenate(
+            (
+                bone_wxyzs,
+                np.tile(
+                    np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+                    (pad_count, 1),
+                ),
+            ),
+            axis=0,
+        )
+    skinned_mesh_handle = server.scene.add_mesh_skinned(
+        entity_path,
+        vertices=vertices,
+        faces=faces,
+        bone_wxyzs=bone_wxyzs,
+        bone_positions=bone_positions,
+        skin_weights=skin_weights,
+        color=color,
+        scale=1.0,
+    )
+    update_skinned_mesh(skinned_mesh_handle, skel_state, scale=scale)
+    return skinned_mesh_handle
+
+
+def update_skinned_mesh(
+    skinned_mesh_handle: Any,
+    skel_state: np.ndarray,
+    *,
+    scale: float = CM_TO_M,
+) -> None:
+    """Update a skinned mesh by sending only bone transforms.
+
+    :param skinned_mesh_handle: The handle returned by :func:`add_skinned_mesh`.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    :param scale: Unit conversion factor for bone translations.
+    """
+    bones = skinned_mesh_handle.bones
+    if len(bones) < skel_state.shape[0]:
+        raise ValueError(
+            f"Skinned mesh has {len(bones)} bones but got {skel_state.shape[0]} joints"
+        )
+
+    positions = skel_state[:, :3].astype(np.float64) * scale
+    wxyzs = _xyzw_to_wxyz(skel_state[:, 3:7])
+    for bone, position, wxyz in zip(bones[: skel_state.shape[0]], positions, wxyzs):
+        bone.position = position
+        bone.wxyz = wxyz
 
 
 def _build_bone_segments(
@@ -303,6 +477,7 @@ def add_character(
     skel_state: np.ndarray,
     *,
     posed_mesh: Mesh | None = None,
+    use_skinned_mesh: bool = False,
     color: tuple[int, int, int] = (200, 200, 200),
     scale: float = CM_TO_M,
     axes_length: float = 0.05,
@@ -314,14 +489,16 @@ def add_character(
     subsequent updates via :func:`update_character`.
 
     - ``{entity_path}/joints/{name}`` — per-joint coordinate frames
-    - ``{entity_path}/mesh`` — posed mesh (if *posed_mesh* is provided)
+    - ``{entity_path}/mesh`` — posed or skinned mesh
 
     :param server: The viser server instance.
     :param entity_path: Root scene-graph path for the character.
     :param character: The character to visualize.
     :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
-    :param posed_mesh: An optional pre-posed mesh.  If *None*, no mesh
-        is added.
+    :param posed_mesh: An optional pre-posed mesh for the legacy mesh path.  If
+        *None* and *use_skinned_mesh* is false, no mesh is added.
+    :param use_skinned_mesh: If true and the character has a skinned mesh, add
+        a client-side skinned mesh instead of uploading posed vertices.
     :param color: RGB color tuple for the mesh.
     :param axes_length: Length of joint axis indicators.
     :param axes_radius: Radius of joint axis indicators.
@@ -339,7 +516,16 @@ def add_character(
         axes_radius=axes_radius,
     )
 
-    if posed_mesh is not None:
+    if use_skinned_mesh and character.has_mesh:
+        handles.mesh_handle = add_skinned_mesh(
+            server,
+            f"{entity_path}/mesh",
+            character,
+            skel_state,
+            color=color,
+            scale=scale,
+        )
+    elif posed_mesh is not None:
         handles.mesh_handle, handles.wireframe_handle = add_mesh(
             server, f"{entity_path}/mesh", posed_mesh, color=color, scale=scale
         )
@@ -377,7 +563,9 @@ def update_character(
             scale=scale,
         )
 
-        if posed_mesh is not None and handles.mesh_handle is not None:
+        if handles.mesh_handle is not None and hasattr(handles.mesh_handle, "bones"):
+            update_skinned_mesh(handles.mesh_handle, skel_state, scale=scale)
+        elif posed_mesh is not None and handles.mesh_handle is not None:
             update_mesh(
                 handles.mesh_handle, handles.wireframe_handle, posed_mesh, scale=scale
             )
@@ -488,8 +676,9 @@ def add_wireframe_toggle(
 
     :func:`add_mesh` (and therefore :func:`add_character`) creates both a solid
     and a wireframe handle; this widget flips their ``.visible`` flags so only
-    one is shown at a time. Sets initial visibility on both handles to match
-    *initial_value*.
+    one is shown at a time. Skinned mesh handles expose ``.wireframe`` directly,
+    so the widget toggles that property instead of requiring a duplicate mesh.
+    Sets initial visibility/state to match *initial_value*.
 
     :param server: The viser server instance.
     :param handles: The character handles whose mesh/wireframe to toggle.
@@ -500,14 +689,26 @@ def add_wireframe_toggle(
     """
     cb = server.gui.add_checkbox(label, initial_value=initial_value)
     if handles.mesh_handle is not None:
-        handles.mesh_handle.visible = not initial_value
+        if handles.wireframe_handle is None and hasattr(
+            handles.mesh_handle, "wireframe"
+        ):
+            handles.mesh_handle.visible = True
+            handles.mesh_handle.wireframe = initial_value
+        else:
+            handles.mesh_handle.visible = not initial_value
     if handles.wireframe_handle is not None:
         handles.wireframe_handle.visible = initial_value
 
     @cb.on_update
     def _(_: object) -> None:
         if handles.mesh_handle is not None:
-            handles.mesh_handle.visible = not cb.value
+            if handles.wireframe_handle is None and hasattr(
+                handles.mesh_handle, "wireframe"
+            ):
+                handles.mesh_handle.visible = True
+                handles.mesh_handle.wireframe = cb.value
+            else:
+                handles.mesh_handle.visible = not cb.value
         if handles.wireframe_handle is not None:
             handles.wireframe_handle.visible = cb.value
 


### PR DESCRIPTION
Summary:

We are already storing mesh color from URDF as per-vertex color, but we didn't handle well the case where not all submeshes have colors defined. This diff unifies vertex color handling across `urdf`, `gltf`, and `usd`, using White as the fallback default color, if any (sub)mesh has color defined. Partial color vector that doesn't match vertex count will throw. `fbx` doesn't seem to handle per-vertex color in the code, so it's untouched.

Stores URDF visual material RGB values as per-vertex `Mesh::colors` when combining visual geometry into a Momentum character mesh. The color extraction now treats black as a valid authored material color instead of using black as the sentinel for missing color; visuals without material colors still receive white fallback vertices only when the combined mesh has at least one colored visual. 

glTF character export now writes full vertex-color arrays, glTF import preserves empty color data while filling mixed primitives with white fallback, and USD export skips malformed partial color arrays instead of writing invalid vertex primvars. This keeps uncolored meshes color-free while preserving mixed-color URDF visuals across glTF and USD.

Reviewed By: cstollmeta

Differential Revision: D104479129


