### PR TITLE
Add Triton backend for skinning (#1433)

### DIFF
--- a/pymomentum/backend/selection.py
+++ b/pymomentum/backend/selection.py
@@ -34,3 +34,17 @@ def resolve_backend(
     ):
         return "triton"
     return "torch"
+
+
+def resolve_fk_backend(
+    backend: str,
+    tensor: torch.Tensor,
+    use_double_precision: bool = False,
+) -> str:
+    resolved = resolve_backend(backend, tensor, use_double_precision)
+    if resolved == "triton" and use_double_precision:
+        raise RuntimeError(
+            "Triton FK does not support double precision; "
+            "pass use_double_precision=False"
+        )
+    return resolved

--- a/pymomentum/backend/skel_state_backend.py
+++ b/pymomentum/backend/skel_state_backend.py
@@ -513,6 +513,41 @@ def skin_points_from_skel_state(
 
 
 @th.jit.script
+def skin_points_from_skel_state_assume_normalized(
+    template: th.Tensor,
+    global_skel_state: th.Tensor,
+    binded_skel_state_inv: th.Tensor,
+    skin_indices_flattened: th.Tensor,
+    skin_weights_flattened: th.Tensor,
+    vert_indices_flattened: th.Tensor,
+) -> th.Tensor:
+    assert template.shape[-1] == 3
+    while template.ndim < global_skel_state.ndim:
+        template = template.unsqueeze(0)
+
+    template = template.expand(
+        list(global_skel_state.shape[:-2]) + list(template.shape[-2:])
+    )
+
+    joint_state = skel_state.multiply_assume_normalized(
+        global_skel_state,
+        binded_skel_state_inv,
+    )
+
+    skinned = th.zeros_like(template)
+    skinned = skinned.index_add(
+        -2,
+        vert_indices_flattened,
+        skel_state.transform_points_assume_normalized(
+            th.index_select(joint_state, -2, skin_indices_flattened),
+            th.index_select(template, -2, vert_indices_flattened),
+        )
+        * skin_weights_flattened[None, :, None],
+    )
+    return skinned
+
+
+@th.jit.script
 def skin_oriented_points_from_skel_state(
     means: th.Tensor,
     quaternions: th.Tensor,

--- a/pymomentum/backend/triton_skel_state.py
+++ b/pymomentum/backend/triton_skel_state.py
@@ -28,6 +28,7 @@ except ImportError:
 
 
 _BLOCK_BATCH = 128
+_BLOCK_SIZE = 256
 _LN2 = math.log(2.0)
 _NORM_EPS = 1e-12
 _EULER_EPS = 1e-6
@@ -151,6 +152,280 @@ if triton is not None and tl is not None:  # noqa: C901
             tl.load(base + 5, mask=mask, other=0.0),
             tl.load(base + 6, mask=mask, other=1.0),
             tl.load(base + 7, mask=mask, other=1.0),
+        )
+
+    @triton.jit
+    def _load_flat_state(data, offset, mask):
+        base = data + offset * 8
+        return (
+            tl.load(base + 0, mask=mask, other=0.0),
+            tl.load(base + 1, mask=mask, other=0.0),
+            tl.load(base + 2, mask=mask, other=0.0),
+            tl.load(base + 3, mask=mask, other=0.0),
+            tl.load(base + 4, mask=mask, other=0.0),
+            tl.load(base + 5, mask=mask, other=0.0),
+            tl.load(base + 6, mask=mask, other=1.0),
+            tl.load(base + 7, mask=mask, other=1.0),
+        )
+
+    @triton.jit
+    def _store_flat_state(output, offset, state, mask):
+        base = output + offset * 8
+        tl.store(base + 0, state[0], mask=mask)
+        tl.store(base + 1, state[1], mask=mask)
+        tl.store(base + 2, state[2], mask=mask)
+        tl.store(base + 3, state[3], mask=mask)
+        tl.store(base + 4, state[4], mask=mask)
+        tl.store(base + 5, state[5], mask=mask)
+        tl.store(base + 6, state[6], mask=mask)
+        tl.store(base + 7, state[7], mask=mask)
+
+    @triton.jit
+    def _multiply_state(state1, state2, NORMALIZE: tl.constexpr):
+        t1x, t1y, t1z, q1x, q1y, q1z, q1w, s1 = state1
+        t2x, t2y, t2z, q2x, q2y, q2z, q2w, s2 = state2
+        if NORMALIZE:
+            q1x, q1y, q1z, q1w = _normalize_quaternion(q1x, q1y, q1z, q1w)
+            q2x, q2y, q2z, q2w = _normalize_quaternion(q2x, q2y, q2z, q2w)
+        rtx, rty, rtz = _rotate_vector(q1x, q1y, q1z, q1w, t2x, t2y, t2z)
+        qx, qy, qz, qw = _quat_multiply(q1x, q1y, q1z, q1w, q2x, q2y, q2z, q2w)
+        return (
+            t1x + s1 * rtx,
+            t1y + s1 * rty,
+            t1z + s1 * rtz,
+            qx,
+            qy,
+            qz,
+            qw,
+            s1 * s2,
+        )
+
+    @triton.jit
+    def _multiply_kernel(
+        state1,
+        state2,
+        output,
+        n_states,
+        NORMALIZE: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        _store_flat_state(
+            output,
+            offsets,
+            _multiply_state(
+                _load_flat_state(state1, offsets, mask),
+                _load_flat_state(state2, offsets, mask),
+                NORMALIZE,
+            ),
+            mask,
+        )
+
+    @triton.jit
+    def _inverse_kernel(state, output, n_states, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        tx, ty, tz, qx, qy, qz, qw, s = _load_flat_state(state, offsets, mask)
+        q_norm2 = tl.maximum(qx * qx + qy * qy + qz * qz + qw * qw, 1.0e-7)
+        iqx = -qx / q_norm2
+        iqy = -qy / q_norm2
+        iqz = -qz / q_norm2
+        iqw = qw / q_norm2
+        niqx, niqy, niqz, niqw = _normalize_quaternion(iqx, iqy, iqz, iqw)
+        rtx, rty, rtz = _rotate_vector(niqx, niqy, niqz, niqw, tx, ty, tz)
+        s_inv = 1.0 / s
+        _store_flat_state(
+            output,
+            offsets,
+            (
+                -s_inv * rtx,
+                -s_inv * rty,
+                -s_inv * rtz,
+                iqx,
+                iqy,
+                iqz,
+                iqw,
+                s_inv,
+            ),
+            mask,
+        )
+
+    @triton.jit
+    def _multiply_backward_kernel(
+        state1,
+        state2,
+        grad_output,
+        grad_state1,
+        grad_state2,
+        n_states,
+        NORMALIZE: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        t1x, t1y, t1z, q1x, q1y, q1z, q1w, s1 = _load_flat_state(state1, offsets, mask)
+        t2x, t2y, t2z, q2x, q2y, q2z, q2w, s2 = _load_flat_state(state2, offsets, mask)
+        gtx, gty, gtz, gqx, gqy, gqz, gqw, gs = _load_flat_state(
+            grad_output, offsets, mask
+        )
+
+        nq1x = q1x
+        nq1y = q1y
+        nq1z = q1z
+        nq1w = q1w
+        nq2x = q2x
+        nq2y = q2y
+        nq2z = q2z
+        nq2w = q2w
+        if NORMALIZE:
+            nq1x, nq1y, nq1z, nq1w = _normalize_quaternion(q1x, q1y, q1z, q1w)
+            nq2x, nq2y, nq2z, nq2w = _normalize_quaternion(q2x, q2y, q2z, q2w)
+
+        rtx, rty, rtz = _rotate_vector(nq1x, nq1y, nq1z, nq1w, t2x, t2y, t2z)
+        (
+            gq1x_from_t,
+            gq1y_from_t,
+            gq1z_from_t,
+            gq1w_from_t,
+            gt2x,
+            gt2y,
+            gt2z,
+        ) = _rotate_vector_backward(
+            nq1x,
+            nq1y,
+            nq1z,
+            nq1w,
+            t2x,
+            t2y,
+            t2z,
+            s1 * gtx,
+            s1 * gty,
+            s1 * gtz,
+        )
+        (
+            gq1x_from_q,
+            gq1y_from_q,
+            gq1z_from_q,
+            gq1w_from_q,
+            gq2x,
+            gq2y,
+            gq2z,
+            gq2w,
+        ) = _quat_multiply_backward(
+            nq1x, nq1y, nq1z, nq1w, nq2x, nq2y, nq2z, nq2w, gqx, gqy, gqz, gqw
+        )
+
+        gq1x = gq1x_from_t + gq1x_from_q
+        gq1y = gq1y_from_t + gq1y_from_q
+        gq1z = gq1z_from_t + gq1z_from_q
+        gq1w = gq1w_from_t + gq1w_from_q
+        if NORMALIZE:
+            gq1x, gq1y, gq1z, gq1w = _normalize_quaternion_backward(
+                q1x, q1y, q1z, q1w, gq1x, gq1y, gq1z, gq1w
+            )
+            gq2x, gq2y, gq2z, gq2w = _normalize_quaternion_backward(
+                q2x, q2y, q2z, q2w, gq2x, gq2y, gq2z, gq2w
+            )
+
+        _store_flat_state(
+            grad_state1,
+            offsets,
+            (
+                gtx,
+                gty,
+                gtz,
+                gq1x,
+                gq1y,
+                gq1z,
+                gq1w,
+                rtx * gtx + rty * gty + rtz * gtz + gs * s2,
+            ),
+            mask,
+        )
+        _store_flat_state(
+            grad_state2,
+            offsets,
+            (gt2x, gt2y, gt2z, gq2x, gq2y, gq2z, gq2w, gs * s1),
+            mask,
+        )
+
+    @triton.jit
+    def _inverse_backward_kernel(
+        state,
+        grad_output,
+        grad_state,
+        n_states,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_states
+        tx, ty, tz, qx, qy, qz, qw, s = _load_flat_state(state, offsets, mask)
+        gtx, gty, gtz, gqx_out, gqy_out, gqz_out, gqw_out, gs_out = _load_flat_state(
+            grad_output, offsets, mask
+        )
+
+        norm2 = qx * qx + qy * qy + qz * qz + qw * qw
+        denom = tl.maximum(norm2, 1.0e-7)
+        iqx = -qx / denom
+        iqy = -qy / denom
+        iqz = -qz / denom
+        iqw = qw / denom
+        niqx, niqy, niqz, niqw = _normalize_quaternion(iqx, iqy, iqz, iqw)
+        rtx, rty, rtz = _rotate_vector(niqx, niqy, niqz, niqw, tx, ty, tz)
+        s_inv = 1.0 / s
+
+        (
+            giqx_from_t,
+            giqy_from_t,
+            giqz_from_t,
+            giqw_from_t,
+            grad_tx,
+            grad_ty,
+            grad_tz,
+        ) = _rotate_vector_backward(
+            niqx,
+            niqy,
+            niqz,
+            niqw,
+            tx,
+            ty,
+            tz,
+            -s_inv * gtx,
+            -s_inv * gty,
+            -s_inv * gtz,
+        )
+        giqx_from_t, giqy_from_t, giqz_from_t, giqw_from_t = (
+            _normalize_quaternion_backward(
+                iqx, iqy, iqz, iqw, giqx_from_t, giqy_from_t, giqz_from_t, giqw_from_t
+            )
+        )
+        giqx = gqx_out + giqx_from_t
+        giqy = gqy_out + giqy_from_t
+        giqz = gqz_out + giqz_from_t
+        giqw = gqw_out + giqw_from_t
+
+        inv_denom = 1.0 / denom
+        grad_qx = -giqx * inv_denom
+        grad_qy = -giqy * inv_denom
+        grad_qz = -giqz * inv_denom
+        grad_qw = giqw * inv_denom
+        grad_denom = -(giqx * (-qx) + giqy * (-qy) + giqz * (-qz) + giqw * qw) * (
+            inv_denom * inv_denom
+        )
+        use_denom_grad = norm2 >= 1.0e-7
+        grad_qx += tl.where(use_denom_grad, grad_denom * 2.0 * qx, 0.0)
+        grad_qy += tl.where(use_denom_grad, grad_denom * 2.0 * qy, 0.0)
+        grad_qz += tl.where(use_denom_grad, grad_denom * 2.0 * qz, 0.0)
+        grad_qw += tl.where(use_denom_grad, grad_denom * 2.0 * qw, 0.0)
+
+        grad_s_inv = -(rtx * gtx + rty * gty + rtz * gtz) + gs_out
+        grad_s = -grad_s_inv * s_inv * s_inv
+        _store_flat_state(
+            grad_state,
+            offsets,
+            (grad_tx, grad_ty, grad_tz, grad_qx, grad_qy, grad_qz, grad_qw, grad_s),
+            mask,
         )
 
     @triton.jit
@@ -486,6 +761,165 @@ def _require_triton() -> None:
         )
 
 
+def _validate_skel_state(state: torch.Tensor) -> None:
+    if not state.is_cuda:
+        raise RuntimeError("Triton skel_state backend requested, but input is on CPU.")
+    if state.dtype != torch.float32:
+        raise RuntimeError("Triton skel_state backend currently only supports float32.")
+    if state.ndim == 0 or state.shape[-1] != 8:
+        raise RuntimeError("Skeleton state tensor must have shape [..., 8].")
+
+
+def _launch_multiply(
+    state1: torch.Tensor,
+    state2: torch.Tensor,
+    normalize: bool,
+) -> torch.Tensor:
+    _validate_skel_state(state1)
+    _validate_skel_state(state2)
+    _require_triton()
+    state1, state2 = torch.broadcast_tensors(state1, state2)
+    shape = state2.shape
+    state1 = state1.contiguous().reshape(-1, 8)
+    state2 = state2.contiguous().reshape(-1, 8)
+    output = torch.empty_like(state2)
+    n_states = state2.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _multiply_kernel[grid](
+        state1,
+        state2,
+        output,
+        n_states,
+        NORMALIZE=normalize,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return output.reshape(shape)
+
+
+def _launch_inverse(state: torch.Tensor) -> torch.Tensor:
+    _validate_skel_state(state)
+    _require_triton()
+    shape = state.shape
+    state = state.contiguous().reshape(-1, 8)
+    output = torch.empty_like(state)
+    n_states = state.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _inverse_kernel[grid](state, output, n_states, BLOCK_SIZE=_BLOCK_SIZE)
+    return output.reshape(shape)
+
+
+def _launch_multiply_backward(
+    state1: torch.Tensor,
+    state2: torch.Tensor,
+    grad_output: torch.Tensor,
+    normalize: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    state1 = state1.contiguous().reshape(-1, 8)
+    state2 = state2.contiguous().reshape(-1, 8)
+    grad_output = grad_output.contiguous().reshape(-1, 8)
+    grad_state1 = torch.empty_like(state1)
+    grad_state2 = torch.empty_like(state2)
+    n_states = state2.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _multiply_backward_kernel[grid](
+        state1,
+        state2,
+        grad_output,
+        grad_state1,
+        grad_state2,
+        n_states,
+        NORMALIZE=normalize,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return grad_state1, grad_state2
+
+
+def _launch_inverse_backward(
+    state: torch.Tensor,
+    grad_output: torch.Tensor,
+) -> torch.Tensor:
+    state = state.contiguous().reshape(-1, 8)
+    grad_output = grad_output.contiguous().reshape(-1, 8)
+    grad_state = torch.empty_like(state)
+    n_states = state.shape[0]
+    grid = (triton.cdiv(n_states, _BLOCK_SIZE),)
+    _inverse_backward_kernel[grid](
+        state,
+        grad_output,
+        grad_state,
+        n_states,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return grad_state
+
+
+class _Multiply(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        state1: torch.Tensor,
+        state2: torch.Tensor,
+        normalize: bool,
+    ) -> torch.Tensor:
+        shape = state2.shape
+        ctx.normalize = normalize
+        ctx.shape = shape
+        ctx.save_for_backward(state1, state2)
+        return _launch_multiply(state1, state2, normalize)
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ):
+        state1, state2 = ctx.saved_tensors
+        grad_state1, grad_state2 = _launch_multiply_backward(
+            state1,
+            state2,
+            grad_output,
+            ctx.normalize,
+        )
+        return grad_state1.reshape(ctx.shape), grad_state2.reshape(ctx.shape), None
+
+
+class _Inverse(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        state: torch.Tensor,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(state)
+        return _launch_inverse(state)
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ):
+        (state,) = ctx.saved_tensors
+        grad_state = _launch_inverse_backward(
+            state,
+            grad_output,
+        )
+        return (grad_state.reshape(state.shape),)
+
+
+def multiply(state1: torch.Tensor, state2: torch.Tensor) -> torch.Tensor:
+    state1, state2 = torch.broadcast_tensors(state1, state2)
+    return _Multiply.apply(state1, state2, True)
+
+
+def multiply_assume_normalized(
+    state1: torch.Tensor, state2: torch.Tensor
+) -> torch.Tensor:
+    state1, state2 = torch.broadcast_tensors(state1, state2)
+    return _Multiply.apply(state1, state2, False)
+
+
+def inverse(state: torch.Tensor) -> torch.Tensor:
+    return _Inverse.apply(state)
+
+
 def _validate_inputs(
     skel_state: torch.Tensor,
     joint_translation_offsets: torch.Tensor,
@@ -606,7 +1040,7 @@ class _SkeletonStateToJointParameters(torch.autograd.Function):
     def backward(
         ctx: torch.autograd.function.FunctionCtx,
         grad_output: torch.Tensor,
-    ) -> tuple[torch.Tensor | None, None, None, None]:
+    ):
         (
             skel_state,
             joint_translation_offsets,

--- a/pymomentum/backend/triton_skinning.py
+++ b/pymomentum/backend/triton_skinning.py
@@ -1,0 +1,579 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_BLOCK_INFLUENCES = 256
+_BLOCK_VERTICES = 32
+
+if triton is not None and tl is not None:
+    from pymomentum.backend.triton_common import (  # @manual=:backend_triton
+        _quat_multiply,
+        _quat_multiply_backward,
+        _rotate_vector,
+        _rotate_vector_backward,
+    )
+
+    @triton.jit
+    def _load_skel_state(data, batch, joint, n_joints, mask):
+        base = data + (batch * n_joints + joint) * 8
+        return (
+            tl.load(base + 0, mask=mask, other=0.0),
+            tl.load(base + 1, mask=mask, other=0.0),
+            tl.load(base + 2, mask=mask, other=0.0),
+            tl.load(base + 3, mask=mask, other=0.0),
+            tl.load(base + 4, mask=mask, other=0.0),
+            tl.load(base + 5, mask=mask, other=0.0),
+            tl.load(base + 6, mask=mask, other=1.0),
+            tl.load(base + 7, mask=mask, other=1.0),
+        )
+
+    @triton.jit
+    def _batch_offset(batch, batch_dim1: tl.constexpr, n_batch_dims: tl.constexpr):
+        if n_batch_dims == 0:
+            return 0, 0
+        if n_batch_dims == 1:
+            return batch, 0
+        return batch // batch_dim1, batch % batch_dim1
+
+    @triton.jit
+    def _load_points(
+        data,
+        batch,
+        vertex,
+        stride_batch0: tl.constexpr,
+        stride_batch1: tl.constexpr,
+        stride_vertex: tl.constexpr,
+        stride_coord: tl.constexpr,
+        batch_dim1: tl.constexpr,
+        n_batch_dims: tl.constexpr,
+        mask,
+    ):
+        batch0, batch1 = _batch_offset(batch, batch_dim1, n_batch_dims)
+        base = (
+            data
+            + batch0 * stride_batch0
+            + batch1 * stride_batch1
+            + vertex * stride_vertex
+        )
+        return (
+            tl.load(base + 0 * stride_coord, mask=mask, other=0.0),
+            tl.load(base + 1 * stride_coord, mask=mask, other=0.0),
+            tl.load(base + 2 * stride_coord, mask=mask, other=0.0),
+        )
+
+    @triton.jit
+    def _add_point_grads(
+        data,
+        batch,
+        vertex,
+        gx,
+        gy,
+        gz,
+        stride_batch0: tl.constexpr,
+        stride_batch1: tl.constexpr,
+        stride_vertex: tl.constexpr,
+        stride_coord: tl.constexpr,
+        batch_dim1: tl.constexpr,
+        n_batch_dims: tl.constexpr,
+        mask,
+    ):
+        batch0, batch1 = _batch_offset(batch, batch_dim1, n_batch_dims)
+        base = (
+            data
+            + batch0 * stride_batch0
+            + batch1 * stride_batch1
+            + vertex * stride_vertex
+        )
+        tl.atomic_add(base + 0 * stride_coord, gx, sem="relaxed", mask=mask)
+        tl.atomic_add(base + 1 * stride_coord, gy, sem="relaxed", mask=mask)
+        tl.atomic_add(base + 2 * stride_coord, gz, sem="relaxed", mask=mask)
+
+    @triton.jit
+    def _skin_vertices(
+        template,
+        global_skel_state,
+        binded_skel_state_inv,
+        skin_indices,
+        skin_weights,
+        output,
+        batch,
+        vertices,
+        n_joints,
+        n_vertices,
+        n_skin_influences,
+        template_stride_batch0: tl.constexpr,
+        template_stride_batch1: tl.constexpr,
+        template_stride_vertex: tl.constexpr,
+        template_stride_coord: tl.constexpr,
+        batch_dim1: tl.constexpr,
+        n_batch_dims: tl.constexpr,
+        vertex_mask,
+    ):
+        influence = tl.arange(0, n_skin_influences)
+        influence_offsets = vertices[:, None] * n_skin_influences + influence[None, :]
+        influence_mask = vertex_mask[:, None]
+        joint = tl.load(skin_indices + influence_offsets, mask=influence_mask, other=0)
+        weight = tl.load(
+            skin_weights + influence_offsets, mask=influence_mask, other=0.0
+        )
+
+        gtx, gty, gtz, gqx, gqy, gqz, gqw, gs = _load_skel_state(
+            global_skel_state, batch, joint, n_joints, influence_mask
+        )
+        btx, bty, btz, bqx, bqy, bqz, bqw, bs = _load_skel_state(
+            binded_skel_state_inv, batch, joint, n_joints, influence_mask
+        )
+        vx, vy, vz = _load_points(
+            template,
+            batch,
+            vertices,
+            template_stride_batch0,
+            template_stride_batch1,
+            template_stride_vertex,
+            template_stride_coord,
+            batch_dim1,
+            n_batch_dims,
+            vertex_mask,
+        )
+
+        rbtx, rbty, rbtz = _rotate_vector(gqx, gqy, gqz, gqw, btx, bty, btz)
+        ctx = gtx + gs * rbtx
+        cty = gty + gs * rbty
+        ctz = gtz + gs * rbtz
+        cqx, cqy, cqz, cqw = _quat_multiply(gqx, gqy, gqz, gqw, bqx, bqy, bqz, bqw)
+        cs = gs * bs
+
+        rvx, rvy, rvz = _rotate_vector(
+            cqx, cqy, cqz, cqw, vx[:, None], vy[:, None], vz[:, None]
+        )
+        out_base = output + (batch * n_vertices + vertices) * 3
+        tl.store(
+            out_base + 0,
+            tl.sum(weight * (ctx + cs * rvx), axis=1),
+            mask=vertex_mask,
+        )
+        tl.store(
+            out_base + 1,
+            tl.sum(weight * (cty + cs * rvy), axis=1),
+            mask=vertex_mask,
+        )
+        tl.store(
+            out_base + 2,
+            tl.sum(weight * (ctz + cs * rvz), axis=1),
+            mask=vertex_mask,
+        )
+
+    @triton.jit
+    def _forward_kernel(
+        template,
+        global_skel_state,
+        binded_skel_state_inv,
+        skin_indices,
+        skin_weights,
+        output,
+        n_joints,
+        n_vertices,
+        n_skin_influences: tl.constexpr,
+        template_stride_batch0: tl.constexpr,
+        template_stride_batch1: tl.constexpr,
+        template_stride_vertex: tl.constexpr,
+        template_stride_coord: tl.constexpr,
+        batch_dim1: tl.constexpr,
+        n_batch_dims: tl.constexpr,
+        BLOCK_VERTICES: tl.constexpr,
+    ):
+        batch = tl.program_id(0)
+        vertices = tl.program_id(1) * BLOCK_VERTICES + tl.arange(0, BLOCK_VERTICES)
+        vertex_mask = vertices < n_vertices
+        _skin_vertices(
+            template,
+            global_skel_state,
+            binded_skel_state_inv,
+            skin_indices,
+            skin_weights,
+            output,
+            batch,
+            vertices,
+            n_joints,
+            n_vertices,
+            n_skin_influences,
+            template_stride_batch0,
+            template_stride_batch1,
+            template_stride_vertex,
+            template_stride_coord,
+            batch_dim1,
+            n_batch_dims,
+            vertex_mask,
+        )
+
+    @triton.jit
+    def _backward_kernel(
+        template,
+        global_skel_state,
+        binded_skel_state_inv,
+        skin_indices_flattened,
+        skin_weights_flattened,
+        vert_indices_flattened,
+        grad_output,
+        grad_template,
+        grad_global_skel_state,
+        n_joints,
+        n_vertices,
+        n_influences,
+        template_stride_batch0: tl.constexpr,
+        template_stride_batch1: tl.constexpr,
+        template_stride_vertex: tl.constexpr,
+        template_stride_coord: tl.constexpr,
+        grad_template_stride_batch0: tl.constexpr,
+        grad_template_stride_batch1: tl.constexpr,
+        grad_template_stride_vertex: tl.constexpr,
+        grad_template_stride_coord: tl.constexpr,
+        batch_dim1: tl.constexpr,
+        n_batch_dims: tl.constexpr,
+        BLOCK_INFLUENCES: tl.constexpr,
+    ):
+        batch = tl.program_id(0)
+        influence = tl.program_id(1) * BLOCK_INFLUENCES + tl.arange(0, BLOCK_INFLUENCES)
+        mask = influence < n_influences
+
+        joint = tl.load(skin_indices_flattened + influence, mask=mask, other=0)
+        vertex = tl.load(vert_indices_flattened + influence, mask=mask, other=0)
+        weight = tl.load(skin_weights_flattened + influence, mask=mask, other=0.0)
+
+        gtx, gty, gtz, gqx, gqy, gqz, gqw, gs = _load_skel_state(
+            global_skel_state, batch, joint, n_joints, mask
+        )
+        btx, bty, btz, bqx, bqy, bqz, bqw, bs = _load_skel_state(
+            binded_skel_state_inv, batch, joint, n_joints, mask
+        )
+        vx, vy, vz = _load_points(
+            template,
+            batch,
+            vertex,
+            template_stride_batch0,
+            template_stride_batch1,
+            template_stride_vertex,
+            template_stride_coord,
+            batch_dim1,
+            n_batch_dims,
+            mask,
+        )
+
+        gout_base = grad_output + (batch * n_vertices + vertex) * 3
+        gyx = weight * tl.load(gout_base + 0, mask=mask, other=0.0)
+        gyy = weight * tl.load(gout_base + 1, mask=mask, other=0.0)
+        gyz = weight * tl.load(gout_base + 2, mask=mask, other=0.0)
+
+        rbtx, rbty, rbtz = _rotate_vector(gqx, gqy, gqz, gqw, btx, bty, btz)
+        cqx, cqy, cqz, cqw = _quat_multiply(gqx, gqy, gqz, gqw, bqx, bqy, bqz, bqw)
+        cs = gs * bs
+
+        rvx, rvy, rvz = _rotate_vector(cqx, cqy, cqz, cqw, vx, vy, vz)
+        grad_cs = gyx * rvx + gyy * rvy + gyz * rvz
+        grad_rvx = cs * gyx
+        grad_rvy = cs * gyy
+        grad_rvz = cs * gyz
+
+        (
+            grad_cqx,
+            grad_cqy,
+            grad_cqz,
+            grad_cqw,
+            grad_vx,
+            grad_vy,
+            grad_vz,
+        ) = _rotate_vector_backward(
+            cqx, cqy, cqz, cqw, vx, vy, vz, grad_rvx, grad_rvy, grad_rvz
+        )
+
+        (
+            grad_gqx_from_quat,
+            grad_gqy_from_quat,
+            grad_gqz_from_quat,
+            grad_gqw_from_quat,
+            _,
+            _,
+            _,
+            _,
+        ) = _quat_multiply_backward(
+            gqx,
+            gqy,
+            gqz,
+            gqw,
+            bqx,
+            bqy,
+            bqz,
+            bqw,
+            grad_cqx,
+            grad_cqy,
+            grad_cqz,
+            grad_cqw,
+        )
+
+        grad_rbtx = gs * gyx
+        grad_rbty = gs * gyy
+        grad_rbtz = gs * gyz
+        (
+            grad_gqx_from_t,
+            grad_gqy_from_t,
+            grad_gqz_from_t,
+            grad_gqw_from_t,
+            _,
+            _,
+            _,
+        ) = _rotate_vector_backward(
+            gqx,
+            gqy,
+            gqz,
+            gqw,
+            btx,
+            bty,
+            btz,
+            grad_rbtx,
+            grad_rbty,
+            grad_rbtz,
+        )
+
+        grad_gs = gyx * rbtx + gyy * rbty + gyz * rbtz + grad_cs * bs
+
+        _add_point_grads(
+            grad_template,
+            batch,
+            vertex,
+            grad_vx,
+            grad_vy,
+            grad_vz,
+            grad_template_stride_batch0,
+            grad_template_stride_batch1,
+            grad_template_stride_vertex,
+            grad_template_stride_coord,
+            batch_dim1,
+            n_batch_dims,
+            mask,
+        )
+
+        grad_joint_base = grad_global_skel_state + (batch * n_joints + joint) * 8
+        tl.atomic_add(grad_joint_base + 0, gyx, sem="relaxed", mask=mask)
+        tl.atomic_add(grad_joint_base + 1, gyy, sem="relaxed", mask=mask)
+        tl.atomic_add(grad_joint_base + 2, gyz, sem="relaxed", mask=mask)
+        tl.atomic_add(
+            grad_joint_base + 3,
+            grad_gqx_from_t + grad_gqx_from_quat,
+            sem="relaxed",
+            mask=mask,
+        )
+        tl.atomic_add(
+            grad_joint_base + 4,
+            grad_gqy_from_t + grad_gqy_from_quat,
+            sem="relaxed",
+            mask=mask,
+        )
+        tl.atomic_add(
+            grad_joint_base + 5,
+            grad_gqz_from_t + grad_gqz_from_quat,
+            sem="relaxed",
+            mask=mask,
+        )
+        tl.atomic_add(
+            grad_joint_base + 6,
+            grad_gqw_from_t + grad_gqw_from_quat,
+            sem="relaxed",
+            mask=mask,
+        )
+        tl.atomic_add(grad_joint_base + 7, grad_gs, sem="relaxed", mask=mask)
+
+
+class _SkinPointsFromSkelState(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        template: torch.Tensor,
+        global_skel_state: torch.Tensor,
+        binded_skel_state_inv: torch.Tensor,
+        skin_indices: torch.Tensor,
+        skin_weights: torch.Tensor,
+        skin_indices_flattened: torch.Tensor,
+        skin_weights_flattened: torch.Tensor,
+        vert_indices_flattened: torch.Tensor,
+        batch_dim1: int,
+        n_batch_dims: int,
+    ) -> torch.Tensor:
+        batch_size = global_skel_state.shape[0]
+        n_joints = global_skel_state.shape[1]
+        n_vertices = template.shape[-2]
+        n_skin_influences = skin_indices.shape[1]
+        output = torch.empty(
+            (batch_size, n_vertices, 3),
+            device=template.device,
+            dtype=template.dtype,
+        )
+        grid = (batch_size, triton.cdiv(n_vertices, _BLOCK_VERTICES))
+        _forward_kernel[grid](
+            template,
+            global_skel_state,
+            binded_skel_state_inv,
+            skin_indices,
+            skin_weights,
+            output,
+            n_joints,
+            n_vertices,
+            n_skin_influences,
+            template.stride(0) if n_batch_dims > 0 else 0,
+            template.stride(1) if n_batch_dims > 1 else 0,
+            template.stride(-2),
+            template.stride(-1),
+            batch_dim1,
+            n_batch_dims,
+            BLOCK_VERTICES=_BLOCK_VERTICES,
+        )
+        ctx.save_for_backward(
+            template,
+            global_skel_state,
+            binded_skel_state_inv,
+            skin_indices_flattened,
+            skin_weights_flattened,
+            vert_indices_flattened,
+        )
+        ctx.batch_dim1 = batch_dim1
+        ctx.n_batch_dims = n_batch_dims
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (
+            template,
+            global_skel_state,
+            binded_skel_state_inv,
+            skin_indices_flattened,
+            skin_weights_flattened,
+            vert_indices_flattened,
+        ) = ctx.saved_tensors
+        batch_size = global_skel_state.shape[0]
+        n_joints = global_skel_state.shape[1]
+        n_vertices = template.shape[-2]
+        n_influences = skin_indices_flattened.numel()
+
+        grad_template = torch.zeros_like(template)
+        grad_global_skel_state = torch.zeros_like(global_skel_state)
+        grid = (
+            batch_size,
+            triton.cdiv(n_influences, _BLOCK_INFLUENCES),
+        )
+        _backward_kernel[grid](
+            template,
+            global_skel_state,
+            binded_skel_state_inv,
+            skin_indices_flattened,
+            skin_weights_flattened,
+            vert_indices_flattened,
+            grad_output.contiguous(),
+            grad_template,
+            grad_global_skel_state,
+            n_joints,
+            n_vertices,
+            n_influences,
+            template.stride(0) if ctx.n_batch_dims > 0 else 0,
+            template.stride(1) if ctx.n_batch_dims > 1 else 0,
+            template.stride(-2),
+            template.stride(-1),
+            grad_template.stride(0) if ctx.n_batch_dims > 0 else 0,
+            grad_template.stride(1) if ctx.n_batch_dims > 1 else 0,
+            grad_template.stride(-2),
+            grad_template.stride(-1),
+            ctx.batch_dim1,
+            ctx.n_batch_dims,
+            BLOCK_INFLUENCES=_BLOCK_INFLUENCES,
+        )
+        return (
+            grad_template,
+            grad_global_skel_state,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def skin_points_from_skel_state(
+    template: torch.Tensor,
+    global_skel_state: torch.Tensor,
+    binded_skel_state_inv: torch.Tensor,
+    skin_indices: torch.Tensor,
+    skin_weights: torch.Tensor,
+    skin_indices_flattened: torch.Tensor,
+    skin_weights_flattened: torch.Tensor,
+    vert_indices_flattened: torch.Tensor,
+) -> torch.Tensor:
+    if triton is None or tl is None:
+        raise RuntimeError("Triton is not available")
+    if not global_skel_state.is_cuda:
+        raise RuntimeError("input is on CPU, but Triton skinning requires CUDA")
+    if global_skel_state.dtype != torch.float32:
+        raise RuntimeError("Triton skinning only supports float32 inputs")
+    if template.shape[-1] != 3:
+        raise ValueError("template must contain 3D points")
+
+    batch_shape = global_skel_state.shape[:-2]
+    if template.ndim == global_skel_state.ndim - 1 and tuple(
+        template.shape[:-2]
+    ) == tuple(global_skel_state.shape[:-3]):
+        template = template.unsqueeze(-3)
+    while template.ndim < global_skel_state.ndim:
+        template = template.unsqueeze(0)
+    template = template.expand(list(batch_shape) + list(template.shape[-2:]))
+    if len(batch_shape) > 2:
+        template = template.contiguous()
+
+    while binded_skel_state_inv.ndim < global_skel_state.ndim:
+        binded_skel_state_inv = binded_skel_state_inv.unsqueeze(0)
+    binded_skel_state_inv = binded_skel_state_inv.expand_as(
+        global_skel_state
+    ).contiguous()
+
+    global_shape = global_skel_state.shape
+    template_shape = template.shape
+    if len(batch_shape) > 2:
+        template_for_kernel = template.view(-1, template_shape[-2], 3)
+        n_batch_dims = 1
+        batch_dim1 = 1
+    else:
+        template_for_kernel = template
+        n_batch_dims = len(batch_shape)
+        batch_dim1 = template_shape[1] if n_batch_dims > 1 else 1
+    flat_global_skel_state = global_skel_state.contiguous().view(
+        -1, global_shape[-2], 8
+    )
+    flat_binded_skel_state_inv = binded_skel_state_inv.view(-1, global_shape[-2], 8)
+
+    result = _SkinPointsFromSkelState.apply(
+        template_for_kernel,
+        flat_global_skel_state,
+        flat_binded_skel_state_inv,
+        skin_indices.contiguous(),
+        skin_weights.contiguous(),
+        skin_indices_flattened.contiguous(),
+        skin_weights_flattened.contiguous(),
+        vert_indices_flattened.contiguous(),
+        batch_dim1,
+        n_batch_dims,
+    )
+    return result.view(template_shape)

--- a/pymomentum/cmake/build_variables.bzl
+++ b/pymomentum/cmake/build_variables.bzl
@@ -23,6 +23,7 @@ backend_triton_sources = [
     "backend/triton_fk.py",
     "backend/triton_quaternion.py",
     "backend/triton_skel_state.py",
+    "backend/triton_skinning.py",
 ]
 
 python_utility_public_headers = [

--- a/pymomentum/skel_state.py
+++ b/pymomentum/skel_state.py
@@ -56,6 +56,7 @@ from typing import Sequence
 
 import torch
 from pymomentum.backend import skel_state_torch
+from pymomentum.backend.selection import resolve_backend
 
 # pyre-strict
 
@@ -163,7 +164,29 @@ def _multiply_split_skel_states(
     return skel_state_torch._multiply_split_skel_states(skel_state1, skel_state2)
 
 
-def multiply(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tensor:
+@torch.jit.ignore
+def _multiply_triton(
+    s1: torch.Tensor,
+    s2: torch.Tensor,
+    assume_normalized: bool,
+) -> torch.Tensor:
+    from pymomentum.backend import triton_skel_state
+
+    if assume_normalized:
+        return triton_skel_state.multiply_assume_normalized(s1, s2)
+    return triton_skel_state.multiply(s1, s2)
+
+
+@torch.jit.ignore
+def _inverse_triton(skeleton_states: torch.Tensor) -> torch.Tensor:
+    from pymomentum.backend import triton_skel_state
+
+    return triton_skel_state.inverse(skeleton_states)
+
+
+def multiply(
+    s1: torch.Tensor, s2: torch.Tensor, backend: str = "torch"
+) -> torch.Tensor:
     """
     Multiply two skeleton states.
 
@@ -171,13 +194,27 @@ def multiply(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tensor:
     :type s1: torch.Tensor
     :parameter s2: The second skeleton state.
     :type s2: torch.Tensor
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
+    :type backend: str
     :return: The product of the two skeleton states.
     :rtype: torch.Tensor
     """
+    backend = resolve_backend(
+        backend,
+        s2,
+        use_double_precision=s1.dtype == torch.float64 or s2.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _multiply_triton(s1, s2, assume_normalized=False)
+    if backend != "torch":
+        raise ValueError(f"Unsupported skel_state backend: {backend}")
+
     return skel_state_torch.multiply(s1, s2)
 
 
-def multiply_assume_normalized(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tensor:
+def multiply_assume_normalized(
+    s1: torch.Tensor, s2: torch.Tensor, backend: str = "torch"
+) -> torch.Tensor:
     """
     Multiply two skeleton states.
     This is an optimized version that assumes both skeleton states are already properly
@@ -187,21 +224,45 @@ def multiply_assume_normalized(s1: torch.Tensor, s2: torch.Tensor) -> torch.Tens
     :type s1: torch.Tensor
     :parameter s2: The second skeleton state.
     :type s2: torch.Tensor
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
+    :type backend: str
     :return: The product of the two skeleton states.
     :rtype: torch.Tensor
     """
+    backend = resolve_backend(
+        backend,
+        s2,
+        use_double_precision=s1.dtype == torch.float64 or s2.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _multiply_triton(s1, s2, assume_normalized=True)
+    if backend != "torch":
+        raise ValueError(f"Unsupported skel_state backend: {backend}")
+
     return skel_state_torch.multiply_assume_normalized(s1, s2)
 
 
-def inverse(skeleton_states: torch.Tensor) -> torch.Tensor:
+def inverse(skeleton_states: torch.Tensor, backend: str = "torch") -> torch.Tensor:
     """
     Compute the inverse of a skeleton state.
 
     :parameter skeleton_states: The skeleton state to invert.
     :type skeleton_states: torch.Tensor
+    :parameter backend: Backend to use. "auto" opts into the experimental Triton backend on CUDA float32, else torch.
+    :type backend: str
     :return: The inverted skeleton state.
     :rtype: torch.Tensor
     """
+    backend = resolve_backend(
+        backend,
+        skeleton_states,
+        use_double_precision=skeleton_states.dtype == torch.float64,
+    )
+    if backend == "triton":
+        return _inverse_triton(skeleton_states)
+    if backend != "torch":
+        raise ValueError(f"Unsupported skel_state backend: {backend}")
+
     return skel_state_torch.inverse(skeleton_states)
 
 

--- a/pymomentum/test/test_skel_state.py
+++ b/pymomentum/test/test_skel_state.py
@@ -55,6 +55,34 @@ def generate_random_skel_state(sz: int) -> torch.Tensor:
 
 
 class TestSkelState(unittest.TestCase):
+    @staticmethod
+    def _random_cuda_skel_state(size: int) -> torch.Tensor:
+        trans = torch.normal(
+            mean=0,
+            std=4,
+            size=(size, 3),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        rot = pym_quaternion.normalize(
+            torch.normal(
+                mean=0,
+                std=4,
+                size=(size, 4),
+                device="cuda",
+                dtype=torch.float32,
+            )
+        )
+        scale = (
+            torch.rand(
+                size=(size, 1),
+                device="cuda",
+                dtype=torch.float32,
+            )
+            + 0.5
+        )
+        return torch.cat([trans, rot, scale], -1)
+
     def test_skel_state_to_transforms(self) -> None:
         character = pym_test_utils.create_test_character()
         nBatch = 2
@@ -104,6 +132,96 @@ class TestSkelState(unittest.TestCase):
             torch.norm(m_inv - m_inv2),
             1e-4,
             "Inverse is correct",
+        )
+
+    def test_triton_backend_requires_cuda(self) -> None:
+        state = generate_random_skel_state(3).to(torch.float32)
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            pym_skel_state.multiply(state, state, backend="triton")
+
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            pym_skel_state.multiply_assume_normalized(state, state, backend="triton")
+
+        with self.assertRaisesRegex(RuntimeError, "input is on CPU"):
+            pym_skel_state.inverse(state, backend="triton")
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton backend requires CUDA")
+    def test_triton_multiply_matches_torch_forward_and_backward(self) -> None:
+        torch.manual_seed(0)
+        state1 = self._random_cuda_skel_state(256)
+        state2 = self._random_cuda_skel_state(256)
+        state1_torch = state1.detach().clone().requires_grad_(True)
+        state2_torch = state2.detach().clone().requires_grad_(True)
+        state1_triton = state1.detach().clone().requires_grad_(True)
+        state2_triton = state2.detach().clone().requires_grad_(True)
+
+        out_torch = pym_skel_state.multiply(state1_torch, state2_torch)
+        out_triton = pym_skel_state.multiply(
+            state1_triton,
+            state2_triton,
+            backend="triton",
+        )
+        self.assertTrue(torch.allclose(out_triton, out_torch, atol=1e-5, rtol=1e-5))
+
+        grad = torch.randn_like(out_torch)
+        torch.autograd.backward(out_torch, grad)
+        torch.autograd.backward(out_triton, grad)
+        self.assertTrue(
+            torch.allclose(state1_triton.grad, state1_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+        self.assertTrue(
+            torch.allclose(state2_triton.grad, state2_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton backend requires CUDA")
+    def test_triton_multiply_assume_normalized_matches_torch_backward(self) -> None:
+        torch.manual_seed(1)
+        state1 = self._random_cuda_skel_state(256)
+        state2 = self._random_cuda_skel_state(256)
+        state1_torch = state1.detach().clone().requires_grad_(True)
+        state2_torch = state2.detach().clone().requires_grad_(True)
+        state1_triton = state1.detach().clone().requires_grad_(True)
+        state2_triton = state2.detach().clone().requires_grad_(True)
+
+        out_torch = pym_skel_state.multiply_assume_normalized(
+            state1_torch,
+            state2_torch,
+        )
+        out_triton = pym_skel_state.multiply_assume_normalized(
+            state1_triton,
+            state2_triton,
+            backend="triton",
+        )
+        self.assertTrue(torch.allclose(out_triton, out_torch, atol=1e-5, rtol=1e-5))
+
+        grad = torch.randn_like(out_torch)
+        torch.autograd.backward(out_torch, grad)
+        torch.autograd.backward(out_triton, grad)
+        self.assertTrue(
+            torch.allclose(state1_triton.grad, state1_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+        self.assertTrue(
+            torch.allclose(state2_triton.grad, state2_torch.grad, atol=1e-5, rtol=1e-5)
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton backend requires CUDA")
+    def test_triton_inverse_matches_torch_forward_and_backward(self) -> None:
+        torch.manual_seed(2)
+        state = self._random_cuda_skel_state(256)
+        state_torch = state.detach().clone().requires_grad_(True)
+        state_triton = state.detach().clone().requires_grad_(True)
+
+        out_torch = pym_skel_state.inverse(state_torch)
+        out_triton = pym_skel_state.inverse(state_triton, backend="triton")
+        self.assertTrue(torch.allclose(out_triton, out_torch, atol=1e-5, rtol=1e-5))
+
+        grad = torch.randn_like(out_torch)
+        torch.autograd.backward(out_torch, grad)
+        torch.autograd.backward(out_triton, grad)
+        grad_diff = (state_triton.grad - state_torch.grad).abs()
+        self.assertTrue(
+            torch.allclose(state_triton.grad, state_torch.grad, atol=1e-5, rtol=1e-5),
+            f"max grad diff={grad_diff.max()}, per component={grad_diff.amax(dim=0)}",
         )
 
     def test_transform_points(self) -> None:

--- a/pymomentum/test/test_triton_backend.py
+++ b/pymomentum/test/test_triton_backend.py
@@ -104,12 +104,12 @@ class TritonBackendTest(unittest.TestCase):
         torch_state = character.model_parameters_to_skeleton_state(
             torch_params,
             use_double_precision=False,
-            fk_backend="torch",
+            backend="torch",
         )
         triton_state = character.model_parameters_to_skeleton_state(
             triton_params,
             use_double_precision=False,
-            fk_backend="triton",
+            backend="triton",
         )
 
         torch.testing.assert_close(torch_state, triton_state, atol=1e-5, rtol=1e-5)
@@ -125,6 +125,134 @@ class TritonBackendTest(unittest.TestCase):
         if torch_grad is None or triton_grad is None:
             return
         torch.testing.assert_close(torch_grad, triton_grad, atol=1e-4, rtol=1e-4)
+
+    def test_skinning_matches_torch(self) -> None:
+        device = _cuda_device()
+        character_cpu = pym_test_utils.create_test_character()
+        character = pym_character.Character(
+            character_cpu,
+            has_parameter_transform=False,
+            has_skeleton=True,
+            has_rest_mesh=True,
+            has_skinning=True,
+        ).to(device)
+
+        torch.manual_seed(0)
+        joint_params = torch.rand(
+            2,
+            3,
+            character_cpu.skeleton.size,
+            7,
+            device=device,
+            dtype=torch.float32,
+        )
+        skel_state = character.joint_parameters_to_skeleton_state(
+            joint_params,
+            use_double_precision=False,
+            backend="triton",
+        )
+
+        rest_vertices = character.mesh.rest_vertices.detach().clone()
+        torch_state = skel_state.detach().clone().requires_grad_()
+        triton_state = skel_state.detach().clone().requires_grad_()
+        torch_vertices = rest_vertices.detach().clone().requires_grad_()
+        triton_vertices = rest_vertices.detach().clone().requires_grad_()
+
+        torch_skinned = character.skin_points(
+            torch_state,
+            torch_vertices,
+            backend="torch",
+        )
+        triton_skinned = character.skin_points(
+            triton_state,
+            triton_vertices,
+            backend="triton",
+        )
+
+        torch.testing.assert_close(
+            torch_skinned,
+            triton_skinned,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+        grad_output = torch.randn_like(torch_skinned)
+        torch_skinned.backward(grad_output)
+        triton_skinned.backward(grad_output)
+
+        torch_state_grad = torch_state.grad
+        triton_state_grad = triton_state.grad
+        torch_vertex_grad = torch_vertices.grad
+        triton_vertex_grad = triton_vertices.grad
+        self.assertIsNotNone(torch_state_grad)
+        self.assertIsNotNone(triton_state_grad)
+        self.assertIsNotNone(torch_vertex_grad)
+        self.assertIsNotNone(triton_vertex_grad)
+        if (
+            torch_state_grad is None
+            or triton_state_grad is None
+            or torch_vertex_grad is None
+            or triton_vertex_grad is None
+        ):
+            return
+        torch.testing.assert_close(
+            torch_state_grad,
+            triton_state_grad,
+            atol=1e-3,
+            rtol=1e-3,
+        )
+        torch.testing.assert_close(
+            torch_vertex_grad,
+            triton_vertex_grad,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def test_skinning_sequence_rest_vertices_are_broadcast(self) -> None:
+        device = _cuda_device()
+        character_cpu = pym_test_utils.create_test_character()
+        character = pym_character.Character(
+            character_cpu,
+            has_parameter_transform=False,
+            has_skeleton=True,
+            has_rest_mesh=True,
+            has_skinning=True,
+        ).to(device)
+
+        torch.manual_seed(0)
+        joint_params = torch.rand(
+            2,
+            3,
+            character_cpu.skeleton.size,
+            7,
+            device=device,
+            dtype=torch.float32,
+        )
+        skel_state = character.joint_parameters_to_skeleton_state(
+            joint_params,
+            use_double_precision=False,
+            backend="triton",
+        )
+        rest_vertices = character.mesh.rest_vertices.unsqueeze(0).expand(2, -1, -1)
+
+        torch_skinned = character.skin_points(
+            skel_state,
+            rest_vertices.unsqueeze(1),
+            backend="torch",
+        )
+        triton_skinned = character.skin_points(
+            skel_state,
+            rest_vertices,
+            backend="triton",
+        )
+
+        self.assertEqual(triton_skinned.shape, torch_skinned.shape)
+        torch.testing.assert_close(
+            torch_skinned,
+            triton_skinned,
+            atol=1e-4,
+            rtol=1e-4,
+        )
 
     def test_inverse_fk_matches_torch(self) -> None:
         device = _cuda_device()
@@ -149,7 +277,7 @@ class TritonBackendTest(unittest.TestCase):
         skel_state = character.joint_parameters_to_skeleton_state(
             joint_params,
             use_double_precision=False,
-            fk_backend="triton",
+            backend="triton",
         )
         torch_state = skel_state.detach().clone().requires_grad_()
         triton_state = skel_state.detach().clone().requires_grad_()
@@ -266,12 +394,12 @@ class TritonBackendTest(unittest.TestCase):
         torch_state = character.joint_parameters_to_skeleton_state(
             torch_params,
             use_double_precision=False,
-            fk_backend="torch",
+            backend="torch",
         )
         triton_state = character.joint_parameters_to_skeleton_state(
             triton_params,
             use_double_precision=False,
-            fk_backend="triton",
+            backend="triton",
         )
 
         torch.testing.assert_close(torch_state, triton_state, atol=1e-5, rtol=1e-5)

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -19,7 +19,7 @@ from pymomentum.backend import (
     trs_backend,
     utils as backend_utils,
 )
-from pymomentum.backend.selection import resolve_backend
+from pymomentum.backend.selection import resolve_backend, resolve_fk_backend
 from pymomentum.torch.parameter_limits import ParameterLimits
 from pymomentum.torch.utility import _unsqueeze_joint_params
 
@@ -291,15 +291,6 @@ class Skeleton(torch.nn.Module):
                 dim=1,
             )
         )
-        if torch.jit.is_scripting():
-            global_skel_state, _ = (
-                skel_state_backend.global_skel_state_from_local_skel_state_impl(
-                    local_skel_state=local_skel_state,
-                    prefix_mul_indices=prefix_mul_indices,
-                    use_double_precision=use_double_precision,
-                )
-            )
-            return global_skel_state
         return skel_state_backend.global_skel_state_from_local_skel_state(
             local_skel_state=local_skel_state,
             prefix_mul_indices=prefix_mul_indices,
@@ -381,26 +372,38 @@ class Skeleton(torch.nn.Module):
         self,
         joint_parameters: torch.Tensor,
         use_double_precision: bool = True,
-        fk_backend: str = "auto",
+        fk_backend: str = "torch",
+    ) -> torch.Tensor:
+        return self._joint_parameters_to_skeleton_state(
+            joint_parameters,
+            use_double_precision=use_double_precision,
+            fk_backend=fk_backend,
+        )
+
+    def _joint_parameters_to_skeleton_state(
+        self,
+        joint_parameters: torch.Tensor,
+        use_double_precision: bool = True,
+        fk_backend: str = "torch",
         active_joints: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        resolved = resolve_backend(
-            fk_backend, joint_parameters.float(), use_double_precision
+        joint_parameters = _unsqueeze_joint_params(joint_parameters)
+        resolved = resolve_fk_backend(
+            fk_backend,
+            joint_parameters.float(),
+            use_double_precision,
         )
-        if resolved == "triton" and use_double_precision:
-            raise RuntimeError(
-                "Triton FK does not support double precision; "
-                "pass use_double_precision=False"
-            )
         if resolved == "triton":
             with torch.amp.autocast("cuda", enabled=False):
                 return triton_fk.joint_parameters_to_skeleton_state(
-                    _unsqueeze_joint_params(joint_parameters.float()),
+                    joint_parameters.float(),
                     self.joint_translation_offsets,
                     self.joint_prerotations,
                     self.joint_parents,
                     active_joints,
                 )
+        if resolved != "torch":
+            raise ValueError(f"Unsupported FK backend: {resolved}")
         return self.local_skeleton_state_to_skeleton_state(
             self.joint_parameters_to_local_skeleton_state(joint_parameters),
             use_double_precision=use_double_precision,
@@ -413,24 +416,9 @@ class Skeleton(torch.nn.Module):
     ) -> torch.Tensor:
         if joint_parameters.ndim == 1:
             joint_parameters = joint_parameters[None, :]
-        if torch.jit.is_scripting():
-            global_skel_state, _ = (
-                skel_state_backend.global_skel_state_from_local_skel_state_impl(
-                    local_skel_state=self.joint_parameters_to_local_skeleton_state(
-                        joint_parameters
-                    ),
-                    prefix_mul_indices=list(
-                        self.pmi.split(
-                            split_size=self._pmi_buffer_sizes,
-                            dim=1,
-                        )
-                    ),
-                    use_double_precision=use_double_precision,
-                )
-            )
-            return global_skel_state
-        return self.joint_parameters_to_skeleton_state(
-            joint_parameters, use_double_precision=use_double_precision
+        return self.local_skeleton_state_to_skeleton_state(
+            self.joint_parameters_to_local_skeleton_state(joint_parameters),
+            use_double_precision=use_double_precision,
         )
 
 
@@ -961,7 +949,6 @@ class Character(torch.nn.Module):
         joint_parameters: torch.Tensor,
         use_double_precision: bool = True,
         fk_backend: str = "torch",
-        active_joints: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if not hasattr(self, "skeleton"):
             raise RuntimeError("Character has no skeleton, please provide one")
@@ -969,7 +956,6 @@ class Character(torch.nn.Module):
             joint_parameters,
             use_double_precision=use_double_precision,
             fk_backend=fk_backend,
-            active_joints=active_joints,
         )
 
     def model_parameters_to_skeleton_state(
@@ -982,14 +968,13 @@ class Character(torch.nn.Module):
             raise RuntimeError(
                 "Character has no parameter transform, please provide one"
             )
-        resolved = resolve_backend(
-            fk_backend, model_parameters.float(), use_double_precision
-        )
         active_joints = self.parameter_transform.active_joints
-        return self.joint_parameters_to_skeleton_state(
+        if not hasattr(self, "skeleton"):
+            raise RuntimeError("Character has no skeleton, please provide one")
+        return self.skeleton._joint_parameters_to_skeleton_state(
             self.model_parameters_to_joint_parameters(model_parameters),
             use_double_precision=use_double_precision,
-            fk_backend=resolved,
+            fk_backend=fk_backend,
             active_joints=active_joints,
         )
 

--- a/pymomentum/torch/character.py
+++ b/pymomentum/torch/character.py
@@ -16,6 +16,7 @@ from pymomentum.backend import (
     skel_state_backend,
     triton_fk,
     triton_skel_state,
+    triton_skinning,
     trs_backend,
     utils as backend_utils,
 )
@@ -372,24 +373,24 @@ class Skeleton(torch.nn.Module):
         self,
         joint_parameters: torch.Tensor,
         use_double_precision: bool = True,
-        fk_backend: str = "torch",
+        backend: str = "torch",
     ) -> torch.Tensor:
         return self._joint_parameters_to_skeleton_state(
             joint_parameters,
             use_double_precision=use_double_precision,
-            fk_backend=fk_backend,
+            backend=backend,
         )
 
     def _joint_parameters_to_skeleton_state(
         self,
         joint_parameters: torch.Tensor,
         use_double_precision: bool = True,
-        fk_backend: str = "torch",
+        backend: str = "torch",
         active_joints: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         joint_parameters = _unsqueeze_joint_params(joint_parameters)
         resolved = resolve_fk_backend(
-            fk_backend,
+            backend,
             joint_parameters.float(),
             use_double_precision,
         )
@@ -433,22 +434,32 @@ class LinearBlendSkinning(torch.nn.Module):
 
         self.register_buffer(
             "inverse_bind_pose",
-            pym_skel_state.from_matrix(
-                torch.tensor(character.inverse_bind_pose, dtype=dtype)
-            )
-            .detach()
-            .clone(),
+            self._normalize_skel_state_quaternion(
+                pym_skel_state.from_matrix(
+                    torch.tensor(character.inverse_bind_pose, dtype=dtype)
+                )
+            ).detach(),
         )
 
         self.num_vertices: int = character.skin_weights.index.shape[0]
+        self.register_buffer(
+            "skin_indices",
+            torch.tensor(character.skin_weights.index, dtype=torch.int32)
+            .detach()
+            .clone(),
+        )
+        self.register_buffer(
+            "skin_weights",
+            torch.tensor(character.skin_weights.weight, dtype=dtype).detach().clone(),
+        )
 
         (
             skin_indices_flattened,
             skin_weights_flattened,
             vert_indices_flattened,
         ) = backend_utils.flatten_skinning_weights_and_indices(
-            skin_weights=torch.tensor(character.skin_weights.weight, dtype=dtype),
-            skin_indices=torch.tensor(character.skin_weights.index, dtype=torch.int32),
+            skin_weights=self.skin_weights,
+            skin_indices=self.skin_indices,
         )
 
         self.register_buffer(
@@ -461,10 +472,22 @@ class LinearBlendSkinning(torch.nn.Module):
             "vert_indices_flattened", vert_indices_flattened.detach().clone()
         )
 
+    @staticmethod
+    def _normalize_skel_state_quaternion(skel_state: torch.Tensor) -> torch.Tensor:
+        return torch.cat(
+            [
+                skel_state[..., :3],
+                pym_quaternion.normalize(skel_state[..., 3:7]),
+                skel_state[..., 7:],
+            ],
+            dim=-1,
+        )
+
     def forward(
         self,
         skel_state: torch.Tensor,
         rest_vertex_positions: torch.Tensor,
+        backend: str = "torch",
     ) -> torch.Tensor:
         assert rest_vertex_positions.shape[-1] == 3
         assert rest_vertex_positions.shape[-2] == self.num_vertices
@@ -473,7 +496,24 @@ class LinearBlendSkinning(torch.nn.Module):
         while inverse_bind_pose.ndim < skel_state.ndim:
             inverse_bind_pose = inverse_bind_pose.unsqueeze(0)
 
-        return skel_state_backend.skin_points_from_skel_state(
+        skel_state = self._normalize_skel_state_quaternion(skel_state)
+
+        resolved = resolve_backend(backend, skel_state.float())
+        if resolved == "triton":
+            with torch.amp.autocast("cuda", enabled=False):
+                return triton_skinning.skin_points_from_skel_state(
+                    template=rest_vertex_positions.float(),
+                    global_skel_state=skel_state.float(),
+                    binded_skel_state_inv=inverse_bind_pose.float(),
+                    skin_indices=self.skin_indices,
+                    skin_weights=self.skin_weights.float(),
+                    skin_indices_flattened=self.skin_indices_flattened,
+                    skin_weights_flattened=self.skin_weights_flattened,
+                    vert_indices_flattened=self.vert_indices_flattened,
+                )
+        if resolved != "torch":
+            raise ValueError(f"Unsupported skinning backend: {resolved}")
+        return skel_state_backend.skin_points_from_skel_state_assume_normalized(
             template=rest_vertex_positions,
             global_skel_state=skel_state,
             binded_skel_state_inv=inverse_bind_pose,
@@ -948,21 +988,21 @@ class Character(torch.nn.Module):
         self,
         joint_parameters: torch.Tensor,
         use_double_precision: bool = True,
-        fk_backend: str = "torch",
+        backend: str = "torch",
     ) -> torch.Tensor:
         if not hasattr(self, "skeleton"):
             raise RuntimeError("Character has no skeleton, please provide one")
         return self.skeleton.joint_parameters_to_skeleton_state(
             joint_parameters,
             use_double_precision=use_double_precision,
-            fk_backend=fk_backend,
+            backend=backend,
         )
 
     def model_parameters_to_skeleton_state(
         self,
         model_parameters: torch.Tensor,
         use_double_precision: bool = True,
-        fk_backend: str = "torch",
+        backend: str = "torch",
     ) -> torch.Tensor:
         if not hasattr(self, "parameter_transform"):
             raise RuntimeError(
@@ -974,7 +1014,7 @@ class Character(torch.nn.Module):
         return self.skeleton._joint_parameters_to_skeleton_state(
             self.model_parameters_to_joint_parameters(model_parameters),
             use_double_precision=use_double_precision,
-            fk_backend=fk_backend,
+            backend=backend,
             active_joints=active_joints,
         )
 
@@ -992,6 +1032,7 @@ class Character(torch.nn.Module):
         self,
         skel_state: torch.Tensor,
         rest_vertex_positions: Optional[torch.Tensor] = None,
+        backend: str = "torch",
     ) -> torch.Tensor:
         if rest_vertex_positions is None:
             if not hasattr(self, "mesh"):
@@ -1004,6 +1045,7 @@ class Character(torch.nn.Module):
         return self.linear_blend_skinning.forward(
             skel_state,
             rest_vertex_positions,
+            backend=backend,
         )
 
     def unpose(


### PR DESCRIPTION
Summary:

Adds a Triton backend for PyMomentum linear blend skinning and wires character skinning through it when Triton is selected. The public PyMomentum backend keyword is consistently `backend=` across quaternion, skeleton-state, FK, and skinning entry points. The forward pass now owns each output vertex, so it no longer needs atomics; backward still uses atomics for the transpose/scatter accumulation. Skeleton states and inverse bind poses are normalized once before skinning rather than once per point influence. The kernel also accepts strided/broadcast rest points, including the common sequence case where rest points are shaped `[n_characters, n_points, 3]` and skeleton states are shaped `[n_characters, n_frames, n_joints, 8]`, avoiding materializing `[n_characters, n_frames, n_points, 3]`.

Reviewed By: cstollmeta

Differential Revision: D106678372


