### PR TITLE
Add Triton FK backend (#1419)

### DIFF
--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -354,7 +354,7 @@ mt_python_library(
 
 mt_python_library(
   NAME backend
-  PYMOMENTUM_SOURCES_VARS backend_torch_core_sources backend_torch_sources
+  PYMOMENTUM_SOURCES_VARS backend_common_sources backend_torch_core_sources backend_torch_sources backend_triton_sources
   PRESERVE_DIRECTORY_STRUCTURE
 )
 

--- a/pymomentum/backend/selection.py
+++ b/pymomentum/backend/selection.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+except ImportError:
+    triton = None
+
+_HAS_TRITON: bool = triton is not None
+
+
+def resolve_backend(
+    backend: str,
+    tensor: torch.Tensor,
+    use_double_precision: bool = False,
+) -> str:
+    if torch.jit.is_scripting():
+        return "torch"
+    if backend != "auto":
+        return backend
+    if (
+        not use_double_precision
+        and tensor.is_cuda
+        and tensor.dtype == torch.float32
+        and _HAS_TRITON
+    ):
+        return "triton"
+    return "torch"

--- a/pymomentum/backend/torch_quaternion.py
+++ b/pymomentum/backend/torch_quaternion.py
@@ -259,14 +259,18 @@ def to_rotation_matrix_assume_normalized(q: torch.Tensor) -> torch.Tensor:
     return result.reshape(list(q.shape[:-1]) + [3, 3])
 
 
-def to_rotation_matrix(q: torch.Tensor) -> torch.Tensor:
+def to_rotation_matrix(q: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
     """
     Convert quaternions to 3x3 rotation matrices.
 
     :parameter q: (nBatch x k x 4) tensor with the quaternions in ((x, y, z), w) format.
+    :parameter eps: Minimum quaternion norm used during normalization.
     :return: (nBatch x k x 3 x 3) tensor with 3x3 rotation matrices.
     """
-    return to_rotation_matrix_assume_normalized(normalize(q))
+    check(q)
+    return to_rotation_matrix_assume_normalized(
+        torch.nn.functional.normalize(q, dim=-1, eps=eps)
+    )
 
 
 def identity(

--- a/pymomentum/backend/triton_common.py
+++ b/pymomentum/backend/triton_common.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from __future__ import annotations
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+if triton is not None and tl is not None:
+
+    @triton.jit
+    def _quat_multiply(x1, y1, z1, w1, x2, y2, z2, w2):
+        return (
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        )
+
+    @triton.jit
+    def _quat_multiply_backward(x1, y1, z1, w1, x2, y2, z2, w2, gx, gy, gz, gw):
+        return (
+            gx * w2 - gy * z2 + gz * y2 - gw * x2,
+            gx * z2 + gy * w2 - gz * x2 - gw * y2,
+            -gx * y2 + gy * x2 + gz * w2 - gw * z2,
+            gx * x2 + gy * y2 + gz * z2 + gw * w2,
+            gx * w1 + gy * z1 - gz * y1 - gw * x1,
+            -gx * z1 + gy * w1 + gz * x1 - gw * y1,
+            gx * y1 - gy * x1 + gz * w1 - gw * z1,
+            gx * x1 + gy * y1 + gz * z1 + gw * w1,
+        )
+
+    @triton.jit
+    def _rotate_vector(qx, qy, qz, qw, vx, vy, vz):
+        return (
+            (1.0 - 2.0 * qy * qy - 2.0 * qz * qz) * vx
+            + (2.0 * qx * qy - 2.0 * qz * qw) * vy
+            + (2.0 * qx * qz + 2.0 * qy * qw) * vz,
+            (2.0 * qx * qy + 2.0 * qz * qw) * vx
+            + (1.0 - 2.0 * qx * qx - 2.0 * qz * qz) * vy
+            + (2.0 * qy * qz - 2.0 * qx * qw) * vz,
+            (2.0 * qx * qz - 2.0 * qy * qw) * vx
+            + (2.0 * qy * qz + 2.0 * qx * qw) * vy
+            + (1.0 - 2.0 * qx * qx - 2.0 * qy * qy) * vz,
+        )
+
+    @triton.jit
+    def _rotate_vector_backward(qx, qy, qz, qw, vx, vy, vz, gx, gy, gz):
+        grad_vx = (
+            (1.0 - 2.0 * qy * qy - 2.0 * qz * qz) * gx
+            + (2.0 * qx * qy + 2.0 * qz * qw) * gy
+            + (2.0 * qx * qz - 2.0 * qy * qw) * gz
+        )
+        grad_vy = (
+            (2.0 * qx * qy - 2.0 * qz * qw) * gx
+            + (1.0 - 2.0 * qx * qx - 2.0 * qz * qz) * gy
+            + (2.0 * qy * qz + 2.0 * qx * qw) * gz
+        )
+        grad_vz = (
+            (2.0 * qx * qz + 2.0 * qy * qw) * gx
+            + (2.0 * qy * qz - 2.0 * qx * qw) * gy
+            + (1.0 - 2.0 * qx * qx - 2.0 * qy * qy) * gz
+        )
+
+        grad_qx = (
+            (2.0 * qy * vy + 2.0 * qz * vz) * gx
+            + (2.0 * qy * vx - 4.0 * qx * vy - 2.0 * qw * vz) * gy
+            + (2.0 * qz * vx + 2.0 * qw * vy - 4.0 * qx * vz) * gz
+        )
+        grad_qy = (
+            (-4.0 * qy * vx + 2.0 * qx * vy + 2.0 * qw * vz) * gx
+            + (2.0 * qx * vx + 2.0 * qz * vz) * gy
+            + (-2.0 * qw * vx + 2.0 * qz * vy - 4.0 * qy * vz) * gz
+        )
+        grad_qz = (
+            (-4.0 * qz * vx - 2.0 * qw * vy + 2.0 * qx * vz) * gx
+            + (2.0 * qw * vx - 4.0 * qz * vy + 2.0 * qy * vz) * gy
+            + (2.0 * qx * vx + 2.0 * qy * vy) * gz
+        )
+        grad_qw = (
+            (-2.0 * qz * vy + 2.0 * qy * vz) * gx
+            + (2.0 * qz * vx - 2.0 * qx * vz) * gy
+            + (-2.0 * qy * vx + 2.0 * qx * vy) * gz
+        )
+        return grad_qx, grad_qy, grad_qz, grad_qw, grad_vx, grad_vy, grad_vz

--- a/pymomentum/backend/triton_fk.py
+++ b/pymomentum/backend/triton_fk.py
@@ -1,0 +1,909 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_BLOCK_BATCH = 128
+_LN2 = math.log(2.0)
+if triton is not None and tl is not None:  # noqa: C901
+    from pymomentum.backend.triton_common import (  # @manual=:backend_triton
+        _quat_multiply,
+        _quat_multiply_backward,
+        _rotate_vector,
+        _rotate_vector_backward,
+    )
+
+    @triton.jit
+    def _euler_to_quaternion(rx, ry, rz):
+        cy = tl.cos(rz * 0.5)
+        sy = tl.sin(rz * 0.5)
+        cp = tl.cos(ry * 0.5)
+        sp = tl.sin(ry * 0.5)
+        cr = tl.cos(rx * 0.5)
+        sr = tl.sin(rx * 0.5)
+        return (
+            sr * cp * cy - cr * sp * sy,
+            cr * sp * cy + sr * cp * sy,
+            cr * cp * sy - sr * sp * cy,
+            cr * cp * cy + sr * sp * sy,
+        )
+
+    @triton.jit
+    def _euler_backward(rx, ry, rz, gx, gy, gz, gw):
+        cy = tl.cos(rz * 0.5)
+        sy = tl.sin(rz * 0.5)
+        cp = tl.cos(ry * 0.5)
+        sp = tl.sin(ry * 0.5)
+        cr = tl.cos(rx * 0.5)
+        sr = tl.sin(rx * 0.5)
+
+        grad_rx = (
+            gx * (0.5 * cr * cp * cy + 0.5 * sr * sp * sy)
+            + gy * (-0.5 * sr * sp * cy + 0.5 * cr * cp * sy)
+            + gz * (-0.5 * sr * cp * sy - 0.5 * cr * sp * cy)
+            + gw * (-0.5 * sr * cp * cy + 0.5 * cr * sp * sy)
+        )
+        grad_ry = (
+            gx * (-0.5 * sr * sp * cy - 0.5 * cr * cp * sy)
+            + gy * (0.5 * cr * cp * cy - 0.5 * sr * sp * sy)
+            + gz * (-0.5 * cr * sp * sy - 0.5 * sr * cp * cy)
+            + gw * (-0.5 * cr * sp * cy + 0.5 * sr * cp * sy)
+        )
+        grad_rz = (
+            gx * (-0.5 * sr * cp * sy - 0.5 * cr * sp * cy)
+            + gy * (-0.5 * cr * sp * sy + 0.5 * sr * cp * cy)
+            + gz * (0.5 * cr * cp * cy + 0.5 * sr * sp * sy)
+            + gw * (-0.5 * cr * cp * sy + 0.5 * sr * sp * cy)
+        )
+        return grad_rx, grad_ry, grad_rz
+
+    @triton.jit
+    def _rotate_vector_backward_parent(qx, qy, qz, qw, vx, vy, vz, gx, gy, gz):
+        grad_qx = (
+            (2.0 * qy * vy + 2.0 * qz * vz) * gx
+            + (2.0 * qy * vx - 4.0 * qx * vy - 2.0 * qw * vz) * gy
+            + (2.0 * qz * vx + 2.0 * qw * vy - 4.0 * qx * vz) * gz
+        )
+        grad_qy = (
+            (-4.0 * qy * vx + 2.0 * qx * vy + 2.0 * qw * vz) * gx
+            + (2.0 * qx * vx + 2.0 * qz * vz) * gy
+            + (-2.0 * qw * vx + 2.0 * qz * vy - 4.0 * qy * vz) * gz
+        )
+        grad_qz = (
+            (-4.0 * qz * vx - 2.0 * qw * vy + 2.0 * qx * vz) * gx
+            + (2.0 * qw * vx - 4.0 * qz * vy + 2.0 * qy * vz) * gy
+            + (2.0 * qx * vx + 2.0 * qy * vy) * gz
+        )
+        grad_qw = (
+            (-2.0 * qz * vy + 2.0 * qy * vz) * gx
+            + (2.0 * qz * vx - 2.0 * qx * vz) * gy
+            + (-2.0 * qy * vx + 2.0 * qx * vy) * gz
+        )
+        return grad_qx, grad_qy, grad_qz, grad_qw
+
+    @triton.jit
+    def _quat_multiply_backward_parent(x1, y1, z1, w1, x2, y2, z2, w2, gx, gy, gz, gw):
+        return (
+            gx * w2 - gy * z2 + gz * y2 - gw * x2,
+            gx * z2 + gy * w2 - gz * x2 - gw * y2,
+            -gx * y2 + gy * x2 + gz * w2 - gw * z2,
+            gx * x2 + gy * y2 + gz * z2 + gw * w2,
+        )
+
+    @triton.jit
+    def _load_local_state(
+        joint_params, offsets, prerotations, batch, joint, n_joints, mask
+    ):
+        param_base = joint_params + batch * n_joints * 7 + joint * 7
+        offset_base = offsets + joint * 3
+        pre_base = prerotations + joint * 4
+
+        tx = tl.load(offset_base + 0) + tl.load(param_base + 0, mask=mask, other=0.0)
+        ty = tl.load(offset_base + 1) + tl.load(param_base + 1, mask=mask, other=0.0)
+        tz = tl.load(offset_base + 2) + tl.load(param_base + 2, mask=mask, other=0.0)
+
+        rx = tl.load(param_base + 3, mask=mask, other=0.0)
+        ry = tl.load(param_base + 4, mask=mask, other=0.0)
+        rz = tl.load(param_base + 5, mask=mask, other=0.0)
+        eqx, eqy, eqz, eqw = _euler_to_quaternion(rx, ry, rz)
+
+        pqx = tl.load(pre_base + 0)
+        pqy = tl.load(pre_base + 1)
+        pqz = tl.load(pre_base + 2)
+        pqw = tl.load(pre_base + 3)
+        qx, qy, qz, qw = _quat_multiply(pqx, pqy, pqz, pqw, eqx, eqy, eqz, eqw)
+        scale = tl.exp2(tl.load(param_base + 6, mask=mask, other=0.0))
+        return tx, ty, tz, qx, qy, qz, qw, scale
+
+    @triton.jit
+    def _forward_one_joint(
+        joint_params,
+        offsets,
+        prerotations,
+        parents,
+        output,
+        batch,
+        joint,
+        n_joints,
+        mask,
+    ):
+        ltx, lty, ltz, lqx, lqy, lqz, lqw, ls = _load_local_state(
+            joint_params, offsets, prerotations, batch, joint, n_joints, mask
+        )
+
+        parent = tl.load(parents + joint)
+        has_parent = parent >= 0
+        parent = tl.maximum(parent, 0)
+        parent_base = output + batch * n_joints * 8 + parent * 8
+        parent_mask = mask & has_parent
+        ptx = tl.load(parent_base + 0, mask=parent_mask, other=0.0)
+        pty = tl.load(parent_base + 1, mask=parent_mask, other=0.0)
+        ptz = tl.load(parent_base + 2, mask=parent_mask, other=0.0)
+        pqx = tl.load(parent_base + 3, mask=parent_mask, other=0.0)
+        pqy = tl.load(parent_base + 4, mask=parent_mask, other=0.0)
+        pqz = tl.load(parent_base + 5, mask=parent_mask, other=0.0)
+        pqw = tl.load(parent_base + 6, mask=parent_mask, other=1.0)
+        ps = tl.load(parent_base + 7, mask=parent_mask, other=1.0)
+
+        rtx, rty, rtz = _rotate_vector(pqx, pqy, pqz, pqw, ltx, lty, ltz)
+        gtx = ptx + ps * rtx
+        gty = pty + ps * rty
+        gtz = ptz + ps * rtz
+        gqx, gqy, gqz, gqw = _quat_multiply(pqx, pqy, pqz, pqw, lqx, lqy, lqz, lqw)
+        gs = ps * ls
+
+        out_base = output + batch * n_joints * 8 + joint * 8
+        tl.store(out_base + 0, gtx, mask=mask)
+        tl.store(out_base + 1, gty, mask=mask)
+        tl.store(out_base + 2, gtz, mask=mask)
+        tl.store(out_base + 3, gqx, mask=mask)
+        tl.store(out_base + 4, gqy, mask=mask)
+        tl.store(out_base + 5, gqz, mask=mask)
+        tl.store(out_base + 6, gqw, mask=mask)
+        tl.store(out_base + 7, gs, mask=mask)
+
+    @triton.jit
+    def _forward_kernel(
+        joint_params,
+        offsets,
+        prerotations,
+        parents,
+        output,
+        batch_size,
+        n_joints,
+        BLOCK_BATCH: tl.constexpr,
+    ):
+        batch = tl.program_id(0) * BLOCK_BATCH + tl.arange(0, BLOCK_BATCH)
+        mask = batch < batch_size
+        joint = 0
+        while joint < n_joints:
+            _forward_one_joint(
+                joint_params,
+                offsets,
+                prerotations,
+                parents,
+                output,
+                batch,
+                joint,
+                n_joints,
+                mask,
+            )
+            joint += 1
+
+    @triton.jit
+    def _load_state(data, batch, joint, n_joints, mask):
+        base = data + batch * n_joints * 8 + joint * 8
+        return (
+            tl.load(base + 0, mask=mask, other=0.0),
+            tl.load(base + 1, mask=mask, other=0.0),
+            tl.load(base + 2, mask=mask, other=0.0),
+            tl.load(base + 3, mask=mask, other=0.0),
+            tl.load(base + 4, mask=mask, other=0.0),
+            tl.load(base + 5, mask=mask, other=0.0),
+            tl.load(base + 6, mask=mask, other=0.0),
+            tl.load(base + 7, mask=mask, other=0.0),
+        )
+
+    @triton.jit
+    def _load_parent_state(parents, global_state, batch, joint, n_joints, mask):
+        parent = tl.load(parents + joint)
+        has_parent = parent >= 0
+        parent = tl.maximum(parent, 0)
+        parent_mask = mask & has_parent
+        parent_base = global_state + batch * n_joints * 8 + parent * 8
+        return (
+            parent,
+            parent_mask,
+            tl.load(parent_base + 3, mask=parent_mask, other=0.0),
+            tl.load(parent_base + 4, mask=parent_mask, other=0.0),
+            tl.load(parent_base + 5, mask=parent_mask, other=0.0),
+            tl.load(parent_base + 6, mask=parent_mask, other=1.0),
+            tl.load(parent_base + 7, mask=parent_mask, other=1.0),
+        )
+
+    @triton.jit
+    def _compute_active_joint_gradients(
+        pqx,
+        pqy,
+        pqz,
+        pqw,
+        ltx,
+        lty,
+        ltz,
+        lqx,
+        lqy,
+        lqz,
+        lqw,
+        gqx,
+        gqy,
+        gqz,
+        gqw,
+        scaled_gtx,
+        scaled_gty,
+        scaled_gtz,
+    ):
+        (
+            grad_parent_qx_t,
+            grad_parent_qy_t,
+            grad_parent_qz_t,
+            grad_parent_qw_t,
+            grad_local_tx,
+            grad_local_ty,
+            grad_local_tz,
+        ) = _rotate_vector_backward(
+            pqx, pqy, pqz, pqw, ltx, lty, ltz, scaled_gtx, scaled_gty, scaled_gtz
+        )
+        (
+            grad_parent_qx_q,
+            grad_parent_qy_q,
+            grad_parent_qz_q,
+            grad_parent_qw_q,
+            grad_local_qx,
+            grad_local_qy,
+            grad_local_qz,
+            grad_local_qw,
+        ) = _quat_multiply_backward(
+            pqx, pqy, pqz, pqw, lqx, lqy, lqz, lqw, gqx, gqy, gqz, gqw
+        )
+        return (
+            grad_parent_qx_t + grad_parent_qx_q,
+            grad_parent_qy_t + grad_parent_qy_q,
+            grad_parent_qz_t + grad_parent_qz_q,
+            grad_parent_qw_t + grad_parent_qw_q,
+            grad_local_tx,
+            grad_local_ty,
+            grad_local_tz,
+            grad_local_qx,
+            grad_local_qy,
+            grad_local_qz,
+            grad_local_qw,
+        )
+
+    @triton.jit
+    def _compute_inactive_joint_gradients(
+        pqx,
+        pqy,
+        pqz,
+        pqw,
+        ltx,
+        lty,
+        ltz,
+        lqx,
+        lqy,
+        lqz,
+        lqw,
+        gqx,
+        gqy,
+        gqz,
+        gqw,
+        scaled_gtx,
+        scaled_gty,
+        scaled_gtz,
+    ):
+        grad_parent_qx_t, grad_parent_qy_t, grad_parent_qz_t, grad_parent_qw_t = (
+            _rotate_vector_backward_parent(
+                pqx, pqy, pqz, pqw, ltx, lty, ltz, scaled_gtx, scaled_gty, scaled_gtz
+            )
+        )
+        grad_parent_qx_q, grad_parent_qy_q, grad_parent_qz_q, grad_parent_qw_q = (
+            _quat_multiply_backward_parent(
+                pqx, pqy, pqz, pqw, lqx, lqy, lqz, lqw, gqx, gqy, gqz, gqw
+            )
+        )
+        return (
+            grad_parent_qx_t + grad_parent_qx_q,
+            grad_parent_qy_t + grad_parent_qy_q,
+            grad_parent_qz_t + grad_parent_qz_q,
+            grad_parent_qw_t + grad_parent_qw_q,
+            scaled_gtx * 0.0,
+            scaled_gty * 0.0,
+            scaled_gtz * 0.0,
+            gqx * 0.0,
+            gqy * 0.0,
+            gqz * 0.0,
+            gqw * 0.0,
+        )
+
+    @triton.jit
+    def _compute_backward_gradients(
+        pqx,
+        pqy,
+        pqz,
+        pqw,
+        ps,
+        ltx,
+        lty,
+        ltz,
+        lqx,
+        lqy,
+        lqz,
+        lqw,
+        ls,
+        gtx,
+        gty,
+        gtz,
+        gqx,
+        gqy,
+        gqz,
+        gqw,
+        gs,
+        compute_joint_grad,
+    ):
+        rtx, rty, rtz = _rotate_vector(pqx, pqy, pqz, pqw, ltx, lty, ltz)
+        scaled_gtx = ps * gtx
+        scaled_gty = ps * gty
+        scaled_gtz = ps * gtz
+        if compute_joint_grad:
+            (
+                grad_parent_qx,
+                grad_parent_qy,
+                grad_parent_qz,
+                grad_parent_qw,
+                grad_local_tx,
+                grad_local_ty,
+                grad_local_tz,
+                grad_local_qx,
+                grad_local_qy,
+                grad_local_qz,
+                grad_local_qw,
+            ) = _compute_active_joint_gradients(
+                pqx,
+                pqy,
+                pqz,
+                pqw,
+                ltx,
+                lty,
+                ltz,
+                lqx,
+                lqy,
+                lqz,
+                lqw,
+                gqx,
+                gqy,
+                gqz,
+                gqw,
+                scaled_gtx,
+                scaled_gty,
+                scaled_gtz,
+            )
+        else:
+            (
+                grad_parent_qx,
+                grad_parent_qy,
+                grad_parent_qz,
+                grad_parent_qw,
+                grad_local_tx,
+                grad_local_ty,
+                grad_local_tz,
+                grad_local_qx,
+                grad_local_qy,
+                grad_local_qz,
+                grad_local_qw,
+            ) = _compute_inactive_joint_gradients(
+                pqx,
+                pqy,
+                pqz,
+                pqw,
+                ltx,
+                lty,
+                ltz,
+                lqx,
+                lqy,
+                lqz,
+                lqw,
+                gqx,
+                gqy,
+                gqz,
+                gqw,
+                scaled_gtx,
+                scaled_gty,
+                scaled_gtz,
+            )
+        return (
+            gtx,
+            gty,
+            gtz,
+            grad_parent_qx,
+            grad_parent_qy,
+            grad_parent_qz,
+            grad_parent_qw,
+            rtx * gtx + rty * gty + rtz * gtz + ls * gs,
+            grad_local_tx,
+            grad_local_ty,
+            grad_local_tz,
+            grad_local_qx,
+            grad_local_qy,
+            grad_local_qz,
+            grad_local_qw,
+            ps * gs,
+        )
+
+    @triton.jit
+    def _accumulate_parent_gradients(
+        grad_work,
+        batch,
+        parent,
+        n_joints,
+        parent_mask,
+        grad_parent_tx,
+        grad_parent_ty,
+        grad_parent_tz,
+        grad_parent_qx,
+        grad_parent_qy,
+        grad_parent_qz,
+        grad_parent_qw,
+        grad_parent_s,
+    ):
+        parent_grad_base = grad_work + batch * n_joints * 8 + parent * 8
+        tl.store(
+            parent_grad_base + 0,
+            tl.load(parent_grad_base + 0, mask=parent_mask, other=0.0) + grad_parent_tx,
+            mask=parent_mask,
+        )
+        tl.store(
+            parent_grad_base + 1,
+            tl.load(parent_grad_base + 1, mask=parent_mask, other=0.0) + grad_parent_ty,
+            mask=parent_mask,
+        )
+        tl.store(
+            parent_grad_base + 2,
+            tl.load(parent_grad_base + 2, mask=parent_mask, other=0.0) + grad_parent_tz,
+            mask=parent_mask,
+        )
+        tl.store(
+            parent_grad_base + 3,
+            tl.load(parent_grad_base + 3, mask=parent_mask, other=0.0) + grad_parent_qx,
+            mask=parent_mask,
+        )
+        tl.store(
+            parent_grad_base + 4,
+            tl.load(parent_grad_base + 4, mask=parent_mask, other=0.0) + grad_parent_qy,
+            mask=parent_mask,
+        )
+        tl.store(
+            parent_grad_base + 5,
+            tl.load(parent_grad_base + 5, mask=parent_mask, other=0.0) + grad_parent_qz,
+            mask=parent_mask,
+        )
+        tl.store(
+            parent_grad_base + 6,
+            tl.load(parent_grad_base + 6, mask=parent_mask, other=0.0) + grad_parent_qw,
+            mask=parent_mask,
+        )
+        tl.store(
+            parent_grad_base + 7,
+            tl.load(parent_grad_base + 7, mask=parent_mask, other=0.0) + grad_parent_s,
+            mask=parent_mask,
+        )
+
+    @triton.jit
+    def _store_joint_param_gradients(
+        joint_params,
+        prerotations,
+        grad_joint_params,
+        batch,
+        joint,
+        n_joints,
+        mask,
+        compute_joint_grad,
+        grad_local_tx,
+        grad_local_ty,
+        grad_local_tz,
+        grad_local_qx,
+        grad_local_qy,
+        grad_local_qz,
+        grad_local_qw,
+        grad_local_s,
+        ls,
+    ):
+        if compute_joint_grad:
+            param_base = joint_params + batch * n_joints * 7 + joint * 7
+            rx = tl.load(param_base + 3, mask=mask, other=0.0)
+            ry = tl.load(param_base + 4, mask=mask, other=0.0)
+            rz = tl.load(param_base + 5, mask=mask, other=0.0)
+            eqx, eqy, eqz, eqw = _euler_to_quaternion(rx, ry, rz)
+
+            pre_base = prerotations + joint * 4
+            pqx_pre = tl.load(pre_base + 0)
+            pqy_pre = tl.load(pre_base + 1)
+            pqz_pre = tl.load(pre_base + 2)
+            pqw_pre = tl.load(pre_base + 3)
+            _, _, _, _, grad_eqx, grad_eqy, grad_eqz, grad_eqw = (
+                _quat_multiply_backward(
+                    pqx_pre,
+                    pqy_pre,
+                    pqz_pre,
+                    pqw_pre,
+                    eqx,
+                    eqy,
+                    eqz,
+                    eqw,
+                    grad_local_qx,
+                    grad_local_qy,
+                    grad_local_qz,
+                    grad_local_qw,
+                )
+            )
+            grad_rx, grad_ry, grad_rz = _euler_backward(
+                rx, ry, rz, grad_eqx, grad_eqy, grad_eqz, grad_eqw
+            )
+
+            grad_base = grad_joint_params + batch * n_joints * 7 + joint * 7
+            tl.store(grad_base + 0, grad_local_tx, mask=mask)
+            tl.store(grad_base + 1, grad_local_ty, mask=mask)
+            tl.store(grad_base + 2, grad_local_tz, mask=mask)
+            tl.store(grad_base + 3, grad_rx, mask=mask)
+            tl.store(grad_base + 4, grad_ry, mask=mask)
+            tl.store(grad_base + 5, grad_rz, mask=mask)
+            tl.store(grad_base + 6, grad_local_s * ls * _LN2, mask=mask)
+
+    @triton.jit
+    def _backward_one_joint(
+        joint_params,
+        offsets,
+        prerotations,
+        parents,
+        active_joints,
+        global_state,
+        grad_work,
+        grad_joint_params,
+        batch,
+        joint,
+        n_joints,
+        mask,
+        HAS_ACTIVE_JOINTS: tl.constexpr,
+    ):
+        ltx, lty, ltz, lqx, lqy, lqz, lqw, ls = _load_local_state(
+            joint_params, offsets, prerotations, batch, joint, n_joints, mask
+        )
+        gtx, gty, gtz, gqx, gqy, gqz, gqw, gs = _load_state(
+            grad_work, batch, joint, n_joints, mask
+        )
+
+        parent, parent_mask, pqx, pqy, pqz, pqw, ps = _load_parent_state(
+            parents, global_state, batch, joint, n_joints, mask
+        )
+        compute_joint_grad = True
+        if HAS_ACTIVE_JOINTS:
+            compute_joint_grad = tl.load(active_joints + joint)
+
+        (
+            grad_parent_tx,
+            grad_parent_ty,
+            grad_parent_tz,
+            grad_parent_qx,
+            grad_parent_qy,
+            grad_parent_qz,
+            grad_parent_qw,
+            grad_parent_s,
+            grad_local_tx,
+            grad_local_ty,
+            grad_local_tz,
+            grad_local_qx,
+            grad_local_qy,
+            grad_local_qz,
+            grad_local_qw,
+            grad_local_s,
+        ) = _compute_backward_gradients(
+            pqx,
+            pqy,
+            pqz,
+            pqw,
+            ps,
+            ltx,
+            lty,
+            ltz,
+            lqx,
+            lqy,
+            lqz,
+            lqw,
+            ls,
+            gtx,
+            gty,
+            gtz,
+            gqx,
+            gqy,
+            gqz,
+            gqw,
+            gs,
+            compute_joint_grad,
+        )
+        _accumulate_parent_gradients(
+            grad_work,
+            batch,
+            parent,
+            n_joints,
+            parent_mask,
+            grad_parent_tx,
+            grad_parent_ty,
+            grad_parent_tz,
+            grad_parent_qx,
+            grad_parent_qy,
+            grad_parent_qz,
+            grad_parent_qw,
+            grad_parent_s,
+        )
+        _store_joint_param_gradients(
+            joint_params,
+            prerotations,
+            grad_joint_params,
+            batch,
+            joint,
+            n_joints,
+            mask,
+            compute_joint_grad,
+            grad_local_tx,
+            grad_local_ty,
+            grad_local_tz,
+            grad_local_qx,
+            grad_local_qy,
+            grad_local_qz,
+            grad_local_qw,
+            grad_local_s,
+            ls,
+        )
+
+    @triton.jit
+    def _backward_kernel(
+        joint_params,
+        offsets,
+        prerotations,
+        parents,
+        active_joints,
+        global_state,
+        grad_work,
+        grad_joint_params,
+        batch_size,
+        n_joints,
+        HAS_ACTIVE_JOINTS: tl.constexpr,
+        BLOCK_BATCH: tl.constexpr,
+    ):
+        batch = tl.program_id(0) * BLOCK_BATCH + tl.arange(0, BLOCK_BATCH)
+        mask = batch < batch_size
+        joint = n_joints - 1
+        while joint >= 0:
+            _backward_one_joint(
+                joint_params,
+                offsets,
+                prerotations,
+                parents,
+                active_joints,
+                global_state,
+                grad_work,
+                grad_joint_params,
+                batch,
+                joint,
+                n_joints,
+                mask,
+                HAS_ACTIVE_JOINTS,
+            )
+            joint -= 1
+
+
+def _require_triton() -> None:
+    if triton is None or tl is None:
+        raise RuntimeError(
+            "Triton FK requested, but Triton is not available in this build."
+        )
+
+
+def _validate_inputs(  # noqa: C901
+    joint_parameters: torch.Tensor,
+    joint_translation_offsets: torch.Tensor,
+    joint_prerotations: torch.Tensor,
+    joint_parents: torch.Tensor,
+) -> None:
+    if not joint_parameters.is_cuda:
+        raise RuntimeError("Triton FK requested, but joint_parameters is on CPU.")
+    if joint_parameters.dtype != torch.float32:
+        raise RuntimeError(
+            "Triton FK currently only supports float32 joint parameters."
+        )
+    if joint_parameters.ndim < 2 or joint_parameters.shape[-1] != 7:
+        raise RuntimeError("joint_parameters must have shape [..., num_joints, 7].")
+    if joint_translation_offsets.device != joint_parameters.device:
+        raise RuntimeError("joint_translation_offsets must be on the same device.")
+    if joint_prerotations.device != joint_parameters.device:
+        raise RuntimeError("joint_prerotations must be on the same device.")
+    if joint_parents.device != joint_parameters.device:
+        raise RuntimeError("joint_parents must be on the same device.")
+    if joint_translation_offsets.dtype != torch.float32:
+        raise RuntimeError("joint_translation_offsets must be float32.")
+    if joint_prerotations.dtype != torch.float32:
+        raise RuntimeError("joint_prerotations must be float32.")
+    if joint_parents.dtype != torch.int32:
+        raise RuntimeError("joint_parents must be int32.")
+    num_joints = joint_parameters.shape[-2]
+    if joint_translation_offsets.shape != (num_joints, 3):
+        raise RuntimeError("joint_translation_offsets must have shape [num_joints, 3].")
+    if joint_prerotations.shape != (num_joints, 4):
+        raise RuntimeError("joint_prerotations must have shape [num_joints, 4].")
+    if joint_parents.shape != (num_joints,):
+        raise RuntimeError("joint_parents must have shape [num_joints].")
+
+
+def _launch_forward(
+    joint_parameters: torch.Tensor,
+    joint_translation_offsets: torch.Tensor,
+    joint_prerotations: torch.Tensor,
+    joint_parents: torch.Tensor,
+) -> torch.Tensor:
+    _validate_inputs(
+        joint_parameters,
+        joint_translation_offsets,
+        joint_prerotations,
+        joint_parents,
+    )
+    _require_triton()
+
+    num_joints = joint_parameters.shape[-2]
+    batch_size = joint_parameters.numel() // (num_joints * 7)
+    output = torch.empty(
+        (*joint_parameters.shape[:-1], 8),
+        device=joint_parameters.device,
+        dtype=joint_parameters.dtype,
+    )
+    grid = (triton.cdiv(batch_size, _BLOCK_BATCH),)
+    _forward_kernel[grid](
+        joint_parameters,
+        joint_translation_offsets,
+        joint_prerotations,
+        joint_parents,
+        output,
+        batch_size,
+        num_joints,
+        BLOCK_BATCH=_BLOCK_BATCH,
+    )
+    return output
+
+
+def _launch_backward(
+    joint_parameters: torch.Tensor,
+    joint_translation_offsets: torch.Tensor,
+    joint_prerotations: torch.Tensor,
+    joint_parents: torch.Tensor,
+    global_state: torch.Tensor,
+    grad_global_state: torch.Tensor,
+    active_joints: torch.Tensor | None,
+) -> torch.Tensor:
+    _require_triton()
+    grad_global_state = grad_global_state.contiguous()
+    grad_work = grad_global_state.clone()
+    has_active_joints = active_joints is not None
+    if active_joints is None:
+        active_joints = torch.empty(
+            (0,),
+            device=joint_parameters.device,
+            dtype=torch.bool,
+        )
+        grad_joint_parameters = torch.empty_like(joint_parameters)
+    else:
+        active_joints = active_joints.contiguous()
+        grad_joint_parameters = torch.zeros_like(joint_parameters)
+
+    num_joints = joint_parameters.shape[-2]
+    batch_size = joint_parameters.numel() // (num_joints * 7)
+    grid = (triton.cdiv(batch_size, _BLOCK_BATCH),)
+    _backward_kernel[grid](
+        joint_parameters,
+        joint_translation_offsets,
+        joint_prerotations,
+        joint_parents,
+        active_joints,
+        global_state,
+        grad_work,
+        grad_joint_parameters,
+        batch_size,
+        num_joints,
+        HAS_ACTIVE_JOINTS=has_active_joints,
+        BLOCK_BATCH=_BLOCK_BATCH,
+    )
+    return grad_joint_parameters
+
+
+class _JointParametersToSkeletonState(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        joint_parameters: torch.Tensor,
+        joint_translation_offsets: torch.Tensor,
+        joint_prerotations: torch.Tensor,
+        joint_parents: torch.Tensor,
+        active_joints: torch.Tensor | None,
+    ) -> torch.Tensor:
+        joint_parameters = joint_parameters.contiguous()
+        joint_translation_offsets = joint_translation_offsets.contiguous()
+        joint_prerotations = joint_prerotations.contiguous()
+        joint_parents = joint_parents.contiguous()
+        output = _launch_forward(
+            joint_parameters,
+            joint_translation_offsets,
+            joint_prerotations,
+            joint_parents,
+        )
+        ctx.save_for_backward(
+            joint_parameters,
+            joint_translation_offsets,
+            joint_prerotations,
+            joint_parents,
+            output,
+        )
+        ctx.active_joints = (
+            active_joints.contiguous() if active_joints is not None else None
+        )
+        return output
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, None, None, None, None]:
+        (
+            joint_parameters,
+            joint_translation_offsets,
+            joint_prerotations,
+            joint_parents,
+            global_state,
+        ) = ctx.saved_tensors
+        grad_joint_parameters = _launch_backward(
+            joint_parameters,
+            joint_translation_offsets,
+            joint_prerotations,
+            joint_parents,
+            global_state,
+            grad_output,
+            ctx.active_joints,
+        )
+        return grad_joint_parameters, None, None, None, None
+
+
+def joint_parameters_to_skeleton_state(
+    joint_parameters: torch.Tensor,
+    joint_translation_offsets: torch.Tensor,
+    joint_prerotations: torch.Tensor,
+    joint_parents: torch.Tensor,
+    active_joints: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return _JointParametersToSkeletonState.apply(
+        joint_parameters,
+        joint_translation_offsets,
+        joint_prerotations,
+        joint_parents,
+        active_joints,
+    )

--- a/pymomentum/backend/triton_quaternion.py
+++ b/pymomentum/backend/triton_quaternion.py
@@ -1,0 +1,242 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_BLOCK_SIZE = 256
+if triton is not None and tl is not None:
+
+    @triton.jit
+    def _normalize_quaternion(x, y, z, w, eps, NORMALIZE: tl.constexpr):
+        if NORMALIZE:
+            norm2 = x * x + y * y + z * z + w * w
+            eps2 = eps * eps
+            inv_norm = tl.rsqrt(tl.maximum(norm2, eps2))
+            return x * inv_norm, y * inv_norm, z * inv_norm, w * inv_norm
+        return x, y, z, w
+
+    @triton.jit
+    def _to_rotation_matrix_kernel(
+        q,
+        output,
+        n_quaternions,
+        eps,
+        NORMALIZE: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_quaternions
+        q_base = q + offsets * 4
+
+        x = tl.load(q_base + 0, mask=mask, other=0.0)
+        y = tl.load(q_base + 1, mask=mask, other=0.0)
+        z = tl.load(q_base + 2, mask=mask, other=0.0)
+        w = tl.load(q_base + 3, mask=mask, other=1.0)
+        x, y, z, w = _normalize_quaternion(x, y, z, w, eps, NORMALIZE)
+
+        xx = x * x
+        yy = y * y
+        zz = z * z
+        xy = x * y
+        xz = x * z
+        xw = x * w
+        yz = y * z
+        yw = y * w
+        zw = z * w
+
+        out_base = output + offsets * 9
+        tl.store(out_base + 0, 1.0 - 2.0 * (yy + zz), mask=mask)
+        tl.store(out_base + 1, 2.0 * (xy - zw), mask=mask)
+        tl.store(out_base + 2, 2.0 * (xz + yw), mask=mask)
+        tl.store(out_base + 3, 2.0 * (xy + zw), mask=mask)
+        tl.store(out_base + 4, 1.0 - 2.0 * (xx + zz), mask=mask)
+        tl.store(out_base + 5, 2.0 * (yz - xw), mask=mask)
+        tl.store(out_base + 6, 2.0 * (xz - yw), mask=mask)
+        tl.store(out_base + 7, 2.0 * (yz + xw), mask=mask)
+        tl.store(out_base + 8, 1.0 - 2.0 * (xx + yy), mask=mask)
+
+    @triton.jit
+    def _to_rotation_matrix_backward_kernel(
+        q,
+        grad_output,
+        grad_q,
+        n_quaternions,
+        eps,
+        NORMALIZE: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_quaternions
+        q_base = q + offsets * 4
+        grad_base = grad_output + offsets * 9
+
+        raw_x = tl.load(q_base + 0, mask=mask, other=0.0)
+        raw_y = tl.load(q_base + 1, mask=mask, other=0.0)
+        raw_z = tl.load(q_base + 2, mask=mask, other=0.0)
+        raw_w = tl.load(q_base + 3, mask=mask, other=1.0)
+        x, y, z, w = _normalize_quaternion(raw_x, raw_y, raw_z, raw_w, eps, NORMALIZE)
+
+        g00 = tl.load(grad_base + 0, mask=mask, other=0.0)
+        g01 = tl.load(grad_base + 1, mask=mask, other=0.0)
+        g02 = tl.load(grad_base + 2, mask=mask, other=0.0)
+        g10 = tl.load(grad_base + 3, mask=mask, other=0.0)
+        g11 = tl.load(grad_base + 4, mask=mask, other=0.0)
+        g12 = tl.load(grad_base + 5, mask=mask, other=0.0)
+        g20 = tl.load(grad_base + 6, mask=mask, other=0.0)
+        g21 = tl.load(grad_base + 7, mask=mask, other=0.0)
+        g22 = tl.load(grad_base + 8, mask=mask, other=0.0)
+
+        gx = (
+            2.0 * y * (g01 + g10)
+            + 2.0 * z * (g02 + g20)
+            + 2.0 * w * (-g12 + g21)
+            - 4.0 * x * (g11 + g22)
+        )
+        gy = (
+            -4.0 * y * (g00 + g22)
+            + 2.0 * x * (g01 + g10)
+            + 2.0 * w * (g02 - g20)
+            + 2.0 * z * (g12 + g21)
+        )
+        gz = (
+            -4.0 * z * (g00 + g11)
+            + 2.0 * x * (g02 + g20)
+            + 2.0 * y * (g12 + g21)
+            + 2.0 * w * (-g01 + g10)
+        )
+        gw = 2.0 * z * (-g01 + g10) + 2.0 * y * (g02 - g20) + 2.0 * x * (-g12 + g21)
+
+        if NORMALIZE:
+            norm2 = raw_x * raw_x + raw_y * raw_y + raw_z * raw_z + raw_w * raw_w
+            eps2 = eps * eps
+            inv_norm = tl.rsqrt(tl.maximum(norm2, eps2))
+            dot = gx * x + gy * y + gz * z + gw * w
+            unclamped_gx = (gx - x * dot) * inv_norm
+            unclamped_gy = (gy - y * dot) * inv_norm
+            unclamped_gz = (gz - z * dot) * inv_norm
+            unclamped_gw = (gw - w * dot) * inv_norm
+            clamped_gx = gx * inv_norm
+            clamped_gy = gy * inv_norm
+            clamped_gz = gz * inv_norm
+            clamped_gw = gw * inv_norm
+            is_unclamped = norm2 >= eps2
+            gx = tl.where(is_unclamped, unclamped_gx, clamped_gx)
+            gy = tl.where(is_unclamped, unclamped_gy, clamped_gy)
+            gz = tl.where(is_unclamped, unclamped_gz, clamped_gz)
+            gw = tl.where(is_unclamped, unclamped_gw, clamped_gw)
+
+        out_base = grad_q + offsets * 4
+        tl.store(out_base + 0, gx, mask=mask)
+        tl.store(out_base + 1, gy, mask=mask)
+        tl.store(out_base + 2, gz, mask=mask)
+        tl.store(out_base + 3, gw, mask=mask)
+
+
+def _require_triton() -> None:
+    if triton is None or tl is None:
+        raise RuntimeError(
+            "Triton quaternion backend requested, but Triton is not available "
+            "in this build."
+        )
+
+
+def _validate_quaternions(q: torch.Tensor, eps: float) -> None:
+    if not q.is_cuda:
+        raise RuntimeError("Triton quaternion backend requested, but input is on CPU.")
+    if q.dtype != torch.float32:
+        raise RuntimeError("Triton quaternion backend currently only supports float32.")
+    if q.ndim == 0 or q.shape[-1] != 4:
+        raise RuntimeError("Quaternion tensor must have shape [..., 4].")
+    if eps <= 0.0:
+        raise RuntimeError("eps must be positive.")
+
+
+def _launch_forward(q: torch.Tensor, normalize: bool, eps: float) -> torch.Tensor:
+    _validate_quaternions(q, eps)
+    _require_triton()
+    n_quaternions = q.numel() // 4
+    output = torch.empty(
+        (*q.shape[:-1], 3, 3),
+        device=q.device,
+        dtype=q.dtype,
+    )
+    grid = (triton.cdiv(n_quaternions, _BLOCK_SIZE),)
+    _to_rotation_matrix_kernel[grid](
+        q,
+        output,
+        n_quaternions,
+        eps,
+        NORMALIZE=normalize,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return output
+
+
+def _launch_backward(
+    q: torch.Tensor,
+    grad_output: torch.Tensor,
+    normalize: bool,
+    eps: float,
+) -> torch.Tensor:
+    _require_triton()
+    grad_output = grad_output.contiguous()
+    grad_q = torch.empty_like(q)
+    n_quaternions = q.numel() // 4
+    grid = (triton.cdiv(n_quaternions, _BLOCK_SIZE),)
+    _to_rotation_matrix_backward_kernel[grid](
+        q,
+        grad_output,
+        grad_q,
+        n_quaternions,
+        eps,
+        NORMALIZE=normalize,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return grad_q
+
+
+class _ToRotationMatrix(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        q: torch.Tensor,
+        normalize: bool,
+        eps: float,
+    ) -> torch.Tensor:
+        q = q.contiguous()
+        output = _launch_forward(q, normalize, eps)
+        ctx.save_for_backward(q)
+        ctx.normalize = normalize
+        ctx.eps = eps
+        return output
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor, None, None]:
+        (q,) = ctx.saved_tensors
+        grad_q = _launch_backward(q, grad_output, ctx.normalize, ctx.eps)
+        return grad_q, None, None
+
+
+def to_rotation_matrix(q: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
+    return _ToRotationMatrix.apply(q, True, eps)
+
+
+def to_rotation_matrix_assume_normalized(q: torch.Tensor) -> torch.Tensor:
+    return _ToRotationMatrix.apply(q, False, 1.0)

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -19,6 +19,8 @@ backend_torch_sources = [
 ]
 
 backend_triton_sources = [
+    "backend/triton_common.py",
+    "backend/triton_fk.py",
     "backend/triton_quaternion.py",
 ]
 

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -3,6 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+backend_common_sources = [
+    "backend/selection.py",
+]
+
 backend_torch_core_sources = [
     "backend/skel_state_torch.py",
     "backend/torch_quaternion.py",
@@ -12,6 +16,10 @@ backend_torch_sources = [
     "backend/skel_state_backend.py",
     "backend/trs_backend.py",
     "backend/utils.py",
+]
+
+backend_triton_sources = [
+    "backend/triton_quaternion.py",
 ]
 
 python_utility_public_headers = [

--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -67,8 +67,16 @@ from collections.abc import Sequence
 
 import torch
 from pymomentum.backend import torch_quaternion
+from pymomentum.backend.selection import resolve_backend
 
 # pyre-strict
+
+
+def _get_triton_quaternion():  # type: ignore[no-untyped-def]
+    """Lazy import to avoid circular dependency with pymomentum.backend."""
+    from pymomentum.backend import triton_quaternion
+
+    return triton_quaternion
 
 
 def check(q: torch.Tensor) -> None:
@@ -191,24 +199,49 @@ def rotate_vector_assume_normalized(q: torch.Tensor, v: torch.Tensor) -> torch.T
     return torch_quaternion.rotate_vector_assume_normalized(q, v)
 
 
-def to_rotation_matrix_assume_normalized(q: torch.Tensor) -> torch.Tensor:
+def to_rotation_matrix_assume_normalized(
+    q: torch.Tensor, backend: str = "torch"
+) -> torch.Tensor:
     """
     Convert quaternions to 3x3 rotation matrices.
 
     :parameter q: (nBatch x k x 4) tensor with the quaternions in ((x, y, z), w) format.
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
     :return: (nBatch x k x 3 x 3) tensor with 3x3 rotation matrices.
     """
+    backend = resolve_backend(
+        backend,
+        q,
+        use_double_precision=q.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _get_triton_quaternion().to_rotation_matrix_assume_normalized(q)
+    if backend != "torch":
+        raise ValueError(f"Unsupported quaternion backend: {backend}")
     return torch_quaternion.to_rotation_matrix_assume_normalized(q)
 
 
-def to_rotation_matrix(q: torch.Tensor) -> torch.Tensor:
+def to_rotation_matrix(
+    q: torch.Tensor, backend: str = "torch", eps: float = 1e-12
+) -> torch.Tensor:
     """
     Convert quaternions to 3x3 rotation matrices.
 
     :parameter q: (nBatch x k x 4) tensor with the quaternions in ((x, y, z), w) format.
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
+    :parameter eps: Minimum quaternion norm used during normalization.
     :return: (nBatch x k x 3 x 3) tensor with 3x3 rotation matrices.
     """
-    return torch_quaternion.to_rotation_matrix(q)
+    backend = resolve_backend(
+        backend,
+        q,
+        use_double_precision=q.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _get_triton_quaternion().to_rotation_matrix(q, eps=eps)
+    if backend != "torch":
+        raise ValueError(f"Unsupported quaternion backend: {backend}")
+    return torch_quaternion.to_rotation_matrix(q, eps=eps)
 
 
 def identity(

--- a/pymomentum/test/test_quaternion.py
+++ b/pymomentum/test/test_quaternion.py
@@ -87,6 +87,11 @@ class TestQuaternion(unittest.TestCase):
             torch.norm(mats2 - mats), 1e-4, "Expected quaternions to match (up to sign)"
         )
 
+    def test_triton_backend_requires_cuda(self) -> None:
+        quats = generateRandomQuats(3).to(torch.float32)
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            quaternion.to_rotation_matrix(quats, backend="triton")
+
     def test_multiply(self) -> None:
         torch.manual_seed(0)  # ensure repeatability
         nMat = 5

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -5,14 +5,20 @@
 
 # pyre-strict
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pymomentum.geometry as pym_geometry  # @manual=:geometry
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.skel_state as pym_skel_state
 import pymomentum.trs as pym_trs
 import torch
-from pymomentum.backend import skel_state_backend, trs_backend, utils as backend_utils
+from pymomentum.backend import (
+    skel_state_backend,
+    triton_fk,
+    trs_backend,
+    utils as backend_utils,
+)
+from pymomentum.backend.selection import resolve_backend
 from pymomentum.torch.parameter_limits import ParameterLimits
 from pymomentum.torch.utility import _unsqueeze_joint_params
 
@@ -87,9 +93,10 @@ class Skeleton(torch.nn.Module):
         local_state_s = torch.exp(0.6931471824645996 * joint_parameters[..., 6:])
         return torch.cat([local_state_t, local_state_q, local_state_s], dim=-1)
 
+    @torch.jit.unused
     def joint_parameters_to_local_trs(
         self, joint_parameters: torch.Tensor
-    ) -> pym_trs.TRSTransform:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Convert joint parameters to local TRS (Translation-Rotation-Scale) state.
 
@@ -136,9 +143,10 @@ class Skeleton(torch.nn.Module):
             joint_rotation=joint_rotation_matrices,
         )
 
+    @torch.jit.unused
     def joint_parameters_to_trs(
         self, joint_parameters: torch.Tensor
-    ) -> pym_trs.TRSTransform:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Convert joint parameters directly to global TRS (Translation-Rotation-Scale) state.
 
@@ -183,10 +191,11 @@ class Skeleton(torch.nn.Module):
             ),
         )
 
+    @torch.jit.unused
     def local_trs_to_global_trs(
         self,
-        local_trs: pym_trs.TRSTransform,
-    ) -> pym_trs.TRSTransform:
+        local_trs: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Convert local TRS state to global TRS state using forward kinematics.
 
@@ -222,10 +231,11 @@ class Skeleton(torch.nn.Module):
             ),
         )
 
+    @torch.jit.unused
     def global_trs_to_local_trs(
         self,
-        global_trs: pym_trs.TRSTransform,
-    ) -> pym_trs.TRSTransform:
+        global_trs: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Convert global TRS state to local TRS state.
 
@@ -274,14 +284,24 @@ class Skeleton(torch.nn.Module):
         local_skel_state: torch.Tensor,
         use_double_precision: bool = True,
     ) -> torch.Tensor:
+        prefix_mul_indices = list(
+            self.pmi.split(
+                split_size=self._pmi_buffer_sizes,
+                dim=1,
+            )
+        )
+        if torch.jit.is_scripting():
+            global_skel_state, _ = (
+                skel_state_backend.global_skel_state_from_local_skel_state_impl(
+                    local_skel_state=local_skel_state,
+                    prefix_mul_indices=prefix_mul_indices,
+                    use_double_precision=use_double_precision,
+                )
+            )
+            return global_skel_state
         return skel_state_backend.global_skel_state_from_local_skel_state(
             local_skel_state=local_skel_state,
-            prefix_mul_indices=list(
-                self.pmi.split(
-                    split_size=self._pmi_buffer_sizes,
-                    dim=1,
-                )
-            ),
+            prefix_mul_indices=prefix_mul_indices,
             use_double_precision=use_double_precision,
         )
 
@@ -337,17 +357,70 @@ class Skeleton(torch.nn.Module):
         ).flatten(-2, -1)
 
     def skeleton_state_to_joint_parameters(
-        self, skel_state: torch.Tensor
+        self,
+        skel_state: torch.Tensor,
     ) -> torch.Tensor:
         return self.local_skeleton_state_to_joint_parameters(
             self.skeleton_state_to_local_skeleton_state(skel_state)
         )
 
-    def forward(self, joint_parameters: torch.Tensor) -> torch.Tensor:
+    def joint_parameters_to_skeleton_state(
+        self,
+        joint_parameters: torch.Tensor,
+        use_double_precision: bool = True,
+        fk_backend: str = "auto",
+        active_joints: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if torch.jit.is_scripting():
+            resolved = "torch" if fk_backend == "auto" else fk_backend
+        else:
+            resolved = resolve_backend(
+                fk_backend, joint_parameters.float(), use_double_precision
+            )
+        if resolved == "triton" and use_double_precision:
+            raise RuntimeError(
+                "Triton FK does not support double precision; "
+                "pass use_double_precision=False"
+            )
+        if resolved == "triton":
+            with torch.amp.autocast("cuda", enabled=False):
+                return triton_fk.joint_parameters_to_skeleton_state(
+                    _unsqueeze_joint_params(joint_parameters.float()),
+                    self.joint_translation_offsets,
+                    self.joint_prerotations,
+                    self.joint_parents,
+                    active_joints,
+                )
+        return self.local_skeleton_state_to_skeleton_state(
+            self.joint_parameters_to_local_skeleton_state(joint_parameters),
+            use_double_precision=use_double_precision,
+        )
+
+    def forward(
+        self,
+        joint_parameters: torch.Tensor,
+        use_double_precision: bool = True,
+    ) -> torch.Tensor:
         if joint_parameters.ndim == 1:
             joint_parameters = joint_parameters[None, :]
-        return self.local_skeleton_state_to_skeleton_state(
-            self.joint_parameters_to_local_skeleton_state(joint_parameters)
+        if torch.jit.is_scripting():
+            global_skel_state, _ = (
+                skel_state_backend.global_skel_state_from_local_skel_state_impl(
+                    local_skel_state=self.joint_parameters_to_local_skeleton_state(
+                        joint_parameters
+                    ),
+                    prefix_mul_indices=list(
+                        self.pmi.split(
+                            split_size=self._pmi_buffer_sizes,
+                            dim=1,
+                        )
+                    ),
+                    use_double_precision=use_double_precision,
+                )
+            )
+            return global_skel_state
+        return self.joint_parameters_to_skeleton_state(
+            joint_parameters, use_double_precision=use_double_precision
         )
 
 
@@ -413,7 +486,7 @@ class LinearBlendSkinning(torch.nn.Module):
 
     def skin_with_trs(
         self,
-        global_trs: pym_trs.TRSTransform,
+        global_trs: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
         rest_vertex_positions: torch.Tensor,
     ) -> torch.Tensor:
         """
@@ -611,6 +684,10 @@ class ParameterTransform(torch.nn.Module):
             torch.tensor(
                 character.parameter_transform.scaling_parameters, requires_grad=False
             ),
+        )
+        self.register_buffer(
+            "active_joints",
+            self.parameter_transform.ne(0).any(dim=1).reshape(-1, 7).any(dim=1),
         )
 
         self.parameter_names: list[str] = character.parameter_transform.names
@@ -873,22 +950,40 @@ class Character(torch.nn.Module):
         self,
         joint_parameters: torch.Tensor,
         use_double_precision: bool = True,
+        fk_backend: str = "torch",
+        active_joints: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        local_skel_state = self.joint_parameters_to_local_skeleton_state(
-            joint_parameters
-        )
-        return self.local_skeleton_state_to_skeleton_state(
-            local_skel_state, use_double_precision=use_double_precision
+        if not hasattr(self, "skeleton"):
+            raise RuntimeError("Character has no skeleton, please provide one")
+        return self.skeleton.joint_parameters_to_skeleton_state(
+            joint_parameters,
+            use_double_precision=use_double_precision,
+            fk_backend=fk_backend,
+            active_joints=active_joints,
         )
 
     def model_parameters_to_skeleton_state(
         self,
         model_parameters: torch.Tensor,
         use_double_precision: bool = True,
+        fk_backend: str = "torch",
     ) -> torch.Tensor:
+        if not hasattr(self, "parameter_transform"):
+            raise RuntimeError(
+                "Character has no parameter transform, please provide one"
+            )
+        if torch.jit.is_scripting():
+            resolved = "torch" if fk_backend == "auto" else fk_backend
+        else:
+            resolved = resolve_backend(
+                fk_backend, model_parameters.float(), use_double_precision
+            )
+        active_joints = self.parameter_transform.active_joints
         return self.joint_parameters_to_skeleton_state(
             self.model_parameters_to_joint_parameters(model_parameters),
             use_double_precision=use_double_precision,
+            fk_backend=resolved,
+            active_joints=active_joints,
         )
 
     def model_parameters_to_blendshape_coefficients(
@@ -904,7 +999,7 @@ class Character(torch.nn.Module):
     def skin_points(
         self,
         skel_state: torch.Tensor,
-        rest_vertex_positions: torch.Tensor | None = None,
+        rest_vertex_positions: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if rest_vertex_positions is None:
             if not hasattr(self, "mesh"):


### PR DESCRIPTION
Summary:

Adds the final-location Triton forward-kinematics backend for `pymomentum.torch.character`, including shared Triton quaternion primitives, backend packaging updates, API selection for `fk_backend`, and a CPU validation test for explicit Triton FK selection.

Also adds a GPU benchmark (`triton_fk_benchmark`) comparing the torch and triton backends. On an A100, the triton backend shows ~6.5x lower peak GPU memory and ~12-15x faster execution for forward+backward passes:

```
num_joints=100, batch_size=256
  torch    forward          mean=6.86ms
  torch    forward+backward mean=16.04ms
  torch    peak memory      forward=7416.0KB  forward+backward=10378.0KB
  triton   forward          mean=0.57ms
  triton   forward+backward mean=1.33ms
  triton   peak memory      forward=800.0KB  forward+backward=1600.0KB
```

The memory reduction comes from the custom autograd function saving only the input joint parameters and output skeleton state for backward, rather than all intermediate tensors from composed PyTorch operations.

Reviewed By: yutingye

Differential Revision: D106041801


