### PR TITLE
Add `skin_offset` parameter to `SkinnedLocator` constructor

### DIFF
--- a/pymomentum/geometry/locators_pybind.cpp
+++ b/pymomentum/geometry/locators_pybind.cpp
@@ -109,7 +109,8 @@ void registerLocatorBindings(
                       const Eigen::VectorXi& parents,
                       const Eigen::VectorXf& skinWeights,
                       const std::optional<Eigen::Vector3f>& position,
-                      float weight) {
+                      float weight,
+                      float skinOffset) {
             if (parents.size() != skinWeights.size()) {
               throw std::runtime_error("parents and skin_weights must have the same size");
             }
@@ -145,13 +146,15 @@ void registerLocatorBindings(
                 parentsTmp,
                 skinWeightsTmp,
                 position.value_or(Eigen::Vector3f::Zero()),
-                weight);
+                weight,
+                skinOffset);
           }),
           py::arg("name"),
           py::arg("parents"),
           py::arg("skin_weights"),
           py::arg("position") = std::nullopt,
-          py::arg("weight") = 1.0f)
+          py::arg("weight") = 1.0f,
+          py::arg("skin_offset") = 0.0f)
       .def_readonly("name", &mm::SkinnedLocator::name, "The skinned locator's name.")
       .def_property_readonly(
           "parents",


### PR DESCRIPTION
Summary:
The `SkinnedLocator` pybind11 constructor was missing the `skin_offset` parameter, even though the underlying C++ struct has the field and the C++ constructor accepts it. This meant there was no way to set `skin_offset` from Python — the property was read-only and the constructor silently defaulted it to 0.0.

Add `skin_offset` as an optional keyword argument (default `0.0`) to the Python `SkinnedLocator.__init__`, passing it through to the C++ constructor. Regenerate the `.pyi` stub to reflect the new parameter.

Differential Revision: D105633481


