### PR TITLE
Support local center-of-mass offsets (#1426)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,6 +850,7 @@ if(MOMENTUM_BUILD_TESTING)
       character_test_helpers
       error_function_helper
       solver_test_helper
+      test_helpers
   )
 
   if(NOT APPLE) # TODO: Fix

--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -24,6 +24,115 @@
 
 namespace momentum {
 
+namespace {
+
+ParameterTransform zeroActiveJointOffsets(
+    ParameterTransform parameterTransform,
+    const std::vector<bool>& activeJoints) {
+  for (size_t jointIndex = 0; jointIndex < activeJoints.size(); ++jointIndex) {
+    if (!activeJoints[jointIndex]) {
+      continue;
+    }
+
+    for (size_t offset = 0; offset < kParametersPerJoint; ++offset) {
+      parameterTransform.offsets(jointIndex * kParametersPerJoint + offset) = 0.0f;
+    }
+  }
+
+  return parameterTransform;
+}
+
+struct SimplifiedJointPlacement {
+  size_t parent = kInvalidIndex;
+  size_t retainedAncestor = kInvalidIndex;
+  Vector3f translationOffset = Vector3f::Zero();
+};
+
+SimplifiedJointPlacement getSimplifiedJointPlacement(
+    const Skeleton& skeleton,
+    const SkeletonState& referenceState,
+    const std::vector<size_t>& lastJoint,
+    const size_t jointIndex) {
+  const Joint& joint = skeleton.joints.at(jointIndex);
+  if (joint.parent == kInvalidIndex) {
+    return {kInvalidIndex, jointIndex, joint.translationOffset};
+  }
+
+  size_t retainedAncestor = jointIndex;
+  size_t simplifiedParent = kInvalidIndex;
+  while (simplifiedParent == kInvalidIndex && retainedAncestor != kInvalidIndex) {
+    retainedAncestor = skeleton.joints.at(retainedAncestor).parent;
+    if (retainedAncestor != kInvalidIndex) {
+      simplifiedParent = lastJoint.at(retainedAncestor);
+    }
+  }
+
+  const Vector3f offset = retainedAncestor != kInvalidIndex
+      ? referenceState.jointState.at(retainedAncestor).transform.inverse() *
+          referenceState.jointState.at(jointIndex).translation()
+      : referenceState.jointState.at(jointIndex).translation();
+  return {simplifiedParent, retainedAncestor, offset};
+}
+
+Joint makeSimplifiedJoint(
+    const Skeleton& skeleton,
+    const size_t jointIndex,
+    const SimplifiedJointPlacement& placement) {
+  Joint result = skeleton.joints.at(jointIndex);
+  result.parent = placement.parent;
+  result.translationOffset = placement.translationOffset;
+
+  size_t parent = skeleton.joints.at(jointIndex).parent;
+  while (parent != placement.retainedAncestor && parent != kInvalidIndex) {
+    result.preRotation = skeleton.joints.at(parent).preRotation * result.preRotation;
+    parent = skeleton.joints.at(parent).parent;
+  }
+
+  return result;
+}
+
+size_t findSimplifiedAncestor(
+    const Skeleton& skeleton,
+    const std::vector<size_t>& intermediateJointMap,
+    const size_t jointIndex) {
+  size_t ancestor = jointIndex;
+  while (ancestor != kInvalidIndex && intermediateJointMap.at(ancestor) == kInvalidIndex) {
+    ancestor = skeleton.joints.at(ancestor).parent;
+  }
+
+  MT_THROW_IF(
+      ancestor == kInvalidIndex,
+      "During skeleton simplification, inactive joint '{}' has no valid parent joint.  "
+      "Every joint in the simplified skeleton must have at least one parent joint that is not disabled.",
+      skeleton.joints.at(jointIndex).name);
+  return intermediateJointMap.at(ancestor);
+}
+
+std::unique_ptr<CollisionGeometry> remapCollisionGeometry(
+    const CollisionGeometry* collision,
+    const std::vector<size_t>& jointMap,
+    const SkeletonState& sourceBindState,
+    const SkeletonState& targetBindState) {
+  if (collision == nullptr) {
+    return {};
+  }
+
+  auto result = std::make_unique<CollisionGeometry>(*collision);
+  for (auto& collisionGeometry : *result) {
+    const auto oldParent = collisionGeometry.parent;
+    collisionGeometry.parent = jointMap.at(collisionGeometry.parent);
+    // Re-express the collision shape's local transform in the new parent's frame:
+    //   newLocal = targetParentBind^-1 * sourceParentBind * oldLocal
+    collisionGeometry.transformation =
+        targetBindState.jointState.at(collisionGeometry.parent).transform.inverse() *
+        sourceBindState.jointState.at(oldParent).transform * collisionGeometry.transformation;
+  }
+
+  return result;
+}
+
+} // namespace
+
 Character::Character(
     const Skeleton& s,
     const ParameterTransform& pt,
@@ -201,22 +310,9 @@ Character Character::simplifySkeleton(const std::vector<bool>& activeJoints) con
   //  start by remapping the skeleton and parameter transform
   // -------------------------------------------------------------------
 
-  // Running count of joints kept in the simplified skeleton.
-  size_t jointCount = 0;
-
   // Build a parameter transform whose offsets are zero for active joints but preserved for
   // inactive ones, so the reference state below "bakes" the inactive offsets in.
-  auto zeroTransform = parameterTransform;
-
-  for (size_t jointIndex = 0; jointIndex < activeJoints.size(); ++jointIndex) {
-    // Zero the offsets for active joints; inactive joints keep their offsets so their effect is
-    // captured in the reference state's world transforms below.
-    if (activeJoints[jointIndex]) {
-      for (size_t o = 0; o < kParametersPerJoint; o++) {
-        zeroTransform.offsets(jointIndex * kParametersPerJoint + o) = 0.0f;
-      }
-    }
-  }
+  const auto zeroTransform = zeroActiveJointOffsets(parameterTransform, activeJoints);
 
   // Maps each original joint index to its position in `simplifiedSkeleton.joints` (or
   // kInvalidIndex if the joint is dropped). Populated below as we iterate.
@@ -236,68 +332,22 @@ Character Character::simplifySkeleton(const std::vector<bool>& activeJoints) con
 
   std::vector<size_t> simplifiedJointMap(skeleton.joints.size(), kInvalidIndex);
   for (size_t aIndex = 0; aIndex < skeleton.joints.size(); aIndex++) {
-    const Joint& j = skeleton.joints[aIndex];
-
-    // Walk up the original hierarchy to find the nearest active ancestor; that becomes this
-    // joint's parent in the simplified skeleton, with the offset re-expressed in the new
-    // parent's local frame.
-    Vector3f offset = j.translationOffset;
-    size_t currentParent = kInvalidIndex;
-    size_t sIndex = aIndex;
-    if (j.parent != kInvalidIndex) {
-      while (currentParent == kInvalidIndex && sIndex != kInvalidIndex) {
-        sIndex = skeleton.joints[sIndex].parent;
-        if (sIndex == kInvalidIndex) {
-          break;
-        }
-        currentParent = lastJoint.at(sIndex);
-      }
-      // Re-express the joint's translation in the (new) parent's local frame; if no parent
-      // remains, the translation is in world space (root joint case).
-      if (sIndex != kInvalidIndex) {
-        offset = referenceState.jointState[sIndex].transform.inverse() *
-            referenceState.jointState[aIndex].translation();
-      } else {
-        offset = referenceState.jointState[aIndex].translation();
-      }
-    }
+    // `retainedAncestor` identifies the original ancestor whose simplified mapping supplies the
+    // new parent frame. Dropped joints between it and this joint are folded into the kept joint.
+    const auto placement = getSimplifiedJointPlacement(skeleton, referenceState, lastJoint, aIndex);
 
     if (activeJoints[aIndex]) {
-      Joint jt = j;
-
-      jt.parent = currentParent;
-
-      jt.translationOffset = offset;
-
-      // Compose pre-rotations from every dropped intermediate ancestor into this joint, so the
-      // pruned hierarchy still produces the same orientation chain.
-      size_t parent = j.parent;
-      while (parent != sIndex && parent != kInvalidIndex) {
-        jt.preRotation = skeleton.joints[parent].preRotation * jt.preRotation;
-        parent = skeleton.joints[parent].parent;
-      }
-
-      simplifiedSkeleton.joints.push_back(jt);
-
-      intermediateJointMap.at(aIndex) = jointCount;
-      jointCount++;
-      lastJoint.at(aIndex) = simplifiedSkeleton.joints.size() - 1;
-
-      simplifiedJointMap.at(aIndex) = jointCount - 1;
+      simplifiedSkeleton.joints.push_back(makeSimplifiedJoint(skeleton, aIndex, placement));
+      const size_t newJointIndex = simplifiedSkeleton.joints.size() - 1;
+      intermediateJointMap.at(aIndex) = newJointIndex;
+      lastJoint.at(aIndex) = newJointIndex;
+      simplifiedJointMap.at(aIndex) = newJointIndex;
     } else {
       // Inactive joints are not added to the simplified skeleton; instead, point their entry in
       // simplifiedJointMap at the nearest active ancestor so consumers (locators, skin weights,
       // etc.) can still resolve them.
-      size_t index = aIndex;
-      while (index != kInvalidIndex && intermediateJointMap.at(index) == kInvalidIndex) {
-        index = skeleton.joints[index].parent;
-      }
-      MT_THROW_IF(
-          index == kInvalidIndex,
-          "During skeleton simplification, inactive joint '{}' has no valid parent joint.  "
-          "Every joint in the simplified skeleton must have at least one parent joint that is not disabled.",
-          skeleton.joints.at(aIndex).name);
-      simplifiedJointMap.at(aIndex) = intermediateJointMap.at(index);
+      simplifiedJointMap.at(aIndex) =
+          findSimplifiedAncestor(skeleton, intermediateJointMap, aIndex);
     }
   }
   MT_THROW_IF(
@@ -342,18 +392,8 @@ Character Character::simplifySkeleton(const std::vector<bool>& activeJoints) con
   // -------------------------------------------------------------------
   //  remap the collision if we have any
   // -------------------------------------------------------------------
-  if (collision != nullptr) {
-    result.collision = std::make_unique<CollisionGeometry>(*collision);
-    for (auto&& c : *result.collision) {
-      const auto oldParent = c.parent;
-      c.parent = result.jointMap.at(c.parent);
-      // Re-express the collision shape's local transform in the new parent's frame:
-      //   newLocal = targetParentBind^-1 * sourceParentBind * oldLocal
-      c.transformation =
-          (targetBindState.jointState[c.parent].transform.inverse() *
-           sourceBindState.jointState[oldParent].transform * c.transformation);
-    }
-  }
+  result.collision =
+      remapCollisionGeometry(collision.get(), result.jointMap, sourceBindState, targetBindState);
 
   return result;
 }

--- a/momentum/character/character.cpp
+++ b/momentum/character/character.cpp
@@ -10,6 +10,7 @@
 #include "momentum/character/blend_shape.h"
 #include "momentum/character/blend_shape_skinning.h"
 #include "momentum/character/character_state.h"
+#include "momentum/character/character_utility.h"
 #include "momentum/character/collision_geometry.h"
 #include "momentum/character/joint.h"
 #include "momentum/character/linear_skinning.h"
@@ -21,6 +22,7 @@
 
 #include <numeric>
 #include <utility>
+#include <vector>
 
 namespace momentum {
 
@@ -108,6 +110,116 @@ size_t findSimplifiedAncestor(
   return intermediateJointMap.at(ancestor);
 }
 
+Matrix3f inertiaInJointFrame(const JointPhysicalProperties& properties) {
+  const Matrix3f inertiaRotation = properties.inertiaRotation.toRotationMatrix();
+  return inertiaRotation * properties.inertia * inertiaRotation.transpose();
+}
+
+void addParallelAxisShift(Matrix3f& inertia, const float mass, const Vector3f& offset) {
+  const float dx = offset.x();
+  const float dy = offset.y();
+  const float dz = offset.z();
+  inertia(0, 0) += mass * (dy * dy + dz * dz);
+  inertia(1, 1) += mass * (dx * dx + dz * dz);
+  inertia(2, 2) += mass * (dx * dx + dy * dy);
+
+  const float xy = -mass * dx * dy;
+  const float xz = -mass * dx * dz;
+  const float yz = -mass * dy * dz;
+  inertia(0, 1) += xy;
+  inertia(1, 0) += xy;
+  inertia(0, 2) += xz;
+  inertia(2, 0) += xz;
+  inertia(1, 2) += yz;
+  inertia(2, 1) += yz;
+}
+
+Matrix3f inertiaShiftedToCenter(
+    const JointPhysicalProperties& properties,
+    const Vector3f& centerOfMassOffset) {
+  Matrix3f result = inertiaInJointFrame(properties);
+  const Vector3f offset = properties.centerOfMassOffset - centerOfMassOffset;
+  addParallelAxisShift(result, properties.mass, offset);
+  return result;
+}
+
+void symmetrizeInPlace(Matrix3f& inertia) {
+  const float xy = 0.5f * (inertia(0, 1) + inertia(1, 0));
+  const float xz = 0.5f * (inertia(0, 2) + inertia(2, 0));
+  const float yz = 0.5f * (inertia(1, 2) + inertia(2, 1));
+  inertia(0, 1) = xy;
+  inertia(1, 0) = xy;
+  inertia(0, 2) = xz;
+  inertia(2, 0) = xz;
+  inertia(1, 2) = yz;
+  inertia(2, 1) = yz;
+}
+
+void mergePhysicalProperties(
+    JointPhysicalProperties& target,
+    const JointPhysicalProperties& source) {
+  const float mergedMass = target.mass + source.mass;
+  const Vector3f mergedCenterOfMassOffset = mergedMass > 0.0f
+      ? (target.mass * target.centerOfMassOffset + source.mass * source.centerOfMassOffset) /
+          mergedMass
+      : target.centerOfMassOffset;
+  Matrix3f mergedInertia = inertiaShiftedToCenter(target, mergedCenterOfMassOffset) +
+      inertiaShiftedToCenter(source, mergedCenterOfMassOffset);
+  symmetrizeInPlace(mergedInertia);
+
+  target.mass = mergedMass;
+  target.centerOfMassOffset = mergedCenterOfMassOffset;
+  target.inertia = mergedInertia;
+  target.inertiaRotation = Quaternionf::Identity();
+}
+
+PhysicalProperties remapPhysicalProperties(
+    const PhysicalProperties& physicalProperties,
+    const Skeleton& sourceSkeleton,
+    const Skeleton& targetSkeleton,
+    const std::vector<size_t>& jointMap,
+    const SkeletonState& sourceBindState,
+    const SkeletonState& targetBindState) {
+  PhysicalProperties result;
+  result.reserve(physicalProperties.size());
+  std::vector<size_t> resultIndexByJoint(targetSkeleton.joints.size(), kInvalidIndex);
+
+  for (const auto& jointProperties : physicalProperties) {
+    const size_t oldJointIndex =
+        resolvePhysicalPropertiesJointIndex(jointProperties, sourceSkeleton);
+    if (oldJointIndex == kInvalidIndex || oldJointIndex >= jointMap.size()) {
+      continue;
+    }
+
+    const size_t newJointIndex = jointMap[oldJointIndex];
+    if (newJointIndex == kInvalidIndex || newJointIndex >= targetSkeleton.joints.size()) {
+      continue;
+    }
+
+    JointPhysicalProperties mappedProperties = jointProperties;
+    mappedProperties.jointIndex = newJointIndex;
+    mappedProperties.jointName = targetSkeleton.joints.at(newJointIndex).name;
+
+    const auto oldToNewLocal = targetBindState.jointState.at(newJointIndex).transform.inverse() *
+        sourceBindState.jointState.at(oldJointIndex).transform;
+    mappedProperties.centerOfMassOffset = oldToNewLocal * jointProperties.centerOfMassOffset;
+    mappedProperties.inertiaRotation =
+        (oldToNewLocal.rotation * jointProperties.inertiaRotation).normalized();
+
+    // Skeleton simplification can fold multiple source joints into one target joint. Keep the
+    // one-body-per-joint invariant by merging those bodies in the target joint frame.
+    size_t& resultIndex = resultIndexByJoint.at(newJointIndex);
+    if (resultIndex == kInvalidIndex) {
+      resultIndex = result.size();
+      result.push_back(std::move(mappedProperties));
+    } else {
+      mergePhysicalProperties(result.at(resultIndex), mappedProperties);
+    }
+  }
+
+  return result;
+}
+
 std::unique_ptr<CollisionGeometry> remapCollisionGeometry(
     const CollisionGeometry* collision,
     const std::vector<size_t>& jointMap,
@@ -147,12 +259,14 @@ Character::Character(
     const std::string& nameIn,
     const momentum::TransformationList& inverseBindPose_in,
     const SkinnedLocatorList& skinnedLocators,
-    std::string_view metadataIn)
+    std::string_view metadataIn,
+    const PhysicalProperties& physicalPropertiesIn)
     : skeleton(s),
       parameterTransform(pt),
       parameterLimits(pl),
       locators(l),
       skinnedLocators(skinnedLocators),
+      physicalProperties(physicalPropertiesIn),
       blendShape(std::move(blendShapes)),
       faceExpressionBlendShape(std::move(faceExpressionBlendShapes)),
       inverseBindPose(inverseBindPose_in),
@@ -188,6 +302,7 @@ Character::Character(const Character& c)
       parameterLimits(c.parameterLimits),
       locators(c.locators),
       skinnedLocators(c.skinnedLocators),
+      physicalProperties(c.physicalProperties),
       blendShape(c.blendShape),
       faceExpressionBlendShape(c.faceExpressionBlendShape),
       inverseBindPose(c.inverseBindPose),
@@ -232,6 +347,7 @@ Character& Character::operator=(const Character& rhs) {
   std::swap(poseShapes, tmp.poseShapes);
   std::swap(skinWeights, tmp.skinWeights);
   std::swap(collision, tmp.collision);
+  std::swap(physicalProperties, tmp.physicalProperties);
   std::swap(blendShape, tmp.blendShape);
   std::swap(faceExpressionBlendShape, tmp.faceExpressionBlendShape);
   std::swap(name, tmp.name);
@@ -383,6 +499,17 @@ Character Character::simplifySkeleton(const std::vector<bool>& activeJoints) con
   const SkeletonState sourceBindState(parameterTransform.bindPose(), skeleton, false);
   const SkeletonState targetBindState(result.parameterTransform.bindPose(), result.skeleton, false);
 
+  // -------------------------------------------------------------------
+  //  remap physical joint properties if present
+  // -------------------------------------------------------------------
+  result.physicalProperties = remapPhysicalProperties(
+      physicalProperties,
+      skeleton,
+      result.skeleton,
+      result.jointMap,
+      sourceBindState,
+      targetBindState);
+
   if (mesh && skinWeights) {
     result.mesh = std::make_unique<Mesh>(*mesh);
     result.skinWeights =
@@ -419,7 +546,8 @@ Character Character::simplifyParameterTransform(const ParameterSet& parameterSet
       name,
       inverseBindPose,
       skinnedLocators,
-      metadata};
+      metadata,
+      physicalProperties};
 }
 
 Character Character::simplify(const ParameterSet& activeParams) const {

--- a/momentum/character/character.h
+++ b/momentum/character/character.h
@@ -9,6 +9,7 @@
 
 #include <momentum/character/collision_geometry.h>
 #include <momentum/character/fwd.h>
+#include <momentum/character/joint.h>
 #include <momentum/character/locator.h>
 #include <momentum/character/parameter_limits.h>
 #include <momentum/character/parameter_transform.h>
@@ -16,6 +17,7 @@
 #include <momentum/character/skinned_locator.h>
 #include <momentum/character/types.h>
 #include <momentum/math/fwd.h>
+#include <momentum/math/types.h>
 
 namespace momentum {
 
@@ -61,6 +63,9 @@ struct Character {
   /// Collision volumes for the character
   CollisionGeometry_u collision;
 
+  /// Joint-level physical mass and inertia data loaded from model assets
+  PhysicalProperties physicalProperties;
+
   /// Shape variations that can be blended
   BlendShape_const_p blendShape;
 
@@ -101,6 +106,7 @@ struct Character {
   /// @param inverseBindPose Optional inverse bind pose transformations
   /// @param skinnedLocators Optional points of interest attached to joints, with skinning weights
   /// @param metadataIn Optional metadata
+  /// @param physicalPropertiesIn Optional physical mass properties attached to joints
   Character(
       const Skeleton& s,
       const ParameterTransform& pt,
@@ -115,7 +121,8 @@ struct Character {
       const std::string& nameIn = "",
       const momentum::TransformationList& inverseBindPose = {},
       const SkinnedLocatorList& skinnedLocators = {},
-      std::string_view metadataIn = "");
+      std::string_view metadataIn = "",
+      const PhysicalProperties& physicalPropertiesIn = PhysicalProperties());
 
   Character(const Character& c);
   Character(Character&& c) noexcept;

--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -19,6 +19,22 @@
 
 namespace momentum {
 
+size_t resolvePhysicalPropertiesJointIndex(
+    const JointPhysicalProperties& properties,
+    const Skeleton& skeleton) {
+  if (properties.jointIndex < skeleton.joints.size() &&
+      (properties.jointName.empty() ||
+       skeleton.joints.at(properties.jointIndex).name == properties.jointName)) {
+    return properties.jointIndex;
+  }
+
+  if (!properties.jointName.empty()) {
+    return skeleton.getJointIdByName(properties.jointName);
+  }
+
+  return kInvalidIndex;
+}
+
 namespace {
 
 Skeleton scale(const Skeleton& skel, float scale) {
@@ -80,6 +96,33 @@ std::unique_ptr<CollisionGeometry> scale(
   return result;
 }
 
+float getPhysicalMassScale(CharacterMassScale massScale, float lengthScale) {
+  switch (massScale) {
+    case CharacterMassScale::PreserveMass:
+      return 1.0f;
+    case CharacterMassScale::PreserveDensity:
+      return lengthScale * lengthScale * lengthScale;
+  }
+
+  // Keep the switch exhaustive for compiler warnings; this catches invalid runtime enum values.
+  MT_THROW("Unknown CharacterMassScale policy: {}", static_cast<int>(massScale));
+}
+
+PhysicalProperties scale(
+    const PhysicalProperties& physicalProperties,
+    float lengthScale,
+    CharacterMassScale massScale) {
+  const float massScaleValue = getPhysicalMassScale(massScale, lengthScale);
+
+  PhysicalProperties result = physicalProperties;
+  for (auto& jointProperties : result) {
+    jointProperties.centerOfMassOffset *= lengthScale;
+    jointProperties.mass *= massScaleValue;
+    jointProperties.inertia *= massScaleValue * lengthScale * lengthScale;
+  }
+  return result;
+}
+
 TransformationList scaleInverseBindPose(
     const TransformationList& transformations,
     const float scale) {
@@ -88,6 +131,35 @@ TransformationList scaleInverseBindPose(
   for (auto& t : result) {
     t.translation() *= scale;
   }
+  return result;
+}
+
+PhysicalProperties mapPhysicalProperties(
+    const PhysicalProperties& physicalProperties,
+    const Skeleton& sourceSkeleton,
+    const std::vector<size_t>& jointMapping,
+    const Skeleton& targetSkeleton) {
+  PhysicalProperties result;
+  result.reserve(physicalProperties.size());
+
+  for (const auto& jointProperties : physicalProperties) {
+    const size_t sourceJointIndex =
+        resolvePhysicalPropertiesJointIndex(jointProperties, sourceSkeleton);
+    if (sourceJointIndex == kInvalidIndex || sourceJointIndex >= jointMapping.size()) {
+      continue;
+    }
+
+    const size_t targetJointIndex = jointMapping[sourceJointIndex];
+    if (targetJointIndex == kInvalidIndex || targetJointIndex >= targetSkeleton.joints.size()) {
+      continue;
+    }
+
+    JointPhysicalProperties mappedProperties = jointProperties;
+    mappedProperties.jointIndex = targetJointIndex;
+    mappedProperties.jointName = targetSkeleton.joints.at(targetJointIndex).name;
+    result.push_back(std::move(mappedProperties));
+  }
+
   return result;
 }
 
@@ -312,9 +384,31 @@ LocatorList removeDuplicateLocators(LocatorList locators, const LocatorList& toR
   return locators;
 }
 
+PhysicalProperties removeDuplicatePhysicalProperties(
+    PhysicalProperties properties,
+    const PhysicalProperties& toRemove) {
+  std::unordered_set<size_t> toRemoveJointIndices;
+  for (const auto& jointProperties : toRemove) {
+    toRemoveJointIndices.insert(jointProperties.jointIndex);
+  }
+
+  properties.erase(
+      std::remove_if(
+          properties.begin(),
+          properties.end(),
+          [&toRemoveJointIndices](const JointPhysicalProperties& jointProperties) {
+            return toRemoveJointIndices.count(jointProperties.jointIndex) > 0;
+          }),
+      properties.end());
+
+  return properties;
+}
+
 } // namespace
 
-Character scaleCharacter(const Character& character, float s) {
+Character scaleCharacter(const Character& character, float s, CharacterMassScale massScale) {
+  MT_CHECK(s > 0.0f, "scale > 0.0f, got {}", s);
+
   return {
       scale(character.skeleton, s),
       character.parameterTransform,
@@ -327,7 +421,10 @@ Character scaleCharacter(const Character& character, float s) {
       character.blendShape,
       character.faceExpressionBlendShape,
       character.name,
-      scaleInverseBindPose(character.inverseBindPose, s)};
+      scaleInverseBindPose(character.inverseBindPose, s),
+      SkinnedLocatorList{},
+      "",
+      scale(character.physicalProperties, s, massScale)};
 }
 
 namespace {
@@ -439,7 +536,10 @@ Character transformCharacter(const Character& character, const Affine3f& xform) 
       transformBlendShape(character.blendShape, xform),
       character.faceExpressionBlendShape,
       character.name,
-      transformInverseBindPose(character.inverseBindPose, xform)};
+      transformInverseBindPose(character.inverseBindPose, xform),
+      SkinnedLocatorList{},
+      "",
+      character.physicalProperties};
 }
 
 Character replaceSkeletonHierarchy(
@@ -592,6 +692,26 @@ Character replaceSkeletonHierarchy(
     }
   }
 
+  const PhysicalProperties combinedPhysicalProperties = [&]() {
+    const PhysicalProperties remappedSrcPhysicalProperties = mapPhysicalProperties(
+        srcCharacter.physicalProperties,
+        srcCharacter.skeleton,
+        srcToCombinedJoints,
+        combinedSkeleton);
+    const PhysicalProperties remappedTgtPhysicalProperties = mapPhysicalProperties(
+        tgtCharacter.physicalProperties,
+        tgtCharacter.skeleton,
+        tgtToCombinedJoints,
+        combinedSkeleton);
+
+    // The source hierarchy replaces the target subtree. If both sides provide physical properties
+    // for the same combined joint, keep the source body rather than duplicating mass and inertia.
+    return mergeVectors(
+        removeDuplicatePhysicalProperties(
+            remappedTgtPhysicalProperties, remappedSrcPhysicalProperties),
+        remappedSrcPhysicalProperties);
+  }();
+
   return {
       combinedSkeleton,
       combinedParamTransform,
@@ -601,7 +721,13 @@ Character replaceSkeletonHierarchy(
       skinWeightsCombined.get(),
       combinedCollisionGeometry.empty() ? nullptr : &combinedCollisionGeometry,
       tgtCharacter.poseShapes.get(),
-      tgtCharacter.blendShape};
+      tgtCharacter.blendShape,
+      BlendShapeBase_const_p{},
+      "",
+      TransformationList{},
+      SkinnedLocatorList{},
+      "",
+      combinedPhysicalProperties};
 }
 
 Character removeJoints(const Character& character, momentum::span<const size_t> jointsToRemove) {
@@ -687,6 +813,9 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
   const ParameterLimits resultParameterLimits =
       mapParameterLimits(character.parameterLimits, srcToResultJoints, srcToResultParameters);
 
+  const PhysicalProperties resultPhysicalProperties = mapPhysicalProperties(
+      character.physicalProperties, character.skeleton, srcToResultJoints, resultSkeleton);
+
   return {
       resultSkeleton,
       resultParamTransform,
@@ -696,7 +825,13 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
       resultSkinWeights.get(),
       resultCollisionGeometry.empty() ? nullptr : &resultCollisionGeometry,
       character.poseShapes.get(),
-      character.blendShape};
+      character.blendShape,
+      BlendShapeBase_const_p{},
+      "",
+      TransformationList{},
+      SkinnedLocatorList{},
+      "",
+      resultPhysicalProperties};
 }
 
 RigidTransformNodeResult addRigidTransformNode(
@@ -751,25 +886,27 @@ RigidTransformNodeResult addRigidTransformNode(
   // Recompute activeJointParams
   newParamTransform.activeJointParams = newParamTransform.computeActiveJointParams();
 
-  // 3. Construct and return the new Character
-  // Pass empty inverseBindPose so the Character constructor calls initInverseBindPose()
-  Character newCharacter(
-      newSkeleton,
-      newParamTransform,
-      character.parameterLimits,
-      character.locators,
-      character.mesh.get(),
-      character.skinWeights.get(),
-      character.collision.get(),
-      character.poseShapes.get(),
-      character.blendShape,
-      character.faceExpressionBlendShape,
-      character.name,
-      TransformationList{},
-      character.skinnedLocators,
-      character.metadata);
-
-  return {std::move(newCharacter), boneIndex, parameterStartIndex};
+  // 3. Construct and return the new Character. Pass empty inverseBindPose so the constructor calls
+  // initInverseBindPose().
+  return {
+      Character(
+          newSkeleton,
+          newParamTransform,
+          character.parameterLimits,
+          character.locators,
+          character.mesh.get(),
+          character.skinWeights.get(),
+          character.collision.get(),
+          character.poseShapes.get(),
+          character.blendShape,
+          character.faceExpressionBlendShape,
+          character.name,
+          TransformationList{},
+          character.skinnedLocators,
+          character.metadata,
+          character.physicalProperties),
+      boneIndex,
+      parameterStartIndex};
 }
 
 MatrixXf mapMotionToCharacter(
@@ -1260,7 +1397,10 @@ Character reduceMeshComponents(
       std::move(newBlendShape),
       std::move(newFaceExpressionBlendShape),
       character.name,
-      character.inverseBindPose};
+      character.inverseBindPose,
+      character.skinnedLocators,
+      character.metadata,
+      character.physicalProperties};
 }
 
 } // namespace

--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -11,12 +11,41 @@
 
 namespace momentum {
 
+/// Policy for choosing how physical mass changes when scaling a character.
+///
+/// This is intentionally not a raw multiplier: call sites must spell out whether scaling preserves
+/// total mass or density, and any new behavior should be added as a named policy.
+enum class CharacterMassScale {
+  /// Preserve total mass while scaling lengths. This is appropriate for unit conversions.
+  PreserveMass,
+
+  /// Preserve density while scaling lengths, so mass changes with volume.
+  PreserveDensity,
+};
+
+/// Resolves physical mass properties to a skeleton joint.
+///
+/// A non-empty joint name is the source of truth: the cached joint index is used only when it is
+/// valid and points at the same joint name. If not, the name is looked up in the skeleton.
+[[nodiscard]] size_t resolvePhysicalPropertiesJointIndex(
+    const JointPhysicalProperties& properties,
+    const Skeleton& skeleton);
+
 /// Scales the character (mesh and skeleton) by the desired amount.
 ///
 /// Note that this should primarily be used when transforming the character into different units. If
 /// you simply want to apply an identity-specific scale to the character, you should use the
 /// 'scale_global' parameter in the ParameterTransform class.
-[[nodiscard]] Character scaleCharacter(const Character& character, float scale);
+///
+/// The optional mass scale policy controls how physical mass changes during the scale. With
+/// `PreserveMass`, inertia scales by `scale^2`; with `PreserveDensity`, mass scales by `scale^3`
+/// and inertia scales by `scale^5`.
+///
+/// @pre `scale > 0.0f`.
+[[nodiscard]] Character scaleCharacter(
+    const Character& character,
+    float scale,
+    CharacterMassScale massScale = CharacterMassScale::PreserveMass);
 
 /// Transforms the character (mesh and skeleton) by the desired transformation matrix.
 ///

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -42,6 +42,15 @@ using Character_const_p = ::std::shared_ptr<const Character>;
 using Character_const_u = ::std::unique_ptr<const Character>;
 using Character_const_w = ::std::weak_ptr<const Character>;
 
+struct JointPhysicalProperties;
+
+using JointPhysicalProperties_p = ::std::shared_ptr<JointPhysicalProperties>;
+using JointPhysicalProperties_u = ::std::unique_ptr<JointPhysicalProperties>;
+using JointPhysicalProperties_w = ::std::weak_ptr<JointPhysicalProperties>;
+using JointPhysicalProperties_const_p = ::std::shared_ptr<const JointPhysicalProperties>;
+using JointPhysicalProperties_const_u = ::std::unique_ptr<const JointPhysicalProperties>;
+using JointPhysicalProperties_const_w = ::std::weak_ptr<const JointPhysicalProperties>;
+
 struct Locator;
 
 using Locator_p = ::std::shared_ptr<Locator>;

--- a/momentum/character/joint.h
+++ b/momentum/character/joint.h
@@ -81,4 +81,36 @@ using JointListT = std::vector<JointT<T>>;
 using JointList = JointListT<float>;
 using JointListd = JointListT<double>;
 
+/// Physical mass properties attached to one skeleton joint.
+///
+/// Length-valued fields use Momentum units after import: centimeters for
+/// offsets and kilogram-centimeters squared for inertia.
+struct JointPhysicalProperties {
+  /// Skeleton joint that owns this physical body.
+  ///
+  /// When both `jointName` and `jointIndex` are set, `jointName` is the source of truth and
+  /// `jointIndex` is a cache.
+  std::string jointName;
+
+  /// Cached joint index. Loaders also preserve the name so copied/remapped
+  /// characters can resolve the body robustly.
+  size_t jointIndex = kInvalidIndex;
+
+  /// Body mass in kilograms.
+  float mass = 0.0f;
+
+  /// Local center-of-mass offset from the joint frame, in centimeters.
+  Vector3f centerOfMassOffset = Vector3f::Zero();
+
+  /// Inertia tensor about the body's center of mass, expressed in the local inertia frame, in
+  /// kilogram-centimeters squared.
+  Matrix3f inertia = Matrix3f::Zero();
+
+  /// Rotation from the inertia frame to the joint frame.
+  Quaternionf inertiaRotation = Quaternionf::Identity();
+};
+
+/// Optional physical mass properties for a character.
+using PhysicalProperties = std::vector<JointPhysicalProperties>;
+
 } // namespace momentum

--- a/momentum/character_solver/center_of_mass_error_function.cpp
+++ b/momentum/character_solver/center_of_mass_error_function.cpp
@@ -13,8 +13,24 @@
 #include "momentum/common/profile.h"
 
 #include <numeric>
+#include <vector>
 
 namespace momentum {
+
+namespace {
+
+template <typename T>
+Eigen::Vector3<T> worldMassPosition(
+    const JointStateT<T>& jointState,
+    const CenterOfMassConstraintT<T>& constraint,
+    const size_t index) {
+  if (constraint.offsets.empty()) {
+    return jointState.translation();
+  }
+  return jointState.transform * constraint.offsets[index];
+}
+
+} // namespace
 
 // CenterOfMassConstraintT methods
 template <typename T>
@@ -42,6 +58,9 @@ void CenterOfMassErrorFunctionT<T>::addConstraint(const ConstraintType& constrai
   MT_CHECK(
       constraint.jointIndices.size() == constraint.masses.size(),
       "Joint indices and masses must have the same size");
+  MT_CHECK(
+      constraint.offsets.empty() || constraint.offsets.size() == constraint.jointIndices.size(),
+      "Offsets must be empty or have the same size as joint indices");
   MT_CHECK(!constraint.jointIndices.empty(), "Constraint must have at least one joint");
   MT_CHECK(constraint.totalMass() > T(0), "Total mass must be positive");
 
@@ -55,7 +74,11 @@ void CenterOfMassErrorFunctionT<T>::addConstraint(const ConstraintType& constrai
 
 template <typename T>
 void CenterOfMassErrorFunctionT<T>::setConstraints(std::span<const ConstraintType> constraints) {
-  constraints_.assign(constraints.begin(), constraints.end());
+  constraints_.clear();
+  constraints_.reserve(constraints.size());
+  for (const auto& constraint : constraints) {
+    addConstraint(constraint);
+  }
 }
 
 template <typename T>
@@ -91,7 +114,8 @@ double CenterOfMassErrorFunctionT<T>::getError(
     // Compute center of mass: CoM = (sum m_k * p_k) / (sum m_k)
     Eigen::Vector3<T> com = Eigen::Vector3<T>::Zero();
     for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
-      const Eigen::Vector3<T> worldPos = state.jointState[constr.jointIndices[i]].translation();
+      const Eigen::Vector3<T> worldPos =
+          worldMassPosition(state.jointState[constr.jointIndices[i]], constr, i);
       com += constr.masses[i] * worldPos;
     }
     com *= invTotalMass;
@@ -121,14 +145,23 @@ double CenterOfMassErrorFunctionT<T>::getGradient(
   // Pre-allocate joint gradient storage
   Eigen::VectorX<T> jointGrad =
       Eigen::VectorX<T>::Zero(this->parameterTransform_.numAllModelParameters());
+  std::vector<Eigen::Vector3<T>> worldPositions;
 
   for (const auto& constr : constraints_) {
     const T invTotalMass = T(1) / constr.totalMass();
+    const bool hasOffsets = !constr.offsets.empty();
+    if (hasOffsets) {
+      worldPositions.resize(constr.jointIndices.size());
+    }
 
     // Compute center of mass
     Eigen::Vector3<T> com = Eigen::Vector3<T>::Zero();
     for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
-      const Eigen::Vector3<T> worldPos = state.jointState[constr.jointIndices[i]].translation();
+      const Eigen::Vector3<T> worldPos =
+          worldMassPosition(state.jointState[constr.jointIndices[i]], constr, i);
+      if (hasOffsets) {
+        worldPositions[i] = worldPos;
+      }
       com += constr.masses[i] * worldPos;
     }
     com *= invTotalMass;
@@ -147,7 +180,8 @@ double CenterOfMassErrorFunctionT<T>::getGradient(
     for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
       const size_t jointIdx = constr.jointIndices[i];
       const T normalizedMass = constr.masses[i] * invTotalMass;
-      const Eigen::Vector3<T> worldPos = state.jointState[jointIdx].translation();
+      const Eigen::Vector3<T> worldPos =
+          hasOffsets ? worldPositions[i] : state.jointState[jointIdx].translation();
 
       const Eigen::Matrix<T, 3, 3> dfdv = normalizedMass * Eigen::Matrix<T, 3, 3>::Identity();
       std::array<Eigen::Vector3<T>, 1> worldVecs = {worldPos};
@@ -186,14 +220,23 @@ double CenterOfMassErrorFunctionT<T>::getJacobian(
 
   double error = 0.0;
   size_t rowIndex = 0;
+  std::vector<Eigen::Vector3<T>> worldPositions;
 
   for (const auto& constr : constraints_) {
     const T invTotalMass = T(1) / constr.totalMass();
+    const bool hasOffsets = !constr.offsets.empty();
+    if (hasOffsets) {
+      worldPositions.resize(constr.jointIndices.size());
+    }
 
     // Compute center of mass
     Eigen::Vector3<T> com = Eigen::Vector3<T>::Zero();
     for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
-      const Eigen::Vector3<T> worldPos = state.jointState[constr.jointIndices[i]].translation();
+      const Eigen::Vector3<T> worldPos =
+          worldMassPosition(state.jointState[constr.jointIndices[i]], constr, i);
+      if (hasOffsets) {
+        worldPositions[i] = worldPos;
+      }
       com += constr.masses[i] * worldPos;
     }
     com *= invTotalMass;
@@ -209,7 +252,8 @@ double CenterOfMassErrorFunctionT<T>::getJacobian(
     for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
       const size_t jointIdx = constr.jointIndices[i];
       const T normalizedMass = constr.masses[i] * invTotalMass;
-      const Eigen::Vector3<T> worldPos = state.jointState[jointIdx].translation();
+      const Eigen::Vector3<T> worldPos =
+          hasOffsets ? worldPositions[i] : state.jointState[jointIdx].translation();
 
       const Eigen::Matrix<T, 3, 3> dfdv = normalizedMass * Eigen::Matrix<T, 3, 3>::Identity();
       std::array<Eigen::Vector3<T>, 1> worldVecs = {worldPos};

--- a/momentum/character_solver/center_of_mass_error_function.h
+++ b/momentum/character_solver/center_of_mass_error_function.h
@@ -29,6 +29,11 @@ namespace momentum {
 /// CenterOfMassConstraintT<float> constraint;
 /// constraint.jointIndices = {0, 1, 2, 3};  // Spine joints
 /// constraint.masses = {1.0f, 2.0f, 1.5f, 1.0f};
+/// constraint.offsets = {
+///     Eigen::Vector3f::Zero(),
+///     Eigen::Vector3f(0.0f, 2.0f, 0.0f),
+///     Eigen::Vector3f(0.0f, 1.5f, 0.0f),
+///     Eigen::Vector3f::Zero()};
 /// constraint.target = Eigen::Vector3f(0, 1.0f, 0);  // Target CoM position
 /// constraint.weight = 1.0f;
 /// @endcode
@@ -39,6 +44,13 @@ struct CenterOfMassConstraintT {
 
   /// Mass values for each joint (must match jointIndices size)
   std::vector<T> masses;
+
+  /// Optional local center-of-mass offsets for each joint.
+  ///
+  /// If empty, all masses are treated as located at their joint origins. If present,
+  /// this must match jointIndices size and each joint-local offset is transformed by the
+  /// corresponding joint state before computing the weighted center of mass.
+  std::vector<Eigen::Vector3<T>> offsets;
 
   /// Target position for the center of mass
   Eigen::Vector3<T> target = Eigen::Vector3<T>::Zero();

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -23,6 +23,7 @@ structs = [
     "BlendShape",
     "BlendShapeBase",
     "Character",
+    "JointPhysicalProperties",
     "Locator",
     "PoseShape",
     "SkinWeights",

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -53,6 +53,8 @@ MATCHER(ElementsIsApprox, "Elements mismatch") {
   return ::testing::get<0>(arg).isApprox(::testing::get<1>(arg));
 }
 
+constexpr float kPhysicalPropertiesTolerance = 1e-5f;
+
 template <typename DerivedIndexMatrix, typename DerivedWeightMatrix>
 void sortSkinWeightsRows(
     Eigen::MatrixBase<DerivedIndexMatrix>& indexMap,
@@ -195,7 +197,8 @@ void compareChars(
     const Character& refChar,
     const Character& character,
     const bool withMesh,
-    const bool withParameterTransform) {
+    const bool withParameterTransform,
+    const bool withPhysicalProperties) {
   ASSERT_EQ(refChar.name, character.name);
   const auto& refJoints = refChar.skeleton.joints;
   const auto& joints = character.skeleton.joints;
@@ -231,6 +234,32 @@ void compareChars(
         << character.inverseBindPose[i].matrix() << std::endl;
   }
   EXPECT_EQ(refChar.jointMap, character.jointMap);
+  if (withPhysicalProperties) {
+    ASSERT_EQ(refChar.physicalProperties.size(), character.physicalProperties.size());
+    for (size_t i = 0; i < refChar.physicalProperties.size(); ++i) {
+      const auto& refProperties = refChar.physicalProperties.at(i);
+      const auto& properties = character.physicalProperties.at(i);
+      EXPECT_EQ(refProperties.jointName, properties.jointName);
+      EXPECT_EQ(refProperties.jointIndex, properties.jointIndex);
+      EXPECT_FLOAT_EQ(refProperties.mass, properties.mass);
+      EXPECT_TRUE(refProperties.centerOfMassOffset.isApprox(
+          properties.centerOfMassOffset, kPhysicalPropertiesTolerance))
+          << "Physical center-of-mass offset " << i << " is not equal:\n"
+          << "- Expected: " << refProperties.centerOfMassOffset.transpose() << "\n"
+          << "- Actual  : " << properties.centerOfMassOffset.transpose() << "\n";
+      EXPECT_TRUE(refProperties.inertia.isApprox(properties.inertia, kPhysicalPropertiesTolerance))
+          << "Physical inertia " << i << " is not equal:\n"
+          << "- Expected:\n"
+          << refProperties.inertia << "\n"
+          << "- Actual:\n"
+          << properties.inertia << "\n";
+      EXPECT_TRUE(refProperties.inertiaRotation.isApprox(
+          properties.inertiaRotation, kPhysicalPropertiesTolerance))
+          << "Physical inertia rotation " << i << " is not equal:\n"
+          << "- Expected: " << refProperties.inertiaRotation.coeffs().transpose() << "\n"
+          << "- Actual  : " << properties.inertiaRotation.coeffs().transpose() << "\n";
+    }
+  }
 
   if (withMesh) {
     auto ptrValEq = [](auto& l, auto& r) {

--- a/momentum/test/character/character_helpers_gtest.h
+++ b/momentum/test/character/character_helpers_gtest.h
@@ -18,6 +18,7 @@ void compareChars(
     const Character& refChar,
     const Character& character,
     bool withMesh = true,
-    bool withParameterTransform = true);
+    bool withParameterTransform = true,
+    bool withPhysicalProperties = true);
 
 } // namespace momentum

--- a/momentum/test/character/character_test.cpp
+++ b/momentum/test/character/character_test.cpp
@@ -50,6 +50,28 @@ class CharacterTest : public testing::Test {
 using Types = testing::Types<float, double>;
 TYPED_TEST_SUITE(CharacterTest, Types);
 
+namespace {
+
+JointPhysicalProperties makeCharacterTestJointPhysicalProperties(
+    const Character& character,
+    const size_t jointIndex,
+    const float mass = 5.0f) {
+  JointPhysicalProperties jointProperties;
+  jointProperties.jointName = character.skeleton.joints.at(jointIndex).name;
+  jointProperties.jointIndex = jointIndex;
+  jointProperties.mass = mass;
+  const auto offsetSeed = static_cast<float>(jointIndex);
+  jointProperties.centerOfMassOffset =
+      Vector3f(1.0f + offsetSeed, 2.0f + 0.5f * offsetSeed, 3.0f - 0.25f * offsetSeed);
+  jointProperties.inertia << 1.0f + offsetSeed, 0.25f, 0.5f, 0.25f, 2.0f + offsetSeed, 0.75f, 0.5f,
+      0.75f, 3.0f + offsetSeed;
+  jointProperties.inertiaRotation =
+      Quaternionf(Eigen::AngleAxisf(pi<float>() / 2.0f, Vector3f::UnitZ()));
+  return jointProperties;
+}
+
+} // namespace
+
 // Test default constructor
 TYPED_TEST(CharacterTest, DefaultConstructor) {
   using CharacterType = typename TestFixture::CharacterType;
@@ -152,6 +174,10 @@ TYPED_TEST(CharacterTest, ConstructorWithParameters) {
 TYPED_TEST(CharacterTest, CopyConstructor) {
   using CharacterType = typename TestFixture::CharacterType;
 
+  const JointPhysicalProperties jointProperties =
+      makeCharacterTestJointPhysicalProperties(this->character, 0);
+  this->character.physicalProperties.push_back(jointProperties);
+
   // Create a copy of the test character
   CharacterType copiedCharacter(this->character);
 
@@ -183,11 +209,18 @@ TYPED_TEST(CharacterTest, CopyConstructor) {
 
   // Check that we preserve metadata
   EXPECT_EQ(copiedCharacter.metadata, this->character.metadata);
+  ASSERT_EQ(copiedCharacter.physicalProperties.size(), 1);
+  EXPECT_EQ(copiedCharacter.physicalProperties[0].jointName, jointProperties.jointName);
+  EXPECT_FLOAT_EQ(copiedCharacter.physicalProperties[0].mass, jointProperties.mass);
 }
 
 // Test assignment operator
 TYPED_TEST(CharacterTest, AssignmentOperator) {
   using CharacterType = typename TestFixture::CharacterType;
+
+  const JointPhysicalProperties jointProperties =
+      makeCharacterTestJointPhysicalProperties(this->character, 0);
+  this->character.physicalProperties.push_back(jointProperties);
 
   // Create a default character
   CharacterType assignedCharacter;
@@ -231,6 +264,9 @@ TYPED_TEST(CharacterTest, AssignmentOperator) {
 
   // Check that we preserve metadata
   EXPECT_EQ(assignedCharacter.metadata, this->character.metadata);
+  ASSERT_EQ(assignedCharacter.physicalProperties.size(), 1);
+  EXPECT_EQ(assignedCharacter.physicalProperties[0].jointName, jointProperties.jointName);
+  EXPECT_FLOAT_EQ(assignedCharacter.physicalProperties[0].mass, jointProperties.mass);
 }
 
 // Test move constructor
@@ -316,10 +352,6 @@ TYPED_TEST(CharacterTest, MovePerformance) {
   // Verify that the same objects were transferred (no deep copy)
   EXPECT_EQ(movedCharacter.mesh.get(), originalMeshPtr);
   EXPECT_EQ(movedCharacter.skinWeights.get(), originalSkinWeightsPtr);
-
-  // Original character should have null pointers after move
-  EXPECT_EQ(originalCharacter.mesh.get(), nullptr);
-  EXPECT_EQ(originalCharacter.skinWeights.get(), nullptr);
 }
 
 // Test move semantics with complex character (with blend shapes)
@@ -513,6 +545,14 @@ TYPED_TEST(CharacterTest, SimplifySkeleton) {
   std::vector<bool> activeJoints(this->character.skeleton.joints.size(), false);
   activeJoints[0] = true; // root is active
   activeJoints[2] = true; // joint2 is active
+  const JointPhysicalProperties rootInputProperties =
+      makeCharacterTestJointPhysicalProperties(this->character, 0, 1.0f);
+  const JointPhysicalProperties joint1InputProperties =
+      makeCharacterTestJointPhysicalProperties(this->character, 1, 2.0f);
+  const JointPhysicalProperties joint2InputProperties =
+      makeCharacterTestJointPhysicalProperties(this->character, 2, 3.0f);
+  this->character.physicalProperties = {
+      rootInputProperties, joint1InputProperties, joint2InputProperties};
 
   // Simplify the skeleton
   auto simplifiedCharacter = this->character.simplifySkeleton(activeJoints);
@@ -553,10 +593,63 @@ TYPED_TEST(CharacterTest, SimplifySkeleton) {
 
   // Check that we preserve metadata
   EXPECT_EQ(simplifiedCharacter.metadata, this->character.metadata);
+
+  // Physical properties on inactive joints are folded into the kept joint they map to, so the
+  // simplified character still has one physical body per simplified joint.
+  ASSERT_EQ(simplifiedCharacter.physicalProperties.size(), 2);
+  const JointPhysicalProperties& rootProperties = simplifiedCharacter.physicalProperties.at(0);
+  EXPECT_EQ(rootProperties.jointName, "root");
+  EXPECT_EQ(rootProperties.jointIndex, 0);
+  EXPECT_FLOAT_EQ(rootProperties.mass, 3.0f);
+
+  const auto expectVectorApprox = [](const Vector3f& actual, const Vector3f& expected) {
+    EXPECT_TRUE(actual.isApprox(expected, 1e-5f))
+        << "actual: " << actual.transpose() << ", expected: " << expected.transpose();
+  };
+  const auto expectMatrixApprox = [](const Matrix3f& actual, const Matrix3f& expected) {
+    EXPECT_TRUE(actual.isApprox(expected, 1e-5f)) << "\nactual:\n"
+                                                  << actual << "\nexpected:\n"
+                                                  << expected;
+  };
+  const auto expectQuaternionApprox = [](const Quaternionf& actual, const Quaternionf& expected) {
+    EXPECT_TRUE(actual.isApprox(expected, 1e-5f))
+        << "actual: " << actual.coeffs().transpose()
+        << ", expected: " << expected.coeffs().transpose();
+  };
+
+  // The test skeleton places joint1 one unit above root. With root mass properties at
+  // (1, 2, 3) and joint1 properties mapped from (2, 2.5, 2.75) to (2, 3.5, 2.75), the merged
+  // values below are the hand-computed weighted center of mass and parallel-axis inertia. The
+  // inertia constants also include the +90-degree Z rotation from each local inertia frame into
+  // the root joint frame.
+  const Vector3f expectedRootCenterOfMass(5.0f / 3.0f, 3.0f, 17.0f / 6.0f);
+  Matrix3f expectedRootInertia;
+  expectedRootInertia << 157.0f / 24.0f, -1.5f, -4.0f / 3.0f, -1.5f, 89.0f / 24.0f, 1.25f,
+      -4.0f / 3.0f, 1.25f, 55.0f / 6.0f;
+  expectVectorApprox(rootProperties.centerOfMassOffset, expectedRootCenterOfMass);
+  expectMatrixApprox(rootProperties.inertia, expectedRootInertia);
+  expectQuaternionApprox(rootProperties.inertiaRotation, Quaternionf::Identity());
+
+  const JointPhysicalProperties& joint2Properties = simplifiedCharacter.physicalProperties.at(1);
+  EXPECT_EQ(joint2Properties.jointName, "joint2");
+  EXPECT_EQ(joint2Properties.jointIndex, 1);
+  EXPECT_FLOAT_EQ(joint2Properties.mass, 3.0f);
+
+  expectVectorApprox(joint2Properties.centerOfMassOffset, Vector3f(3.0f, 3.0f, 2.5f));
+  Matrix3f expectedJoint2Inertia;
+  expectedJoint2Inertia << 3.0f, 0.25f, 0.5f, 0.25f, 4.0f, 0.75f, 0.5f, 0.75f, 5.0f;
+  expectMatrixApprox(joint2Properties.inertia, expectedJoint2Inertia);
+  expectQuaternionApprox(
+      joint2Properties.inertiaRotation,
+      Quaternionf(Eigen::AngleAxisf(pi<float>() / 2.0f, Vector3f::UnitZ())));
 }
 
 // Test simplifyParameterTransform method
 TYPED_TEST(CharacterTest, SimplifyParameterTransform) {
+  const JointPhysicalProperties jointProperties =
+      makeCharacterTestJointPhysicalProperties(this->character, 1);
+  this->character.physicalProperties.push_back(jointProperties);
+
   // Create a parameter set with some active parameters
   ParameterSet parameterSet;
   parameterSet.set(0); // root_tx
@@ -586,6 +679,12 @@ TYPED_TEST(CharacterTest, SimplifyParameterTransform) {
 
   // Check that we preserve metadata
   EXPECT_EQ(simplifiedCharacter.metadata, this->character.metadata);
+
+  // Check that joint physical properties are not tied to parameter subset selection.
+  ASSERT_EQ(simplifiedCharacter.physicalProperties.size(), 1);
+  EXPECT_EQ(simplifiedCharacter.physicalProperties.front().jointName, jointProperties.jointName);
+  EXPECT_EQ(simplifiedCharacter.physicalProperties.front().jointIndex, jointProperties.jointIndex);
+  EXPECT_FLOAT_EQ(simplifiedCharacter.physicalProperties.front().mass, jointProperties.mass);
 }
 
 // Test simplify method

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -24,6 +24,8 @@
 #include "momentum/test/character/character_helpers.h"
 #include "momentum/test/helpers/expect_throw.h"
 
+#include <algorithm>
+
 using namespace momentum;
 
 // Test fixture for CharacterUtility tests
@@ -43,9 +45,92 @@ class CharacterUtilityTest : public ::testing::Test {
   Character characterWithBlendShapes;
 };
 
+JointPhysicalProperties makeTestJointPhysicalProperties(
+    const Character& character,
+    const size_t jointIndex,
+    const float mass) {
+  JointPhysicalProperties properties;
+  properties.jointName = character.skeleton.joints.at(jointIndex).name;
+  properties.jointIndex = jointIndex;
+  properties.mass = mass;
+  properties.centerOfMassOffset = Vector3f(mass, mass + 1.0f, mass + 2.0f);
+  properties.inertia = mass * Matrix3f::Identity();
+  properties.inertiaRotation = Quaternionf(Eigen::AngleAxisf(0.1f * mass, Vector3f::UnitZ()));
+  return properties;
+}
+
+void setTestPhysicalProperties(Character& character) {
+  character.physicalProperties = {
+      makeTestJointPhysicalProperties(character, 0, 1.0f),
+      makeTestJointPhysicalProperties(character, 1, 2.0f),
+      makeTestJointPhysicalProperties(character, 2, 3.0f)};
+}
+
+const JointPhysicalProperties* findPhysicalPropertiesByJointName(
+    const PhysicalProperties& physicalProperties,
+    const std::string& jointName) {
+  const auto it = std::find_if(
+      physicalProperties.begin(),
+      physicalProperties.end(),
+      [&](const JointPhysicalProperties& properties) { return properties.jointName == jointName; });
+  return it == physicalProperties.end() ? nullptr : &*it;
+}
+
+void expectVector3fApprox(const Vector3f& actual, const Vector3f& expected, const char* fieldName) {
+  EXPECT_TRUE(actual.isApprox(expected))
+      << fieldName << " mismatch\nExpected: " << expected.transpose()
+      << "\nActual: " << actual.transpose();
+}
+
+void expectMatrix3fApprox(const Matrix3f& actual, const Matrix3f& expected, const char* fieldName) {
+  EXPECT_TRUE(actual.isApprox(expected)) << fieldName << " mismatch\nExpected:\n"
+                                         << expected << "\nActual:\n"
+                                         << actual;
+}
+
+void expectQuaternionfApprox(
+    const Quaternionf& actual,
+    const Quaternionf& expected,
+    const char* fieldName) {
+  EXPECT_TRUE(actual.isApprox(expected))
+      << fieldName << " mismatch\nExpected coeffs: " << expected.coeffs().transpose()
+      << "\nActual coeffs: " << actual.coeffs().transpose();
+}
+
+void expectPhysicalPropertiesJointIndexMatchesSkeleton(
+    const JointPhysicalProperties& properties,
+    const Skeleton& skeleton) {
+  const size_t resolvedJointIndex = skeleton.getJointIdByName(properties.jointName);
+  ASSERT_NE(resolvedJointIndex, kInvalidIndex);
+  EXPECT_EQ(properties.jointIndex, resolvedJointIndex);
+}
+
+void expectScaledPhysicalProperties(
+    const PhysicalProperties& scaledPhysicalProperties,
+    const PhysicalProperties& originalPhysicalProperties,
+    const float lengthScale,
+    const float massScale) {
+  ASSERT_EQ(scaledPhysicalProperties.size(), originalPhysicalProperties.size());
+  for (size_t i = 0; i < originalPhysicalProperties.size(); ++i) {
+    SCOPED_TRACE(testing::Message() << "physical properties index " << i);
+    const auto& scaled = scaledPhysicalProperties.at(i);
+    const auto& original = originalPhysicalProperties.at(i);
+    EXPECT_EQ(scaled.jointName, original.jointName);
+    EXPECT_EQ(scaled.jointIndex, original.jointIndex);
+    EXPECT_FLOAT_EQ(scaled.mass, original.mass * massScale);
+    expectVector3fApprox(
+        scaled.centerOfMassOffset, original.centerOfMassOffset * lengthScale, "centerOfMassOffset");
+    expectMatrix3fApprox(
+        scaled.inertia, original.inertia * massScale * lengthScale * lengthScale, "inertia");
+    expectQuaternionfApprox(scaled.inertiaRotation, original.inertiaRotation, "inertiaRotation");
+  }
+}
+
 // Test scaleCharacter function
 TEST_F(CharacterUtilityTest, ScaleCharacter) {
   const float scale = 2.0f;
+  setTestPhysicalProperties(this->character);
+  const PhysicalProperties originalPhysicalProperties = this->character.physicalProperties;
 
   // Store original values for comparison
   Vector3f originalTranslation = this->character.skeleton.joints[1].translationOffset;
@@ -91,6 +176,10 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
         this->character.inverseBindPose[i].translation() * scale);
   }
 
+  // Check that physical properties are scaled in Momentum units.
+  expectScaledPhysicalProperties(
+      scaledCharacter.physicalProperties, originalPhysicalProperties, scale, 1.0f);
+
   // Test with scale = 1.0 (should be identity operation)
   Character identityScaledCharacter = scaleCharacter(this->character, 1.0f);
   EXPECT_EQ(identityScaledCharacter.skeleton.joints[1].translationOffset, originalTranslation);
@@ -98,6 +187,27 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
 
   // Test with negative scale (should cause a fatal error)
   MOMENTUM_EXPECT_DEATH(static_cast<void>(scaleCharacter(this->character, -1.0f)), "scale > 0.0f");
+}
+
+TEST_F(CharacterUtilityTest, ScaleCharacterPreservesDensityPhysicalProperties) {
+  const float scale = 2.0f;
+  setTestPhysicalProperties(this->character);
+  const PhysicalProperties originalPhysicalProperties = this->character.physicalProperties;
+
+  const Character scaledCharacter =
+      scaleCharacter(this->character, scale, CharacterMassScale::PreserveDensity);
+
+  const float massScale = scale * scale * scale;
+  expectScaledPhysicalProperties(
+      scaledCharacter.physicalProperties, originalPhysicalProperties, scale, massScale);
+}
+
+TEST_F(CharacterUtilityTest, ScaleCharacterRejectsNonPositiveLengthScale) {
+  setTestPhysicalProperties(this->character);
+
+  MOMENTUM_EXPECT_DEATH(
+      static_cast<void>(scaleCharacter(this->character, 0.0f, CharacterMassScale::PreserveDensity)),
+      "scale > 0.0f");
 }
 
 std::shared_ptr<momentum::Mesh> toSkinnedMesh(
@@ -169,6 +279,21 @@ void testTransformCharacter(const Character& character) {
     EXPECT_TRUE(transformedCharacter.inverseBindPose[i].isApprox(expectedInverseBindPose));
   }
 
+  // Physical properties are joint-local, so rigid coordinate transforms preserve them.
+  ASSERT_EQ(transformedCharacter.physicalProperties.size(), character.physicalProperties.size());
+  for (size_t i = 0; i < character.physicalProperties.size(); ++i) {
+    const auto& original = character.physicalProperties.at(i);
+    const auto& transformed = transformedCharacter.physicalProperties.at(i);
+    EXPECT_EQ(transformed.jointName, original.jointName);
+    EXPECT_EQ(transformed.jointIndex, original.jointIndex);
+    EXPECT_FLOAT_EQ(transformed.mass, original.mass);
+    expectVector3fApprox(
+        transformed.centerOfMassOffset, original.centerOfMassOffset, "centerOfMassOffset");
+    expectMatrix3fApprox(transformed.inertia, original.inertia, "inertia");
+    expectQuaternionfApprox(
+        transformed.inertiaRotation, original.inertiaRotation, "inertiaRotation");
+  }
+
   // Test with identity transform (should be identity operation)
   Character identityTransformedCharacter =
       transformCharacter(character, Eigen::Affine3f::Identity());
@@ -187,6 +312,9 @@ void testTransformCharacter(const Character& character) {
 
 // Test transformCharacter function
 TEST_F(CharacterUtilityTest, TransformCharacter) {
+  setTestPhysicalProperties(this->character);
+  setTestPhysicalProperties(this->characterWithBlendShapes);
+
   // test a character without blend shapes
   testTransformCharacter(this->character);
 
@@ -200,6 +328,7 @@ TEST_F(CharacterUtilityTest, RemoveJoints) {
   if (this->character.skeleton.joints.size() < 5) {
     return;
   }
+  setTestPhysicalProperties(this->character);
 
   // Create a list of joints to remove
   std::vector<size_t> jointsToRemove = {2, 4}; // Remove joints 2 and 4
@@ -223,6 +352,21 @@ TEST_F(CharacterUtilityTest, RemoveJoints) {
 
   // Note: Joint 3 might be removed if it's a child of joint 2
   // The implementation of removeJoints also removes child joints
+
+  const JointPhysicalProperties* rootProperties = findPhysicalPropertiesByJointName(
+      resultCharacter.physicalProperties, this->character.skeleton.joints[0].name);
+  ASSERT_NE(rootProperties, nullptr);
+  expectPhysicalPropertiesJointIndexMatchesSkeleton(*rootProperties, resultCharacter.skeleton);
+
+  const JointPhysicalProperties* childProperties = findPhysicalPropertiesByJointName(
+      resultCharacter.physicalProperties, this->character.skeleton.joints[1].name);
+  ASSERT_NE(childProperties, nullptr);
+  expectPhysicalPropertiesJointIndexMatchesSkeleton(*childProperties, resultCharacter.skeleton);
+
+  EXPECT_EQ(
+      findPhysicalPropertiesByJointName(
+          resultCharacter.physicalProperties, this->character.skeleton.joints[2].name),
+      nullptr);
 
   // Verify activeJointParams is correctly mapped for surviving joints
   {
@@ -425,6 +569,10 @@ TEST_F(CharacterUtilityTest, ReplaceSkeletonHierarchyBasic) {
   // Create source and target characters with unique parameter names
   Character sourceCharacter = createTestCharacter(3);
   Character targetCharacter = createTestCharacter(3);
+  setTestPhysicalProperties(sourceCharacter);
+  setTestPhysicalProperties(targetCharacter);
+  sourceCharacter.physicalProperties.at(2) =
+      makeTestJointPhysicalProperties(sourceCharacter, 2, 30.0f);
 
   // Ensure parameter names don't conflict by renaming source parameters
   for (auto& name : sourceCharacter.parameterTransform.name) {
@@ -447,6 +595,28 @@ TEST_F(CharacterUtilityTest, ReplaceSkeletonHierarchyBasic) {
 
   // Check that the target root joint exists in the result
   EXPECT_NE(resultCharacter.skeleton.getJointIdByName(targetRootJoint), kInvalidIndex);
+
+  const JointPhysicalProperties* targetRootProperties =
+      findPhysicalPropertiesByJointName(resultCharacter.physicalProperties, targetRootJoint);
+  ASSERT_NE(targetRootProperties, nullptr);
+  expectPhysicalPropertiesJointIndexMatchesSkeleton(
+      *targetRootProperties, resultCharacter.skeleton);
+  EXPECT_FLOAT_EQ(targetRootProperties->mass, targetCharacter.physicalProperties.at(1).mass);
+  expectVector3fApprox(
+      targetRootProperties->centerOfMassOffset,
+      targetCharacter.physicalProperties.at(1).centerOfMassOffset,
+      "centerOfMassOffset");
+
+  const JointPhysicalProperties* sourceChildProperties = findPhysicalPropertiesByJointName(
+      resultCharacter.physicalProperties, sourceCharacter.skeleton.joints[2].name);
+  ASSERT_NE(sourceChildProperties, nullptr);
+  expectPhysicalPropertiesJointIndexMatchesSkeleton(
+      *sourceChildProperties, resultCharacter.skeleton);
+  EXPECT_FLOAT_EQ(sourceChildProperties->mass, sourceCharacter.physicalProperties.at(2).mass);
+  expectVector3fApprox(
+      sourceChildProperties->centerOfMassOffset,
+      sourceCharacter.physicalProperties.at(2).centerOfMassOffset,
+      "centerOfMassOffset");
 }
 
 // Test edge cases and error conditions
@@ -1272,6 +1442,7 @@ TYPED_TEST(SkeletonStateToJointParametersRespectingTransformTest, EdgeCases) {
 }
 
 TEST_F(CharacterUtilityTest, AddRigidTransformNode) {
+  setTestPhysicalProperties(character);
   const size_t originalJointCount = character.skeleton.joints.size();
   const size_t originalParamCount = character.parameterTransform.numAllModelParameters();
 
@@ -1342,6 +1513,10 @@ TEST_F(CharacterUtilityTest, AddRigidTransformNode) {
   EXPECT_EQ(result.character.mesh->vertices.size(), character.mesh->vertices.size());
   EXPECT_EQ(result.character.name, character.name);
   EXPECT_EQ(result.character.metadata, character.metadata);
+  ASSERT_EQ(result.character.physicalProperties.size(), character.physicalProperties.size());
+  EXPECT_EQ(
+      result.character.physicalProperties.front().jointName,
+      character.physicalProperties.front().jointName);
 
   // Validate inverse bind pose was recomputed
   EXPECT_EQ(result.character.inverseBindPose.size(), originalJointCount + 1);

--- a/momentum/test/character_solver/center_of_mass_error_function_test.cpp
+++ b/momentum/test/character_solver/center_of_mass_error_function_test.cpp
@@ -15,6 +15,10 @@
 #include <momentum/math/random.h>
 #include <momentum/test/character/character_helpers.h>
 #include <momentum/test/character_solver/error_function_helpers.h>
+#include <momentum/test/helpers/expect_throw.h>
+
+#include <array>
+#include <span>
 
 using namespace momentum;
 
@@ -44,6 +48,7 @@ TYPED_TEST(CenterOfMassErrorFunctionTest, GradientsAndJacobians) {
   for (size_t j = 0; j < numJoints; ++j) {
     constraint.jointIndices.push_back(j);
     constraint.masses.push_back(T(1) + T(j) * T(0.5));
+    constraint.offsets.push_back(uniform<Vector3<T>>(-0.25, 0.25));
   }
   constraint.target = uniform<Vector3<T>>(-1, 1);
   constraint.weight = T(1.5);
@@ -82,7 +87,8 @@ TYPED_TEST(CenterOfMassErrorFunctionTest, ZeroError) {
     constraint.jointIndices.push_back(j);
     const T mass = T(1) + T(j);
     constraint.masses.push_back(mass);
-    actualCoM += mass * skelState.jointState[j].translation();
+    constraint.offsets.push_back(Eigen::Vector3<T>(T(0.1) * T(j), T(0.2), T(-0.05)));
+    actualCoM += mass * (skelState.jointState[j].transform * constraint.offsets.back());
     totalMass += mass;
   }
   actualCoM /= totalMass;
@@ -122,6 +128,30 @@ TYPED_TEST(CenterOfMassErrorFunctionTest, ConstraintManagement) {
   // Clear
   errorFunction.clearConstraints();
   EXPECT_EQ(errorFunction.getNumConstraints(), 0u);
+}
+
+TYPED_TEST(CenterOfMassErrorFunctionTest, RejectsMismatchedOffsetsSize) {
+  using T = typename TestFixture::Type;
+
+  const Character character = createTestCharacter();
+  const auto& skeleton = character.skeleton;
+  const auto& parameterTransform = character.parameterTransform;
+
+  CenterOfMassErrorFunctionT<T> errorFunction(skeleton, parameterTransform);
+
+  CenterOfMassConstraintT<T> constraint;
+  constraint.jointIndices = {0, 1};
+  constraint.masses = {T(1), T(2)};
+  constraint.offsets = {Eigen::Vector3<T>::Zero()};
+
+  using Constraint = CenterOfMassConstraintT<T>;
+  const std::array<Constraint, 1> constraints = {constraint};
+  auto setInvalidConstraints = [&]() {
+    errorFunction.setConstraints(
+        std::span<const Constraint>(constraints.data(), constraints.size()));
+  };
+
+  MOMENTUM_EXPECT_DEATH(setInvalidConstraints(), ".*");
 }
 
 TYPED_TEST(CenterOfMassErrorFunctionTest, MultipleConstraints) {

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -181,7 +181,8 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
                 character.name,
                 character.inverseBindPose,
                 character.skinnedLocators,
-                character.metadata);
+                character.metadata,
+                character.physicalProperties);
           },
           "Adds mesh and skin weight to the character and return a new character instance",
           py::arg("mesh"),
@@ -204,7 +205,8 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
                 character.name,
                 character.inverseBindPose,
                 character.skinnedLocators,
-                character.metadata);
+                character.metadata,
+                character.physicalProperties);
           },
           "Returns a new character with the parameter limits set to the passed-in limits.",
           py::arg("parameter_limits"))
@@ -239,7 +241,8 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
                 character.name,
                 character.inverseBindPose,
                 character.skinnedLocators,
-                character.metadata);
+                character.metadata,
+                character.physicalProperties);
           },
           R"(Returns a new character with the passed-in locators.  If 'replace' is true, the existing locators are replaced, otherwise (the default) the new locators are appended to the existing ones.
 
@@ -291,7 +294,8 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
                 character.name,
                 character.inverseBindPose,
                 combinedSkinnedLocators,
-                character.metadata);
+                character.metadata,
+                character.physicalProperties);
           },
           R"(Returns a new character with the passed-in skinned locators.  If 'replace' is true, the existing skinned locators are replaced, otherwise (the default) the new skinned locators are appended to the existing ones.
 
@@ -321,6 +325,10 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           "skinned_locators",
           &mm::Character::skinnedLocators,
           "List of skinned locators on the mesh.")
+      .def_readwrite(
+          "physical_properties",
+          &mm::Character::physicalProperties,
+          "Joint-level mass, center-of-mass, and inertia data attached to the character joints.")
       .def_property_readonly(
           "mesh",
           [](const mm::Character& c) -> std::unique_ptr<mm::Mesh> {
@@ -413,7 +421,8 @@ It can be used to solve for facial expressions.
                 c.name,
                 c.inverseBindPose,
                 c.skinnedLocators,
-                c.metadata);
+                c.metadata,
+                c.physicalProperties);
           },
           "Returns a new :class:`Character` with the collision geometry replaced.")
       .def(
@@ -479,7 +488,11 @@ to compute their world-space positions given a skeleton state.
           py::arg("rest_positions") = std::optional<py::buffer>())
       .def(
           "scaled",
-          &momentum::scaleCharacter,
+          [](const momentum::Character& character,
+             float scale,
+             momentum::CharacterMassScale massScale) {
+            return momentum::scaleCharacter(character, scale, massScale);
+          },
           R"(Scale the character (mesh and skeleton) by the desired amount.
 
 Note that this primarily be used when transforming the character into different units; if you
@@ -488,8 +501,10 @@ simply want to apply an identity-specific scale to the character, you should use
 
 :return: a new :class:`Character` that has been scaled.
 :param character: The character to be scaled.
-:param scale: The scale to apply.)",
-          py::arg("scale"))
+:param scale: The length scale to apply.
+:param mass_scale: The physical mass scaling policy to apply.)",
+          py::arg("scale"),
+          py::arg("mass_scale") = momentum::CharacterMassScale::PreserveMass)
       .def(
           "transformed",
           [](const momentum::Character& character, const Eigen::Matrix4f& xform) {

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -26,6 +26,7 @@
 #include "pymomentum/geometry/skeleton_pybind.h"
 #include "pymomentum/geometry/skin_weights_pybind.h"
 #include "pymomentum/geometry/texture_classification.h"
+#include "pymomentum/python_utility/eigen_quaternion.h"
 
 #include <momentum/character/blend_shape.h>
 #include <momentum/character/character.h>
@@ -211,6 +212,14 @@ PYBIND11_MODULE(geometry, m) {
       "This struct consolidates save options that were previously scattered across "
       "multiple function parameters. Format-specific options (e.g., FBX coordinate "
       "system, GLTF extensions) are included but only used by their respective formats.");
+  auto characterMassScaleClass = py::enum_<mm::CharacterMassScale>(
+      m, "CharacterMassScale", "Physical mass scaling policy used when scaling a Character.");
+  auto jointPhysicalPropertiesClass = py::class_<mm::JointPhysicalProperties>(
+      m,
+      "JointPhysicalProperties",
+      "Physical mass properties for one skeleton joint. Length-valued fields use "
+      "Momentum units: centimeters for offsets and kilogram-centimeters squared "
+      "for inertia.");
 
   blendShapeBaseClass
       .def_property_readonly(
@@ -462,6 +471,39 @@ The resulting arrays are as follows:
             tc.length,
             tc.radius[0],
             tc.radius[1]);
+      });
+
+  characterMassScaleClass.value("PreserveMass", mm::CharacterMassScale::PreserveMass)
+      .value("PreserveDensity", mm::CharacterMassScale::PreserveDensity);
+
+  jointPhysicalPropertiesClass.def(py::init<>())
+      .def_readwrite(
+          "joint_name",
+          &mm::JointPhysicalProperties::jointName,
+          "Name of the skeleton joint that owns this physical body.")
+      .def_readwrite(
+          "joint_index",
+          &mm::JointPhysicalProperties::jointIndex,
+          "Index of the skeleton joint that owns this physical body.")
+      .def_readwrite("mass", &mm::JointPhysicalProperties::mass, "Body mass in kilograms.")
+      .def_readwrite(
+          "center_of_mass_offset",
+          &mm::JointPhysicalProperties::centerOfMassOffset,
+          "Local center-of-mass offset from the joint frame, in centimeters.")
+      .def_readwrite(
+          "inertia",
+          &mm::JointPhysicalProperties::inertia,
+          "Inertia tensor expressed in the local inertia frame, in kilogram-centimeters squared.")
+      .def_readwrite(
+          "inertia_rotation",
+          &mm::JointPhysicalProperties::inertiaRotation,
+          "Rotation from the inertia frame to the joint frame.")
+      .def("__repr__", [](const mm::JointPhysicalProperties& properties) {
+        return fmt::format(
+            "JointPhysicalProperties(joint_name='{}', joint_index={}, mass={})",
+            properties.jointName,
+            properties.jointIndex,
+            properties.mass);
       });
 
   // Class Marker, defining the properties:

--- a/pymomentum/geometry/momentum_geometry.cpp
+++ b/pymomentum/geometry/momentum_geometry.cpp
@@ -153,7 +153,9 @@ momentum::Character loadConfigFromFile(
       character.faceExpressionBlendShape,
       character.name,
       character.inverseBindPose,
-      character.skinnedLocators};
+      character.skinnedLocators,
+      character.metadata,
+      character.physicalProperties};
 }
 
 momentum::Character loadFBXCharacterFromBytes(
@@ -188,7 +190,9 @@ momentum::Character loadConfigFromBytes(
       character.faceExpressionBlendShape,
       character.name,
       character.inverseBindPose,
-      character.skinnedLocators};
+      character.skinnedLocators,
+      character.metadata,
+      character.physicalProperties};
 }
 
 momentum::Character loadLocatorsFromBytes(
@@ -394,7 +398,9 @@ momentum::Character replaceRestMesh(const momentum::Character& character, RowMat
       character.faceExpressionBlendShape,
       character.name,
       character.inverseBindPose,
-      character.skinnedLocators};
+      character.skinnedLocators,
+      character.metadata,
+      character.physicalProperties};
 }
 
 // Get a boolean vector for selected vertices from selected bones.


### PR DESCRIPTION
Summary:

Allows center-of-mass constraints to provide optional joint-local mass offsets. Existing constraints without offsets keep using joint origins on the hot path, while imported physical properties can place each mass at its local center of mass. setConstraints now shares addConstraint validation for malformed constraints.

Reviewed By: cstollmeta

Differential Revision: D104556526


