### PR TITLE
Fix remaining SIMD constraint joint bounds

### DIFF
--- a/momentum/character_solver_simd/simd_distance_error_function.cpp
+++ b/momentum/character_solver_simd/simd_distance_error_function.cpp
@@ -55,7 +55,7 @@ void SimdDistanceConstraints::addConstraint(
     const Vector3f& origin,
     const float target,
     const float targetWeight) {
-  MT_CHECK(jointIndex < constraintCount.size());
+  MT_CHECK(jointIndex < static_cast<size_t>(numJoints));
 
   uint32_t index = 0;
   while (true) {

--- a/momentum/character_solver_simd/simd_fixed_axis_error_function.cpp
+++ b/momentum/character_solver_simd/simd_fixed_axis_error_function.cpp
@@ -52,7 +52,7 @@ void SimdFixedAxisConstraints::addConstraint(
     const Vector3f& localAxis,
     const Vector3f& globalAxis,
     const float targetWeight) {
-  MT_CHECK(jointIndex < constraintCount.size());
+  MT_CHECK(jointIndex < static_cast<size_t>(numJoints));
 
   uint32_t index = 0;
   while (true) {

--- a/momentum/character_solver_simd/simd_normal_error_function.cpp
+++ b/momentum/character_solver_simd/simd_normal_error_function.cpp
@@ -62,7 +62,7 @@ bool SimdNormalConstraints::addConstraint(
     const Vector3f& normal,
     const Vector3f& target,
     const float targetWeight) {
-  MT_CHECK(jointIndex < constraintCount.size());
+  MT_CHECK(jointIndex < static_cast<size_t>(numJoints));
 
   // add the constraint to the corresponding arrays of the jointIndex if there's enough space
   uint32_t index = 0;

--- a/momentum/character_solver_simd/simd_orientation_error_function.cpp
+++ b/momentum/character_solver_simd/simd_orientation_error_function.cpp
@@ -64,7 +64,7 @@ void SimdOrientationConstraints::addConstraint(
     const Eigen::Quaternionf& offset,
     const Eigen::Quaternionf& target,
     const float targetWeight) {
-  MT_CHECK(jointIndex < constraintCount.size());
+  MT_CHECK(jointIndex < static_cast<size_t>(numJoints));
 
   uint32_t index = 0;
   while (true) {

--- a/momentum/character_solver_simd/simd_plane_error_function.cpp
+++ b/momentum/character_solver_simd/simd_plane_error_function.cpp
@@ -62,7 +62,7 @@ void SimdPlaneConstraints::addConstraint(
     const Vector3f& targetNormal,
     const float targetOffset,
     const float targetWeight) {
-  MT_CHECK(jointIndex < constraintCount.size());
+  MT_CHECK(jointIndex < static_cast<size_t>(numJoints));
 
   // add the constraint to the corresponding arrays of the jointIndex if there's enough space
   uint32_t index = 0;

--- a/momentum/character_solver_simd/simd_projection_error_function.cpp
+++ b/momentum/character_solver_simd/simd_projection_error_function.cpp
@@ -55,7 +55,7 @@ void SimdProjectionConstraints::addConstraint(
     const Eigen::Matrix<float, 3, 4>& proj,
     const Eigen::Vector2f& target,
     const float targetWeight) {
-  MT_CHECK(jointIndex < constraintCount.size());
+  MT_CHECK(jointIndex < static_cast<size_t>(numJoints));
 
   uint32_t index = 0;
   while (true) {

--- a/momentum/test/character_solver_simd/simd_distance_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_distance_error_function_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "momentum/character_solver/distance_error_function.h"
 #include "momentum/character_solver_simd/simd_distance_error_function.h"
 
@@ -21,6 +23,28 @@
 #include "momentum/test/character_solver/error_function_helpers.h"
 
 using namespace momentum;
+
+TEST(Momentum_ErrorFunctions, SimdDistanceConstraintsRejectsJointIndexOutsideSkeleton) {
+  const Character character = createTestCharacter(3);
+  const Skeleton& skeleton = character.skeleton;
+  SimdDistanceConstraints constraints(&skeleton);
+
+  const size_t invalidJointIndex = skeleton.joints.size();
+  ASSERT_LT(invalidJointIndex, SimdDistanceConstraints::kMaxJoints);
+
+  const auto addInvalidConstraint = [&]() {
+    constraints.addConstraint(invalidJointIndex, Vector3f::Zero(), Vector3f::UnitX(), 1.0f, 1.0f);
+  };
+
+  // MT_CHECK aborts via XR_CHECK in XR-logger builds, but throws std::runtime_error in the
+  // non-XR backend.
+#if defined(MOMENTUM_WITH_XR_LOGGER)
+  EXPECT_DEATH_IF_SUPPORTED(
+      addInvalidConstraint(), "jointIndex < static_cast<size_t>\\(numJoints\\)");
+#else
+  EXPECT_THROW(addInvalidConstraint(), std::runtime_error);
+#endif
+}
 
 // Verify SIMD distance error function matches the scalar reference at multiple constraint counts
 // that exercise both partial and full SIMD packets.

--- a/momentum/test/character_solver_simd/simd_fixed_axis_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_fixed_axis_error_function_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "momentum/character_solver/fixed_axis_error_function.h"
 #include "momentum/character_solver_simd/simd_fixed_axis_error_function.h"
 
@@ -21,6 +23,28 @@
 #include "momentum/test/character_solver/error_function_helpers.h"
 
 using namespace momentum;
+
+TEST(Momentum_ErrorFunctions, SimdFixedAxisConstraintsRejectsJointIndexOutsideSkeleton) {
+  const Character character = createTestCharacter(3);
+  const Skeleton& skeleton = character.skeleton;
+  SimdFixedAxisConstraints constraints(&skeleton);
+
+  const size_t invalidJointIndex = skeleton.joints.size();
+  ASSERT_LT(invalidJointIndex, SimdFixedAxisConstraints::kMaxJoints);
+
+  const auto addInvalidConstraint = [&]() {
+    constraints.addConstraint(invalidJointIndex, Vector3f::UnitX(), Vector3f::UnitY(), 1.0f);
+  };
+
+  // MT_CHECK aborts via XR_CHECK in XR-logger builds, but throws std::runtime_error in the
+  // non-XR backend.
+#if defined(MOMENTUM_WITH_XR_LOGGER)
+  EXPECT_DEATH_IF_SUPPORTED(
+      addInvalidConstraint(), "jointIndex < static_cast<size_t>\\(numJoints\\)");
+#else
+  EXPECT_THROW(addInvalidConstraint(), std::runtime_error);
+#endif
+}
 
 TEST(Momentum_ErrorFunctions, SimdFixedAxisFunctionIsSame) {
   const bool verbose = false;

--- a/momentum/test/character_solver_simd/simd_normal_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_normal_error_function_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "momentum/character_solver/normal_error_function.h"
 #include "momentum/character_solver_simd/simd_normal_error_function.h"
 
@@ -24,6 +26,29 @@
 #include "momentum/test/character_solver/error_function_helpers.h"
 
 using namespace momentum;
+
+TEST(Momentum_ErrorFunctions, SimdNormalConstraintsRejectsJointIndexOutsideSkeleton) {
+  const Character character = createTestCharacter(3);
+  const Skeleton& skeleton = character.skeleton;
+  SimdNormalConstraints constraints(&skeleton);
+
+  const size_t invalidJointIndex = skeleton.joints.size();
+  ASSERT_LT(invalidJointIndex, SimdNormalConstraints::kMaxJoints);
+
+  const auto addInvalidConstraint = [&]() {
+    (void)constraints.addConstraint(
+        invalidJointIndex, Vector3f::Zero(), Vector3f::UnitX(), Vector3f::UnitY(), 1.0f);
+  };
+
+  // MT_CHECK aborts via XR_CHECK in XR-logger builds, but throws std::runtime_error in the
+  // non-XR backend.
+#if defined(MOMENTUM_WITH_XR_LOGGER)
+  EXPECT_DEATH_IF_SUPPORTED(
+      addInvalidConstraint(), "jointIndex < static_cast<size_t>\\(numJoints\\)");
+#else
+  EXPECT_THROW(addInvalidConstraint(), std::runtime_error);
+#endif
+}
 
 // TODO: Test for double once we have SIMD implementation for double
 TEST(Momentum_ErrorFunctions, SimdNormalFunctionIsSame) {

--- a/momentum/test/character_solver_simd/simd_orientation_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_orientation_error_function_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "momentum/character_solver/orientation_error_function.h"
 #include "momentum/character_solver_simd/simd_orientation_error_function.h"
 
@@ -21,6 +23,29 @@
 #include "momentum/test/character_solver/error_function_helpers.h"
 
 using namespace momentum;
+
+TEST(Momentum_ErrorFunctions, SimdOrientationConstraintsRejectsJointIndexOutsideSkeleton) {
+  const Character character = createTestCharacter(3);
+  const Skeleton& skeleton = character.skeleton;
+  SimdOrientationConstraints constraints(&skeleton);
+
+  const size_t invalidJointIndex = skeleton.joints.size();
+  ASSERT_LT(invalidJointIndex, SimdOrientationConstraints::kMaxJoints);
+
+  const auto addInvalidConstraint = [&]() {
+    constraints.addConstraint(
+        invalidJointIndex, Eigen::Quaternionf::Identity(), Eigen::Quaternionf::Identity(), 1.0f);
+  };
+
+  // MT_CHECK aborts via XR_CHECK in XR-logger builds, but throws std::runtime_error in the
+  // non-XR backend.
+#if defined(MOMENTUM_WITH_XR_LOGGER)
+  EXPECT_DEATH_IF_SUPPORTED(
+      addInvalidConstraint(), "jointIndex < static_cast<size_t>\\(numJoints\\)");
+#else
+  EXPECT_THROW(addInvalidConstraint(), std::runtime_error);
+#endif
+}
 
 TEST(Momentum_ErrorFunctions, SimdOrientationFunctionIsSame) {
   const bool verbose = false;

--- a/momentum/test/character_solver_simd/simd_plane_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_plane_error_function_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "momentum/character_solver/plane_error_function.h"
 #include "momentum/character_solver_simd/simd_plane_error_function.h"
 
@@ -78,6 +80,28 @@ void runSimdPlaneEquivalenceSweep(bool above) {
 }
 
 } // namespace
+
+TEST(Momentum_ErrorFunctions, SimdPlaneConstraintsRejectsJointIndexOutsideSkeleton) {
+  const Character character = createTestCharacter(3);
+  const Skeleton& skeleton = character.skeleton;
+  SimdPlaneConstraints constraints(&skeleton);
+
+  const size_t invalidJointIndex = skeleton.joints.size();
+  ASSERT_LT(invalidJointIndex, SimdPlaneConstraints::kMaxJoints);
+
+  const auto addInvalidConstraint = [&]() {
+    constraints.addConstraint(invalidJointIndex, Vector3f::Zero(), Vector3f::UnitX(), 0.0f, 1.0f);
+  };
+
+  // MT_CHECK aborts via XR_CHECK in XR-logger builds, but throws std::runtime_error in the
+  // non-XR backend.
+#if defined(MOMENTUM_WITH_XR_LOGGER)
+  EXPECT_DEATH_IF_SUPPORTED(
+      addInvalidConstraint(), "jointIndex < static_cast<size_t>\\(numJoints\\)");
+#else
+  EXPECT_THROW(addInvalidConstraint(), std::runtime_error);
+#endif
+}
 
 // TODO: Test for double once we have SIMD implementation for double
 TEST(Momentum_ErrorFunctions, SimdPlaneFunctionIsSame) {

--- a/momentum/test/character_solver_simd/simd_projection_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_projection_error_function_test.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "momentum/character_solver/projection_error_function.h"
 #include "momentum/character_solver_simd/simd_projection_error_function.h"
 
@@ -21,6 +23,33 @@
 #include "momentum/test/character_solver/error_function_helpers.h"
 
 using namespace momentum;
+
+TEST(Momentum_ErrorFunctions, SimdProjectionConstraintsRejectsJointIndexOutsideSkeleton) {
+  const Character character = createTestCharacter(3);
+  const Skeleton& skeleton = character.skeleton;
+  SimdProjectionConstraints constraints(&skeleton);
+
+  const size_t invalidJointIndex = skeleton.joints.size();
+  ASSERT_LT(invalidJointIndex, SimdProjectionConstraints::kMaxJoints);
+
+  const auto addInvalidConstraint = [&]() {
+    constraints.addConstraint(
+        invalidJointIndex,
+        Vector3f::Zero(),
+        Eigen::Matrix<float, 3, 4>::Zero(),
+        Vector2f::Zero(),
+        1.0f);
+  };
+
+  // MT_CHECK aborts via XR_CHECK in XR-logger builds, but throws std::runtime_error in the
+  // non-XR backend.
+#if defined(MOMENTUM_WITH_XR_LOGGER)
+  EXPECT_DEATH_IF_SUPPORTED(
+      addInvalidConstraint(), "jointIndex < static_cast<size_t>\\(numJoints\\)");
+#else
+  EXPECT_THROW(addInvalidConstraint(), std::runtime_error);
+#endif
+}
 
 TEST(Momentum_ErrorFunctions, SimdProjectionFunctionIsSame) {
   const bool verbose = false;


### PR DESCRIPTION
Summary: Several SIMD constraint stores validated `jointIndex` against `constraintCount.size()`, the fixed `kMaxJoints` counter array, while their striped data buffers are allocated for the runtime `numJoints`. This updates the remaining stores outside the existing aim and position diffs to validate against `numJoints` and adds invalid-joint regression tests for distance, fixed-axis, normal, orientation, plane, and projection constraints.

Differential Revision: D106746784


