### PR TITLE
Expose character from SDF collision error function (#1405)

### DIFF
--- a/momentum/character_solver/sdf_collision_error_function.h
+++ b/momentum/character_solver/sdf_collision_error_function.h
@@ -89,6 +89,10 @@ class SDFCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
       bool filterRestPoseIntersections = true,
       uint8_t maxCollisionsPerVertex = 1);
 
+  SDFCollisionErrorFunctionT(const SDFCollisionErrorFunctionT&) = default;
+  SDFCollisionErrorFunctionT& operator=(const SDFCollisionErrorFunctionT&) = delete;
+  SDFCollisionErrorFunctionT(SDFCollisionErrorFunctionT&&) noexcept = default;
+  SDFCollisionErrorFunctionT& operator=(SDFCollisionErrorFunctionT&&) noexcept = delete;
   ~SDFCollisionErrorFunctionT() override = default;
 
   [[nodiscard]] double getError(
@@ -114,6 +118,11 @@ class SDFCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
 
   [[nodiscard]] bool needsMesh() const override {
     return true;
+  }
+
+  /// Returns the character used to update mesh state for SDF collision evaluation.
+  [[nodiscard]] const Character* getCharacter() const override {
+    return &character_;
   }
 
   [[nodiscard]] size_t getNumActiveVertices() const {


### PR DESCRIPTION
Summary:

Add `SDFCollisionErrorFunctionT::getCharacter()` so generic mesh-based solver wrappers can access the full `Character` when `needsMesh()` is true. This is intentionally a pointer override because `SkeletonErrorFunctionT::getCharacter()` returns `nullptr` for skeleton-only error functions that do not have a full character. This diff is limited to the non-experimental Momentum API surface so it can land independently in the open source repo.

Differential Revision: D105594224


