### PR TITLE
clang-diagnostic-unused-parameter in momentum_ik_autograd.cpp

### DIFF
--- a/pymomentum/solver/momentum_ik_autograd.cpp
+++ b/pymomentum/solver/momentum_ik_autograd.cpp
@@ -894,7 +894,7 @@ std::tuple<at::Tensor, at::Tensor, std::vector<at::Tensor>> ResidualFunction<T>:
     const std::vector<std::unique_ptr<TensorErrorFunction<T>>>& errorFunctions,
     [[maybe_unused]] at::Tensor errorFunctionWeights,
     [[maybe_unused]] size_t numActiveErrorFunctions,
-    const std::vector<int>& weightsMap) {
+    [[maybe_unused]] const std::vector<int>& weightsMap) {
   const at::Tensor& grad_resid = dLoss_dResults[0];
   const at::Tensor& jacobian = results[1];
 


### PR DESCRIPTION
Reviewed By: nickyhe-gemini

Differential Revision: D105428777


