### PR TITLE
Add Triton matrix-to-quaternion backend (#1429)

### DIFF
--- a/pymomentum/backend/triton_quaternion.py
+++ b/pymomentum/backend/triton_quaternion.py
@@ -145,6 +145,270 @@ if triton is not None and tl is not None:
         tl.store(out_base + 2, gz, mask=mask)
         tl.store(out_base + 3, gw, mask=mask)
 
+    @triton.jit
+    def _from_rotation_matrix_kernel(
+        matrices,
+        output,
+        n_matrices,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_matrices
+        matrix_base = matrices + offsets * 9
+
+        m00 = tl.load(matrix_base + 0, mask=mask, other=1.0)
+        m01 = tl.load(matrix_base + 1, mask=mask, other=0.0)
+        m02 = tl.load(matrix_base + 2, mask=mask, other=0.0)
+        m10 = tl.load(matrix_base + 3, mask=mask, other=0.0)
+        m11 = tl.load(matrix_base + 4, mask=mask, other=1.0)
+        m12 = tl.load(matrix_base + 5, mask=mask, other=0.0)
+        m20 = tl.load(matrix_base + 6, mask=mask, other=0.0)
+        m21 = tl.load(matrix_base + 7, mask=mask, other=0.0)
+        m22 = tl.load(matrix_base + 8, mask=mask, other=1.0)
+
+        qw_abs = tl.sqrt(tl.maximum(1.0 + m00 + m11 + m22, 1.0e-15))
+        qx_abs = tl.sqrt(tl.maximum(1.0 + m00 - m11 - m22, 1.0e-15))
+        qy_abs = tl.sqrt(tl.maximum(1.0 - m00 + m11 - m22, 1.0e-15))
+        qz_abs = tl.sqrt(tl.maximum(1.0 - m00 - m11 + m22, 1.0e-15))
+
+        flr = 0.01
+        qw_denom = 2.0 * tl.maximum(qw_abs, flr)
+        qx_denom = 2.0 * tl.maximum(qx_abs, flr)
+        qy_denom = 2.0 * tl.maximum(qy_abs, flr)
+        qz_denom = 2.0 * tl.maximum(qz_abs, flr)
+
+        x = (m21 - m12) / qw_denom
+        y = (m02 - m20) / qw_denom
+        z = (m10 - m01) / qw_denom
+        w = (qw_abs * qw_abs) / qw_denom
+
+        use_x = qx_abs > qw_abs
+        x = tl.where(use_x, (qx_abs * qx_abs) / qx_denom, x)
+        y = tl.where(use_x, (m10 + m01) / qx_denom, y)
+        z = tl.where(use_x, (m02 + m20) / qx_denom, z)
+        w = tl.where(use_x, (m21 - m12) / qx_denom, w)
+
+        use_y = (qy_abs > qw_abs) & (qy_abs > qx_abs)
+        x = tl.where(use_y, (m10 + m01) / qy_denom, x)
+        y = tl.where(use_y, (qy_abs * qy_abs) / qy_denom, y)
+        z = tl.where(use_y, (m12 + m21) / qy_denom, z)
+        w = tl.where(use_y, (m02 - m20) / qy_denom, w)
+
+        use_z = (qz_abs > qw_abs) & (qz_abs > qx_abs) & (qz_abs > qy_abs)
+        x = tl.where(use_z, (m20 + m02) / qz_denom, x)
+        y = tl.where(use_z, (m21 + m12) / qz_denom, y)
+        z = tl.where(use_z, (qz_abs * qz_abs) / qz_denom, z)
+        w = tl.where(use_z, (m10 - m01) / qz_denom, w)
+
+        norm2 = x * x + y * y + z * z + w * w
+        inv_norm = tl.rsqrt(tl.maximum(norm2, 1.0e-24))
+
+        out_base = output + offsets * 4
+        tl.store(out_base + 0, x * inv_norm, mask=mask)
+        tl.store(out_base + 1, y * inv_norm, mask=mask)
+        tl.store(out_base + 2, z * inv_norm, mask=mask)
+        tl.store(out_base + 3, w * inv_norm, mask=mask)
+
+    @triton.jit
+    def _accumulate_q_abs_grad(
+        grad_a,
+        a,
+        s,
+        sign00: tl.constexpr,
+        sign11: tl.constexpr,
+        sign22: tl.constexpr,
+    ):
+        grad_s = tl.where(s > 1.0e-15, grad_a * 0.5 / a, 0.0)
+        return sign00 * grad_s, sign11 * grad_s, sign22 * grad_s
+
+    @triton.jit
+    def _grad_div_num_by_2clamped_abs(grad_value, numerator, a):
+        denom = 2.0 * tl.maximum(a, 0.01)
+        grad_num = grad_value / denom
+        grad_a = tl.where(a >= 0.01, grad_value * (-numerator / (2.0 * a * a)), 0.0)
+        return grad_num, grad_a
+
+    @triton.jit
+    def _grad_abs_square_by_2clamped_abs(grad_value, a):
+        grad_a_unclamped = 0.5 * grad_value
+        grad_a_clamped = grad_value * a / 0.01
+        return tl.where(a >= 0.01, grad_a_unclamped, grad_a_clamped)
+
+    @triton.jit
+    def _from_rotation_matrix_backward_kernel(
+        matrices,
+        grad_output,
+        grad_matrices,
+        n_matrices,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_matrices
+        matrix_base = matrices + offsets * 9
+
+        m00 = tl.load(matrix_base + 0, mask=mask, other=1.0)
+        m01 = tl.load(matrix_base + 1, mask=mask, other=0.0)
+        m02 = tl.load(matrix_base + 2, mask=mask, other=0.0)
+        m10 = tl.load(matrix_base + 3, mask=mask, other=0.0)
+        m11 = tl.load(matrix_base + 4, mask=mask, other=1.0)
+        m12 = tl.load(matrix_base + 5, mask=mask, other=0.0)
+        m20 = tl.load(matrix_base + 6, mask=mask, other=0.0)
+        m21 = tl.load(matrix_base + 7, mask=mask, other=0.0)
+        m22 = tl.load(matrix_base + 8, mask=mask, other=1.0)
+
+        s0 = 1.0 + m00 + m11 + m22
+        s1 = 1.0 + m00 - m11 - m22
+        s2 = 1.0 - m00 + m11 - m22
+        s3 = 1.0 - m00 - m11 + m22
+        qw_abs = tl.sqrt(tl.maximum(s0, 1.0e-15))
+        qx_abs = tl.sqrt(tl.maximum(s1, 1.0e-15))
+        qy_abs = tl.sqrt(tl.maximum(s2, 1.0e-15))
+        qz_abs = tl.sqrt(tl.maximum(s3, 1.0e-15))
+
+        qw_denom = 2.0 * tl.maximum(qw_abs, 0.01)
+        qx_denom = 2.0 * tl.maximum(qx_abs, 0.01)
+        qy_denom = 2.0 * tl.maximum(qy_abs, 0.01)
+        qz_denom = 2.0 * tl.maximum(qz_abs, 0.01)
+
+        rx = (m21 - m12) / qw_denom
+        ry = (m02 - m20) / qw_denom
+        rz = (m10 - m01) / qw_denom
+        rw = (qw_abs * qw_abs) / qw_denom
+
+        xx = (qx_abs * qx_abs) / qx_denom
+        xy = (m10 + m01) / qx_denom
+        xz = (m02 + m20) / qx_denom
+        xw = (m21 - m12) / qx_denom
+
+        yx = (m10 + m01) / qy_denom
+        yy = (qy_abs * qy_abs) / qy_denom
+        yz = (m12 + m21) / qy_denom
+        yw = (m02 - m20) / qy_denom
+
+        zx = (m20 + m02) / qz_denom
+        zy = (m21 + m12) / qz_denom
+        zz = (qz_abs * qz_abs) / qz_denom
+        zw = (m10 - m01) / qz_denom
+
+        use_x = qx_abs > qw_abs
+        use_y = (qy_abs > qw_abs) & (qy_abs > qx_abs)
+        use_z = (qz_abs > qw_abs) & (qz_abs > qx_abs) & (qz_abs > qy_abs)
+
+        raw_x = tl.where(use_z, zx, tl.where(use_y, yx, tl.where(use_x, xx, rx)))
+        raw_y = tl.where(use_z, zy, tl.where(use_y, yy, tl.where(use_x, xy, ry)))
+        raw_z = tl.where(use_z, zz, tl.where(use_y, yz, tl.where(use_x, xz, rz)))
+        raw_w = tl.where(use_z, zw, tl.where(use_y, yw, tl.where(use_x, xw, rw)))
+
+        norm2 = raw_x * raw_x + raw_y * raw_y + raw_z * raw_z + raw_w * raw_w
+        inv_norm = tl.rsqrt(tl.maximum(norm2, 1.0e-24))
+        qx = raw_x * inv_norm
+        qy = raw_y * inv_norm
+        qz = raw_z * inv_norm
+        qw = raw_w * inv_norm
+
+        grad_base = grad_output + offsets * 4
+        gx = tl.load(grad_base + 0, mask=mask, other=0.0)
+        gy = tl.load(grad_base + 1, mask=mask, other=0.0)
+        gz = tl.load(grad_base + 2, mask=mask, other=0.0)
+        gw = tl.load(grad_base + 3, mask=mask, other=0.0)
+
+        dot = gx * qx + gy * qy + gz * qz + gw * qw
+        raw_gx = (gx - qx * dot) * inv_norm
+        raw_gy = (gy - qy * dot) * inv_norm
+        raw_gz = (gz - qz * dot) * inv_norm
+        raw_gw = (gw - qw * dot) * inv_norm
+
+        g00 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g01 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g02 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g10 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g11 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g12 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g20 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g21 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g22 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gx, m21 - m12, qw_abs)
+        rg21 = grad_num
+        rg12 = -grad_num
+        rga = grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gy, m02 - m20, qw_abs)
+        rg02 = grad_num
+        rg20 = -grad_num
+        rga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gz, m10 - m01, qw_abs)
+        rg10 = grad_num
+        rg01 = -grad_num
+        rga += grad_a
+        rga += _grad_abs_square_by_2clamped_abs(raw_gw, qw_abs)
+        rg00, rg11, rg22 = _accumulate_q_abs_grad(rga, qw_abs, s0, 1.0, 1.0, 1.0)
+
+        xga = _grad_abs_square_by_2clamped_abs(raw_gx, qx_abs)
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gy, m10 + m01, qx_abs)
+        xg10 = grad_num
+        xg01 = grad_num
+        xga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gz, m02 + m20, qx_abs)
+        xg02 = grad_num
+        xg20 = grad_num
+        xga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gw, m21 - m12, qx_abs)
+        xg21 = grad_num
+        xg12 = -grad_num
+        xga += grad_a
+        xg00, xg11, xg22 = _accumulate_q_abs_grad(xga, qx_abs, s1, 1.0, -1.0, -1.0)
+
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gx, m10 + m01, qy_abs)
+        yg10 = grad_num
+        yg01 = grad_num
+        yga = grad_a
+        yga += _grad_abs_square_by_2clamped_abs(raw_gy, qy_abs)
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gz, m12 + m21, qy_abs)
+        yg12 = grad_num
+        yg21 = grad_num
+        yga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gw, m02 - m20, qy_abs)
+        yg02 = grad_num
+        yg20 = -grad_num
+        yga += grad_a
+        yg00, yg11, yg22 = _accumulate_q_abs_grad(yga, qy_abs, s2, -1.0, 1.0, -1.0)
+
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gx, m20 + m02, qz_abs)
+        zg20 = grad_num
+        zg02 = grad_num
+        zga = grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gy, m21 + m12, qz_abs)
+        zg21 = grad_num
+        zg12 = grad_num
+        zga += grad_a
+        zga += _grad_abs_square_by_2clamped_abs(raw_gz, qz_abs)
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gw, m10 - m01, qz_abs)
+        zg10 = grad_num
+        zg01 = -grad_num
+        zga += grad_a
+        zg00, zg11, zg22 = _accumulate_q_abs_grad(zga, qz_abs, s3, -1.0, -1.0, 1.0)
+
+        g00 = tl.where(use_z, zg00, tl.where(use_y, yg00, tl.where(use_x, xg00, rg00)))
+        g01 = tl.where(use_z, zg01, tl.where(use_y, yg01, tl.where(use_x, xg01, rg01)))
+        g02 = tl.where(use_z, zg02, tl.where(use_y, yg02, tl.where(use_x, xg02, rg02)))
+        g10 = tl.where(use_z, zg10, tl.where(use_y, yg10, tl.where(use_x, xg10, rg10)))
+        g11 = tl.where(use_z, zg11, tl.where(use_y, yg11, tl.where(use_x, xg11, rg11)))
+        g12 = tl.where(use_z, zg12, tl.where(use_y, yg12, tl.where(use_x, xg12, rg12)))
+        g20 = tl.where(use_z, zg20, tl.where(use_y, yg20, tl.where(use_x, xg20, rg20)))
+        g21 = tl.where(use_z, zg21, tl.where(use_y, yg21, tl.where(use_x, xg21, rg21)))
+        g22 = tl.where(use_z, zg22, tl.where(use_y, yg22, tl.where(use_x, xg22, rg22)))
+
+        out_base = grad_matrices + offsets * 9
+        tl.store(out_base + 0, g00, mask=mask)
+        tl.store(out_base + 1, g01, mask=mask)
+        tl.store(out_base + 2, g02, mask=mask)
+        tl.store(out_base + 3, g10, mask=mask)
+        tl.store(out_base + 4, g11, mask=mask)
+        tl.store(out_base + 5, g12, mask=mask)
+        tl.store(out_base + 6, g20, mask=mask)
+        tl.store(out_base + 7, g21, mask=mask)
+        tl.store(out_base + 8, g22, mask=mask)
+
 
 def _require_triton() -> None:
     if triton is None or tl is None:
@@ -163,6 +427,15 @@ def _validate_quaternions(q: torch.Tensor, eps: float) -> None:
         raise RuntimeError("Quaternion tensor must have shape [..., 4].")
     if eps <= 0.0:
         raise RuntimeError("eps must be positive.")
+
+
+def _validate_rotation_matrices(matrices: torch.Tensor) -> None:
+    if not matrices.is_cuda:
+        raise RuntimeError("Triton quaternion backend requested, but input is on CPU.")
+    if matrices.dtype != torch.float32:
+        raise RuntimeError("Triton quaternion backend currently only supports float32.")
+    if matrices.ndim < 2 or matrices.shape[-2:] != (3, 3):
+        raise RuntimeError("Rotation matrix tensor must have shape [..., 3, 3].")
 
 
 def _launch_forward(q: torch.Tensor, normalize: bool, eps: float) -> torch.Tensor:
@@ -184,6 +457,44 @@ def _launch_forward(q: torch.Tensor, normalize: bool, eps: float) -> torch.Tenso
         BLOCK_SIZE=_BLOCK_SIZE,
     )
     return output
+
+
+def _launch_from_rotation_matrix(matrices: torch.Tensor) -> torch.Tensor:
+    _validate_rotation_matrices(matrices)
+    _require_triton()
+    n_matrices = matrices.numel() // 9
+    output = torch.empty(
+        (*matrices.shape[:-2], 4),
+        device=matrices.device,
+        dtype=matrices.dtype,
+    )
+    grid = (triton.cdiv(n_matrices, _BLOCK_SIZE),)
+    _from_rotation_matrix_kernel[grid](
+        matrices,
+        output,
+        n_matrices,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return output
+
+
+def _launch_from_rotation_matrix_backward(
+    matrices: torch.Tensor,
+    grad_output: torch.Tensor,
+) -> torch.Tensor:
+    _require_triton()
+    grad_output = grad_output.contiguous()
+    grad_matrices = torch.empty_like(matrices)
+    n_matrices = matrices.numel() // 9
+    grid = (triton.cdiv(n_matrices, _BLOCK_SIZE),)
+    _from_rotation_matrix_backward_kernel[grid](
+        matrices,
+        grad_output,
+        grad_matrices,
+        n_matrices,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return grad_matrices
 
 
 def _launch_backward(
@@ -234,9 +545,34 @@ class _ToRotationMatrix(torch.autograd.Function):
         return grad_q, None, None
 
 
+class _FromRotationMatrix(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        matrices: torch.Tensor,
+    ) -> torch.Tensor:
+        matrices = matrices.contiguous()
+        output = _launch_from_rotation_matrix(matrices)
+        ctx.save_for_backward(matrices)
+        return output
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor]:
+        (matrices,) = ctx.saved_tensors
+        grad_matrices = _launch_from_rotation_matrix_backward(matrices, grad_output)
+        return (grad_matrices,)
+
+
 def to_rotation_matrix(q: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
     return _ToRotationMatrix.apply(q, True, eps)
 
 
 def to_rotation_matrix_assume_normalized(q: torch.Tensor) -> torch.Tensor:
     return _ToRotationMatrix.apply(q, False, 1.0)
+
+
+def from_rotation_matrix(matrices: torch.Tensor) -> torch.Tensor:
+    return _FromRotationMatrix.apply(matrices)

--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -299,7 +299,9 @@ def euler_zyx_to_quaternion(euler_zyx: torch.Tensor) -> torch.Tensor:
     return torch_quaternion.euler_zyx_to_quaternion(euler_zyx)
 
 
-def from_rotation_matrix(matrices: torch.Tensor, eta: float = 1e-6) -> torch.Tensor:
+def from_rotation_matrix(
+    matrices: torch.Tensor, eta: float = 1e-6, backend: str = "torch"
+) -> torch.Tensor:
     """
     Convert a rotation matrix to a quaternion using numerically stable method.
 
@@ -309,8 +311,18 @@ def from_rotation_matrix(matrices: torch.Tensor, eta: float = 1e-6) -> torch.Ten
 
     :parameter matrices: A tensor of shape (..., 3, 3) representing the rotation matrices.
     :parameter eta: Numerical precision threshold (unused, kept for compatibility).
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
     :return: A tensor of shape (..., 4) representing the quaternions in ((x, y, z), w) format.
     """
+    backend = resolve_backend(
+        backend,
+        matrices,
+        use_double_precision=matrices.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _get_triton_quaternion().from_rotation_matrix(matrices)
+    if backend != "torch":
+        raise ValueError(f"Unsupported quaternion backend: {backend}")
     return torch_quaternion.from_rotation_matrix(matrices, eta)
 
 

--- a/pymomentum/quaternion_np.py
+++ b/pymomentum/quaternion_np.py
@@ -334,7 +334,7 @@ def euler_zyx_to_quaternion(euler_zyx: NDArray) -> NDArray:
     return np.stack((x, y, z, w), axis=-1)
 
 
-def from_rotation_matrix(matrices: NDArray, eta: float = 1e-6) -> NDArray:
+def from_rotation_matrix(matrices: NDArray) -> NDArray:
     """
     Convert a rotation matrix to a quaternion using numerically stable method.
 
@@ -343,7 +343,6 @@ def from_rotation_matrix(matrices: NDArray, eta: float = 1e-6) -> NDArray:
     stability across all rotation matrix configurations.
 
     :parameter matrices: An array of shape (..., 3, 3) representing the rotation matrices.
-    :parameter eta: Numerical precision threshold (unused, kept for compatibility).
     :return: An array of shape (..., 4) representing the quaternions in ((x, y, z), w) format.
     """
     m = matrices

--- a/pymomentum/test/test_quaternion.py
+++ b/pymomentum/test/test_quaternion.py
@@ -92,6 +92,10 @@ class TestQuaternion(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
             quaternion.to_rotation_matrix(quats, backend="triton")
 
+        mats = quaternion.to_rotation_matrix(quats)
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            quaternion.from_rotation_matrix(mats, backend="triton")
+
     def test_multiply(self) -> None:
         torch.manual_seed(0)  # ensure repeatability
         nMat = 5

--- a/pymomentum/test/test_triton_backend.py
+++ b/pymomentum/test/test_triton_backend.py
@@ -11,6 +11,7 @@ import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_tes
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.torch.character as pym_character
 import torch
+from pymomentum.backend import selection as backend_selection
 
 
 def _cuda_device() -> torch.device:
@@ -22,6 +23,31 @@ def _cuda_device() -> torch.device:
 
 
 class TritonBackendTest(unittest.TestCase):
+    def test_auto_backend_selection(self) -> None:
+        cpu_tensor = torch.empty((1,), dtype=torch.float32)
+
+        self.assertEqual(backend_selection.resolve_backend("auto", cpu_tensor), "torch")
+        self.assertEqual(
+            backend_selection.resolve_backend(
+                "auto",
+                cpu_tensor.to(torch.float64),
+                use_double_precision=True,
+            ),
+            "torch",
+        )
+        self.assertEqual(
+            backend_selection.resolve_backend("torch", cpu_tensor), "torch"
+        )
+        self.assertEqual(
+            backend_selection.resolve_backend("triton", cpu_tensor), "triton"
+        )
+
+        if torch.cuda.is_available() and backend_selection._HAS_TRITON:
+            cuda_tensor = cpu_tensor.cuda()
+            self.assertEqual(
+                backend_selection.resolve_backend("auto", cuda_tensor), "triton"
+            )
+
     def test_fk_matches_torch(self) -> None:
         device = _cuda_device()
         character_cpu = pym_test_utils.create_test_character()
@@ -177,6 +203,38 @@ class TritonBackendTest(unittest.TestCase):
             assume_normalized=True,
             eps=1e-12,
         )
+
+    def test_quaternion_from_rotation_matrix_matches_torch(self) -> None:
+        device = _cuda_device()
+
+        torch.manual_seed(0)
+        quaternions = pym_quaternion.normalize(
+            torch.randn((2, 3, 257, 4), device=device, dtype=torch.float32)
+        )
+        matrices = pym_quaternion.to_rotation_matrix(quaternions)
+
+        torch_matrices = matrices.detach().clone().requires_grad_()
+        triton_matrices = matrices.detach().clone().requires_grad_()
+
+        torch_result = pym_quaternion.from_rotation_matrix(torch_matrices)
+        triton_result = pym_quaternion.from_rotation_matrix(
+            triton_matrices,
+            backend="triton",
+        )
+
+        torch.testing.assert_close(torch_result, triton_result, atol=1e-6, rtol=1e-6)
+
+        grad_output = torch.randn_like(torch_result)
+        torch_result.backward(grad_output)
+        triton_result.backward(grad_output)
+
+        torch_grad = torch_matrices.grad
+        triton_grad = triton_matrices.grad
+        self.assertIsNotNone(torch_grad)
+        self.assertIsNotNone(triton_grad)
+        if torch_grad is None or triton_grad is None:
+            return
+        torch.testing.assert_close(torch_grad, triton_grad, atol=1e-5, rtol=1e-5)
 
     def test_zero_quaternion_is_finite(self) -> None:
         device = _cuda_device()

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -362,10 +362,7 @@ class Skeleton(torch.nn.Module):
         skel_state: torch.Tensor,
         backend: str = "torch",
     ) -> torch.Tensor:
-        if torch.jit.is_scripting():
-            resolved = "torch" if backend == "auto" else backend
-        else:
-            resolved = resolve_backend(backend, skel_state.float())
+        resolved = resolve_backend(backend, skel_state.float())
         if resolved == "triton":
             with torch.amp.autocast("cuda", enabled=False):
                 return triton_skel_state.skeleton_state_to_joint_parameters(
@@ -387,12 +384,9 @@ class Skeleton(torch.nn.Module):
         fk_backend: str = "auto",
         active_joints: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if torch.jit.is_scripting():
-            resolved = "torch" if fk_backend == "auto" else fk_backend
-        else:
-            resolved = resolve_backend(
-                fk_backend, joint_parameters.float(), use_double_precision
-            )
+        resolved = resolve_backend(
+            fk_backend, joint_parameters.float(), use_double_precision
+        )
         if resolved == "triton" and use_double_precision:
             raise RuntimeError(
                 "Triton FK does not support double precision; "
@@ -988,12 +982,9 @@ class Character(torch.nn.Module):
             raise RuntimeError(
                 "Character has no parameter transform, please provide one"
             )
-        if torch.jit.is_scripting():
-            resolved = "torch" if fk_backend == "auto" else fk_backend
-        else:
-            resolved = resolve_backend(
-                fk_backend, model_parameters.float(), use_double_precision
-            )
+        resolved = resolve_backend(
+            fk_backend, model_parameters.float(), use_double_precision
+        )
         active_joints = self.parameter_transform.active_joints
         return self.joint_parameters_to_skeleton_state(
             self.model_parameters_to_joint_parameters(model_parameters),


### PR DESCRIPTION
Summary:

Add `pymomentum.quaternion.from_rotation_matrix` support for the Triton backend, move backend auto/JIT selection into `resolve_backend`, remove the unused `eta` argument, and switch Kinesis-facing quaternion conversion call sites from `pytorch3d.transforms` to `pymomentum.quaternion` so CUDA float32 paths can use the new backend.

Reviewed By: shugurov

Differential Revision: D106187851


