### PR TITLE
Keep finite-difference errors in double precision (#1415)

### DIFF
--- a/momentum/test/character_solver/error_function_helpers.cpp
+++ b/momentum/test/character_solver/error_function_helpers.cpp
@@ -59,14 +59,14 @@ Eigen::VectorX<T> computeNumericalGradient(
     if (errorFunction->needsMesh()) {
       meshState.update(parameters, state, character);
     }
-    const T h_1 = errorFunction->getError(parameters, state, meshState);
+    const double h_1 = errorFunction->getError(parameters, state, meshState);
     parameters(p) = referenceParameters(p) + stepSize;
     state.set(transform.apply(parameters), character.skeleton);
     if (errorFunction->needsMesh()) {
       meshState.update(parameters, state, character);
     }
-    const T h1 = errorFunction->getError(parameters, state, meshState);
-    gradient(p) = (h1 - h_1) / (2.0 * stepSize);
+    const double h1 = errorFunction->getError(parameters, state, meshState);
+    gradient(p) = static_cast<T>((h1 - h_1) / (2.0 * static_cast<double>(stepSize)));
   }
   return gradient;
 }


### PR DESCRIPTION
Summary:

Keep finite-difference error values in `double` precision when checking error-function gradients so float tests are not dominated by rounding in the finite-difference numerator.

Reviewed By: cdtwigg

Differential Revision: D106309208


