### PR TITLE
Simplify glTF mesh loading (#1386)

### DIFF
--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -144,6 +144,12 @@ size_t addMeshToModel(fx::gltf::Document& model, const Mesh& mesh, const bool ad
     setBufferView(model, def["texfaces"], fx::gltf::BufferView::TargetType::ArrayBuffer);
   }
 
+  if (addColor && !mesh.colors.empty() && mesh.colors.size() != mesh.vertices.size()) {
+    MT_LOGW(
+        "Skipping vertex colors because color count ({}) does not match vertex count ({})",
+        mesh.colors.size(),
+        mesh.vertices.size());
+  }
   if (mesh.colors.size() == mesh.vertices.size() && addColor) {
     prim.attributes["COLOR_0"] =
         createAccessorBuffer<const Vector3b>(model, mesh.colors, true, true);
@@ -433,7 +439,7 @@ size_t addMeshToModel(
 
     // create model mesh
     const auto& mesh = *character.mesh;
-    auto newMeshIdx = addMeshToModel(model, mesh);
+    auto newMeshIdx = addMeshToModel(model, mesh, !mesh.colors.empty());
     if (newMeshIdx >= model.meshes.size()) {
       // Mesh not valid, skip
       return kInvalidIndex;

--- a/momentum/io/gltf/gltf_mesh_io.cpp
+++ b/momentum/io/gltf/gltf_mesh_io.cpp
@@ -119,17 +119,27 @@ addMesh(const fx::gltf::Document& model, const fx::gltf::Primitive& primitive, M
   }
   MT_LOGT_IF(texcoord.empty(), "no texture coords found");
 
+  const bool hadColors = !mesh->colors.empty();
+  const bool hasColors = !col.empty();
+  const size_t vertexOffset = mesh->vertices.size();
+
   // append new faces
   mesh->faces.insert(mesh->faces.end(), idx.begin(), idx.end());
   mesh->vertices.insert(mesh->vertices.end(), pos.begin(), pos.end());
   mesh->normals.insert(mesh->normals.end(), nml.begin(), nml.end());
-  mesh->colors.insert(mesh->colors.end(), col.begin(), col.end());
+  if (hasColors) {
+    if (!hadColors && vertexOffset > 0) {
+      mesh->colors.resize(vertexOffset, Vector3b::Constant(255));
+    }
+    mesh->colors.insert(mesh->colors.end(), col.begin(), col.end());
+  } else if (hadColors) {
+    mesh->colors.resize(mesh->vertices.size(), Vector3b::Constant(255));
+  }
   mesh->texcoords.insert(mesh->texcoords.end(), texcoord.begin(), texcoord.end());
   mesh->texcoord_faces.insert(mesh->texcoord_faces.end(), texfaces.begin(), texfaces.end());
 
-  // make sure we have enough normals and colors
+  // make sure we have enough normals
   mesh->normals.resize(mesh->vertices.size(), Vector3f::Zero());
-  mesh->colors.resize(mesh->vertices.size(), Vector3b::Zero());
   mesh->confidence.resize(mesh->vertices.size(), 1.0f);
   return pos.size();
 }

--- a/momentum/io/gltf/gltf_mesh_io.cpp
+++ b/momentum/io/gltf/gltf_mesh_io.cpp
@@ -13,9 +13,24 @@
 #include "momentum/io/gltf/utils/accessor_utils.h"
 #include "momentum/io/gltf/utils/coordinate_utils.h"
 
+#include <algorithm>
+
 namespace momentum {
 
 namespace {
+
+struct TextureBuffers {
+  std::vector<Vector2f> coords;
+  std::vector<Vector3i> faces;
+};
+
+struct MeshBuffers {
+  std::vector<Vector3i> faces;
+  std::vector<Vector3f> positions;
+  std::vector<Vector3f> normals;
+  std::vector<Vector3b> colors;
+  TextureBuffers texture;
+};
 
 nlohmann::json getMomentumExtension(const nlohmann::json& extensionsAndExtras) {
   if (extensionsAndExtras.count("extensions") != 0 &&
@@ -24,6 +39,183 @@ nlohmann::json getMomentumExtension(const nlohmann::json& extensionsAndExtras) {
   } else {
     return nlohmann::json::object();
   }
+}
+
+std::vector<uint32_t> loadIndexBuffer(
+    const fx::gltf::Document& model,
+    const fx::gltf::Primitive& primitive) {
+  auto indices = copyAccessorBuffer<uint32_t>(model, primitive.indices);
+  if (!indices.empty()) {
+    return indices;
+  }
+
+  const auto shortIndices = copyAccessorBuffer<uint16_t>(model, primitive.indices);
+  indices.reserve(shortIndices.size());
+  for (const auto index : shortIndices) {
+    indices.push_back(index);
+  }
+  return indices;
+}
+
+std::vector<Vector3i> makeTriangleFaces(const std::vector<uint32_t>& indices) {
+  MT_CHECK(indices.size() % 3 == 0, "{} % 3 = {}", indices.size(), indices.size() % 3);
+
+  std::vector<Vector3i> faces(indices.size() / 3);
+  if (!faces.empty()) {
+    std::copy_n(indices.data(), indices.size(), &faces[0][0]);
+  }
+  return faces;
+}
+
+std::vector<Vector3i> loadTriangleFaces(
+    const fx::gltf::Document& model,
+    const fx::gltf::Primitive& primitive) {
+  return makeTriangleFaces(loadIndexBuffer(model, primitive));
+}
+
+template <typename T>
+std::vector<T> loadOptionalAttribute(
+    const fx::gltf::Document& model,
+    const fx::gltf::Primitive& primitive,
+    const char* attributeName) {
+  const auto attribute = primitive.attributes.find(attributeName);
+  if (attribute == primitive.attributes.end()) {
+    return {};
+  }
+  return copyAccessorBuffer<T>(model, attribute->second);
+}
+
+std::vector<Vector3f> loadPositions(
+    const fx::gltf::Document& model,
+    const fx::gltf::Primitive& primitive) {
+  auto positions = copyAccessorBuffer<Vector3f>(model, primitive.attributes.at("POSITION"));
+  toMomentumVec3f(positions);
+  return positions;
+}
+
+void offsetFaces(std::vector<Vector3i>& faces, const size_t vertexOffset) {
+  if (vertexOffset == 0) {
+    return;
+  }
+
+  for (auto& face : faces) {
+    face[0] += vertexOffset;
+    face[1] += vertexOffset;
+    face[2] += vertexOffset;
+  }
+}
+
+TextureBuffers loadMomentumTextureBuffers(
+    const fx::gltf::Document& model,
+    const nlohmann::json& extension) {
+  TextureBuffers texture;
+  texture.coords = copyAccessorBuffer<Vector2f>(model, extension.at("texcoords"));
+  texture.faces = makeTriangleFaces(copyAccessorBuffer<uint32_t>(model, extension.at("texfaces")));
+  return texture;
+}
+
+TextureBuffers loadStandardTextureBuffers(
+    const fx::gltf::Document& model,
+    const fx::gltf::Primitive& primitive,
+    const size_t numPositions,
+    const size_t vertexOffset,
+    std::vector<Vector3i>& faces) {
+  TextureBuffers texture;
+  texture.coords = loadOptionalAttribute<Vector2f>(model, primitive, "TEXCOORD_0");
+
+  offsetFaces(faces, vertexOffset);
+  if (texture.coords.size() == numPositions) {
+    texture.faces = faces;
+  }
+
+  MT_CHECK(
+      texture.coords.empty() || texture.coords.size() == numPositions,
+      "texcoord: {}, pos: {}",
+      texture.coords.size(),
+      numPositions);
+
+  return texture;
+}
+
+TextureBuffers loadTextureBuffers(
+    const fx::gltf::Document& model,
+    const fx::gltf::Primitive& primitive,
+    const size_t numPositions,
+    const size_t vertexOffset,
+    std::vector<Vector3i>& faces) {
+  const auto extension = getMomentumExtension(primitive);
+  if (extension.count("texcoords") > 0 && extension.count("texfaces") > 0) {
+    return loadMomentumTextureBuffers(model, extension);
+  }
+
+  return loadStandardTextureBuffers(model, primitive, numPositions, vertexOffset, faces);
+}
+
+MeshBuffers loadMeshBuffers(
+    const fx::gltf::Document& model,
+    const fx::gltf::Primitive& primitive,
+    const size_t vertexOffset) {
+  MeshBuffers buffers;
+  buffers.faces = loadTriangleFaces(model, primitive);
+  buffers.positions = loadPositions(model, primitive);
+
+  if (buffers.faces.empty() || buffers.positions.empty()) {
+    return buffers;
+  }
+
+  buffers.normals = loadOptionalAttribute<Vector3f>(model, primitive, "NORMAL");
+  MT_CHECK(
+      buffers.normals.empty() || buffers.normals.size() == buffers.positions.size(),
+      "nml: {}, pos: {}",
+      buffers.normals.size(),
+      buffers.positions.size());
+  MT_LOGT_IF(buffers.normals.empty(), "no vertex normal found");
+
+  buffers.colors = loadOptionalAttribute<Vector3b>(model, primitive, "COLOR_0");
+  MT_CHECK(
+      buffers.colors.empty() || buffers.colors.size() == buffers.positions.size(),
+      "col: {}, pos: {}",
+      buffers.colors.size(),
+      buffers.positions.size());
+  MT_LOGT_IF(buffers.colors.empty(), "no vertex color found");
+
+  // NOTE: gltf does not support multiple texcoords per vertex, so we only load the GLTF texcoords
+  //       if we don't have our own custom extension
+  buffers.texture =
+      loadTextureBuffers(model, primitive, buffers.positions.size(), vertexOffset, buffers.faces);
+  MT_LOGT_IF(buffers.texture.coords.empty(), "no texture coords found");
+
+  return buffers;
+}
+
+void appendColors(Mesh& mesh, const std::vector<Vector3b>& colors, const size_t vertexOffset) {
+  const bool hadColors = !mesh.colors.empty();
+  if (!colors.empty()) {
+    if (!hadColors && vertexOffset > 0) {
+      mesh.colors.resize(vertexOffset, Vector3b::Constant(255));
+    }
+    mesh.colors.insert(mesh.colors.end(), colors.begin(), colors.end());
+    return;
+  }
+
+  if (hadColors) {
+    mesh.colors.resize(mesh.vertices.size(), Vector3b::Constant(255));
+  }
+}
+
+void appendMeshBuffers(Mesh& mesh, const MeshBuffers& buffers, const size_t vertexOffset) {
+  mesh.faces.insert(mesh.faces.end(), buffers.faces.begin(), buffers.faces.end());
+  mesh.vertices.insert(mesh.vertices.end(), buffers.positions.begin(), buffers.positions.end());
+  mesh.normals.insert(mesh.normals.end(), buffers.normals.begin(), buffers.normals.end());
+  appendColors(mesh, buffers.colors, vertexOffset);
+  mesh.texcoords.insert(
+      mesh.texcoords.end(), buffers.texture.coords.begin(), buffers.texture.coords.end());
+  mesh.texcoord_faces.insert(
+      mesh.texcoord_faces.end(), buffers.texture.faces.begin(), buffers.texture.faces.end());
+
+  // make sure we have enough normals
+  mesh.normals.resize(mesh.vertices.size(), Vector3f::Zero());
+  mesh.confidence.resize(mesh.vertices.size(), 1.0f);
 }
 
 } // namespace
@@ -35,113 +227,16 @@ addMesh(const fx::gltf::Document& model, const fx::gltf::Primitive& primitive, M
     return 0;
   }
 
-  // load index buffer
-  auto idxDense = copyAccessorBuffer<uint32_t>(model, primitive.indices);
-  if (idxDense.empty()) {
-    // Try fallback with short indices.
-    auto a = copyAccessorBuffer<uint16_t>(model, primitive.indices);
-    for (const auto& ae : a) {
-      idxDense.push_back(ae);
-    }
-  }
-  MT_CHECK(idxDense.size() % 3 == 0, "{} % 3 = {}", idxDense.size(), idxDense.size() % 3);
-  std::vector<Vector3i> idx(idxDense.size() / 3);
-  if (!idx.empty()) {
-    std::copy_n(idxDense.data(), idxDense.size(), &idx[0][0]);
-  }
-
-  // load vertex position buffer
-  auto pos = copyAccessorBuffer<Vector3f>(model, primitive.attributes.at("POSITION"));
-  toMomentumVec3f(pos);
+  const size_t vertexOffset = mesh->vertices.size();
+  const auto buffers = loadMeshBuffers(model, primitive, vertexOffset);
 
   // if we have no points or indices, skip loading
-  if (idx.empty() || pos.empty()) {
+  if (buffers.faces.empty() || buffers.positions.empty()) {
     return 0;
   }
 
-  // load optional normal buffer
-  std::vector<Vector3f> nml;
-  const auto normId = primitive.attributes.find("NORMAL");
-  if (normId != primitive.attributes.end()) {
-    nml = copyAccessorBuffer<Vector3f>(model, normId->second);
-  }
-  MT_CHECK(nml.empty() || nml.size() == pos.size(), "nml: {}, pos: {}", nml.size(), pos.size());
-  MT_LOGT_IF(nml.empty(), "no vertex normal found");
-
-  // load optional color buffer
-  std::vector<Vector3b> col;
-  const auto colorId = primitive.attributes.find("COLOR_0");
-  if (colorId != primitive.attributes.end()) {
-    col = copyAccessorBuffer<Vector3b>(model, colorId->second);
-  }
-  MT_CHECK(col.empty() || col.size() == pos.size(), "col: {}, pos: {}", col.size(), pos.size());
-  MT_LOGT_IF(col.empty(), "no vertex color found");
-
-  // NOTE: gltf does not support multiple texcoords per vertex, so we only load the GLTF texcoords
-  //       if we don't have our own custom extension
-  const auto& extension = getMomentumExtension(primitive);
-  std::vector<Vector2f> texcoord;
-  std::vector<Vector3i> texfaces;
-  if (extension.count("texcoords") > 0 && extension.count("texfaces") > 0) {
-    texcoord = copyAccessorBuffer<Vector2f>(model, extension.at("texcoords"));
-
-    // load "face index buffer
-    auto fidxDense = copyAccessorBuffer<uint32_t>(model, extension.at("texfaces"));
-    MT_CHECK(fidxDense.size() % 3 == 0, "{} % 3 = {}", fidxDense.size(), fidxDense.size() % 3);
-    texfaces.resize(fidxDense.size() / 3);
-    if (!fidxDense.empty()) {
-      MT_THROW_IF(texfaces.empty(), "texfaces is empty but fidxDense is not empty");
-      std::copy_n(fidxDense.data(), fidxDense.size(), &texfaces[0][0]);
-    }
-  } else {
-    // load optional standard GLTF texcoord buffer
-    auto texcoordId = primitive.attributes.find("TEXCOORD_0");
-    if (texcoordId != primitive.attributes.end()) {
-      texcoord = copyAccessorBuffer<Vector2f>(model, texcoordId->second);
-    }
-    const auto kVertexOffset = mesh->vertices.size();
-    // Update vertex indices of the faces!!!
-    if (kVertexOffset > 0) {
-      for (auto&& iFace : idx) {
-        iFace[0] += kVertexOffset;
-        iFace[1] += kVertexOffset;
-        iFace[2] += kVertexOffset;
-      }
-    }
-    if (texcoord.size() == pos.size()) {
-      texfaces = idx;
-    }
-    MT_CHECK(
-        texcoord.empty() || texcoord.size() == pos.size(),
-        "texcoord: {}, pos: {}",
-        texcoord.size(),
-        pos.size());
-  }
-  MT_LOGT_IF(texcoord.empty(), "no texture coords found");
-
-  const bool hadColors = !mesh->colors.empty();
-  const bool hasColors = !col.empty();
-  const size_t vertexOffset = mesh->vertices.size();
-
-  // append new faces
-  mesh->faces.insert(mesh->faces.end(), idx.begin(), idx.end());
-  mesh->vertices.insert(mesh->vertices.end(), pos.begin(), pos.end());
-  mesh->normals.insert(mesh->normals.end(), nml.begin(), nml.end());
-  if (hasColors) {
-    if (!hadColors && vertexOffset > 0) {
-      mesh->colors.resize(vertexOffset, Vector3b::Constant(255));
-    }
-    mesh->colors.insert(mesh->colors.end(), col.begin(), col.end());
-  } else if (hadColors) {
-    mesh->colors.resize(mesh->vertices.size(), Vector3b::Constant(255));
-  }
-  mesh->texcoords.insert(mesh->texcoords.end(), texcoord.begin(), texcoord.end());
-  mesh->texcoord_faces.insert(mesh->texcoord_faces.end(), texfaces.begin(), texfaces.end());
-
-  // make sure we have enough normals
-  mesh->normals.resize(mesh->vertices.size(), Vector3f::Zero());
-  mesh->confidence.resize(mesh->vertices.size(), 1.0f);
-  return pos.size();
+  appendMeshBuffers(*mesh, buffers, vertexOffset);
+  return buffers.positions.size();
 }
 
 size_t addBlendShapes(

--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -17,6 +17,8 @@
 #include <urdf_model/pose.h>
 #include <urdf_parser/urdf_parser.h>
 
+#include <algorithm>
+#include <optional>
 #include <unordered_map>
 
 namespace momentum {
@@ -443,20 +445,28 @@ void resolveMimicJoints(ParsingData& data) {
   }
 }
 
-/// Extracts per-vertex color from a URDF visual's material, returning white if no color is set.
-/// Sets hasColor to true if the material has a non-black color.
-Eigen::Vector3b extractVertexColor(const urdf::Visual& visual, bool& hasColor) {
-  if (visual.material &&
-      (visual.material->color.r > 0 || visual.material->color.g > 0 ||
-       visual.material->color.b > 0)) {
-    const auto& c = visual.material->color;
-    hasColor = true;
-    return {
-        static_cast<uint8_t>(std::clamp(c.r, 0.0f, 1.0f) * 255.0f),
-        static_cast<uint8_t>(std::clamp(c.g, 0.0f, 1.0f) * 255.0f),
-        static_cast<uint8_t>(std::clamp(c.b, 0.0f, 1.0f) * 255.0f)};
+[[nodiscard]] Eigen::Vector3b toVertexColor(const urdf::Color& color) {
+  return {
+      static_cast<uint8_t>(std::clamp(color.r, 0.0f, 1.0f) * 255.0f),
+      static_cast<uint8_t>(std::clamp(color.g, 0.0f, 1.0f) * 255.0f),
+      static_cast<uint8_t>(std::clamp(color.b, 0.0f, 1.0f) * 255.0f)};
+}
+
+/// Extracts per-vertex color from a URDF visual's material.
+std::optional<Eigen::Vector3b> extractVertexColor(const urdf::Visual& visual) {
+  if (!visual.material) {
+    return std::nullopt;
   }
-  return {255, 255, 255};
+
+  const auto& material = *visual.material;
+  const bool looksLikeTextureOnlyMaterial = !material.texture_filename.empty() &&
+      material.color.r == 0.0f && material.color.g == 0.0f && material.color.b == 0.0f &&
+      material.color.a == 1.0f;
+  if (looksLikeTextureOnlyMaterial) {
+    return std::nullopt;
+  }
+
+  return toVertexColor(material.color);
 }
 
 /// Builds a combined mesh and skin weights from per-link visual data.
@@ -501,7 +511,8 @@ std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
         v = jointWorldTransform.rotation * v + jointWorldTransform.translation;
       }
 
-      const Eigen::Vector3b vertexColor = extractVertexColor(*visual, hasAnyColor);
+      const auto vertexColor = extractVertexColor(*visual);
+      hasAnyColor = hasAnyColor || vertexColor.has_value();
 
       // Merge into the combined mesh
       const auto vertexOffset = static_cast<int32_t>(combinedMesh.vertices.size());
@@ -511,7 +522,8 @@ std::optional<std::pair<Mesh, SkinWeights>> buildCombinedMesh(
         combinedMesh.faces.emplace_back(
             face[0] + vertexOffset, face[1] + vertexOffset, face[2] + vertexOffset);
       }
-      combinedMesh.colors.resize(combinedMesh.vertices.size(), vertexColor);
+      combinedMesh.colors.resize(
+          combinedMesh.vertices.size(), vertexColor.value_or(Eigen::Vector3b{255, 255, 255}));
 
       // Extend skin weights: all new vertices are rigidly bound to this joint
       const auto prevVertexCount = skinWeights.index.rows();

--- a/momentum/io/usd/usd_mesh_io.cpp
+++ b/momentum/io/usd/usd_mesh_io.cpp
@@ -306,7 +306,12 @@ void saveMeshToUsd(const Mesh& mesh, UsdGeomMesh& meshPrim) {
   }
 
   // Write vertex colors
-  if (!mesh.colors.empty()) {
+  if (!mesh.colors.empty() && mesh.colors.size() != mesh.vertices.size()) {
+    MT_LOGW(
+        "Skipping vertex colors because color count ({}) does not match vertex count ({})",
+        mesh.colors.size(),
+        mesh.vertices.size());
+  } else if (!mesh.colors.empty()) {
     UsdGeomPrimvarsAPI primvarsAPI(meshPrim);
     auto colorPrimvar = primvarsAPI.CreatePrimvar(
         _tokens->displayColor, SdfValueTypeNames->Color3fArray, UsdGeomTokens->vertex);

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -28,6 +28,12 @@ std::optional<filesystem::path> getTestFilePath(const std::string& filename) {
   return filesystem::path(envVar.value()) / filename;
 }
 
+void expectColorEq(const Eigen::Vector3b& actual, const Eigen::Vector3b& expected) {
+  EXPECT_EQ(static_cast<int>(actual.x()), static_cast<int>(expected.x()));
+  EXPECT_EQ(static_cast<int>(actual.y()), static_cast<int>(expected.y()));
+  EXPECT_EQ(static_cast<int>(actual.z()), static_cast<int>(expected.z()));
+}
+
 TEST(IoUrdfTest, LoadCharacter) {
   auto urdfPath = getTestFilePath("character.urdf");
   if (!urdfPath.has_value()) {
@@ -111,7 +117,7 @@ TEST(IoUrdfTest, GenerateSphereMesh) {
 }
 
 TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
-  // Create a simple URDF with primitive visual geometries
+  // Create a simple URDF with primitive visual geometries and material colors.
   const std::string urdfContent = R"(
     <?xml version="1.0"?>
     <robot name="test_robot">
@@ -121,6 +127,9 @@ TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
           <geometry>
             <box size="0.1 0.2 0.3"/>
           </geometry>
+          <material name="base_red">
+            <color rgba="1 0 0 1"/>
+          </material>
         </visual>
       </link>
       <link name="child_link">
@@ -129,6 +138,9 @@ TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
           <geometry>
             <cylinder radius="0.05" length="0.2"/>
           </geometry>
+          <material name="child_black">
+            <color rgba="0 0 0 1"/>
+          </material>
         </visual>
       </link>
       <joint name="joint1" type="revolute">
@@ -162,6 +174,9 @@ TEST(IoUrdfTest, LoadUrdfWithPrimitiveVisuals) {
   const size_t boxVertices = 8;
   const size_t cylinderVertices = 2 + 2 * 32; // 2 centers + 2 rings of 32
   EXPECT_EQ(character.mesh->vertices.size(), boxVertices + cylinderVertices);
+  ASSERT_EQ(character.mesh->colors.size(), character.mesh->vertices.size());
+  expectColorEq(character.mesh->colors.at(0), Eigen::Vector3b(255, 0, 0));
+  expectColorEq(character.mesh->colors.at(boxVertices), Eigen::Vector3b(0, 0, 0));
 
   // Verify skin weights: first 8 vertices should be bound to joint 0 (base_link),
   // remaining to joint 1 (child_link)

--- a/momentum/test/io/io_usd_gltf_roundtrip_test.cpp
+++ b/momentum/test/io/io_usd_gltf_roundtrip_test.cpp
@@ -84,6 +84,16 @@ void compareMeshesCrossFormat(const Mesh_u& a, const Mesh_u& b) {
   // NOTE: polyFaces/polyFaceSizes/polyTexcoordFaces are skipped — GLTF doesn't populate them.
 }
 
+void expectMeshColorsEq(const Mesh& mesh, const std::vector<Vector3b>& expectedColors) {
+  ASSERT_EQ(mesh.colors.size(), expectedColors.size());
+  for (size_t i = 0; i < expectedColors.size(); ++i) {
+    for (int c = 0; c < 3; ++c) {
+      EXPECT_EQ(static_cast<int>(mesh.colors[i][c]), static_cast<int>(expectedColors[i][c]))
+          << "Color mismatch at vertex " << i << ", channel " << c;
+    }
+  }
+}
+
 /// Compares skin weights using order-independent per-vertex comparison of nonzero influences.
 void compareSkinWeightsData(const SkinWeights& a, const SkinWeights& b) {
   ASSERT_EQ(a.index.rows(), b.index.rows());
@@ -177,6 +187,32 @@ TEST_F(IoUsdGltfRoundtripTest, BasicCharacter_IndependentSave) {
   ASSERT_TRUE(gltfChar.skinWeights);
   ASSERT_TRUE(usdChar.skinWeights);
   compareSkinWeightsData(*gltfChar.skinWeights, *usdChar.skinWeights);
+}
+
+TEST_F(IoUsdGltfRoundtripTest, MixedVertexColors_GltfAndUsdRoundTrip) {
+  ASSERT_TRUE(testCharacter.mesh);
+  ASSERT_GE(testCharacter.mesh->vertices.size(), 3);
+
+  std::vector<Vector3b> expectedColors(
+      testCharacter.mesh->vertices.size(), Vector3b::Constant(255));
+  expectedColors.front() = Vector3b(255, 0, 0);
+  expectedColors[expectedColors.size() / 2] = Vector3b(0, 0, 0);
+  expectedColors.back() = Vector3b(0, 0, 255);
+  testCharacter.mesh->colors = expectedColors;
+
+  auto gltfFile = temporaryFile("roundtrip_mixed_colors", "glb");
+  saveGltfCharacter(gltfFile.path(), testCharacter);
+  auto gltfChar = loadGltfCharacter(gltfFile.path());
+
+  auto usdFile = temporaryFile("roundtrip_mixed_colors", "usda");
+  saveUsd(usdFile.path(), testCharacter);
+  auto usdChar = loadUsdCharacter(usdFile.path());
+
+  ASSERT_TRUE(gltfChar.mesh);
+  ASSERT_TRUE(usdChar.mesh);
+  expectMeshColorsEq(*gltfChar.mesh, expectedColors);
+  expectMeshColorsEq(*usdChar.mesh, expectedColors);
+  compareMeshesCrossFormat(gltfChar.mesh, usdChar.mesh);
 }
 
 TEST_F(IoUsdGltfRoundtripTest, CharacterWithSkeletonStates) {

--- a/pymomentum/test/test_viser_vis.py
+++ b/pymomentum/test/test_viser_vis.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 import unittest
+from typing import Any
 
 import numpy as np
 import pymomentum.geometry as geo  # @manual=:geometry
@@ -76,6 +77,58 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             joint_params = np.zeros(character.skeleton.size * 7, dtype=np.float32)
             return character.pose_mesh(joint_params)
 
+        def _solid_mesh_visibilities(self, mesh_handle: Any) -> list[bool]:
+            if isinstance(mesh_handle, list):
+                return [bool(part.handle.visible) for part in mesh_handle]
+            return [bool(mesh_handle.visible)]
+
+        def _make_uncolored_character(self, character: geo.Character) -> geo.Character:
+            mesh = geo.Mesh(
+                vertices=character.mesh.vertices,
+                faces=character.mesh.faces,
+                normals=character.mesh.normals,
+            )
+            return character.with_mesh_and_skin_weights(mesh, character.skin_weights)
+
+        def _make_colored_skinned_character_and_skel_state(
+            self,
+        ) -> tuple[geo.Character, np.ndarray]:
+            character, _ = self._make_character_and_skel_state()
+            vertices = np.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                    [1.0, 0.0, 1.0],
+                    [0.0, 1.0, 1.0],
+                ],
+                dtype=np.float32,
+            )
+            faces = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.int32)
+            colors = np.array(
+                [
+                    [255, 0, 0],
+                    [255, 0, 0],
+                    [255, 0, 0],
+                    [0, 0, 255],
+                    [0, 0, 255],
+                    [0, 0, 255],
+                ],
+                dtype=np.uint8,
+            )
+            mesh = geo.Mesh(vertices=vertices, faces=faces, colors=colors)
+            skin_weights = geo.SkinWeights(
+                index=np.zeros((vertices.shape[0], 1), dtype=np.int32),
+                weights=np.ones((vertices.shape[0], 1), dtype=np.float32),
+            )
+            character = character.with_mesh_and_skin_weights(mesh, skin_weights)
+            model_params = np.zeros(
+                character.parameter_transform.size, dtype=np.float32
+            )
+            skel_state = geo.model_parameters_to_skeleton_state(character, model_params)
+            return character, skel_state
+
         def test_add_and_update_joints(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
             handles, bones_handle = add_joints(
@@ -104,6 +157,11 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             character, _ = self._make_character_and_skel_state()
             posed_mesh = self._posed_mesh(character)
             self.assertGreater(len(posed_mesh.vertices), 0)
+            posed_mesh = geo.Mesh(
+                vertices=posed_mesh.vertices,
+                faces=posed_mesh.faces,
+                normals=posed_mesh.normals,
+            )
             solid_handle, wireframe_handle = add_mesh(
                 self.server, "test_mesh", posed_mesh
             )
@@ -120,6 +178,7 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
 
         def test_add_and_update_skinned_mesh(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
+            character = self._make_uncolored_character(character)
             skinned_handle = add_skinned_mesh(
                 self.server, "test_skinned_mesh", character, skel_state
             )
@@ -137,6 +196,92 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
                 )
 
             skinned_handle.remove()
+
+        def test_add_and_update_skinned_mesh_with_vertex_colors(self) -> None:
+            character, skel_state = (
+                self._make_colored_skinned_character_and_skel_state()
+            )
+            skinned_handle = add_skinned_mesh(
+                self.server, "test_color_skinned_mesh", character, skel_state
+            )
+            self.assertIsInstance(skinned_handle, list)
+            self.assertEqual(len(skinned_handle), 2)
+            self.assertEqual(
+                {tuple(part.handle.color) for part in skinned_handle},
+                {(255, 0, 0), (0, 0, 255)},
+            )
+
+            moved = skel_state.copy()
+            moved[:, 0] += 1.0
+            scale = 2.0
+            update_skinned_mesh(skinned_handle, moved, scale=scale)
+            for part in skinned_handle:
+                self.assertGreaterEqual(len(part.handle.bones), character.skeleton.size)
+                for i, bone in enumerate(part.handle.bones[: character.skeleton.size]):
+                    np.testing.assert_allclose(
+                        np.asarray(bone.position),
+                        moved[i, :3] * scale,
+                        atol=1e-5,
+                    )
+
+            for part in skinned_handle:
+                part.handle.remove()
+
+        def test_add_and_update_mesh_with_vertex_colors(self) -> None:
+            vertices = np.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                    [1.0, 0.0, 1.0],
+                    [0.0, 1.0, 1.0],
+                ],
+                dtype=np.float32,
+            )
+            faces = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.int32)
+            colors = np.array(
+                [
+                    [255, 0, 0],
+                    [255, 0, 0],
+                    [255, 0, 0],
+                    [0, 0, 255],
+                    [0, 0, 255],
+                    [0, 0, 255],
+                ],
+                dtype=np.uint8,
+            )
+            mesh = geo.Mesh(vertices=vertices, faces=faces, colors=colors)
+
+            solid_handle, wireframe_handle = add_mesh(
+                self.server, "test_color_mesh", mesh
+            )
+            self.assertIsInstance(solid_handle, list)
+            self.assertEqual(len(solid_handle), 2)
+            self.assertEqual(
+                {tuple(part.handle.color) for part in solid_handle},
+                {(255, 0, 0), (0, 0, 255)},
+            )
+
+            moved_mesh = geo.Mesh(
+                vertices=vertices + np.array([1.0, 2.0, 3.0], dtype=np.float32),
+                faces=faces,
+                colors=colors,
+            )
+            update_mesh(solid_handle, wireframe_handle, moved_mesh, scale=1.0)
+            moved_vertices = np.asarray(moved_mesh.vertices, dtype=np.float32)
+            for part in solid_handle:
+                np.testing.assert_allclose(
+                    np.asarray(part.handle.vertices),
+                    moved_vertices[part.vertex_indices],
+                )
+            np.testing.assert_allclose(
+                np.asarray(wireframe_handle.vertices), moved_vertices
+            )
+
+            for part in solid_handle:
+                part.handle.remove()
+            wireframe_handle.remove()
 
         def test_add_character_with_and_without_mesh(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
@@ -178,22 +323,23 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
 
             # Skinned mesh: no secondary wireframe handle is needed because the
             # skinned mesh handle exposes a wireframe property directly.
+            uncolored_character = self._make_uncolored_character(character)
             skinned = add_character(
                 self.server,
                 "test_char_skinned",
-                character,
+                uncolored_character,
                 skel_state,
                 use_skinned_mesh=True,
             )
             self.assertIsNotNone(skinned.mesh_handle)
             self.assertIsNone(skinned.wireframe_handle)
             self.assertGreaterEqual(
-                len(skinned.mesh_handle.bones), character.skeleton.size
+                len(skinned.mesh_handle.bones), uncolored_character.skeleton.size
             )
             moved[:, 1] += 0.25
-            update_character(self.server, skinned, character, moved)
+            update_character(self.server, skinned, uncolored_character, moved)
             for i, bone in enumerate(
-                skinned.mesh_handle.bones[: character.skeleton.size]
+                skinned.mesh_handle.bones[: uncolored_character.skeleton.size]
             ):
                 np.testing.assert_allclose(
                     np.asarray(bone.position),
@@ -266,21 +412,29 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
 
             # Default initial_value=False: solid visible, wireframe hidden.
             cb = add_wireframe_toggle(self.server, handles)
-            self.assertTrue(handles.mesh_handle.visible)
+            self.assertEqual(
+                self._solid_mesh_visibilities(handles.mesh_handle),
+                [True] * len(self._solid_mesh_visibilities(handles.mesh_handle)),
+            )
             self.assertFalse(handles.wireframe_handle.visible)
 
             # Flip the checkbox; visibility should swap.
             cb.value = True
-            self.assertFalse(handles.mesh_handle.visible)
+            solid_visibilities = self._solid_mesh_visibilities(handles.mesh_handle)
+            self.assertEqual(
+                solid_visibilities,
+                [False] * len(solid_visibilities),
+            )
             self.assertTrue(handles.wireframe_handle.visible)
 
             cb.remove()
             remove_character(handles)
 
+            uncolored_character = self._make_uncolored_character(character)
             skinned = add_character(
                 self.server,
                 "test_wf_skinned",
-                character,
+                uncolored_character,
                 skel_state,
                 use_skinned_mesh=True,
             )
@@ -297,6 +451,45 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
 
             skinned_cb.remove()
             remove_character(skinned)
+
+            colored_character, colored_skel_state = (
+                self._make_colored_skinned_character_and_skel_state()
+            )
+            colored_skinned = add_character(
+                self.server,
+                "test_wf_color_skinned",
+                colored_character,
+                colored_skel_state,
+                use_skinned_mesh=True,
+            )
+            self.assertIsInstance(colored_skinned.mesh_handle, list)
+            self.assertIsNone(colored_skinned.wireframe_handle)
+
+            colored_skinned_cb = add_wireframe_toggle(self.server, colored_skinned)
+            for part in colored_skinned.mesh_handle:
+                self.assertTrue(part.handle.visible)
+                self.assertFalse(part.handle.wireframe)
+
+            colored_skinned_cb.value = True
+            for part in colored_skinned.mesh_handle:
+                self.assertTrue(part.handle.visible)
+                self.assertTrue(part.handle.wireframe)
+
+            moved = colored_skel_state.copy()
+            moved[:, 2] += 0.5
+            update_character(self.server, colored_skinned, colored_character, moved)
+            for part in colored_skinned.mesh_handle:
+                for i, bone in enumerate(
+                    part.handle.bones[: colored_character.skeleton.size]
+                ):
+                    np.testing.assert_allclose(
+                        np.asarray(bone.position),
+                        moved[i, :3] * 0.01,
+                        atol=1e-5,
+                    )
+
+            colored_skinned_cb.remove()
+            remove_character(colored_skinned)
 
         def test_add_log_panel(self) -> None:
             panel = add_log_panel(self.server, echo_to_stdout=False)

--- a/pymomentum/test/test_viser_vis.py
+++ b/pymomentum/test/test_viser_vis.py
@@ -27,19 +27,23 @@ except ImportError:
 # still letting BUCK exercise the suite normally (viser is a hard dep there).
 if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suite
     from pymomentum.viser_vis import (
+        _max_nonzero_skin_influences,
         _normalize_param_limit,
+        _normalize_skin_weights,
         _xyzw_to_wxyz,
         add_character,
         add_character_param_sliders,
         add_joints,
         add_log_panel,
         add_mesh,
+        add_skinned_mesh,
         add_wireframe_toggle,
         CharacterHandles,
         remove_character,
         update_character,
         update_joints,
         update_mesh,
+        update_skinned_mesh,
     )
 
     class TestViserVis(unittest.TestCase):
@@ -114,6 +118,26 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             solid_handle.remove()
             wireframe_handle.remove()
 
+        def test_add_and_update_skinned_mesh(self) -> None:
+            character, skel_state = self._make_character_and_skel_state()
+            skinned_handle = add_skinned_mesh(
+                self.server, "test_skinned_mesh", character, skel_state
+            )
+            self.assertGreaterEqual(len(skinned_handle.bones), character.skeleton.size)
+
+            moved = skel_state.copy()
+            moved[:, 0] += 1.0
+            scale = 2.0
+            update_skinned_mesh(skinned_handle, moved, scale=scale)
+            for i, bone in enumerate(skinned_handle.bones[: character.skeleton.size]):
+                np.testing.assert_allclose(
+                    np.asarray(bone.position),
+                    moved[i, :3] * scale,
+                    atol=1e-5,
+                )
+
+            skinned_handle.remove()
+
         def test_add_character_with_and_without_mesh(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
             posed_mesh = self._posed_mesh(character)
@@ -152,6 +176,32 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             self.assertGreater(len(no_mesh.joint_frames), 0)
             remove_character(no_mesh)
 
+            # Skinned mesh: no secondary wireframe handle is needed because the
+            # skinned mesh handle exposes a wireframe property directly.
+            skinned = add_character(
+                self.server,
+                "test_char_skinned",
+                character,
+                skel_state,
+                use_skinned_mesh=True,
+            )
+            self.assertIsNotNone(skinned.mesh_handle)
+            self.assertIsNone(skinned.wireframe_handle)
+            self.assertGreaterEqual(
+                len(skinned.mesh_handle.bones), character.skeleton.size
+            )
+            moved[:, 1] += 0.25
+            update_character(self.server, skinned, character, moved)
+            for i, bone in enumerate(
+                skinned.mesh_handle.bones[: character.skeleton.size]
+            ):
+                np.testing.assert_allclose(
+                    np.asarray(bone.position),
+                    moved[i, :3] * 0.01,
+                    atol=1e-5,
+                )
+            remove_character(skinned)
+
         def test_xyzw_to_wxyz(self) -> None:
             # xyzw [0.1, 0.2, 0.3, 0.9] -> wxyz [0.9, 0.1, 0.2, 0.3]
             q_xyzw = np.array([0.1, 0.2, 0.3, 0.9])
@@ -172,6 +222,21 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             lo, hi = _normalize_param_limit("hip_rx", -1e35, 1e35)
             self.assertAlmostEqual(lo, -math.pi)
             self.assertAlmostEqual(hi, math.pi)
+
+        def test_skin_weight_influence_helpers(self) -> None:
+            weights = np.array(
+                [
+                    [0.40, 0.30, 0.20, 0.05, 0.05],
+                    [0.00, 0.00, 0.00, 0.00, 0.00],
+                ],
+                dtype=np.float32,
+            )
+            result = _normalize_skin_weights(weights)
+
+            self.assertEqual(_max_nonzero_skin_influences(weights), 5)
+            np.testing.assert_allclose(result[0], weights[0], atol=1e-6)
+            np.testing.assert_allclose(result[0].sum(), 1.0, atol=1e-6)
+            np.testing.assert_allclose(result[1], np.zeros(5, dtype=np.float32))
 
         def test_add_character_param_sliders(self) -> None:
             character, _ = self._make_character_and_skel_state()
@@ -211,6 +276,27 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
 
             cb.remove()
             remove_character(handles)
+
+            skinned = add_character(
+                self.server,
+                "test_wf_skinned",
+                character,
+                skel_state,
+                use_skinned_mesh=True,
+            )
+            self.assertIsNotNone(skinned.mesh_handle)
+            self.assertIsNone(skinned.wireframe_handle)
+
+            skinned_cb = add_wireframe_toggle(self.server, skinned)
+            self.assertTrue(skinned.mesh_handle.visible)
+            self.assertFalse(skinned.mesh_handle.wireframe)
+
+            skinned_cb.value = True
+            self.assertTrue(skinned.mesh_handle.visible)
+            self.assertTrue(skinned.mesh_handle.wireframe)
+
+            skinned_cb.remove()
+            remove_character(skinned)
 
         def test_add_log_panel(self) -> None:
             panel = add_log_panel(self.server, echo_to_stdout=False)

--- a/pymomentum/viser_vis.py
+++ b/pymomentum/viser_vis.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING, TypeAlias
 
 import numpy as np
 from pymomentum.quaternion_np import from_rotation_matrix
@@ -76,6 +76,19 @@ class CharacterHandles:
     wireframe_handle: Any | None = None
 
 
+@dataclass
+class _ColoredMeshPart:
+    """A uniformly colored submesh derived from a per-vertex colored mesh."""
+
+    handle: Any
+    vertex_indices: np.ndarray
+
+
+_ColoredMeshGroups: TypeAlias = list[
+    tuple[tuple[int, int, int], np.ndarray, np.ndarray]
+]
+
+
 #: Default scale factor to convert momentum units (cm) to meters for viser.
 CM_TO_M: float = 0.01
 
@@ -84,6 +97,91 @@ def _xyzw_to_wxyz(q: np.ndarray) -> np.ndarray:
     """Convert quaternion from ``[x, y, z, w]`` (pymomentum) to ``[w, x, y, z]`` (viser)."""
     q_arr = np.asarray(q, dtype=np.float64)
     return np.concatenate((q_arr[..., 3:4], q_arr[..., :3]), axis=-1)
+
+
+def _get_vertex_colors(mesh: Mesh, n_vertices: int) -> np.ndarray | None:
+    colors = np.asarray(mesh.colors, dtype=np.uint8)
+    if colors.size == 0:
+        return None
+    if colors.ndim != 2 or colors.shape != (n_vertices, 3):
+        return None
+    return colors
+
+
+def _color_for_face(face_colors: np.ndarray) -> tuple[int, int, int]:
+    if np.all(face_colors == face_colors[0]):
+        color = face_colors[0]
+    else:
+        color = np.rint(np.mean(face_colors, axis=0)).astype(np.uint8)
+    return (int(color[0]), int(color[1]), int(color[2]))
+
+
+def _add_colored_mesh_parts(
+    server: viser.ViserServer,
+    entity_path: str,
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    colors: np.ndarray,
+) -> list[_ColoredMeshPart]:
+    parts: list[_ColoredMeshPart] = []
+    for color_index, (color, vertex_indices, part_faces) in enumerate(
+        _colored_mesh_groups(faces, colors)
+    ):
+        handle = server.scene.add_mesh_simple(
+            f"{entity_path}/color_{color_index}",
+            vertices=vertices[vertex_indices],
+            faces=part_faces,
+            color=color,
+        )
+        parts.append(_ColoredMeshPart(handle=handle, vertex_indices=vertex_indices))
+    return parts
+
+
+def _colored_mesh_groups(faces: np.ndarray, colors: np.ndarray) -> _ColoredMeshGroups:
+    face_indices_by_color: dict[tuple[int, int, int], list[int]] = {}
+    for face_index, face in enumerate(faces):
+        color = _color_for_face(colors[face])
+        face_indices_by_color.setdefault(color, []).append(face_index)
+
+    groups: _ColoredMeshGroups = []
+    for color, face_indices in face_indices_by_color.items():
+        part_faces_original = faces[np.asarray(face_indices, dtype=np.int64)]
+        vertex_indices, inverse_faces = np.unique(
+            part_faces_original.reshape(-1), return_inverse=True
+        )
+        part_faces = inverse_faces.reshape((-1, 3)).astype(np.int32)
+        groups.append((color, vertex_indices, part_faces))
+    return groups
+
+
+def _solid_mesh_handles(mesh_handle: Any | None) -> list[Any]:
+    if mesh_handle is None:
+        return []
+    if isinstance(mesh_handle, list):
+        return [part.handle for part in mesh_handle]
+    return [mesh_handle]
+
+
+def _set_solid_mesh_visible(mesh_handle: Any | None, visible: bool) -> None:
+    for handle in _solid_mesh_handles(mesh_handle):
+        handle.visible = visible
+
+
+def _remove_solid_mesh(mesh_handle: Any | None) -> None:
+    for handle in _solid_mesh_handles(mesh_handle):
+        handle.remove()
+
+
+def _skinned_mesh_handles(mesh_handle: Any | None) -> list[Any]:
+    if mesh_handle is None:
+        return []
+    if hasattr(mesh_handle, "bones"):
+        return [mesh_handle]
+    if isinstance(mesh_handle, list):
+        handles = [part.handle for part in mesh_handle]
+        if all(hasattr(handle, "bones") for handle in handles):
+            return handles
+    return []
 
 
 def add_mesh(
@@ -105,16 +203,24 @@ def add_mesh(
     :param color: RGB color tuple ``(r, g, b)`` in 0–255.
     :param scale: Unit conversion factor applied to vertex positions.
         Defaults to :data:`CM_TO_M` (0.01) to convert momentum's cm to meters.
-    :return: A tuple of (solid_handle, wireframe_handle).
+    :return: A tuple of (solid_handle, wireframe_handle). The solid handle is a list
+        of uniformly colored submesh handles when per-vertex colors are present.
     """
     vertices = np.asarray(mesh.vertices, dtype=np.float32) * scale
     faces = np.asarray(mesh.faces, dtype=np.int32)
-    solid = server.scene.add_mesh_simple(
-        entity_path,
-        vertices=vertices,
-        faces=faces,
-        color=color,
-    )
+    vertex_colors = _get_vertex_colors(mesh, vertices.shape[0])
+    solid: Any
+    if vertex_colors is None:
+        solid = server.scene.add_mesh_simple(
+            entity_path,
+            vertices=vertices,
+            faces=faces,
+            color=color,
+        )
+    else:
+        solid = _add_colored_mesh_parts(
+            server, entity_path, vertices, faces, vertex_colors
+        )
     wireframe = server.scene.add_mesh_simple(
         f"{entity_path}_wireframe",
         vertices=vertices,
@@ -186,7 +292,11 @@ def update_mesh(
     :param scale: Unit conversion factor.  Defaults to :data:`CM_TO_M`.
     """
     vertices = np.asarray(mesh.vertices, dtype=np.float32) * scale
-    mesh_handle.vertices = vertices
+    if isinstance(mesh_handle, list):
+        for part in mesh_handle:
+            part.handle.vertices = vertices[part.vertex_indices]
+    else:
+        mesh_handle.vertices = vertices
     if wireframe_handle is not None:
         wireframe_handle.vertices = vertices
 
@@ -268,7 +378,8 @@ def add_skinned_mesh(
     :param color: RGB color tuple ``(r, g, b)`` in 0–255.
     :param scale: Unit conversion factor applied to vertices and bone
         translations. Defaults to :data:`CM_TO_M`.
-    :return: The viser skinned mesh handle.
+    :return: The viser skinned mesh handle. When per-vertex colors are present,
+        returns a list of uniformly colored skinned submesh handles.
     """
     if not character.has_mesh:
         raise ValueError("add_skinned_mesh() requires a character with mesh skinning")
@@ -322,18 +433,60 @@ def add_skinned_mesh(
             ),
             axis=0,
         )
-    skinned_mesh_handle = server.scene.add_mesh_skinned(
-        entity_path,
-        vertices=vertices,
-        faces=faces,
-        bone_wxyzs=bone_wxyzs,
-        bone_positions=bone_positions,
-        skin_weights=skin_weights,
-        color=color,
-        scale=1.0,
-    )
+    vertex_colors = _get_vertex_colors(mesh, vertices.shape[0])
+    skinned_mesh_handle: Any
+    if vertex_colors is None:
+        skinned_mesh_handle = server.scene.add_mesh_skinned(
+            entity_path,
+            vertices=vertices,
+            faces=faces,
+            bone_wxyzs=bone_wxyzs,
+            bone_positions=bone_positions,
+            skin_weights=skin_weights,
+            color=color,
+            scale=1.0,
+        )
+    else:
+        skinned_mesh_handle = _add_colored_skinned_mesh_parts(
+            server,
+            entity_path,
+            vertices,
+            faces,
+            skin_weights,
+            bone_wxyzs,
+            bone_positions,
+            vertex_colors,
+        )
     update_skinned_mesh(skinned_mesh_handle, skel_state, scale=scale)
     return skinned_mesh_handle
+
+
+def _add_colored_skinned_mesh_parts(
+    server: viser.ViserServer,
+    entity_path: str,
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    skin_weights: np.ndarray,
+    bone_wxyzs: np.ndarray,
+    bone_positions: np.ndarray,
+    colors: np.ndarray,
+) -> list[_ColoredMeshPart]:
+    parts: list[_ColoredMeshPart] = []
+    for color_index, (color, vertex_indices, part_faces) in enumerate(
+        _colored_mesh_groups(faces, colors)
+    ):
+        handle = server.scene.add_mesh_skinned(
+            f"{entity_path}/color_{color_index}",
+            vertices=vertices[vertex_indices],
+            faces=part_faces,
+            bone_wxyzs=bone_wxyzs,
+            bone_positions=bone_positions,
+            skin_weights=skin_weights[vertex_indices],
+            color=color,
+            scale=1.0,
+        )
+        parts.append(_ColoredMeshPart(handle=handle, vertex_indices=vertex_indices))
+    return parts
 
 
 def update_skinned_mesh(
@@ -345,18 +498,33 @@ def update_skinned_mesh(
     """Update a skinned mesh by sending only bone transforms.
 
     :param skinned_mesh_handle: The handle returned by :func:`add_skinned_mesh`.
+        This may be a list of uniformly colored skinned submesh handles.
     :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
     :param scale: Unit conversion factor for bone translations.
     """
-    bones = skinned_mesh_handle.bones
-    if len(bones) < skel_state.shape[0]:
-        raise ValueError(
-            f"Skinned mesh has {len(bones)} bones but got {skel_state.shape[0]} joints"
-        )
+    handles = _skinned_mesh_handles(skinned_mesh_handle)
+    if not handles:
+        raise ValueError("update_skinned_mesh() requires skinned mesh handle(s)")
 
     positions = skel_state[:, :3].astype(np.float64) * scale
     wxyzs = _xyzw_to_wxyz(skel_state[:, 3:7])
-    for bone, position, wxyz in zip(bones[: skel_state.shape[0]], positions, wxyzs):
+    for handle in handles:
+        _update_skinned_mesh_handle(handle, positions, wxyzs, skel_state.shape[0])
+
+
+def _update_skinned_mesh_handle(
+    skinned_mesh_handle: Any,
+    positions: np.ndarray,
+    wxyzs: np.ndarray,
+    n_joints: int,
+) -> None:
+    bones = skinned_mesh_handle.bones
+    if len(bones) < n_joints:
+        raise ValueError(
+            f"Skinned mesh has {len(bones)} bones but got {n_joints} joints"
+        )
+
+    for bone, position, wxyz in zip(bones[:n_joints], positions, wxyzs):
         bone.position = position
         bone.wxyz = wxyz
 
@@ -563,7 +731,7 @@ def update_character(
             scale=scale,
         )
 
-        if handles.mesh_handle is not None and hasattr(handles.mesh_handle, "bones"):
+        if _skinned_mesh_handles(handles.mesh_handle):
             update_skinned_mesh(handles.mesh_handle, skel_state, scale=scale)
         elif posed_mesh is not None and handles.mesh_handle is not None:
             update_mesh(
@@ -590,8 +758,7 @@ def remove_character(
             handle.remove()
         if handles.bones_handle is not None:
             handles.bones_handle.remove()
-        if handles.mesh_handle is not None:
-            handles.mesh_handle.remove()
+        _remove_solid_mesh(handles.mesh_handle)
         if handles.wireframe_handle is not None:
             handles.wireframe_handle.remove()
 
@@ -688,27 +855,28 @@ def add_wireframe_toggle(
     :return: The viser checkbox handle.
     """
     cb = server.gui.add_checkbox(label, initial_value=initial_value)
-    if handles.mesh_handle is not None:
-        if handles.wireframe_handle is None and hasattr(
-            handles.mesh_handle, "wireframe"
-        ):
-            handles.mesh_handle.visible = True
-            handles.mesh_handle.wireframe = initial_value
-        else:
-            handles.mesh_handle.visible = not initial_value
+    skinned_handles = (
+        _skinned_mesh_handles(handles.mesh_handle)
+        if handles.wireframe_handle is None
+        else []
+    )
+    if skinned_handles:
+        for handle in skinned_handles:
+            handle.visible = True
+            handle.wireframe = initial_value
+    else:
+        _set_solid_mesh_visible(handles.mesh_handle, not initial_value)
     if handles.wireframe_handle is not None:
         handles.wireframe_handle.visible = initial_value
 
     @cb.on_update
     def _(_: object) -> None:
-        if handles.mesh_handle is not None:
-            if handles.wireframe_handle is None and hasattr(
-                handles.mesh_handle, "wireframe"
-            ):
-                handles.mesh_handle.visible = True
-                handles.mesh_handle.wireframe = cb.value
-            else:
-                handles.mesh_handle.visible = not cb.value
+        if skinned_handles:
+            for handle in skinned_handles:
+                handle.visible = True
+                handle.wireframe = cb.value
+        else:
+            _set_solid_mesh_visible(handles.mesh_handle, not cb.value)
         if handles.wireframe_handle is not None:
             handles.wireframe_handle.visible = cb.value
 

--- a/pymomentum/viser_vis.py
+++ b/pymomentum/viser_vis.py
@@ -35,6 +35,8 @@ frame.  The typical usage pattern is::
 Individual functions are also available:
 
 - :func:`add_mesh` / :func:`update_mesh` — manage a :class:`~pymomentum.geometry.Mesh`
+- :func:`add_skinned_mesh` / :func:`update_skinned_mesh` — upload mesh data once
+  and update only bone transforms
 - :func:`add_joints` / :func:`update_joints` — manage skeleton joint frames
 - :func:`add_character` / :func:`update_character` / :func:`remove_character` —
   manage a complete character
@@ -53,6 +55,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, TYPE_CHECKING
 
 import numpy as np
+from pymomentum.quaternion_np import from_rotation_matrix
 
 if TYPE_CHECKING:
     import viser
@@ -79,7 +82,8 @@ CM_TO_M: float = 0.01
 
 def _xyzw_to_wxyz(q: np.ndarray) -> np.ndarray:
     """Convert quaternion from ``[x, y, z, w]`` (pymomentum) to ``[w, x, y, z]`` (viser)."""
-    return np.array([q[3], q[0], q[1], q[2]], dtype=np.float64)
+    q_arr = np.asarray(q, dtype=np.float64)
+    return np.concatenate((q_arr[..., 3:4], q_arr[..., :3]), axis=-1)
 
 
 def add_mesh(
@@ -185,6 +189,176 @@ def update_mesh(
     mesh_handle.vertices = vertices
     if wireframe_handle is not None:
         wireframe_handle.vertices = vertices
+
+
+def _max_nonzero_skin_influences(
+    skin_weights: np.ndarray,
+    *,
+    weight_threshold: float = 1e-8,
+) -> int:
+    """Return the maximum number of nonzero skinning influences on any vertex."""
+    if skin_weights.shape[0] == 0:
+        return 0
+    return int(
+        np.max(np.count_nonzero(np.abs(skin_weights) > weight_threshold, axis=1))
+    )
+
+
+def _normalize_skin_weights(skin_weights: np.ndarray) -> np.ndarray:
+    """Renormalize skin weights without dropping any nonzero influences."""
+    result = skin_weights.copy()
+    row_sums = np.sum(result, axis=1, keepdims=True)
+    return np.divide(
+        result,
+        row_sums,
+        out=np.zeros_like(result),
+        where=row_sums > 0.0,
+    )
+
+
+def max_skin_influences(character: Character) -> int:
+    """Return the maximum nonzero skinning influences per vertex for *character*.
+
+    :param character: Character to inspect.
+    :return: The largest number of nonzero skin weights on any mesh vertex, or
+        zero if the character has no skinned mesh.
+    """
+    if not character.has_mesh:
+        return 0
+    skin_weights = np.asarray(
+        character.skin_weights.to_dense(character.skeleton.size), dtype=np.float32
+    )
+    return _max_nonzero_skin_influences(skin_weights)
+
+
+def can_use_skinned_mesh(character: Character) -> bool:
+    """Return whether Viser client-side skinning can represent *character*.
+
+    Viser uses at most four skinning influences per vertex. Characters with
+    more influences should use the posed-vertex mesh path to preserve the
+    original deformation.
+
+    :param character: Character to inspect.
+    :return: ``True`` if the character has a mesh and no vertex has more than
+        four nonzero skin weights.
+    """
+    return character.has_mesh and max_skin_influences(character) <= 4
+
+
+def add_skinned_mesh(
+    server: viser.ViserServer,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    color: tuple[int, int, int] = (200, 200, 200),
+    scale: float = CM_TO_M,
+) -> Any:
+    """Add a client-side skinned mesh to the viser scene.
+
+    Unlike :func:`add_mesh`, this sends rest vertices, faces, skin weights, and
+    bind-pose bones once. Subsequent animation only needs
+    :func:`update_skinned_mesh`, which updates per-joint bone transforms rather
+    than re-uploading all posed vertex positions.
+
+    :param server: The viser server instance.
+    :param entity_path: Scene-graph path for the mesh node.
+    :param character: Character with a mesh, skin weights, and bind pose.
+    :param skel_state: Initial skeleton state array of shape ``(n_joints, 8)``.
+    :param color: RGB color tuple ``(r, g, b)`` in 0–255.
+    :param scale: Unit conversion factor applied to vertices and bone
+        translations. Defaults to :data:`CM_TO_M`.
+    :return: The viser skinned mesh handle.
+    """
+    if not character.has_mesh:
+        raise ValueError("add_skinned_mesh() requires a character with mesh skinning")
+
+    skeleton_size = character.skeleton.size
+    mesh = character.mesh
+    vertices = np.asarray(mesh.vertices, dtype=np.float32) * scale
+    faces = np.asarray(mesh.faces, dtype=np.int32)
+    skin_weights = np.asarray(
+        character.skin_weights.to_dense(skeleton_size), dtype=np.float32
+    )
+    if skin_weights.shape != (vertices.shape[0], skeleton_size):
+        raise ValueError(
+            "Expected dense skin weights with shape "
+            f"({vertices.shape[0]}, {skeleton_size}); got {skin_weights.shape}"
+        )
+    max_influences = _max_nonzero_skin_influences(skin_weights)
+    if max_influences > 4:
+        raise ValueError(
+            "Viser skinned meshes support at most 4 skinning influences per "
+            f"vertex; this character has {max_influences}"
+        )
+    skin_weights = _normalize_skin_weights(skin_weights)
+
+    bind_pose = np.asarray(character.bind_pose, dtype=np.float32)
+    expected_bind_pose_shape = (skeleton_size, 4, 4)
+    if bind_pose.shape != expected_bind_pose_shape:
+        raise ValueError(
+            f"Expected bind pose shape {expected_bind_pose_shape}; got {bind_pose.shape}"
+        )
+
+    bone_positions = bind_pose[:, :3, 3].astype(np.float32) * scale
+    bone_wxyzs = _xyzw_to_wxyz(from_rotation_matrix(bind_pose[:, :3, :3])).astype(
+        np.float32
+    )
+    if skeleton_size < 4:
+        # Viser's skinned mesh path always extracts four influences per vertex,
+        # so characters with fewer than four joints need zero-weight padding.
+        pad_count = 4 - skeleton_size
+        skin_weights = np.pad(skin_weights, ((0, 0), (0, pad_count)))
+        bone_positions = np.concatenate(
+            (bone_positions, np.zeros((pad_count, 3), dtype=np.float32)), axis=0
+        )
+        bone_wxyzs = np.concatenate(
+            (
+                bone_wxyzs,
+                np.tile(
+                    np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+                    (pad_count, 1),
+                ),
+            ),
+            axis=0,
+        )
+    skinned_mesh_handle = server.scene.add_mesh_skinned(
+        entity_path,
+        vertices=vertices,
+        faces=faces,
+        bone_wxyzs=bone_wxyzs,
+        bone_positions=bone_positions,
+        skin_weights=skin_weights,
+        color=color,
+        scale=1.0,
+    )
+    update_skinned_mesh(skinned_mesh_handle, skel_state, scale=scale)
+    return skinned_mesh_handle
+
+
+def update_skinned_mesh(
+    skinned_mesh_handle: Any,
+    skel_state: np.ndarray,
+    *,
+    scale: float = CM_TO_M,
+) -> None:
+    """Update a skinned mesh by sending only bone transforms.
+
+    :param skinned_mesh_handle: The handle returned by :func:`add_skinned_mesh`.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    :param scale: Unit conversion factor for bone translations.
+    """
+    bones = skinned_mesh_handle.bones
+    if len(bones) < skel_state.shape[0]:
+        raise ValueError(
+            f"Skinned mesh has {len(bones)} bones but got {skel_state.shape[0]} joints"
+        )
+
+    positions = skel_state[:, :3].astype(np.float64) * scale
+    wxyzs = _xyzw_to_wxyz(skel_state[:, 3:7])
+    for bone, position, wxyz in zip(bones[: skel_state.shape[0]], positions, wxyzs):
+        bone.position = position
+        bone.wxyz = wxyz
 
 
 def _build_bone_segments(
@@ -303,6 +477,7 @@ def add_character(
     skel_state: np.ndarray,
     *,
     posed_mesh: Mesh | None = None,
+    use_skinned_mesh: bool = False,
     color: tuple[int, int, int] = (200, 200, 200),
     scale: float = CM_TO_M,
     axes_length: float = 0.05,
@@ -314,14 +489,16 @@ def add_character(
     subsequent updates via :func:`update_character`.
 
     - ``{entity_path}/joints/{name}`` — per-joint coordinate frames
-    - ``{entity_path}/mesh`` — posed mesh (if *posed_mesh* is provided)
+    - ``{entity_path}/mesh`` — posed or skinned mesh
 
     :param server: The viser server instance.
     :param entity_path: Root scene-graph path for the character.
     :param character: The character to visualize.
     :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
-    :param posed_mesh: An optional pre-posed mesh.  If *None*, no mesh
-        is added.
+    :param posed_mesh: An optional pre-posed mesh for the legacy mesh path.  If
+        *None* and *use_skinned_mesh* is false, no mesh is added.
+    :param use_skinned_mesh: If true and the character has a skinned mesh, add
+        a client-side skinned mesh instead of uploading posed vertices.
     :param color: RGB color tuple for the mesh.
     :param axes_length: Length of joint axis indicators.
     :param axes_radius: Radius of joint axis indicators.
@@ -339,7 +516,16 @@ def add_character(
         axes_radius=axes_radius,
     )
 
-    if posed_mesh is not None:
+    if use_skinned_mesh and character.has_mesh:
+        handles.mesh_handle = add_skinned_mesh(
+            server,
+            f"{entity_path}/mesh",
+            character,
+            skel_state,
+            color=color,
+            scale=scale,
+        )
+    elif posed_mesh is not None:
         handles.mesh_handle, handles.wireframe_handle = add_mesh(
             server, f"{entity_path}/mesh", posed_mesh, color=color, scale=scale
         )
@@ -377,7 +563,9 @@ def update_character(
             scale=scale,
         )
 
-        if posed_mesh is not None and handles.mesh_handle is not None:
+        if handles.mesh_handle is not None and hasattr(handles.mesh_handle, "bones"):
+            update_skinned_mesh(handles.mesh_handle, skel_state, scale=scale)
+        elif posed_mesh is not None and handles.mesh_handle is not None:
             update_mesh(
                 handles.mesh_handle, handles.wireframe_handle, posed_mesh, scale=scale
             )
@@ -488,8 +676,9 @@ def add_wireframe_toggle(
 
     :func:`add_mesh` (and therefore :func:`add_character`) creates both a solid
     and a wireframe handle; this widget flips their ``.visible`` flags so only
-    one is shown at a time. Sets initial visibility on both handles to match
-    *initial_value*.
+    one is shown at a time. Skinned mesh handles expose ``.wireframe`` directly,
+    so the widget toggles that property instead of requiring a duplicate mesh.
+    Sets initial visibility/state to match *initial_value*.
 
     :param server: The viser server instance.
     :param handles: The character handles whose mesh/wireframe to toggle.
@@ -500,14 +689,26 @@ def add_wireframe_toggle(
     """
     cb = server.gui.add_checkbox(label, initial_value=initial_value)
     if handles.mesh_handle is not None:
-        handles.mesh_handle.visible = not initial_value
+        if handles.wireframe_handle is None and hasattr(
+            handles.mesh_handle, "wireframe"
+        ):
+            handles.mesh_handle.visible = True
+            handles.mesh_handle.wireframe = initial_value
+        else:
+            handles.mesh_handle.visible = not initial_value
     if handles.wireframe_handle is not None:
         handles.wireframe_handle.visible = initial_value
 
     @cb.on_update
     def _(_: object) -> None:
         if handles.mesh_handle is not None:
-            handles.mesh_handle.visible = not cb.value
+            if handles.wireframe_handle is None and hasattr(
+                handles.mesh_handle, "wireframe"
+            ):
+                handles.mesh_handle.visible = True
+                handles.mesh_handle.wireframe = cb.value
+            else:
+                handles.mesh_handle.visible = not cb.value
         if handles.wireframe_handle is not None:
             handles.wireframe_handle.visible = cb.value
 


### PR DESCRIPTION
Summary:

Split glTF primitive mesh loading into small helpers for index buffers, optional vertex attributes, texture data, and mesh append bookkeeping so addMesh remains easy to follow without changing behavior.

Reviewed By: cstollmeta

Differential Revision: D104485816


