### PR TITLE
Add Triton skeleton state ops (#1431)

### DIFF
--- a/pymomentum/backend/torch_quaternion.py
+++ b/pymomentum/backend/torch_quaternion.py
@@ -295,6 +295,15 @@ def identity(
     )
 
 
+def _sinc_half(angles: torch.Tensor) -> torch.Tensor:
+    """Compute sin(θ/2)/θ with a Taylor expansion near the origin."""
+    return torch.where(
+        torch.abs(angles) < 1e-6,
+        0.5 - (angles * angles) / 48.0,
+        torch.sin(angles / 2.0) / angles.clamp(min=1e-10),
+    )
+
+
 def from_axis_angle(axis_angle: torch.Tensor) -> torch.Tensor:
     """
     Convert an axis-angle tensor to a quaternion.
@@ -303,11 +312,24 @@ def from_axis_angle(axis_angle: torch.Tensor) -> torch.Tensor:
     :return: A tensor of shape (..., 4) representing the quaternion in ((x, y, z), w) format.
     """
     angles = axis_angle.norm(dim=-1, keepdim=True)
-    normed_axes = axis_angle / angles.clamp(min=1e-8)
-    sin_half_angles = torch.sin(angles / 2)
     cos_half_angles = torch.cos(angles / 2)
+    return torch.cat([axis_angle * _sinc_half(angles), cos_half_angles], dim=-1)
 
-    return torch.cat([normed_axes * sin_half_angles, cos_half_angles], dim=-1)
+
+def to_axis_angle(quaternions: torch.Tensor) -> torch.Tensor:
+    """
+    Convert a quaternion to an axis-angle tensor.
+
+    :parameter quaternions: A tensor of shape (..., 4) representing quaternions in ((x, y, z), w) format.
+    :return: A tensor of shape (..., 3) representing the axis-angle with magnitude in [0, π].
+    """
+    # Map to the short-arc hemisphere (w >= 0) so angles stay in [0, π]
+    # and _sinc_half is bounded away from zero.
+    quaternions = torch.where(quaternions[..., 3:] < 0, -quaternions, quaternions)
+    vector = quaternions[..., :3]
+    scalar = quaternions[..., 3:]
+    angles = 2.0 * torch.atan2(torch.linalg.norm(vector, dim=-1, keepdim=True), scalar)
+    return vector / _sinc_half(angles)
 
 
 def euler_xyz_to_quaternion(euler_xyz: torch.Tensor) -> torch.Tensor:

--- a/pymomentum/backend/triton_quaternion.py
+++ b/pymomentum/backend/triton_quaternion.py
@@ -145,6 +145,270 @@ if triton is not None and tl is not None:
         tl.store(out_base + 2, gz, mask=mask)
         tl.store(out_base + 3, gw, mask=mask)
 
+    @triton.jit
+    def _from_rotation_matrix_kernel(
+        matrices,
+        output,
+        n_matrices,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_matrices
+        matrix_base = matrices + offsets * 9
+
+        m00 = tl.load(matrix_base + 0, mask=mask, other=1.0)
+        m01 = tl.load(matrix_base + 1, mask=mask, other=0.0)
+        m02 = tl.load(matrix_base + 2, mask=mask, other=0.0)
+        m10 = tl.load(matrix_base + 3, mask=mask, other=0.0)
+        m11 = tl.load(matrix_base + 4, mask=mask, other=1.0)
+        m12 = tl.load(matrix_base + 5, mask=mask, other=0.0)
+        m20 = tl.load(matrix_base + 6, mask=mask, other=0.0)
+        m21 = tl.load(matrix_base + 7, mask=mask, other=0.0)
+        m22 = tl.load(matrix_base + 8, mask=mask, other=1.0)
+
+        qw_abs = tl.sqrt(tl.maximum(1.0 + m00 + m11 + m22, 1.0e-15))
+        qx_abs = tl.sqrt(tl.maximum(1.0 + m00 - m11 - m22, 1.0e-15))
+        qy_abs = tl.sqrt(tl.maximum(1.0 - m00 + m11 - m22, 1.0e-15))
+        qz_abs = tl.sqrt(tl.maximum(1.0 - m00 - m11 + m22, 1.0e-15))
+
+        flr = 0.01
+        qw_denom = 2.0 * tl.maximum(qw_abs, flr)
+        qx_denom = 2.0 * tl.maximum(qx_abs, flr)
+        qy_denom = 2.0 * tl.maximum(qy_abs, flr)
+        qz_denom = 2.0 * tl.maximum(qz_abs, flr)
+
+        x = (m21 - m12) / qw_denom
+        y = (m02 - m20) / qw_denom
+        z = (m10 - m01) / qw_denom
+        w = (qw_abs * qw_abs) / qw_denom
+
+        use_x = qx_abs > qw_abs
+        x = tl.where(use_x, (qx_abs * qx_abs) / qx_denom, x)
+        y = tl.where(use_x, (m10 + m01) / qx_denom, y)
+        z = tl.where(use_x, (m02 + m20) / qx_denom, z)
+        w = tl.where(use_x, (m21 - m12) / qx_denom, w)
+
+        use_y = (qy_abs > qw_abs) & (qy_abs > qx_abs)
+        x = tl.where(use_y, (m10 + m01) / qy_denom, x)
+        y = tl.where(use_y, (qy_abs * qy_abs) / qy_denom, y)
+        z = tl.where(use_y, (m12 + m21) / qy_denom, z)
+        w = tl.where(use_y, (m02 - m20) / qy_denom, w)
+
+        use_z = (qz_abs > qw_abs) & (qz_abs > qx_abs) & (qz_abs > qy_abs)
+        x = tl.where(use_z, (m20 + m02) / qz_denom, x)
+        y = tl.where(use_z, (m21 + m12) / qz_denom, y)
+        z = tl.where(use_z, (qz_abs * qz_abs) / qz_denom, z)
+        w = tl.where(use_z, (m10 - m01) / qz_denom, w)
+
+        norm2 = x * x + y * y + z * z + w * w
+        inv_norm = tl.rsqrt(tl.maximum(norm2, 1.0e-24))
+
+        out_base = output + offsets * 4
+        tl.store(out_base + 0, x * inv_norm, mask=mask)
+        tl.store(out_base + 1, y * inv_norm, mask=mask)
+        tl.store(out_base + 2, z * inv_norm, mask=mask)
+        tl.store(out_base + 3, w * inv_norm, mask=mask)
+
+    @triton.jit
+    def _accumulate_q_abs_grad(
+        grad_a,
+        a,
+        s,
+        sign00: tl.constexpr,
+        sign11: tl.constexpr,
+        sign22: tl.constexpr,
+    ):
+        grad_s = tl.where(s > 1.0e-15, grad_a * 0.5 / a, 0.0)
+        return sign00 * grad_s, sign11 * grad_s, sign22 * grad_s
+
+    @triton.jit
+    def _grad_div_num_by_2clamped_abs(grad_value, numerator, a):
+        denom = 2.0 * tl.maximum(a, 0.01)
+        grad_num = grad_value / denom
+        grad_a = tl.where(a >= 0.01, grad_value * (-numerator / (2.0 * a * a)), 0.0)
+        return grad_num, grad_a
+
+    @triton.jit
+    def _grad_abs_square_by_2clamped_abs(grad_value, a):
+        grad_a_unclamped = 0.5 * grad_value
+        grad_a_clamped = grad_value * a / 0.01
+        return tl.where(a >= 0.01, grad_a_unclamped, grad_a_clamped)
+
+    @triton.jit
+    def _from_rotation_matrix_backward_kernel(
+        matrices,
+        grad_output,
+        grad_matrices,
+        n_matrices,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_matrices
+        matrix_base = matrices + offsets * 9
+
+        m00 = tl.load(matrix_base + 0, mask=mask, other=1.0)
+        m01 = tl.load(matrix_base + 1, mask=mask, other=0.0)
+        m02 = tl.load(matrix_base + 2, mask=mask, other=0.0)
+        m10 = tl.load(matrix_base + 3, mask=mask, other=0.0)
+        m11 = tl.load(matrix_base + 4, mask=mask, other=1.0)
+        m12 = tl.load(matrix_base + 5, mask=mask, other=0.0)
+        m20 = tl.load(matrix_base + 6, mask=mask, other=0.0)
+        m21 = tl.load(matrix_base + 7, mask=mask, other=0.0)
+        m22 = tl.load(matrix_base + 8, mask=mask, other=1.0)
+
+        s0 = 1.0 + m00 + m11 + m22
+        s1 = 1.0 + m00 - m11 - m22
+        s2 = 1.0 - m00 + m11 - m22
+        s3 = 1.0 - m00 - m11 + m22
+        qw_abs = tl.sqrt(tl.maximum(s0, 1.0e-15))
+        qx_abs = tl.sqrt(tl.maximum(s1, 1.0e-15))
+        qy_abs = tl.sqrt(tl.maximum(s2, 1.0e-15))
+        qz_abs = tl.sqrt(tl.maximum(s3, 1.0e-15))
+
+        qw_denom = 2.0 * tl.maximum(qw_abs, 0.01)
+        qx_denom = 2.0 * tl.maximum(qx_abs, 0.01)
+        qy_denom = 2.0 * tl.maximum(qy_abs, 0.01)
+        qz_denom = 2.0 * tl.maximum(qz_abs, 0.01)
+
+        rx = (m21 - m12) / qw_denom
+        ry = (m02 - m20) / qw_denom
+        rz = (m10 - m01) / qw_denom
+        rw = (qw_abs * qw_abs) / qw_denom
+
+        xx = (qx_abs * qx_abs) / qx_denom
+        xy = (m10 + m01) / qx_denom
+        xz = (m02 + m20) / qx_denom
+        xw = (m21 - m12) / qx_denom
+
+        yx = (m10 + m01) / qy_denom
+        yy = (qy_abs * qy_abs) / qy_denom
+        yz = (m12 + m21) / qy_denom
+        yw = (m02 - m20) / qy_denom
+
+        zx = (m20 + m02) / qz_denom
+        zy = (m21 + m12) / qz_denom
+        zz = (qz_abs * qz_abs) / qz_denom
+        zw = (m10 - m01) / qz_denom
+
+        use_x = qx_abs > qw_abs
+        use_y = (qy_abs > qw_abs) & (qy_abs > qx_abs)
+        use_z = (qz_abs > qw_abs) & (qz_abs > qx_abs) & (qz_abs > qy_abs)
+
+        raw_x = tl.where(use_z, zx, tl.where(use_y, yx, tl.where(use_x, xx, rx)))
+        raw_y = tl.where(use_z, zy, tl.where(use_y, yy, tl.where(use_x, xy, ry)))
+        raw_z = tl.where(use_z, zz, tl.where(use_y, yz, tl.where(use_x, xz, rz)))
+        raw_w = tl.where(use_z, zw, tl.where(use_y, yw, tl.where(use_x, xw, rw)))
+
+        norm2 = raw_x * raw_x + raw_y * raw_y + raw_z * raw_z + raw_w * raw_w
+        inv_norm = tl.rsqrt(tl.maximum(norm2, 1.0e-24))
+        qx = raw_x * inv_norm
+        qy = raw_y * inv_norm
+        qz = raw_z * inv_norm
+        qw = raw_w * inv_norm
+
+        grad_base = grad_output + offsets * 4
+        gx = tl.load(grad_base + 0, mask=mask, other=0.0)
+        gy = tl.load(grad_base + 1, mask=mask, other=0.0)
+        gz = tl.load(grad_base + 2, mask=mask, other=0.0)
+        gw = tl.load(grad_base + 3, mask=mask, other=0.0)
+
+        dot = gx * qx + gy * qy + gz * qz + gw * qw
+        raw_gx = (gx - qx * dot) * inv_norm
+        raw_gy = (gy - qy * dot) * inv_norm
+        raw_gz = (gz - qz * dot) * inv_norm
+        raw_gw = (gw - qw * dot) * inv_norm
+
+        g00 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g01 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g02 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g10 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g11 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g12 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g20 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g21 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        g22 = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gx, m21 - m12, qw_abs)
+        rg21 = grad_num
+        rg12 = -grad_num
+        rga = grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gy, m02 - m20, qw_abs)
+        rg02 = grad_num
+        rg20 = -grad_num
+        rga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gz, m10 - m01, qw_abs)
+        rg10 = grad_num
+        rg01 = -grad_num
+        rga += grad_a
+        rga += _grad_abs_square_by_2clamped_abs(raw_gw, qw_abs)
+        rg00, rg11, rg22 = _accumulate_q_abs_grad(rga, qw_abs, s0, 1.0, 1.0, 1.0)
+
+        xga = _grad_abs_square_by_2clamped_abs(raw_gx, qx_abs)
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gy, m10 + m01, qx_abs)
+        xg10 = grad_num
+        xg01 = grad_num
+        xga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gz, m02 + m20, qx_abs)
+        xg02 = grad_num
+        xg20 = grad_num
+        xga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gw, m21 - m12, qx_abs)
+        xg21 = grad_num
+        xg12 = -grad_num
+        xga += grad_a
+        xg00, xg11, xg22 = _accumulate_q_abs_grad(xga, qx_abs, s1, 1.0, -1.0, -1.0)
+
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gx, m10 + m01, qy_abs)
+        yg10 = grad_num
+        yg01 = grad_num
+        yga = grad_a
+        yga += _grad_abs_square_by_2clamped_abs(raw_gy, qy_abs)
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gz, m12 + m21, qy_abs)
+        yg12 = grad_num
+        yg21 = grad_num
+        yga += grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gw, m02 - m20, qy_abs)
+        yg02 = grad_num
+        yg20 = -grad_num
+        yga += grad_a
+        yg00, yg11, yg22 = _accumulate_q_abs_grad(yga, qy_abs, s2, -1.0, 1.0, -1.0)
+
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gx, m20 + m02, qz_abs)
+        zg20 = grad_num
+        zg02 = grad_num
+        zga = grad_a
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gy, m21 + m12, qz_abs)
+        zg21 = grad_num
+        zg12 = grad_num
+        zga += grad_a
+        zga += _grad_abs_square_by_2clamped_abs(raw_gz, qz_abs)
+        grad_num, grad_a = _grad_div_num_by_2clamped_abs(raw_gw, m10 - m01, qz_abs)
+        zg10 = grad_num
+        zg01 = -grad_num
+        zga += grad_a
+        zg00, zg11, zg22 = _accumulate_q_abs_grad(zga, qz_abs, s3, -1.0, -1.0, 1.0)
+
+        g00 = tl.where(use_z, zg00, tl.where(use_y, yg00, tl.where(use_x, xg00, rg00)))
+        g01 = tl.where(use_z, zg01, tl.where(use_y, yg01, tl.where(use_x, xg01, rg01)))
+        g02 = tl.where(use_z, zg02, tl.where(use_y, yg02, tl.where(use_x, xg02, rg02)))
+        g10 = tl.where(use_z, zg10, tl.where(use_y, yg10, tl.where(use_x, xg10, rg10)))
+        g11 = tl.where(use_z, zg11, tl.where(use_y, yg11, tl.where(use_x, xg11, rg11)))
+        g12 = tl.where(use_z, zg12, tl.where(use_y, yg12, tl.where(use_x, xg12, rg12)))
+        g20 = tl.where(use_z, zg20, tl.where(use_y, yg20, tl.where(use_x, xg20, rg20)))
+        g21 = tl.where(use_z, zg21, tl.where(use_y, yg21, tl.where(use_x, xg21, rg21)))
+        g22 = tl.where(use_z, zg22, tl.where(use_y, yg22, tl.where(use_x, xg22, rg22)))
+
+        out_base = grad_matrices + offsets * 9
+        tl.store(out_base + 0, g00, mask=mask)
+        tl.store(out_base + 1, g01, mask=mask)
+        tl.store(out_base + 2, g02, mask=mask)
+        tl.store(out_base + 3, g10, mask=mask)
+        tl.store(out_base + 4, g11, mask=mask)
+        tl.store(out_base + 5, g12, mask=mask)
+        tl.store(out_base + 6, g20, mask=mask)
+        tl.store(out_base + 7, g21, mask=mask)
+        tl.store(out_base + 8, g22, mask=mask)
+
 
 def _require_triton() -> None:
     if triton is None or tl is None:
@@ -163,6 +427,15 @@ def _validate_quaternions(q: torch.Tensor, eps: float) -> None:
         raise RuntimeError("Quaternion tensor must have shape [..., 4].")
     if eps <= 0.0:
         raise RuntimeError("eps must be positive.")
+
+
+def _validate_rotation_matrices(matrices: torch.Tensor) -> None:
+    if not matrices.is_cuda:
+        raise RuntimeError("Triton quaternion backend requested, but input is on CPU.")
+    if matrices.dtype != torch.float32:
+        raise RuntimeError("Triton quaternion backend currently only supports float32.")
+    if matrices.ndim < 2 or matrices.shape[-2:] != (3, 3):
+        raise RuntimeError("Rotation matrix tensor must have shape [..., 3, 3].")
 
 
 def _launch_forward(q: torch.Tensor, normalize: bool, eps: float) -> torch.Tensor:
@@ -184,6 +457,44 @@ def _launch_forward(q: torch.Tensor, normalize: bool, eps: float) -> torch.Tenso
         BLOCK_SIZE=_BLOCK_SIZE,
     )
     return output
+
+
+def _launch_from_rotation_matrix(matrices: torch.Tensor) -> torch.Tensor:
+    _validate_rotation_matrices(matrices)
+    _require_triton()
+    n_matrices = matrices.numel() // 9
+    output = torch.empty(
+        (*matrices.shape[:-2], 4),
+        device=matrices.device,
+        dtype=matrices.dtype,
+    )
+    grid = (triton.cdiv(n_matrices, _BLOCK_SIZE),)
+    _from_rotation_matrix_kernel[grid](
+        matrices,
+        output,
+        n_matrices,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return output
+
+
+def _launch_from_rotation_matrix_backward(
+    matrices: torch.Tensor,
+    grad_output: torch.Tensor,
+) -> torch.Tensor:
+    _require_triton()
+    grad_output = grad_output.contiguous()
+    grad_matrices = torch.empty_like(matrices)
+    n_matrices = matrices.numel() // 9
+    grid = (triton.cdiv(n_matrices, _BLOCK_SIZE),)
+    _from_rotation_matrix_backward_kernel[grid](
+        matrices,
+        grad_output,
+        grad_matrices,
+        n_matrices,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return grad_matrices
 
 
 def _launch_backward(
@@ -234,9 +545,34 @@ class _ToRotationMatrix(torch.autograd.Function):
         return grad_q, None, None
 
 
+class _FromRotationMatrix(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        matrices: torch.Tensor,
+    ) -> torch.Tensor:
+        matrices = matrices.contiguous()
+        output = _launch_from_rotation_matrix(matrices)
+        ctx.save_for_backward(matrices)
+        return output
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor]:
+        (matrices,) = ctx.saved_tensors
+        grad_matrices = _launch_from_rotation_matrix_backward(matrices, grad_output)
+        return (grad_matrices,)
+
+
 def to_rotation_matrix(q: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
     return _ToRotationMatrix.apply(q, True, eps)
 
 
 def to_rotation_matrix_assume_normalized(q: torch.Tensor) -> torch.Tensor:
     return _ToRotationMatrix.apply(q, False, 1.0)
+
+
+def from_rotation_matrix(matrices: torch.Tensor) -> torch.Tensor:
+    return _FromRotationMatrix.apply(matrices)

--- a/pymomentum/backend/triton_skel_state.py
+++ b/pymomentum/backend/triton_skel_state.py
@@ -28,6 +28,7 @@ except ImportError:
 
 
 _BLOCK_BATCH = 128
+_BLOCK_SIZE = 256
 _LN2 = math.log(2.0)
 _NORM_EPS = 1e-12
 _EULER_EPS = 1e-6
@@ -151,6 +152,280 @@ if triton is not None and tl is not None:  # noqa: C901
             tl.load(base + 5, mask=mask, other=0.0),
             tl.load(base + 6, mask=mask, other=1.0),
             tl.load(base + 7, mask=mask, other=1.0),
+        )
+
+    @triton.jit
+    def _load_flat_state(data, offset, mask):
+        base = data + offset * 8
+        return (
+            tl.load(base + 0, mask=mask, other=0.0),
+            tl.load(base + 1, mask=mask, other=0.0),
+            tl.load(base + 2, mask=mask, other=0.0),
+            tl.load(base + 3, mask=mask, other=0.0),
+            tl.load(base + 4, mask=mask, other=0.0),
+            tl.load(base + 5, mask=mask, other=0.0),
+            tl.load(base + 6, mask=mask, other=1.0),
+            tl.load(base + 7, mask=mask, other=1.0),
+        )
+
+    @triton.jit
+    def _store_flat_state(output, offset, state, mask):
+        base = output + offset * 8
+        tl.store(base + 0, state[0], mask=mask)
+        tl.store(base + 1, state[1], mask=mask)
+        tl.store(base + 2, state[2], mask=mask)
+        tl.store(base + 3, state[3], mask=mask)
+        tl.store(base + 4, state[4], mask=mask)
+        tl.store(base + 5, state[5], mask=mask)
+        tl.store(base + 6, state[6], mask=mask)
+        tl.store(base + 7, state[7], mask=mask)
+
+    @triton.jit
+    def _multiply_state(state1, state2, NORMALIZE: tl.constexpr):
+        t1x, t1y, t1z, q1x, q1y, q1z, q1w, s1 = state1
+        t2x, t2y, t2z, q2x, q2y, q2z, q2w, s2 = state2
+        if NORMALIZE:
+            q1x, q1y, q1z, q1w = _normalize_quaternion(q1x, q1y, q1z, q1w)
+            q2x, q2y, q2z, q2w = _normalize_quaternion(q2x, q2y, q2z, q2w)
+        rtx, rty, rtz = _rotate_vector(q1x, q1y, q1z, q1w, t2x, t2y, t2z)
+        qx, qy, qz, qw = _quat_multiply(q1x, q1y, q1z, q1w, q2x, q2y, q2z, q2w)
+        return (
+            t1x + s1 * rtx,
+            t1y + s1 * rty,
+            t1z + s1 * rtz,
+            qx,
+            qy,
+            qz,
+            qw,
+            s1 * s2,
+        )
+
+    @triton.jit
+    def _multiply_kernel(
+        state1,
+        state2,
+        output,
+        n_states,
+        NORMALIZE: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        _store_flat_state(
+            output,
+            offsets,
+            _multiply_state(
+                _load_flat_state(state1, offsets, mask),
+                _load_flat_state(state2, offsets, mask),
+                NORMALIZE,
+            ),
+            mask,
+        )
+
+    @triton.jit
+    def _inverse_kernel(state, output, n_states, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        tx, ty, tz, qx, qy, qz, qw, s = _load_flat_state(state, offsets, mask)
+        q_norm2 = tl.maximum(qx * qx + qy * qy + qz * qz + qw * qw, 1.0e-7)
+        iqx = -qx / q_norm2
+        iqy = -qy / q_norm2
+        iqz = -qz / q_norm2
+        iqw = qw / q_norm2
+        niqx, niqy, niqz, niqw = _normalize_quaternion(iqx, iqy, iqz, iqw)
+        rtx, rty, rtz = _rotate_vector(niqx, niqy, niqz, niqw, tx, ty, tz)
+        s_inv = 1.0 / s
+        _store_flat_state(
+            output,
+            offsets,
+            (
+                -s_inv * rtx,
+                -s_inv * rty,
+                -s_inv * rtz,
+                iqx,
+                iqy,
+                iqz,
+                iqw,
+                s_inv,
+            ),
+            mask,
+        )
+
+    @triton.jit
+    def _multiply_backward_kernel(
+        state1,
+        state2,
+        grad_output,
+        grad_state1,
+        grad_state2,
+        n_states,
+        NORMALIZE: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        t1x, t1y, t1z, q1x, q1y, q1z, q1w, s1 = _load_flat_state(state1, offsets, mask)
+        t2x, t2y, t2z, q2x, q2y, q2z, q2w, s2 = _load_flat_state(state2, offsets, mask)
+        gtx, gty, gtz, gqx, gqy, gqz, gqw, gs = _load_flat_state(
+            grad_output, offsets, mask
+        )
+
+        nq1x = q1x
+        nq1y = q1y
+        nq1z = q1z
+        nq1w = q1w
+        nq2x = q2x
+        nq2y = q2y
+        nq2z = q2z
+        nq2w = q2w
+        if NORMALIZE:
+            nq1x, nq1y, nq1z, nq1w = _normalize_quaternion(q1x, q1y, q1z, q1w)
+            nq2x, nq2y, nq2z, nq2w = _normalize_quaternion(q2x, q2y, q2z, q2w)
+
+        rtx, rty, rtz = _rotate_vector(nq1x, nq1y, nq1z, nq1w, t2x, t2y, t2z)
+        (
+            gq1x_from_t,
+            gq1y_from_t,
+            gq1z_from_t,
+            gq1w_from_t,
+            gt2x,
+            gt2y,
+            gt2z,
+        ) = _rotate_vector_backward(
+            nq1x,
+            nq1y,
+            nq1z,
+            nq1w,
+            t2x,
+            t2y,
+            t2z,
+            s1 * gtx,
+            s1 * gty,
+            s1 * gtz,
+        )
+        (
+            gq1x_from_q,
+            gq1y_from_q,
+            gq1z_from_q,
+            gq1w_from_q,
+            gq2x,
+            gq2y,
+            gq2z,
+            gq2w,
+        ) = _quat_multiply_backward(
+            nq1x, nq1y, nq1z, nq1w, nq2x, nq2y, nq2z, nq2w, gqx, gqy, gqz, gqw
+        )
+
+        gq1x = gq1x_from_t + gq1x_from_q
+        gq1y = gq1y_from_t + gq1y_from_q
+        gq1z = gq1z_from_t + gq1z_from_q
+        gq1w = gq1w_from_t + gq1w_from_q
+        if NORMALIZE:
+            gq1x, gq1y, gq1z, gq1w = _normalize_quaternion_backward(
+                q1x, q1y, q1z, q1w, gq1x, gq1y, gq1z, gq1w
+            )
+            gq2x, gq2y, gq2z, gq2w = _normalize_quaternion_backward(
+                q2x, q2y, q2z, q2w, gq2x, gq2y, gq2z, gq2w
+            )
+
+        _store_flat_state(
+            grad_state1,
+            offsets,
+            (
+                gtx,
+                gty,
+                gtz,
+                gq1x,
+                gq1y,
+                gq1z,
+                gq1w,
+                rtx * gtx + rty * gty + rtz * gtz + gs * s2,
+            ),
+            mask,
+        )
+        _store_flat_state(
+            grad_state2,
+            offsets,
+            (gt2x, gt2y, gt2z, gq2x, gq2y, gq2z, gq2w, gs * s1),
+            mask,
+        )
+
+    @triton.jit
+    def _inverse_backward_kernel(
+        state,
+        grad_output,
+        grad_state,
+        n_states,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        tx, ty, tz, qx, qy, qz, qw, s = _load_flat_state(state, offsets, mask)
+        gtx, gty, gtz, gqx_out, gqy_out, gqz_out, gqw_out, gs_out = _load_flat_state(
+            grad_output, offsets, mask
+        )
+
+        norm2 = qx * qx + qy * qy + qz * qz + qw * qw
+        denom = tl.maximum(norm2, 1.0e-7)
+        iqx = -qx / denom
+        iqy = -qy / denom
+        iqz = -qz / denom
+        iqw = qw / denom
+        niqx, niqy, niqz, niqw = _normalize_quaternion(iqx, iqy, iqz, iqw)
+        rtx, rty, rtz = _rotate_vector(niqx, niqy, niqz, niqw, tx, ty, tz)
+        s_inv = 1.0 / s
+
+        (
+            giqx_from_t,
+            giqy_from_t,
+            giqz_from_t,
+            giqw_from_t,
+            grad_tx,
+            grad_ty,
+            grad_tz,
+        ) = _rotate_vector_backward(
+            niqx,
+            niqy,
+            niqz,
+            niqw,
+            tx,
+            ty,
+            tz,
+            -s_inv * gtx,
+            -s_inv * gty,
+            -s_inv * gtz,
+        )
+        giqx_from_t, giqy_from_t, giqz_from_t, giqw_from_t = (
+            _normalize_quaternion_backward(
+                iqx, iqy, iqz, iqw, giqx_from_t, giqy_from_t, giqz_from_t, giqw_from_t
+            )
+        )
+        giqx = gqx_out + giqx_from_t
+        giqy = gqy_out + giqy_from_t
+        giqz = gqz_out + giqz_from_t
+        giqw = gqw_out + giqw_from_t
+
+        inv_denom = 1.0 / denom
+        grad_qx = -giqx * inv_denom
+        grad_qy = -giqy * inv_denom
+        grad_qz = -giqz * inv_denom
+        grad_qw = giqw * inv_denom
+        grad_denom = -(giqx * (-qx) + giqy * (-qy) + giqz * (-qz) + giqw * qw) * (
+            inv_denom * inv_denom
+        )
+        use_denom_grad = norm2 >= 1.0e-7
+        grad_qx += tl.where(use_denom_grad, grad_denom * 2.0 * qx, 0.0)
+        grad_qy += tl.where(use_denom_grad, grad_denom * 2.0 * qy, 0.0)
+        grad_qz += tl.where(use_denom_grad, grad_denom * 2.0 * qz, 0.0)
+        grad_qw += tl.where(use_denom_grad, grad_denom * 2.0 * qw, 0.0)
+
+        grad_s_inv = -(rtx * gtx + rty * gty + rtz * gtz) + gs_out
+        grad_s = -grad_s_inv * s_inv * s_inv
+        _store_flat_state(
+            grad_state,
+            offsets,
+            (grad_tx, grad_ty, grad_tz, grad_qx, grad_qy, grad_qz, grad_qw, grad_s),
+            mask,
         )
 
     @triton.jit
@@ -486,6 +761,165 @@ def _require_triton() -> None:
         )
 
 
+def _validate_skel_state(state: torch.Tensor) -> None:
+    if not state.is_cuda:
+        raise RuntimeError("Triton skel_state backend requested, but input is on CPU.")
+    if state.dtype != torch.float32:
+        raise RuntimeError("Triton skel_state backend currently only supports float32.")
+    if state.ndim == 0 or state.shape[-1] != 8:
+        raise RuntimeError("Skeleton state tensor must have shape [..., 8].")
+
+
+def _launch_multiply(
+    state1: torch.Tensor,
+    state2: torch.Tensor,
+    normalize: bool,
+) -> torch.Tensor:
+    _validate_skel_state(state1)
+    _validate_skel_state(state2)
+    _require_triton()
+    state1, state2 = torch.broadcast_tensors(state1, state2)
+    shape = state2.shape
+    state1 = state1.contiguous().reshape(-1, 8)
+    state2 = state2.contiguous().reshape(-1, 8)
+    output = torch.empty_like(state2)
+    n_states = state2.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _multiply_kernel[grid](
+        state1,
+        state2,
+        output,
+        n_states,
+        NORMALIZE=normalize,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return output.reshape(shape)
+
+
+def _launch_inverse(state: torch.Tensor) -> torch.Tensor:
+    _validate_skel_state(state)
+    _require_triton()
+    shape = state.shape
+    state = state.contiguous().reshape(-1, 8)
+    output = torch.empty_like(state)
+    n_states = state.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _inverse_kernel[grid](state, output, n_states, BLOCK_SIZE=_BLOCK_SIZE)
+    return output.reshape(shape)
+
+
+def _launch_multiply_backward(
+    state1: torch.Tensor,
+    state2: torch.Tensor,
+    grad_output: torch.Tensor,
+    normalize: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    state1 = state1.contiguous().reshape(-1, 8)
+    state2 = state2.contiguous().reshape(-1, 8)
+    grad_output = grad_output.contiguous().reshape(-1, 8)
+    grad_state1 = torch.empty_like(state1)
+    grad_state2 = torch.empty_like(state2)
+    n_states = state2.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _multiply_backward_kernel[grid](
+        state1,
+        state2,
+        grad_output,
+        grad_state1,
+        grad_state2,
+        n_states,
+        NORMALIZE=normalize,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return grad_state1, grad_state2
+
+
+def _launch_inverse_backward(
+    state: torch.Tensor,
+    grad_output: torch.Tensor,
+) -> torch.Tensor:
+    state = state.contiguous().reshape(-1, 8)
+    grad_output = grad_output.contiguous().reshape(-1, 8)
+    grad_state = torch.empty_like(state)
+    n_states = state.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _inverse_backward_kernel[grid](
+        state,
+        grad_output,
+        grad_state,
+        n_states,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return grad_state
+
+
+class _Multiply(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        state1: torch.Tensor,
+        state2: torch.Tensor,
+        normalize: bool,
+    ) -> torch.Tensor:
+        shape = state2.shape
+        ctx.normalize = normalize
+        ctx.shape = shape
+        ctx.save_for_backward(state1, state2)
+        return _launch_multiply(state1, state2, normalize)
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ):
+        state1, state2 = ctx.saved_tensors
+        grad_state1, grad_state2 = _launch_multiply_backward(
+            state1,
+            state2,
+            grad_output,
+            ctx.normalize,
+        )
+        return grad_state1.reshape(ctx.shape), grad_state2.reshape(ctx.shape), None
+
+
+class _Inverse(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        state: torch.Tensor,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(state)
+        return _launch_inverse(state)
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ):
+        (state,) = ctx.saved_tensors
+        grad_state = _launch_inverse_backward(
+            state,
+            grad_output,
+        )
+        return (grad_state.reshape(state.shape),)
+
+
+def multiply(state1: torch.Tensor, state2: torch.Tensor) -> torch.Tensor:
+    state1, state2 = torch.broadcast_tensors(state1, state2)
+    return _Multiply.apply(state1, state2, True)
+
+
+def multiply_assume_normalized(
+    state1: torch.Tensor, state2: torch.Tensor
+) -> torch.Tensor:
+    state1, state2 = torch.broadcast_tensors(state1, state2)
+    return _Multiply.apply(state1, state2, False)
+
+
+def inverse(state: torch.Tensor) -> torch.Tensor:
+    return _Inverse.apply(state)
+
+
 def _validate_inputs(
     skel_state: torch.Tensor,
     joint_translation_offsets: torch.Tensor,
@@ -606,7 +1040,7 @@ class _SkeletonStateToJointParameters(torch.autograd.Function):
     def backward(
         ctx: torch.autograd.function.FunctionCtx,
         grad_output: torch.Tensor,
-    ) -> tuple[torch.Tensor | None, None, None, None]:
+    ):
         (
             skel_state,
             joint_translation_offsets,

--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -263,10 +263,28 @@ def from_axis_angle(axis_angle: torch.Tensor) -> torch.Tensor:
     """
     Convert an axis-angle tensor to a quaternion.
 
+    The axis-angle representation is a 3-vector whose direction is the rotation axis
+    and whose magnitude is the rotation angle in radians. This is equivalent to the
+    exponential map from so(3) to unit quaternions.
+
     :parameter axis_angle: A tensor of shape (..., 3) representing the axis-angle.
     :return: A tensor of shape (..., 4) representing the quaternion in ((x, y, z), w) format.
     """
     return torch_quaternion.from_axis_angle(axis_angle)
+
+
+def to_axis_angle(quaternions: torch.Tensor) -> torch.Tensor:
+    """
+    Convert a quaternion to an axis-angle tensor.
+
+    Returns the inverse of :func:`from_axis_angle`: a 3-vector whose direction is the
+    rotation axis and whose magnitude is the rotation angle. This is equivalent to
+    the logarithmic map from unit quaternions to so(3).
+
+    :parameter quaternions: A tensor of shape (..., 4) representing quaternions in ((x, y, z), w) format.
+    :return: A tensor of shape (..., 3) representing the axis-angle with magnitude in [0, π].
+    """
+    return torch_quaternion.to_axis_angle(quaternions)
 
 
 def euler_xyz_to_quaternion(euler_xyz: torch.Tensor) -> torch.Tensor:

--- a/pymomentum/quaternion.py
+++ b/pymomentum/quaternion.py
@@ -299,7 +299,9 @@ def euler_zyx_to_quaternion(euler_zyx: torch.Tensor) -> torch.Tensor:
     return torch_quaternion.euler_zyx_to_quaternion(euler_zyx)
 
 
-def from_rotation_matrix(matrices: torch.Tensor, eta: float = 1e-6) -> torch.Tensor:
+def from_rotation_matrix(
+    matrices: torch.Tensor, eta: float = 1e-6, backend: str = "torch"
+) -> torch.Tensor:
     """
     Convert a rotation matrix to a quaternion using numerically stable method.
 
@@ -309,8 +311,18 @@ def from_rotation_matrix(matrices: torch.Tensor, eta: float = 1e-6) -> torch.Ten
 
     :parameter matrices: A tensor of shape (..., 3, 3) representing the rotation matrices.
     :parameter eta: Numerical precision threshold (unused, kept for compatibility).
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
     :return: A tensor of shape (..., 4) representing the quaternions in ((x, y, z), w) format.
     """
+    backend = resolve_backend(
+        backend,
+        matrices,
+        use_double_precision=matrices.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _get_triton_quaternion().from_rotation_matrix(matrices)
+    if backend != "torch":
+        raise ValueError(f"Unsupported quaternion backend: {backend}")
     return torch_quaternion.from_rotation_matrix(matrices, eta)
 
 

--- a/pymomentum/quaternion_np.py
+++ b/pymomentum/quaternion_np.py
@@ -334,7 +334,7 @@ def euler_zyx_to_quaternion(euler_zyx: NDArray) -> NDArray:
     return np.stack((x, y, z, w), axis=-1)
 
 
-def from_rotation_matrix(matrices: NDArray, eta: float = 1e-6) -> NDArray:
+def from_rotation_matrix(matrices: NDArray) -> NDArray:
     """
     Convert a rotation matrix to a quaternion using numerically stable method.
 
@@ -343,7 +343,6 @@ def from_rotation_matrix(matrices: NDArray, eta: float = 1e-6) -> NDArray:
     stability across all rotation matrix configurations.
 
     :parameter matrices: An array of shape (..., 3, 3) representing the rotation matrices.
-    :parameter eta: Numerical precision threshold (unused, kept for compatibility).
     :return: An array of shape (..., 4) representing the quaternions in ((x, y, z), w) format.
     """
     m = matrices

--- a/pymomentum/skel_state.py
+++ b/pymomentum/skel_state.py
@@ -56,6 +56,7 @@ from typing import Sequence
 
 import torch
 from pymomentum.backend import skel_state_torch
+from pymomentum.backend.selection import resolve_backend
 
 # pyre-strict
 
@@ -163,7 +164,29 @@ def _multiply_split_skel_states(
     return skel_state_torch._multiply_split_skel_states(skel_state1, skel_state2)
 
 
-def multiply(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tensor:
+@torch.jit.ignore
+def _multiply_triton(
+    s1: torch.Tensor,
+    s2: torch.Tensor,
+    assume_normalized: bool,
+) -> torch.Tensor:
+    from pymomentum.backend import triton_skel_state
+
+    if assume_normalized:
+        return triton_skel_state.multiply_assume_normalized(s1, s2)
+    return triton_skel_state.multiply(s1, s2)
+
+
+@torch.jit.ignore
+def _inverse_triton(skeleton_states: torch.Tensor) -> torch.Tensor:
+    from pymomentum.backend import triton_skel_state
+
+    return triton_skel_state.inverse(skeleton_states)
+
+
+def multiply(
+    s1: torch.Tensor, s2: torch.Tensor, backend: str = "torch"
+) -> torch.Tensor:
     """
     Multiply two skeleton states.
 
@@ -171,13 +194,27 @@ def multiply(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tensor:
     :type s1: torch.Tensor
     :parameter s2: The second skeleton state.
     :type s2: torch.Tensor
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
+    :type backend: str
     :return: The product of the two skeleton states.
     :rtype: torch.Tensor
     """
+    backend = resolve_backend(
+        backend,
+        s2,
+        use_double_precision=s1.dtype == torch.float64 or s2.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _multiply_triton(s1, s2, assume_normalized=False)
+    if backend != "torch":
+        raise ValueError(f"Unsupported skel_state backend: {backend}")
+
     return skel_state_torch.multiply(s1, s2)
 
 
-def multiply_assume_normalized(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tensor:
+def multiply_assume_normalized(
+    s1: torch.Tensor, s2: torch.Tensor, backend: str = "torch"
+) -> torch.Tensor:
     """
     Multiply two skeleton states.
     This is an optimized version that assumes both skeleton states are already properly
@@ -187,21 +224,45 @@ def multiply_assume_normalized(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tens
     :type s1: torch.Tensor
     :parameter s2: The second skeleton state.
     :type s2: torch.Tensor
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
+    :type backend: str
     :return: The product of the two skeleton states.
     :rtype: torch.Tensor
     """
+    backend = resolve_backend(
+        backend,
+        s2,
+        use_double_precision=s1.dtype == torch.float64 or s2.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _multiply_triton(s1, s2, assume_normalized=True)
+    if backend != "torch":
+        raise ValueError(f"Unsupported skel_state backend: {backend}")
+
     return skel_state_torch.multiply_assume_normalized(s1, s2)
 
 
-def inverse(skeleton_states: torch.Tensor) -> torch.Tensor:
+def inverse(skeleton_states: torch.Tensor, backend: str = "torch") -> torch.Tensor:
     """
     Compute the inverse of a skeleton state.
 
     :parameter skeleton_states: The skeleton state to invert.
     :type skeleton_states: torch.Tensor
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
+    :type backend: str
     :return: The inverted skeleton state.
     :rtype: torch.Tensor
     """
+    backend = resolve_backend(
+        backend,
+        skeleton_states,
+        use_double_precision=skeleton_states.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _inverse_triton(skeleton_states)
+    if backend != "torch":
+        raise ValueError(f"Unsupported skel_state backend: {backend}")
+
     return skel_state_torch.inverse(skeleton_states)
 
 

--- a/pymomentum/test/test_quaternion.py
+++ b/pymomentum/test/test_quaternion.py
@@ -712,6 +712,123 @@ class TestQuaternion(unittest.TestCase):
                 "Round-trip quaternion conversion should be consistent up to sign",
             )
 
+    def test_axis_angle_round_trip(self) -> None:
+        torch.manual_seed(0)
+        # Keep angles in [0, pi) so axis-angle representation is unique.
+        dirs = torch.nn.functional.normalize(
+            torch.randn(50, 3, dtype=torch.float64), dim=-1
+        )
+        magnitudes = torch.rand(50, 1, dtype=torch.float64) * (math.pi - 0.01)
+        axis_angles = dirs * magnitudes
+
+        quats = quaternion.from_axis_angle(axis_angles)
+        recovered = quaternion.to_axis_angle(quats)
+        torch.testing.assert_close(axis_angles, recovered, atol=1e-6, rtol=1e-6)
+
+    def test_axis_angle_known_values(self) -> None:
+        axis_angles = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [math.pi / 2.0, 0.0, 0.0],
+                [0.0, math.pi, 0.0],
+                [0.0, 0.0, math.pi / 3.0],
+            ],
+            dtype=torch.float64,
+        )
+        expected_quats = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0],
+                [math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.5, math.sqrt(3.0) / 2.0],
+            ],
+            dtype=torch.float64,
+        )
+
+        quats = quaternion.from_axis_angle(axis_angles)
+        torch.testing.assert_close(quats, expected_quats, atol=1e-12, rtol=1e-12)
+        torch.testing.assert_close(
+            quaternion.to_axis_angle(quats), axis_angles, atol=1e-12, rtol=1e-12
+        )
+
+    def test_axis_angle_sinc_half_near_zero(self) -> None:
+        """Verify the Taylor expansion gives accurate results near the origin."""
+        torch.manual_seed(0)
+        near_zero = torch.randn(20, 3, dtype=torch.float64) * 1e-8
+        quats = quaternion.from_axis_angle(near_zero)
+        recovered = quaternion.to_axis_angle(quats)
+        torch.testing.assert_close(near_zero, recovered, atol=1e-10, rtol=1e-4)
+
+        # Verify exact zero works.
+        zero = torch.zeros(3, dtype=torch.float64)
+        quats_zero = quaternion.from_axis_angle(zero)
+        torch.testing.assert_close(
+            quats_zero, quaternion.identity(dtype=torch.float64), atol=1e-12, rtol=0.0
+        )
+        recovered_zero = quaternion.to_axis_angle(quats_zero)
+        torch.testing.assert_close(zero, recovered_zero, atol=1e-12, rtol=0.0)
+
+    def test_to_axis_angle_negative_w(self) -> None:
+        """to_axis_angle must handle quaternions with w < 0 (angle > pi)."""
+        # A quaternion with negative w represents the same rotation as its
+        # negation (which has positive w). to_axis_angle should not produce nan.
+        q = torch.tensor([0.0, 0.0, 0.0, -1.0], dtype=torch.float64)
+        aa = quaternion.to_axis_angle(q)
+        self.assertTrue(torch.isfinite(aa).all())
+        torch.testing.assert_close(
+            aa, torch.zeros(3, dtype=torch.float64), atol=1e-12, rtol=0.0
+        )
+
+        # Near-2pi rotation: w slightly negative, small vector part.
+        q2 = quaternion.normalize(
+            torch.tensor([1e-4, 0.0, 0.0, -1.0], dtype=torch.float64)
+        )
+        aa2 = quaternion.to_axis_angle(q2)
+        self.assertTrue(torch.isfinite(aa2).all())
+        torch.testing.assert_close(
+            aa2, quaternion.to_axis_angle(-q2), atol=1e-12, rtol=1e-12
+        )
+        recovered_q2 = quaternion.from_axis_angle(aa2)
+        expected_q2 = torch.where(q2[..., 3:] < 0, -q2, q2)
+        torch.testing.assert_close(
+            quaternion.normalize(recovered_q2),
+            expected_q2,
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+    def test_axis_angle_gradcheck_near_sinc_half_branch(self) -> None:
+        """Check value/gradient stability around the _sinc_half Taylor branch."""
+        near_zero = torch.tensor(
+            [[1e-7, -2e-7, 3e-7]], dtype=torch.float64, requires_grad=True
+        )
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                quaternion.from_axis_angle,
+                (near_zero,),
+                eps=1e-8,
+                atol=1e-5,
+                rtol=1e-3,
+            )
+        )
+
+        small_angle_quat = (
+            quaternion.from_axis_angle(
+                torch.tensor([[1e-4, -2e-4, 3e-4]], dtype=torch.float64)
+            )
+            .detach()
+            .requires_grad_(True)
+        )
+        self.assertTrue(
+            torch.autograd.gradcheck(
+                quaternion.to_axis_angle,
+                (small_angle_quat,),
+                eps=1e-6,
+                atol=1e-5,
+                rtol=1e-3,
+            )
+        )
+
     def test_backprop_gradient_consistency(self) -> None:
         """Test that custom backprop functions match PyTorch autograd gradients."""
         torch.manual_seed(0)

--- a/pymomentum/test/test_quaternion.py
+++ b/pymomentum/test/test_quaternion.py
@@ -92,6 +92,10 @@ class TestQuaternion(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
             quaternion.to_rotation_matrix(quats, backend="triton")
 
+        mats = quaternion.to_rotation_matrix(quats)
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            quaternion.from_rotation_matrix(mats, backend="triton")
+
     def test_multiply(self) -> None:
         torch.manual_seed(0)  # ensure repeatability
         nMat = 5

--- a/pymomentum/test/test_skel_state.py
+++ b/pymomentum/test/test_skel_state.py
@@ -55,6 +55,34 @@ def generate_random_skel_state(sz: int) -> torch.Tensor:
 
 
 class TestSkelState(unittest.TestCase):
+    @staticmethod
+    def _random_cuda_skel_state(size: int) -> torch.Tensor:
+        trans = torch.normal(
+            mean=0,
+            std=4,
+            size=(size, 3),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        rot = pym_quaternion.normalize(
+            torch.normal(
+                mean=0,
+                std=4,
+                size=(size, 4),
+                device="cuda",
+                dtype=torch.float32,
+            )
+        )
+        scale = (
+            torch.rand(
+                size=(size, 1),
+                device="cuda",
+                dtype=torch.float32,
+            )
+            + 0.5
+        )
+        return torch.cat([trans, rot, scale], -1)
+
     def test_skel_state_to_transforms(self) -> None:
         character = pym_test_utils.create_test_character()
         nBatch = 2
@@ -104,6 +132,96 @@ class TestSkelState(unittest.TestCase):
             torch.norm(m_inv - m_inv2),
             1e-4,
             "Inverse is correct",
+        )
+
+    def test_triton_backend_requires_cuda(self) -> None:
+        state = generate_random_skel_state(3).to(torch.float32)
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            pym_skel_state.multiply(state, state, backend="triton")
+
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            pym_skel_state.multiply_assume_normalized(state, state, backend="triton")
+
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            pym_skel_state.inverse(state, backend="triton")
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton backend requires CUDA")
+    def test_triton_multiply_matches_torch_forward_and_backward(self) -> None:
+        torch.manual_seed(0)
+        state1 = self._random_cuda_skel_state(256)
+        state2 = self._random_cuda_skel_state(256)
+        state1_torch = state1.detach().clone().requires_grad_(True)
+        state2_torch = state2.detach().clone().requires_grad_(True)
+        state1_triton = state1.detach().clone().requires_grad_(True)
+        state2_triton = state2.detach().clone().requires_grad_(True)
+
+        out_torch = pym_skel_state.multiply(state1_torch, state2_torch)
+        out_triton = pym_skel_state.multiply(
+            state1_triton,
+            state2_triton,
+            backend="triton",
+        )
+        self.assertTrue(torch.allclose(out_triton, out_torch, atol=1e-5, rtol=1e-5))
+
+        grad = torch.randn_like(out_torch)
+        torch.autograd.backward(out_torch, grad)
+        torch.autograd.backward(out_triton, grad)
+        self.assertTrue(
+            torch.allclose(state1_triton.grad, state1_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+        self.assertTrue(
+            torch.allclose(state2_triton.grad, state2_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton backend requires CUDA")
+    def test_triton_multiply_assume_normalized_matches_torch_backward(self) -> None:
+        torch.manual_seed(1)
+        state1 = self._random_cuda_skel_state(256)
+        state2 = self._random_cuda_skel_state(256)
+        state1_torch = state1.detach().clone().requires_grad_(True)
+        state2_torch = state2.detach().clone().requires_grad_(True)
+        state1_triton = state1.detach().clone().requires_grad_(True)
+        state2_triton = state2.detach().clone().requires_grad_(True)
+
+        out_torch = pym_skel_state.multiply_assume_normalized(
+            state1_torch,
+            state2_torch,
+        )
+        out_triton = pym_skel_state.multiply_assume_normalized(
+            state1_triton,
+            state2_triton,
+            backend="triton",
+        )
+        self.assertTrue(torch.allclose(out_triton, out_torch, atol=1e-5, rtol=1e-5))
+
+        grad = torch.randn_like(out_torch)
+        torch.autograd.backward(out_torch, grad)
+        torch.autograd.backward(out_triton, grad)
+        self.assertTrue(
+            torch.allclose(state1_triton.grad, state1_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+        self.assertTrue(
+            torch.allclose(state2_triton.grad, state2_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton backend requires CUDA")
+    def test_triton_inverse_matches_torch_forward_and_backward(self) -> None:
+        torch.manual_seed(2)
+        state = self._random_cuda_skel_state(256)
+        state_torch = state.detach().clone().requires_grad_(True)
+        state_triton = state.detach().clone().requires_grad_(True)
+
+        out_torch = pym_skel_state.inverse(state_torch)
+        out_triton = pym_skel_state.inverse(state_triton, backend="triton")
+        self.assertTrue(torch.allclose(out_triton, out_torch, atol=1e-5, rtol=1e-5))
+
+        grad = torch.randn_like(out_torch)
+        torch.autograd.backward(out_torch, grad)
+        torch.autograd.backward(out_triton, grad)
+        grad_diff = (state_triton.grad - state_torch.grad).abs()
+        self.assertTrue(
+            torch.allclose(state_triton.grad, state_torch.grad, atol=1e-5, rtol=1e-5),
+            f"max grad diff={grad_diff.max()}, per component={grad_diff.amax(dim=0)}",
         )
 
     def test_transform_points(self) -> None:

--- a/pymomentum/test/test_triton_backend.py
+++ b/pymomentum/test/test_triton_backend.py
@@ -11,6 +11,7 @@ import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_tes
 import pymomentum.quaternion as pym_quaternion
 import pymomentum.torch.character as pym_character
 import torch
+from pymomentum.backend import selection as backend_selection
 
 
 def _cuda_device() -> torch.device:
@@ -22,6 +23,31 @@ def _cuda_device() -> torch.device:
 
 
 class TritonBackendTest(unittest.TestCase):
+    def test_auto_backend_selection(self) -> None:
+        cpu_tensor = torch.empty((1,), dtype=torch.float32)
+
+        self.assertEqual(backend_selection.resolve_backend("auto", cpu_tensor), "torch")
+        self.assertEqual(
+            backend_selection.resolve_backend(
+                "auto",
+                cpu_tensor.to(torch.float64),
+                use_double_precision=True,
+            ),
+            "torch",
+        )
+        self.assertEqual(
+            backend_selection.resolve_backend("torch", cpu_tensor), "torch"
+        )
+        self.assertEqual(
+            backend_selection.resolve_backend("triton", cpu_tensor), "triton"
+        )
+
+        if torch.cuda.is_available() and backend_selection._HAS_TRITON:
+            cuda_tensor = cpu_tensor.cuda()
+            self.assertEqual(
+                backend_selection.resolve_backend("auto", cuda_tensor), "triton"
+            )
+
     def test_fk_matches_torch(self) -> None:
         device = _cuda_device()
         character_cpu = pym_test_utils.create_test_character()
@@ -177,6 +203,38 @@ class TritonBackendTest(unittest.TestCase):
             assume_normalized=True,
             eps=1e-12,
         )
+
+    def test_quaternion_from_rotation_matrix_matches_torch(self) -> None:
+        device = _cuda_device()
+
+        torch.manual_seed(0)
+        quaternions = pym_quaternion.normalize(
+            torch.randn((2, 3, 257, 4), device=device, dtype=torch.float32)
+        )
+        matrices = pym_quaternion.to_rotation_matrix(quaternions)
+
+        torch_matrices = matrices.detach().clone().requires_grad_()
+        triton_matrices = matrices.detach().clone().requires_grad_()
+
+        torch_result = pym_quaternion.from_rotation_matrix(torch_matrices)
+        triton_result = pym_quaternion.from_rotation_matrix(
+            triton_matrices,
+            backend="triton",
+        )
+
+        torch.testing.assert_close(torch_result, triton_result, atol=1e-6, rtol=1e-6)
+
+        grad_output = torch.randn_like(torch_result)
+        torch_result.backward(grad_output)
+        triton_result.backward(grad_output)
+
+        torch_grad = torch_matrices.grad
+        triton_grad = triton_matrices.grad
+        self.assertIsNotNone(torch_grad)
+        self.assertIsNotNone(triton_grad)
+        if torch_grad is None or triton_grad is None:
+            return
+        torch.testing.assert_close(torch_grad, triton_grad, atol=1e-5, rtol=1e-5)
 
     def test_zero_quaternion_is_finite(self) -> None:
         device = _cuda_device()

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -362,10 +362,7 @@ class Skeleton(torch.nn.Module):
         skel_state: torch.Tensor,
         backend: str = "torch",
     ) -> torch.Tensor:
-        if torch.jit.is_scripting():
-            resolved = "torch" if backend == "auto" else backend
-        else:
-            resolved = resolve_backend(backend, skel_state.float())
+        resolved = resolve_backend(backend, skel_state.float())
         if resolved == "triton":
             with torch.amp.autocast("cuda", enabled=False):
                 return triton_skel_state.skeleton_state_to_joint_parameters(
@@ -387,12 +384,9 @@ class Skeleton(torch.nn.Module):
         fk_backend: str = "auto",
         active_joints: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if torch.jit.is_scripting():
-            resolved = "torch" if fk_backend == "auto" else fk_backend
-        else:
-            resolved = resolve_backend(
-                fk_backend, joint_parameters.float(), use_double_precision
-            )
+        resolved = resolve_backend(
+            fk_backend, joint_parameters.float(), use_double_precision
+        )
         if resolved == "triton" and use_double_precision:
             raise RuntimeError(
                 "Triton FK does not support double precision; "
@@ -988,12 +982,9 @@ class Character(torch.nn.Module):
             raise RuntimeError(
                 "Character has no parameter transform, please provide one"
             )
-        if torch.jit.is_scripting():
-            resolved = "torch" if fk_backend == "auto" else fk_backend
-        else:
-            resolved = resolve_backend(
-                fk_backend, model_parameters.float(), use_double_precision
-            )
+        resolved = resolve_backend(
+            fk_backend, model_parameters.float(), use_double_precision
+        )
         active_joints = self.parameter_transform.active_joints
         return self.joint_parameters_to_skeleton_state(
             self.model_parameters_to_joint_parameters(model_parameters),


### PR DESCRIPTION
Summary:

Add Triton implementations for `skel_state.multiply`, `skel_state.multiply_assume_normalized`, and `skel_state.inverse`, including explicit backward kernels so the Triton path does not fall back through torch autograd. Route Kinesis skeleton-state multiply/inverse call sites through `backend="auto"` so CUDA float32 tensors can use the Triton backend while preserving the torch path for unsupported cases.

Reviewed By: nickyhe-gemini

Differential Revision: D106236958


