### PR TITLE
Remove `fromRotationMatrix`/`fromQuaternion` from `JointParametersT` (#1439)

### DIFF
--- a/momentum/character/types.h
+++ b/momentum/character/types.h
@@ -130,17 +130,6 @@ struct JointParametersT : public EigenStrongType<JointParametersT, ::Eigen::Vect
   using t = ::Eigen::VectorX<T>;
   using EigenStrongType<JointParametersT, t>::EigenStrongType;
   using EigenStrongType<JointParametersT, t>::operator=;
-
-  [[nodiscard]] static ::Eigen::Vector3<T> fromRotationMatrix(const ::Eigen::Matrix3<T>& m) {
-    // From JointState::set(), we can see that localRotation = rz * ry * rx, but the order in
-    // JointParameters is [rx, ry, rz]. Therefore, the conversion should be
-    // rotationMatrixToEulerZYX.reverse.
-    return rotationMatrixToEulerZYX(m).reverse();
-  }
-
-  [[nodiscard]] static ::Eigen::Vector3<T> fromQuaternion(const ::Eigen::Quaternion<T>& q) {
-    return fromRotationMatrix(q.toRotationMatrix());
-  }
 };
 
 using JointParameters = JointParametersT<float>;


### PR DESCRIPTION
Summary:

`JointParametersT::fromRotationMatrix` and `JointParametersT::fromQuaternion` are misleading convenience methods — converting a rotation to joint parameters generally requires accounting for pre-rotation, joint limits, and other skeleton-specific state, not just a bare Euler decomposition.

Reviewed By: cstollmeta

Differential Revision: D106730915


