### PR TITLE
Add `MT_CHECK_NOTNULL` for `posedMesh_` in vertex error functions

### DIFF
--- a/momentum/character_solver/camera_vertex_projection_error_function.cpp
+++ b/momentum/character_solver/camera_vertex_projection_error_function.cpp
@@ -11,6 +11,7 @@
 #include "momentum/character/mesh_state.h"
 #include "momentum/character/skeleton_state.h"
 #include "momentum/character_solver/skeleton_derivative.h"
+#include "momentum/common/checks.h"
 
 #include <dispenso/parallel_for.h>
 
@@ -83,6 +84,8 @@ double CameraVertexProjectionErrorFunctionT<T>::getError(
     const ModelParametersT<T>& params,
     const SkeletonStateT<T>& skeletonState,
     const MeshStateT<T>& meshState) {
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
+
   double error = 0;
 
   const auto& intrinsics = (intrinsicsMapping_ && intrinsicsMapping_->hasActiveParams())
@@ -131,6 +134,7 @@ double CameraVertexProjectionErrorFunctionT<T>::getGradient(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   const bool hasIntrinsics = intrinsicsMapping_ && intrinsicsMapping_->hasActiveParams();
   const auto& intrinsics =
@@ -253,6 +257,7 @@ double CameraVertexProjectionErrorFunctionT<T>::getJacobian(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   const bool hasIntrinsics = intrinsicsMapping_ && intrinsicsMapping_->hasActiveParams();
   const auto& intrinsics =

--- a/momentum/character_solver/vertex_error_function.cpp
+++ b/momentum/character_solver/vertex_error_function.cpp
@@ -68,6 +68,7 @@ double VertexErrorFunctionT<T, Data, FuncDim>::getError(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   double error = 0.0;
   for (size_t i = 0; i < numConstraints; ++i) {
@@ -101,6 +102,7 @@ double VertexErrorFunctionT<T, Data, FuncDim>::getGradient(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   auto dispensoOptions = dispenso::ParForOptions();
   dispensoOptions.maxThreads = static_cast<uint32_t>(maxThreads_);
@@ -197,6 +199,7 @@ double VertexErrorFunctionT<T, Data, FuncDim>::getJacobian(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   auto dispensoOptions = dispenso::ParForOptions();
   dispensoOptions.maxThreads = static_cast<uint32_t>(maxThreads_);

--- a/momentum/character_solver/vertex_normal_error_function.cpp
+++ b/momentum/character_solver/vertex_normal_error_function.cpp
@@ -113,6 +113,7 @@ double VertexNormalErrorFunctionT<T>::getGradient(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   const SkeletonDerivativeT<T> skeletonDerivative(
       this->skeleton_,
@@ -259,6 +260,7 @@ double VertexNormalErrorFunctionT<T>::getJacobian(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   const SkeletonDerivativeT<T> skeletonDerivative(
       this->skeleton_,

--- a/momentum/character_solver/vertex_position_error_function.cpp
+++ b/momentum/character_solver/vertex_position_error_function.cpp
@@ -65,6 +65,7 @@ double VertexPositionErrorFunctionT<T>::getGradient(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   auto dispensoOptions = dispenso::ParForOptions();
   dispensoOptions.maxThreads = static_cast<uint32_t>(this->maxThreads_);
@@ -153,6 +154,7 @@ double VertexPositionErrorFunctionT<T>::getJacobian(
   if (numConstraints == 0) {
     return 0.0;
   }
+  MT_CHECK_NOTNULL(meshState.posedMesh_);
 
   auto dispensoOptions = dispenso::ParForOptions();
   dispensoOptions.maxThreads = static_cast<uint32_t>(this->maxThreads_);


### PR DESCRIPTION
Summary:
Vertex error functions dereference `meshState.posedMesh_` without checking for null, which can lead to crashes when a `MeshState` is constructed without a mesh. Add `MT_CHECK_NOTNULL(meshState.posedMesh_)` guards after the early-return-on-empty-constraints check in all `getError`, `getGradient`, and `getJacobian` methods across `VertexErrorFunctionT`, `VertexPositionErrorFunctionT`, `VertexNormalErrorFunctionT`, and `CameraVertexProjectionErrorFunctionT`.

Also fix the vertex error function benchmark to properly construct `MeshState(modelParams, skelState, character)` instead of using default construction, which left `posedMesh_` null.

Reviewed By: yutingye

Differential Revision: D105600758


