### PR TITLE
Load URDF collision capsules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1044,6 +1044,7 @@ if(MOMENTUM_BUILD_EXAMPLES)
     LINK_LIBRARIES
       io_character
       io_marker
+      io_urdf
       CLI11::CLI11
   )
 

--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -88,6 +88,12 @@ MatrixXf mapMotionToCharacter(
 /// Maps the input JointParameter vector to a target character by matching joint names. Mismatched
 /// names will be discarded (source) or set to zero (target). For every matched joint, all 7
 /// parameters will be copied over.
+///
+/// @pre `std::get<0>(inputIdentity).size() * kParametersPerJoint ==
+/// std::get<1>(inputIdentity).size()`. Callers that may not have identity data (e.g. glTF motion
+/// files saved without identity offsets) must check this before assembling the tuple — passing
+/// joint names paired with an empty identity vector violates the precondition. Either skip the call
+/// entirely or pass a fully empty `IdentityParameters{}`, which yields a zero-padded result.
 JointParameters mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter);

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -10,14 +10,18 @@
 #include "convert_model_helpers.h"
 
 #include <momentum/character/character.h>
+#include <momentum/common/exception.h>
 #include <momentum/common/log.h>
 #include <momentum/io/character_io.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
 #include <momentum/io/marker/marker_io.h>
 #include <momentum/io/skeleton/locator_io.h>
+#include <momentum/io/skeleton/parameter_transform_io.h>
 
 #include <CLI/CLI.hpp>
+
+#include <fstream>
 
 using namespace momentum;
 
@@ -30,7 +34,7 @@ std::shared_ptr<Options> setupOptions(CLI::App& app) {
   app.add_option(
          "-m,--model",
          opt->input_model_file,
-         "Input model (.fbx/.glb); not required if reading animation from glb or fbx")
+         "Input model (.fbx/.glb/.gltf/.urdf); not required if reading animation from glb or fbx")
       ->check(CLI::ExistingFile);
   app.add_option("-p,--parameters", opt->input_params_file, "Input model parameter file (.model)")
       ->check(CLI::ExistingFile);
@@ -40,16 +44,20 @@ std::shared_ptr<Options> setupOptions(CLI::App& app) {
   app.add_option("-d,--motion", opt->input_motion_file, "Input motion data file (.glb/.fbx)")
       ->check(CLI::ExistingFile);
 
-  app.add_option("-o,--out", opt->output_model_file, "Output file (.fbx/.glb)")->required();
+  app.add_option("-o,--out", opt->output_model_file, "Output file (.fbx/.glb/.gltf)")->required();
 
   app.add_option(
-      "--out-locator-local",
+      "--out-locators-local",
       opt->output_locator_local,
       "Output a locator file (.locators) in local space for transferring between identities");
   app.add_option(
-      "--out-locator-global",
+      "--out-locators-global",
       opt->output_locator_global,
       "Output a locator file (.locators) in global space for authoring a template");
+  app.add_option(
+      "--out-parameters",
+      opt->output_params_file,
+      "Output a model parameter file (.model) containing the parameter transform and limits");
   app.add_option("--fbx-namespace", opt->fbx_namespace, "Namespace in output fbx file");
 
   app.add_flag(
@@ -156,6 +164,23 @@ void saveLocatorFiles(const Options& options, const Character& character) {
   }
 }
 
+// Saves the character's parameter transform and limits to a .model file if an
+// output path is specified.
+void saveParameterFile(const Options& options, const Character& character) {
+  if (options.output_params_file.empty()) {
+    return;
+  }
+
+  MT_LOGI("Saving model parameter file...");
+  std::ofstream ofs(options.output_params_file);
+  MT_THROW_IF(
+      !ofs.is_open(),
+      "Cannot open output parameter file for writing: {}",
+      options.output_params_file);
+  ofs << writeModelDefinition(
+      character.skeleton, character.parameterTransform, character.parameterLimits);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -177,8 +202,7 @@ int main(int argc, char** argv) {
     const bool hasModel = !options->input_model_file.empty();
     Character character;
     if (hasModel) {
-      character = loadFullCharacter(
-          options->input_model_file, options->input_params_file, options->input_locator_file);
+      character = loadModelCharacter(*options);
     }
 
     // Load motion data
@@ -200,6 +224,9 @@ int main(int argc, char** argv) {
 
     // Save locator files
     saveLocatorFiles(*options, character);
+
+    // Save model parameter file
+    saveParameterFile(*options, character);
   } catch (std::exception& e) {
     MT_LOGE("Failed to convert model. Error: {}", e.what());
     return EXIT_FAILURE;

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -122,12 +122,19 @@ void saveGltfOutput(
     bool hasMotion) {
   MT_LOGI("Saving gltf/glb file...");
   if (hasMotion) {
+    // Empty offsets mean "the loaded motion has no per-joint identity vector"; passing the
+    // skeleton's joint names paired with an empty identity vector would violate
+    // mapIdentityToCharacter's size precondition. Use a fully empty IdentityParameters so the
+    // glTF writer sees "no identity data" rather than a mismatched tuple.
+    const IdentityParameters offsets = motionData.offsets.size() == 0
+        ? IdentityParameters{}
+        : IdentityParameters{character.skeleton.getJointNames(), motionData.offsets};
     saveGltfCharacter(
         outputFile,
         character,
         motionData.fps,
         {character.parameterTransform.name, motionData.poses},
-        {character.skeleton.getJointNames(), motionData.offsets},
+        offsets,
         markerSequence.frames);
   } else {
     saveGltfCharacter(outputFile, character);

--- a/momentum/examples/convert_model/convert_model_helpers.cpp
+++ b/momentum/examples/convert_model/convert_model_helpers.cpp
@@ -19,6 +19,22 @@
 #include <momentum/io/skeleton/locator_io.h>
 #include <momentum/io/skeleton/parameter_transform_io.h>
 #include <momentum/io/skeleton/parameters_io.h>
+#include <momentum/io/urdf/urdf_io.h>
+
+namespace {
+
+void applyOptionalInputs(momentum::Character& character, const momentum::Options& options) {
+  if (!options.input_params_file.empty()) {
+    auto def = momentum::loadMomentumModel(options.input_params_file);
+    momentum::loadParameters(def, character);
+  }
+  if (!options.input_locator_file.empty()) {
+    character.locators = momentum::loadLocators(
+        options.input_locator_file, character.skeleton, character.parameterTransform);
+  }
+}
+
+} // namespace
 
 namespace momentum {
 
@@ -72,16 +88,23 @@ void initializeCharacterFromFbx(
     const Character& fbxCharacter,
     const Options& options) {
   character = fbxCharacter;
-  if (!options.input_params_file.empty()) {
-    auto def = loadMomentumModel(options.input_params_file);
-    loadParameters(def, character);
-  } else {
+  if (options.input_params_file.empty()) {
     character.parameterTransform = ParameterTransform::identity(character.skeleton.getJointNames());
   }
-  if (!options.input_locator_file.empty()) {
-    character.locators =
-        loadLocators(options.input_locator_file, character.skeleton, character.parameterTransform);
+  applyOptionalInputs(character, options);
+}
+
+Character loadModelCharacter(const Options& options) {
+  const filesystem::path modelPath(options.input_model_file);
+  if (modelPath.extension() != ".urdf") {
+    return loadFullCharacter(
+        options.input_model_file, options.input_params_file, options.input_locator_file);
   }
+
+  MT_LOGI("Loading URDF model...");
+  Character character = loadUrdfCharacter(modelPath);
+  applyOptionalInputs(character, options);
+  return character;
 }
 
 MatrixXf convertToModelParams(

--- a/momentum/examples/convert_model/convert_model_helpers.h
+++ b/momentum/examples/convert_model/convert_model_helpers.h
@@ -24,6 +24,7 @@ struct Options {
   std::string output_model_file;
   std::string output_locator_local;
   std::string output_locator_global;
+  std::string output_params_file;
   std::string fbx_namespace;
   bool save_markers = false;
   bool character_mesh_save = false;
@@ -55,6 +56,9 @@ MotionData loadFbxMotion(
     Character& character,
     bool hasModel,
     const Options& options);
+
+/// Loads the input model character, applying optional parameter and locator files.
+Character loadModelCharacter(const Options& options);
 
 /// Initializes the character from FBX data when no separate model was provided.
 /// Applies parameter transform and locators if specified in the options.

--- a/momentum/examples/convert_model/convert_model_integration_test.cpp
+++ b/momentum/examples/convert_model/convert_model_integration_test.cpp
@@ -10,6 +10,8 @@
 
 #include <gtest/gtest.h>
 
+#include <fstream>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -120,9 +122,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise01_Glb_Glb_Fbx_Full) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal,
        "--save-markers",
        "--character-mesh",
@@ -199,9 +201,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise06_NoModel_GlbMotion_Gltf) {
        testFile("character_with_motion.glb"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0) << "convert_model should succeed";
@@ -274,9 +276,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise10_Glb_Glb_Glb_Locators) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0) << "convert_model should succeed";
@@ -422,6 +424,34 @@ TEST_F(ConvertModelIntegrationTest, Error_UnknownMotionFormat) {
   EXPECT_EQ(rc, 0);
 }
 
+// Test: Parameter output writes a valid .model file
+TEST_F(ConvertModelIntegrationTest, ParameterOutput_WritesModelFile) {
+  const auto out = outputFile("params_test.glb");
+  const auto outParams = outputFile("exported.model");
+
+  int rc = runConvertModel(
+      {"--model",
+       testFile("character_with_motion.glb"),
+       "--parameters",
+       testFile("character.model"),
+       "--out",
+       out,
+       "--out-parameters",
+       outParams});
+
+  ASSERT_EQ(rc, 0);
+  ASSERT_TRUE(std::filesystem::exists(outParams));
+  EXPECT_GT(std::filesystem::file_size(outParams), 0u);
+
+  std::ifstream paramsFile(outParams);
+  ASSERT_TRUE(paramsFile.is_open());
+  const std::string paramsData{
+      std::istreambuf_iterator<char>{paramsFile}, std::istreambuf_iterator<char>{}};
+  EXPECT_NE(paramsData.find("[ParameterTransform]"), std::string::npos);
+  EXPECT_NE(paramsData.find("root.tx = 1*root_tx"), std::string::npos);
+  EXPECT_NE(paramsData.find("joint2.rz = 0.5*shared_rz"), std::string::npos);
+}
+
 // Test: Locator output (local and global)
 TEST_F(ConvertModelIntegrationTest, LocatorOutput_LocalAndGlobal) {
   const auto out = outputFile("locator_test.fbx");
@@ -435,9 +465,9 @@ TEST_F(ConvertModelIntegrationTest, LocatorOutput_LocalAndGlobal) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0);

--- a/momentum/examples/convert_model/convert_model_test.cpp
+++ b/momentum/examples/convert_model/convert_model_test.cpp
@@ -14,8 +14,11 @@
 #include <momentum/io/character_io.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
+#include <momentum/test/io/io_helpers.h>
 
 #include <gtest/gtest.h>
+
+#include <fstream>
 
 using namespace momentum;
 
@@ -145,6 +148,38 @@ TEST_F(ConvertModelTest, InitializeCharacterFromFbx_WithParamsAndLocators_LoadsB
 
   EXPECT_GT(character.parameterTransform.numAllModelParameters(), 0);
   EXPECT_GT(character.locators.size(), 0);
+}
+
+TEST_F(ConvertModelTest, LoadModelCharacter_Urdf_LoadsCharacter) {
+  auto tempDir = temporaryDirectory("convert_model_urdf");
+  const auto urdfPath = tempDir.path() / "robot.urdf";
+  {
+    std::ofstream file(urdfPath);
+    ASSERT_TRUE(file.good());
+    file << R"(
+      <?xml version="1.0"?>
+      <robot name="convert_model_robot">
+        <link name="base_link"/>
+        <link name="child_link"/>
+        <joint name="joint1" type="fixed">
+          <parent link="base_link"/>
+          <child link="child_link"/>
+          <origin xyz="0 0 0.5" rpy="0 0 0"/>
+        </joint>
+      </robot>
+    )";
+  }
+
+  Options options;
+  options.input_model_file = urdfPath.string();
+
+  const Character character = loadModelCharacter(options);
+
+  ASSERT_EQ(character.skeleton.joints.size(), 2);
+  EXPECT_EQ(character.name, "convert_model_robot");
+  EXPECT_EQ(character.skeleton.joints[0].name, "base_link");
+  EXPECT_EQ(character.skeleton.joints[1].name, "child_link");
+  EXPECT_EQ(character.skeleton.joints[1].parent, 0);
 }
 
 // ============================================================================

--- a/momentum/io/gltf/gltf_animation_io.cpp
+++ b/momentum/io/gltf/gltf_animation_io.cpp
@@ -222,9 +222,15 @@ std::tuple<MatrixXf, JointParameters, float> loadMotionOnCharacterCommon(
     const std::variant<filesystem::path, std::span<const std::byte>>& input,
     const Character& character) {
   const auto [loadedChar, motion, identity, fps] = loadCharacterWithMotionCommon(input);
+  // glTF files that store motion without per-joint identity offsets surface as an empty `identity`
+  // vector. Skip mapIdentityToCharacter in that case to preserve the "no identity present" signal
+  // and to avoid violating its size precondition (joint names paired with an empty values vector).
+  const JointParameters mappedIdentity = identity.size() != 0
+      ? mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character)
+      : identity;
   return {
       mapMotionToCharacter({loadedChar.parameterTransform.name, motion}, character),
-      mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character),
+      mappedIdentity,
       fps};
 }
 

--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -18,7 +18,9 @@
 #include <urdf_parser/urdf_parser.h>
 
 #include <algorithm>
+#include <array>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -49,6 +51,7 @@ struct ParsingData {
   std::vector<Eigen::Triplet<float>> triplets;
   ParameterLimits limits;
   PhysicalProperties physicalProperties;
+  CollisionGeometry collision;
   size_t totalDoFs = 0;
 
   std::vector<LinkVisualData> linkVisuals;
@@ -122,6 +125,21 @@ void addPhysicalPropertiesForUrdfLink(
     default:
       return "UNKNOWN";
   }
+}
+
+[[nodiscard]] std::string_view toString(const urdf::Geometry& geometry) {
+  switch (geometry.type) {
+    case urdf::Geometry::SPHERE:
+      return "SPHERE";
+    case urdf::Geometry::BOX:
+      return "BOX";
+    case urdf::Geometry::CYLINDER:
+      return "CYLINDER";
+    case urdf::Geometry::MESH:
+      return "MESH";
+  }
+
+  return "UNKNOWN";
 }
 
 /// Returns the principal axis index (0=X, 1=Y, 2=Z) and sign (+1/-1) for a URDF axis vector.
@@ -230,6 +248,46 @@ std::optional<Mesh> loadVisualMesh(
       MT_LOGW("Unknown URDF geometry type: {}", static_cast<int>(geometry.type));
       return std::nullopt;
   }
+}
+
+std::optional<TaperedCapsule> loadCollisionCapsule(
+    const urdf::Collision& collision,
+    std::string_view linkName,
+    size_t jointIndex) {
+  if (!collision.geometry) {
+    MT_LOGW("Ignoring URDF collision on link '{}' because it has no geometry.", linkName);
+    return std::nullopt;
+  }
+
+  const auto& geometry = *collision.geometry;
+  if (geometry.type != urdf::Geometry::CYLINDER) {
+    MT_LOGW(
+        "Ignoring unsupported URDF collision geometry '{}' on link '{}'. "
+        "Only cylinder collision geometry can be imported as Momentum tapered capsules.",
+        toString(geometry),
+        linkName);
+    return std::nullopt;
+  }
+
+  const auto& cylinder = dynamic_cast<const urdf::Cylinder&>(geometry);
+  const auto collisionOrigin = toMomentumTransform<float>(collision.origin);
+
+  // Convention conversion: URDF cylinders are centered at the origin with their axis along
+  // +Z, while Momentum TaperedCapsules start at the origin with their axis along +X.
+  //   - Rotation: compose the URDF collision origin rotation with a UnitX→UnitZ rotation so the
+  //     local +X axis of the Momentum capsule maps to the local +Z axis of the URDF cylinder.
+  //   - Translation: convert the URDF center position to centimeters, then shift along the
+  //     URDF cylinder's local +Z by -length/2 so the capsule starts where the cylinder ends.
+  TaperedCapsule capsule;
+  capsule.parent = jointIndex;
+  capsule.length = static_cast<float>(cylinder.length) * toCm<float>();
+  capsule.radius = Eigen::Vector2f::Constant(static_cast<float>(cylinder.radius) * toCm<float>());
+  capsule.transformation.rotation = collisionOrigin.rotation *
+      Eigen::Quaternionf::FromTwoVectors(Eigen::Vector3f::UnitX(), Eigen::Vector3f::UnitZ());
+  capsule.transformation.translation = collisionOrigin.translation * toCm<float>() +
+      collisionOrigin.rotation * Eigen::Vector3f(0.0f, 0.0f, -0.5f * capsule.length);
+
+  return capsule;
 }
 
 constexpr std::array<const char*, 3> kTranslationNames = {"tx", "ty", "tz"};
@@ -444,6 +502,17 @@ bool loadUrdfSkeletonRecursive(
     data.linkVisuals.push_back(std::move(visualData));
   }
 
+  for (const auto& collision : urdfLink->collision_array) {
+    if (!collision) {
+      MT_LOGW("Ignoring null URDF collision on link '{}'.", urdfLink->name);
+      continue;
+    }
+    auto capsule = loadCollisionCapsule(*collision, urdfLink->name, static_cast<size_t>(jointId));
+    if (capsule) {
+      data.collision.push_back(*capsule);
+    }
+  }
+
   // Continue parsing child links and joints
   for (const auto& childLink : urdfLink->child_links) {
     if (!loadUrdfSkeletonRecursive(data, jointId, urdfModel, childLink.get())) {
@@ -627,6 +696,7 @@ Character loadUrdfCharacterFromUrdfModel(
   data.parameterTransform.activeJointParams = data.parameterTransform.computeActiveJointParams();
 
   const std::string robotName = urdfModel->getName();
+  const CollisionGeometry* collision = data.collision.empty() ? nullptr : &data.collision;
 
   auto meshResult = buildCombinedMesh(data, urdfDir);
   if (meshResult) {
@@ -638,7 +708,7 @@ Character loadUrdfCharacterFromUrdfModel(
         LocatorList{},
         &mesh,
         &skinWeights,
-        nullptr, // collision
+        collision,
         nullptr, // poseShapes
         {}, // blendShapes
         {}, // faceExpressionBlendShapes
@@ -656,7 +726,7 @@ Character loadUrdfCharacterFromUrdfModel(
       LocatorList{},
       nullptr, // mesh
       nullptr, // skinWeights
-      nullptr, // collision
+      collision,
       nullptr, // poseShapes
       {}, // blendShapes
       {}, // faceExpressionBlendShapes

--- a/momentum/io/urdf/urdf_io.h
+++ b/momentum/io/urdf/urdf_io.h
@@ -66,9 +66,11 @@ namespace momentum {
 
 /// Loads a character from a URDF file.
 ///
-/// Parses the skeleton (joints, hierarchy, limits), parameter transform, and visual meshes.
-/// Mesh files referenced by `<visual>` elements (STL, OBJ) are resolved relative to the
-/// URDF file's directory.
+/// Parses the skeleton (joints, hierarchy, limits), parameter transform, visual meshes, and
+/// supported collision proxies. Currently only `<cylinder>` collision geometry is imported
+/// (as Momentum tapered capsules); other shapes (`<box>`, `<sphere>`, `<mesh>`) are skipped
+/// with a warning. Mesh files referenced by `<visual>` elements (STL, OBJ) are resolved
+/// relative to the URDF file's directory.
 ///
 /// @param filepath Path to the URDF file.
 /// @return The loaded character with skeleton, parameter transform, limits, and optionally

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -117,6 +117,14 @@ std::string urdfWithRevoluteMixedInertialLinks() {
   )";
 }
 
+void expectVectorNear(
+    const Eigen::Vector3f& actual,
+    const Eigen::Vector3f& expected,
+    float tolerance = 1e-5f) {
+  EXPECT_LE((actual - expected).norm(), tolerance)
+      << "actual: " << actual.transpose() << ", expected: " << expected.transpose();
+}
+
 TEST(IoUrdfTest, LoadCharacter) {
   auto urdfPath = getTestFilePath("character.urdf");
   if (!urdfPath.has_value()) {
@@ -411,6 +419,110 @@ TEST(IoUrdfTest, GltfRoundTripPreservesPhysicalProperties) {
   EXPECT_EQ(tip.jointName, "tip_link");
   EXPECT_EQ(tip.jointIndex, 2);
   expectPhysicalPropertiesJointMatches(gltfCharacter, tip);
+}
+
+TEST(IoUrdfTest, LoadUrdfWithCollisionCapsules) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="collision_robot">
+      <link name="base_link">
+        <collision name="base_capsule">
+          <origin xyz="0.01 0.02 0.03" rpy="0 1.57079632679 0"/>
+          <geometry>
+            <cylinder radius="0.04" length="0.2"/>
+          </geometry>
+        </collision>
+      </link>
+      <link name="child_link">
+        <collision name="child_capsule">
+          <origin xyz="0 0 0.05" rpy="0 0 0"/>
+          <geometry>
+            <cylinder radius="0.01" length="0.1"/>
+          </geometry>
+        </collision>
+        <collision name="unsupported_box">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="fixed_joint" type="fixed">
+        <parent link="base_link"/>
+        <child link="child_link"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_NE(character.collision, nullptr);
+  ASSERT_EQ(character.collision->size(), 2);
+
+  const auto& baseCapsule = character.collision->at(0);
+  EXPECT_EQ(baseCapsule.parent, 0);
+  EXPECT_FLOAT_EQ(baseCapsule.length, 20.0f);
+  EXPECT_TRUE(baseCapsule.radius.isApprox(Eigen::Vector2f::Constant(4.0f)));
+  expectVectorNear(baseCapsule.transformation.translation, Eigen::Vector3f(-9.0f, 2.0f, 3.0f));
+  expectVectorNear(
+      baseCapsule.transformation.translation +
+          baseCapsule.transformation.getAxisX() * baseCapsule.length,
+      Eigen::Vector3f(11.0f, 2.0f, 3.0f));
+
+  const auto& childCapsule = character.collision->at(1);
+  EXPECT_EQ(childCapsule.parent, 1);
+  EXPECT_FLOAT_EQ(childCapsule.length, 10.0f);
+  EXPECT_TRUE(childCapsule.radius.isApprox(Eigen::Vector2f::Constant(1.0f)));
+  expectVectorNear(childCapsule.transformation.translation, Eigen::Vector3f::Zero());
+  expectVectorNear(
+      childCapsule.transformation.translation +
+          childCapsule.transformation.getAxisX() * childCapsule.length,
+      Eigen::Vector3f(0.0f, 0.0f, 10.0f));
+}
+
+TEST(IoUrdfTest, LoadUrdfSkipsUnsupportedCollisionGeometries) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="unsupported_collision_robot">
+      <link name="base_link">
+        <collision name="unsupported_box">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </collision>
+        <collision name="unsupported_sphere">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </collision>
+        <collision name="unsupported_mesh">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <mesh filename="missing.stl"/>
+          </geometry>
+        </collision>
+        <collision name="supported_cylinder">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <cylinder radius="0.02" length="0.1"/>
+          </geometry>
+        </collision>
+      </link>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  // Only the cylinder is imported; box, sphere, and mesh collisions are skipped with warnings.
+  ASSERT_NE(character.collision, nullptr);
+  ASSERT_EQ(character.collision->size(), 1);
+  EXPECT_FLOAT_EQ(character.collision->at(0).length, 10.0f);
+  EXPECT_TRUE(character.collision->at(0).radius.isApprox(Eigen::Vector2f::Constant(2.0f)));
 }
 
 TEST(IoUrdfTest, LoadUrdfWithSphereVisual) {

--- a/momentum/website/docs_cpp/03_examples/03_convert_model.md
+++ b/momentum/website/docs_cpp/03_examples/03_convert_model.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Convert Model
 
-The `convert_model` example demonstrates how to convert a character model and its associated animation file between FBX and GLB formats. Use the `-m` or `--model` option to specify the input model, followed by the path to the model file (`.fbx` or `.glb`). If no input model is provided, the tool will automatically read the animation from an existing GLB or FBX file.
+The `convert_model` example demonstrates how to convert a character model and its associated animation file between FBX and GLB formats. Use the `-m` or `--model` option to specify the input model, followed by the path to the model file (`.fbx`, `.glb`, `.gltf`, or `.urdf`). If no input model is provided, the tool will automatically read the animation from an existing GLB or FBX file.
 
 <FbInternalOnly>
 
@@ -19,13 +19,15 @@ convert_model [OPTIONS]
 
 Options:
   -h,--help                   Print this help message and exit
-  -m,--model TEXT:FILE        Input model (.fbx/.glb); not required if reading animation from glb or fbx
+  -m,--model TEXT:FILE        Input model (.fbx/.glb/.gltf/.urdf); not required if reading animation from glb or fbx
   -p,--parameters TEXT:FILE   Input model parameter file (.model)
   -l,--locator TEXT:FILE      Input locator file (.locators)
-  -d,--motion TEXT:FILE       Input motion data file (.mmo/.glb/.fbx)
-  -o,--out TEXT REQUIRED      Output file (.fbx/.glb)
-  --out-locator TEXT          Output a locator file (.locators)
-  --save-markers              Save marker data from motion file in output (glb only)
+  -d,--motion TEXT:FILE       Input motion data file (.glb/.fbx)
+  -o,--out TEXT REQUIRED      Output file (.fbx/.glb/.gltf)
+  --out-locators-local TEXT   Output a locator file (.locators) in local space for transferring between identities
+  --out-locators-global TEXT  Output a locator file (.locators) in global space for authoring a template
+  --out-parameters TEXT       Output a model parameter file (.model) containing the parameter transform and limits
+  --save-markers              Save marker data from input motion file in the output
   -c,--character-mesh         (FBX Output file only) Saves the Character Mesh to the output file.
 ```
 


### PR DESCRIPTION
Summary: Parse URDF collision elements and convert supported cylinder proxies into Momentum tapered capsules, while warning and skipping unsupported URDF collision shapes.

Differential Revision: D106701751


