### PR TITLE
Replace QR solve for inverse parameter_transform with SVD (#1392)

### DIFF
--- a/momentum/character/inverse_parameter_transform.cpp
+++ b/momentum/character/inverse_parameter_transform.cpp
@@ -11,21 +11,15 @@
 #include "momentum/common/checks.h"
 #include "momentum/common/exception.h"
 #include "momentum/common/log.h"
+#include "momentum/math/utility.h"
 
 namespace momentum {
-
-template <typename T>
-Eigen::SparseMatrix<T> toColumnMajor(const SparseRowMatrix<T>& mat) {
-  Eigen::SparseMatrix<T> result = mat;
-  result.makeCompressed();
-  return result;
-}
 
 template <typename T>
 InverseParameterTransformT<T>::InverseParameterTransformT(
     const ParameterTransformT<T>& paramTransform)
     : transform(paramTransform.transform),
-      inverseTransform(toColumnMajor<T>(paramTransform.transform)),
+      pseudoInverseMatrix(pseudoInverse(MatrixX<T>(paramTransform.transform))),
       offsets(paramTransform.offsets) {}
 
 template <typename T>
@@ -38,7 +32,7 @@ CharacterParametersT<T> InverseParameterTransformT<T>::apply(
       transform.rows());
   MT_CHECK(offsets.size() == transform.rows(), "{} is not {}", offsets.size(), transform.rows());
   CharacterParametersT<T> result;
-  result.pose = inverseTransform.solve(jointParameters.v - offsets);
+  result.pose = pseudoInverseMatrix * (jointParameters.v - offsets);
   result.offsets = jointParameters.v - transform * result.pose.v;
   return result;
 }

--- a/momentum/character/inverse_parameter_transform.h
+++ b/momentum/character/inverse_parameter_transform.h
@@ -12,8 +12,6 @@
 #include <momentum/character/types.h>
 #include <momentum/math/types.h>
 
-#include <Eigen/Sparse>
-
 namespace momentum {
 
 /// Maps from joint parameters back to the model parameters.
@@ -31,11 +29,7 @@ template <typename T>
 struct InverseParameterTransformT {
  public:
   const SparseRowMatrix<T> transform;
-  const Eigen::SparseQR<Eigen::SparseMatrix<T>, Eigen::COLAMDOrdering<int>> inverseTransform;
-  // TODO: `offsets` is unused by the inverse mapping below and is documented as deprecated; remove
-  // it and update all constructors/consumers.
-  /// @deprecated Constant offset factor for each joint; retained for ABI compatibility but no
-  /// longer consulted by `apply()`.
+  const MatrixX<T> pseudoInverseMatrix;
   const Eigen::VectorX<T> offsets;
 
   explicit InverseParameterTransformT(const ParameterTransformT<T>& paramTransform);

--- a/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
+++ b/pymomentum/tensor_momentum/tensor_parameter_transform.cpp
@@ -444,31 +444,13 @@ variable_list ApplyInverseParameterTransformFunction::backward(
       dLoss_dModelParameters.size(1) != inverseParamTransform->numAllModelParameters(),
       "Unexpected error: mismatch in parameter transform sizes.");
 
-  const auto nBatch = dLoss_dModelParameters.size(0);
-
-  const int nModelParams = static_cast<int>(inverseParamTransform->numAllModelParameters());
-  const int nJointParams = static_cast<int>(inverseParamTransform->numJointParameters());
-
-  auto result = at::zeros({nBatch, nJointParams}, at::kFloat);
-
-  // To solve for the model parameters, given the joint parameters,
-  // inverseParameterTransform uses the QR decomposition,
-  //    modelParams = R^{-1} * Q^T * jointParams
-  // When taking the backwards-mode derivative, we need to apply the transpose
-  // of this,
-  //    dLoss_dJointParams = (R^{-1} * Q^T)^T * dLoss_dModelParams
-  //                       = (R^{-1})^T * Q * dLoss_dModelParams
-  // As the Q matrix is an implicitly (nJointParam x nJointParam) matrix, so
-  // to apply it we need to pad the dLoss_dModelParams vector with zeros;
-  // we'll use the tmp vector to store it.
-  Eigen::VectorXf tmp = Eigen::VectorXf::Zero(nJointParams);
-  const auto& qrDecomposition = inverseParamTransform->inverseTransform;
-  for (int64_t iBatch = 0; iBatch < nBatch; ++iBatch) {
-    tmp.head(nModelParams) =
-        qrDecomposition.matrixR().triangularView<Eigen::Upper>().transpose().solve(
-            toEigenMap<float>(dLoss_dModelParameters.select(0, iBatch)));
-    toEigenMap<float>(result.select(0, iBatch)) = (qrDecomposition.matrixQ() * tmp).eval();
-  }
+  // The forward pass computes:
+  //    modelParams = pseudoInverseMatrix * (jointParams - offsets)
+  // The backward-mode derivative is the transpose:
+  //    dLoss_dJointParams = pseudoInverseMatrix^T * dLoss_dModelParams
+  // In batched row-vector form: result = dLoss_dModelParameters @ pinv
+  const auto pinvTensor = to2DTensor(inverseParamTransform->pseudoInverseMatrix);
+  auto result = at::mm(dLoss_dModelParameters, pinvTensor);
 
   if (squeeze) {
     result = result.sum(0);


### PR DESCRIPTION
Summary:

The existing QR solve may produce wrong results with parameter transforms that have bad condition numbers. The pseudo inverse through SVD is more stable.

Reviewed By: cdtwigg

Differential Revision: D104731671


