### PR TITLE
Harden renderer normalization cleanup

### DIFF
--- a/momentum/rasterizer/geometry.cpp
+++ b/momentum/rasterizer/geometry.cpp
@@ -561,7 +561,7 @@ std::array<Mesh, 2> makeCheckerboard(float width, int numChecks, int subdivision
         width * (static_cast<float>(i) / static_cast<float>(numChecks * subdivisions) - 0.5f));
   }
 
-  std::array<Mesh, 2> result;
+  std::array<Mesh, 2> result{};
 
   for (size_t iMesh = 0; iMesh < 2; ++iMesh) {
     std::vector<Eigen::Vector3f> positions;

--- a/pymomentum/renderer/momentum_render.cpp
+++ b/pymomentum/renderer/momentum_render.cpp
@@ -157,22 +157,22 @@ momentum::Camera makeOutsideInCameraForBody(
   // If `horizontal`, we place the camera horizontally, with camera up vector
   // facing upward. We assume the world Y axis points upward.
   // Otherwise, the camera is placed perpendicular to the spine direction.
-  Eigen::Vector3f camera_up_world;
+  Eigen::Vector3f camera_up_world = Eigen::Vector3f::Zero();
 
   if (horizontal) {
     camera_up_world = Eigen::Vector3f::UnitY();
     camera_forward_world[1] = 0.0;
-    camera_forward_world = camera_forward_world.normalized();
+    camera_forward_world = camera_forward_world.stableNormalized();
     if (camera_forward_world.norm() < 1e-5) {
       // The horizontal camera placement is degenerate. Revert back to the
       // original placement.
       camera_forward_world = -body_forward_world;
       camera_up_world = spineLocalToWorldXF.linear() * Eigen::Vector3f::UnitX();
-      camera_up_world = camera_up_world.normalized();
+      camera_up_world = camera_up_world.stableNormalized();
     }
   } else {
     camera_up_world = spineLocalToWorldXF.linear() * Eigen::Vector3f::UnitX();
-    camera_up_world = camera_up_world.normalized();
+    camera_up_world = camera_up_world.stableNormalized();
   }
 
   if (cameraAngle != 0.0) {

--- a/pymomentum/renderer/software_rasterizer.cpp
+++ b/pymomentum/renderer/software_rasterizer.cpp
@@ -281,10 +281,11 @@ void rasterizeSpheres(
     radiusAccessor.emplace(*radius, nSpheres);
   }
 
+  std::optional<VectorArrayAccessor<float, 3>> colorAccessor;
   std::optional<typename VectorArrayAccessor<float, 3>::ElementView> colorView;
   if (color.has_value()) {
-    VectorArrayAccessor<float, 3> colorAccessor(*color, LeadingDimensions{}, nSpheres);
-    colorView = colorAccessor.view({});
+    colorAccessor.emplace(*color, LeadingDimensions{}, nSpheres);
+    colorView = colorAccessor->view({});
   }
 
   // Create mdspans while holding GIL
@@ -386,10 +387,11 @@ void rasterizeCylinders(
     radiusAccessor.emplace(*radius, nCylinders);
   }
 
+  std::optional<VectorArrayAccessor<float, 3>> colorAccessor;
   std::optional<typename VectorArrayAccessor<float, 3>::ElementView> colorView;
   if (color.has_value()) {
-    VectorArrayAccessor<float, 3> colorAccessor(*color, LeadingDimensions{}, nCylinders);
-    colorView = colorAccessor.view({});
+    colorAccessor.emplace(*color, LeadingDimensions{}, nCylinders);
+    colorView = colorAccessor->view({});
   }
 
   // Create mdspans while holding GIL
@@ -409,12 +411,16 @@ void rasterizeCylinders(
       materialCur.diffuseColor = colorView->get(i);
     }
 
-    const float length = (endPos - startPos).norm();
+    const Eigen::Vector3f direction = endPos - startPos;
+    const float length = direction.norm();
+    if (length <= 1e-8f) {
+      continue;
+    }
+
     Eigen::Affine3f transform = Eigen::Affine3f::Identity();
     transform.translate(startPos);
     transform.rotate(
-        Eigen::Quaternionf::FromTwoVectors(
-            Eigen::Vector3f::UnitX(), (endPos - startPos).normalized()));
+        Eigen::Quaternionf::FromTwoVectors(Eigen::Vector3f::UnitX(), direction.stableNormalized()));
     transform.scale(Eigen::Vector3f(length, radiusVal, radiusVal));
 
     momentum::rasterizer::rasterizeMesh(


### PR DESCRIPTION
Summary: Avoid fragile renderer cleanup patterns by keeping optional color accessors alive for the full render call, using `stableNormalized()` for camera and cylinder directions, skipping zero-length cylinders before constructing a rotation, and value-initializing the checkerboard result array.

Differential Revision: D105771223


