### PR TITLE
Add URDF input, model-parameter output, and locator flag rename to convert_model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1044,6 +1044,7 @@ if(MOMENTUM_BUILD_EXAMPLES)
     LINK_LIBRARIES
       io_character
       io_marker
+      io_urdf
       CLI11::CLI11
   )
 

--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -88,6 +88,12 @@ MatrixXf mapMotionToCharacter(
 /// Maps the input JointParameter vector to a target character by matching joint names. Mismatched
 /// names will be discarded (source) or set to zero (target). For every matched joint, all 7
 /// parameters will be copied over.
+///
+/// @pre `std::get<0>(inputIdentity).size() * kParametersPerJoint ==
+/// std::get<1>(inputIdentity).size()`. Callers that may not have identity data (e.g. glTF motion
+/// files saved without identity offsets) must check this before assembling the tuple — passing
+/// joint names paired with an empty identity vector violates the precondition. Either skip the call
+/// entirely or pass a fully empty `IdentityParameters{}`, which yields a zero-padded result.
 JointParameters mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter);

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -10,14 +10,18 @@
 #include "convert_model_helpers.h"
 
 #include <momentum/character/character.h>
+#include <momentum/common/exception.h>
 #include <momentum/common/log.h>
 #include <momentum/io/character_io.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
 #include <momentum/io/marker/marker_io.h>
 #include <momentum/io/skeleton/locator_io.h>
+#include <momentum/io/skeleton/parameter_transform_io.h>
 
 #include <CLI/CLI.hpp>
+
+#include <fstream>
 
 using namespace momentum;
 
@@ -30,7 +34,7 @@ std::shared_ptr<Options> setupOptions(CLI::App& app) {
   app.add_option(
          "-m,--model",
          opt->input_model_file,
-         "Input model (.fbx/.glb); not required if reading animation from glb or fbx")
+         "Input model (.fbx/.glb/.gltf/.urdf); not required if reading animation from glb or fbx")
       ->check(CLI::ExistingFile);
   app.add_option("-p,--parameters", opt->input_params_file, "Input model parameter file (.model)")
       ->check(CLI::ExistingFile);
@@ -40,16 +44,20 @@ std::shared_ptr<Options> setupOptions(CLI::App& app) {
   app.add_option("-d,--motion", opt->input_motion_file, "Input motion data file (.glb/.fbx)")
       ->check(CLI::ExistingFile);
 
-  app.add_option("-o,--out", opt->output_model_file, "Output file (.fbx/.glb)")->required();
+  app.add_option("-o,--out", opt->output_model_file, "Output file (.fbx/.glb/.gltf)")->required();
 
   app.add_option(
-      "--out-locator-local",
+      "--out-locators-local",
       opt->output_locator_local,
       "Output a locator file (.locators) in local space for transferring between identities");
   app.add_option(
-      "--out-locator-global",
+      "--out-locators-global",
       opt->output_locator_global,
       "Output a locator file (.locators) in global space for authoring a template");
+  app.add_option(
+      "--out-parameters",
+      opt->output_params_file,
+      "Output a model parameter file (.model) containing the parameter transform and limits");
   app.add_option("--fbx-namespace", opt->fbx_namespace, "Namespace in output fbx file");
 
   app.add_flag(
@@ -156,6 +164,23 @@ void saveLocatorFiles(const Options& options, const Character& character) {
   }
 }
 
+// Saves the character's parameter transform and limits to a .model file if an
+// output path is specified.
+void saveParameterFile(const Options& options, const Character& character) {
+  if (options.output_params_file.empty()) {
+    return;
+  }
+
+  MT_LOGI("Saving model parameter file...");
+  std::ofstream ofs(options.output_params_file);
+  MT_THROW_IF(
+      !ofs.is_open(),
+      "Cannot open output parameter file for writing: {}",
+      options.output_params_file);
+  ofs << writeModelDefinition(
+      character.skeleton, character.parameterTransform, character.parameterLimits);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -177,8 +202,7 @@ int main(int argc, char** argv) {
     const bool hasModel = !options->input_model_file.empty();
     Character character;
     if (hasModel) {
-      character = loadFullCharacter(
-          options->input_model_file, options->input_params_file, options->input_locator_file);
+      character = loadModelCharacter(*options);
     }
 
     // Load motion data
@@ -200,6 +224,9 @@ int main(int argc, char** argv) {
 
     // Save locator files
     saveLocatorFiles(*options, character);
+
+    // Save model parameter file
+    saveParameterFile(*options, character);
   } catch (std::exception& e) {
     MT_LOGE("Failed to convert model. Error: {}", e.what());
     return EXIT_FAILURE;

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -122,12 +122,19 @@ void saveGltfOutput(
     bool hasMotion) {
   MT_LOGI("Saving gltf/glb file...");
   if (hasMotion) {
+    // Empty offsets mean "the loaded motion has no per-joint identity vector"; passing the
+    // skeleton's joint names paired with an empty identity vector would violate
+    // mapIdentityToCharacter's size precondition. Use a fully empty IdentityParameters so the
+    // glTF writer sees "no identity data" rather than a mismatched tuple.
+    const IdentityParameters offsets = motionData.offsets.size() == 0
+        ? IdentityParameters{}
+        : IdentityParameters{character.skeleton.getJointNames(), motionData.offsets};
     saveGltfCharacter(
         outputFile,
         character,
         motionData.fps,
         {character.parameterTransform.name, motionData.poses},
-        {character.skeleton.getJointNames(), motionData.offsets},
+        offsets,
         markerSequence.frames);
   } else {
     saveGltfCharacter(outputFile, character);

--- a/momentum/examples/convert_model/convert_model_helpers.cpp
+++ b/momentum/examples/convert_model/convert_model_helpers.cpp
@@ -19,6 +19,22 @@
 #include <momentum/io/skeleton/locator_io.h>
 #include <momentum/io/skeleton/parameter_transform_io.h>
 #include <momentum/io/skeleton/parameters_io.h>
+#include <momentum/io/urdf/urdf_io.h>
+
+namespace {
+
+void applyOptionalInputs(momentum::Character& character, const momentum::Options& options) {
+  if (!options.input_params_file.empty()) {
+    auto def = momentum::loadMomentumModel(options.input_params_file);
+    momentum::loadParameters(def, character);
+  }
+  if (!options.input_locator_file.empty()) {
+    character.locators = momentum::loadLocators(
+        options.input_locator_file, character.skeleton, character.parameterTransform);
+  }
+}
+
+} // namespace
 
 namespace momentum {
 
@@ -72,16 +88,23 @@ void initializeCharacterFromFbx(
     const Character& fbxCharacter,
     const Options& options) {
   character = fbxCharacter;
-  if (!options.input_params_file.empty()) {
-    auto def = loadMomentumModel(options.input_params_file);
-    loadParameters(def, character);
-  } else {
+  if (options.input_params_file.empty()) {
     character.parameterTransform = ParameterTransform::identity(character.skeleton.getJointNames());
   }
-  if (!options.input_locator_file.empty()) {
-    character.locators =
-        loadLocators(options.input_locator_file, character.skeleton, character.parameterTransform);
+  applyOptionalInputs(character, options);
+}
+
+Character loadModelCharacter(const Options& options) {
+  const filesystem::path modelPath(options.input_model_file);
+  if (modelPath.extension() != ".urdf") {
+    return loadFullCharacter(
+        options.input_model_file, options.input_params_file, options.input_locator_file);
   }
+
+  MT_LOGI("Loading URDF model...");
+  Character character = loadUrdfCharacter(modelPath);
+  applyOptionalInputs(character, options);
+  return character;
 }
 
 MatrixXf convertToModelParams(

--- a/momentum/examples/convert_model/convert_model_helpers.h
+++ b/momentum/examples/convert_model/convert_model_helpers.h
@@ -24,6 +24,7 @@ struct Options {
   std::string output_model_file;
   std::string output_locator_local;
   std::string output_locator_global;
+  std::string output_params_file;
   std::string fbx_namespace;
   bool save_markers = false;
   bool character_mesh_save = false;
@@ -55,6 +56,9 @@ MotionData loadFbxMotion(
     Character& character,
     bool hasModel,
     const Options& options);
+
+/// Loads the input model character, applying optional parameter and locator files.
+Character loadModelCharacter(const Options& options);
 
 /// Initializes the character from FBX data when no separate model was provided.
 /// Applies parameter transform and locators if specified in the options.

--- a/momentum/examples/convert_model/convert_model_integration_test.cpp
+++ b/momentum/examples/convert_model/convert_model_integration_test.cpp
@@ -10,6 +10,8 @@
 
 #include <gtest/gtest.h>
 
+#include <fstream>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -120,9 +122,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise01_Glb_Glb_Fbx_Full) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal,
        "--save-markers",
        "--character-mesh",
@@ -199,9 +201,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise06_NoModel_GlbMotion_Gltf) {
        testFile("character_with_motion.glb"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0) << "convert_model should succeed";
@@ -274,9 +276,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise10_Glb_Glb_Glb_Locators) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0) << "convert_model should succeed";
@@ -422,6 +424,34 @@ TEST_F(ConvertModelIntegrationTest, Error_UnknownMotionFormat) {
   EXPECT_EQ(rc, 0);
 }
 
+// Test: Parameter output writes a valid .model file
+TEST_F(ConvertModelIntegrationTest, ParameterOutput_WritesModelFile) {
+  const auto out = outputFile("params_test.glb");
+  const auto outParams = outputFile("exported.model");
+
+  int rc = runConvertModel(
+      {"--model",
+       testFile("character_with_motion.glb"),
+       "--parameters",
+       testFile("character.model"),
+       "--out",
+       out,
+       "--out-parameters",
+       outParams});
+
+  ASSERT_EQ(rc, 0);
+  ASSERT_TRUE(std::filesystem::exists(outParams));
+  EXPECT_GT(std::filesystem::file_size(outParams), 0u);
+
+  std::ifstream paramsFile(outParams);
+  ASSERT_TRUE(paramsFile.is_open());
+  const std::string paramsData{
+      std::istreambuf_iterator<char>{paramsFile}, std::istreambuf_iterator<char>{}};
+  EXPECT_NE(paramsData.find("[ParameterTransform]"), std::string::npos);
+  EXPECT_NE(paramsData.find("root.tx = 1*root_tx"), std::string::npos);
+  EXPECT_NE(paramsData.find("joint2.rz = 0.5*shared_rz"), std::string::npos);
+}
+
 // Test: Locator output (local and global)
 TEST_F(ConvertModelIntegrationTest, LocatorOutput_LocalAndGlobal) {
   const auto out = outputFile("locator_test.fbx");
@@ -435,9 +465,9 @@ TEST_F(ConvertModelIntegrationTest, LocatorOutput_LocalAndGlobal) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0);

--- a/momentum/examples/convert_model/convert_model_test.cpp
+++ b/momentum/examples/convert_model/convert_model_test.cpp
@@ -14,8 +14,11 @@
 #include <momentum/io/character_io.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
+#include <momentum/test/io/io_helpers.h>
 
 #include <gtest/gtest.h>
+
+#include <fstream>
 
 using namespace momentum;
 
@@ -145,6 +148,38 @@ TEST_F(ConvertModelTest, InitializeCharacterFromFbx_WithParamsAndLocators_LoadsB
 
   EXPECT_GT(character.parameterTransform.numAllModelParameters(), 0);
   EXPECT_GT(character.locators.size(), 0);
+}
+
+TEST_F(ConvertModelTest, LoadModelCharacter_Urdf_LoadsCharacter) {
+  auto tempDir = temporaryDirectory("convert_model_urdf");
+  const auto urdfPath = tempDir.path() / "robot.urdf";
+  {
+    std::ofstream file(urdfPath);
+    ASSERT_TRUE(file.good());
+    file << R"(
+      <?xml version="1.0"?>
+      <robot name="convert_model_robot">
+        <link name="base_link"/>
+        <link name="child_link"/>
+        <joint name="joint1" type="fixed">
+          <parent link="base_link"/>
+          <child link="child_link"/>
+          <origin xyz="0 0 0.5" rpy="0 0 0"/>
+        </joint>
+      </robot>
+    )";
+  }
+
+  Options options;
+  options.input_model_file = urdfPath.string();
+
+  const Character character = loadModelCharacter(options);
+
+  ASSERT_EQ(character.skeleton.joints.size(), 2);
+  EXPECT_EQ(character.name, "convert_model_robot");
+  EXPECT_EQ(character.skeleton.joints[0].name, "base_link");
+  EXPECT_EQ(character.skeleton.joints[1].name, "child_link");
+  EXPECT_EQ(character.skeleton.joints[1].parent, 0);
 }
 
 // ============================================================================

--- a/momentum/io/gltf/gltf_animation_io.cpp
+++ b/momentum/io/gltf/gltf_animation_io.cpp
@@ -222,9 +222,15 @@ std::tuple<MatrixXf, JointParameters, float> loadMotionOnCharacterCommon(
     const std::variant<filesystem::path, std::span<const std::byte>>& input,
     const Character& character) {
   const auto [loadedChar, motion, identity, fps] = loadCharacterWithMotionCommon(input);
+  // glTF files that store motion without per-joint identity offsets surface as an empty `identity`
+  // vector. Skip mapIdentityToCharacter in that case to preserve the "no identity present" signal
+  // and to avoid violating its size precondition (joint names paired with an empty values vector).
+  const JointParameters mappedIdentity = identity.size() != 0
+      ? mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character)
+      : identity;
   return {
       mapMotionToCharacter({loadedChar.parameterTransform.name, motion}, character),
-      mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character),
+      mappedIdentity,
       fps};
 }
 

--- a/momentum/website/docs_cpp/03_examples/03_convert_model.md
+++ b/momentum/website/docs_cpp/03_examples/03_convert_model.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Convert Model
 
-The `convert_model` example demonstrates how to convert a character model and its associated animation file between FBX and GLB formats. Use the `-m` or `--model` option to specify the input model, followed by the path to the model file (`.fbx` or `.glb`). If no input model is provided, the tool will automatically read the animation from an existing GLB or FBX file.
+The `convert_model` example demonstrates how to convert a character model and its associated animation file between FBX and GLB formats. Use the `-m` or `--model` option to specify the input model, followed by the path to the model file (`.fbx`, `.glb`, `.gltf`, or `.urdf`). If no input model is provided, the tool will automatically read the animation from an existing GLB or FBX file.
 
 <FbInternalOnly>
 
@@ -19,13 +19,15 @@ convert_model [OPTIONS]
 
 Options:
   -h,--help                   Print this help message and exit
-  -m,--model TEXT:FILE        Input model (.fbx/.glb); not required if reading animation from glb or fbx
+  -m,--model TEXT:FILE        Input model (.fbx/.glb/.gltf/.urdf); not required if reading animation from glb or fbx
   -p,--parameters TEXT:FILE   Input model parameter file (.model)
   -l,--locator TEXT:FILE      Input locator file (.locators)
-  -d,--motion TEXT:FILE       Input motion data file (.mmo/.glb/.fbx)
-  -o,--out TEXT REQUIRED      Output file (.fbx/.glb)
-  --out-locator TEXT          Output a locator file (.locators)
-  --save-markers              Save marker data from motion file in output (glb only)
+  -d,--motion TEXT:FILE       Input motion data file (.glb/.fbx)
+  -o,--out TEXT REQUIRED      Output file (.fbx/.glb/.gltf)
+  --out-locators-local TEXT   Output a locator file (.locators) in local space for transferring between identities
+  --out-locators-global TEXT  Output a locator file (.locators) in global space for authoring a template
+  --out-parameters TEXT       Output a model parameter file (.model) containing the parameter transform and limits
+  --save-markers              Save marker data from input motion file in the output
   -c,--character-mesh         (FBX Output file only) Saves the Character Mesh to the output file.
 ```
 


### PR DESCRIPTION
Summary:
Extends `convert_model` so model inputs can be URDF: `loadModelCharacter` dispatches on the input file extension, sharing parameter/locator overlay logic between the FBX and URDF paths via a new `applyOptionalInputs` helper. Adds `--out-parameters` to export the parameter transform and limits as a `.model` file.

**Breaking CLI change**: `--out-locator-{local,global}` renamed to plural `--out-locators-{local,global}` for consistency with the new `--out-parameters`. Scripts and CI jobs using the old flag name must be updated.

Updates BUCK/CMake deps (adds `io_urdf` to `convert_model` and `io_test_helper`/`io_urdf` to `convert_model_test`), removes redundant `oncall` from `oxx_test` targets (file already declares one), and refreshes the website docs to match the new CLI surface.

Reviewed By: cstollmeta

Differential Revision: D104552410


