### PR TITLE
Skip identity remap when loaded motion has no identity vector

### DIFF
--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -88,6 +88,12 @@ MatrixXf mapMotionToCharacter(
 /// Maps the input JointParameter vector to a target character by matching joint names. Mismatched
 /// names will be discarded (source) or set to zero (target). For every matched joint, all 7
 /// parameters will be copied over.
+///
+/// @pre `std::get<0>(inputIdentity).size() * kParametersPerJoint ==
+/// std::get<1>(inputIdentity).size()`. Callers that may not have identity data (e.g. glTF motion
+/// files saved without identity offsets) must check this before assembling the tuple — passing
+/// joint names paired with an empty identity vector violates the precondition. Either skip the call
+/// entirely or pass a fully empty `IdentityParameters{}`, which yields a zero-padded result.
 JointParameters mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter);

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -122,12 +122,19 @@ void saveGltfOutput(
     bool hasMotion) {
   MT_LOGI("Saving gltf/glb file...");
   if (hasMotion) {
+    // Empty offsets mean "the loaded motion has no per-joint identity vector"; passing the
+    // skeleton's joint names paired with an empty identity vector would violate
+    // mapIdentityToCharacter's size precondition. Use a fully empty IdentityParameters so the
+    // glTF writer sees "no identity data" rather than a mismatched tuple.
+    const IdentityParameters offsets = motionData.offsets.size() == 0
+        ? IdentityParameters{}
+        : IdentityParameters{character.skeleton.getJointNames(), motionData.offsets};
     saveGltfCharacter(
         outputFile,
         character,
         motionData.fps,
         {character.parameterTransform.name, motionData.poses},
-        {character.skeleton.getJointNames(), motionData.offsets},
+        offsets,
         markerSequence.frames);
   } else {
     saveGltfCharacter(outputFile, character);

--- a/momentum/io/gltf/gltf_animation_io.cpp
+++ b/momentum/io/gltf/gltf_animation_io.cpp
@@ -222,9 +222,15 @@ std::tuple<MatrixXf, JointParameters, float> loadMotionOnCharacterCommon(
     const std::variant<filesystem::path, std::span<const std::byte>>& input,
     const Character& character) {
   const auto [loadedChar, motion, identity, fps] = loadCharacterWithMotionCommon(input);
+  // glTF files that store motion without per-joint identity offsets surface as an empty `identity`
+  // vector. Skip mapIdentityToCharacter in that case to preserve the "no identity present" signal
+  // and to avoid violating its size precondition (joint names paired with an empty values vector).
+  const JointParameters mappedIdentity = identity.size() != 0
+      ? mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character)
+      : identity;
   return {
       mapMotionToCharacter({loadedChar.parameterTransform.name, motion}, character),
-      mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character),
+      mappedIdentity,
       fps};
 }
 


### PR DESCRIPTION
Summary:
glTF motion files can carry pose data without per-joint identity offsets. When `loadMotionOnCharacter` reassembles an `IdentityParameters` tuple from the loaded character's joint names paired with an empty identity vector, it trips `mapIdentityToCharacter`'s precondition that `jointNames.size() * kParametersPerJoint == identity.size()`. Skip the remap at the call site when the identity vector is empty, preserving the empty value so downstream code can detect "no identity present".

Apply the same guard to `convert_model`'s glTF save path, where reconstructing `IdentityParameters` from `getJointNames()` paired with empty offsets hits the same precondition. The save path uses a fully empty `IdentityParameters{}` so the glTF writer sees "no identity data" rather than a name-only-empty mismatched tuple.

Documents the precondition on `mapIdentityToCharacter` so future callers handle the empty case explicitly at the call site rather than pushing the policy into the low-level helper.

Differential Revision: D106701749


