### PR TITLE
Display collision proxies in Viser viewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1044,6 +1044,7 @@ if(MOMENTUM_BUILD_EXAMPLES)
     LINK_LIBRARIES
       io_character
       io_marker
+      io_urdf
       CLI11::CLI11
   )
 

--- a/momentum/character/character_utility.h
+++ b/momentum/character/character_utility.h
@@ -88,6 +88,12 @@ MatrixXf mapMotionToCharacter(
 /// Maps the input JointParameter vector to a target character by matching joint names. Mismatched
 /// names will be discarded (source) or set to zero (target). For every matched joint, all 7
 /// parameters will be copied over.
+///
+/// @pre `std::get<0>(inputIdentity).size() * kParametersPerJoint ==
+/// std::get<1>(inputIdentity).size()`. Callers that may not have identity data (e.g. glTF motion
+/// files saved without identity offsets) must check this before assembling the tuple — passing
+/// joint names paired with an empty identity vector violates the precondition. Either skip the call
+/// entirely or pass a fully empty `IdentityParameters{}`, which yields a zero-padded result.
 JointParameters mapIdentityToCharacter(
     const IdentityParameters& inputIdentity,
     const Character& targetCharacter);

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -10,14 +10,18 @@
 #include "convert_model_helpers.h"
 
 #include <momentum/character/character.h>
+#include <momentum/common/exception.h>
 #include <momentum/common/log.h>
 #include <momentum/io/character_io.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
 #include <momentum/io/marker/marker_io.h>
 #include <momentum/io/skeleton/locator_io.h>
+#include <momentum/io/skeleton/parameter_transform_io.h>
 
 #include <CLI/CLI.hpp>
+
+#include <fstream>
 
 using namespace momentum;
 
@@ -30,7 +34,7 @@ std::shared_ptr<Options> setupOptions(CLI::App& app) {
   app.add_option(
          "-m,--model",
          opt->input_model_file,
-         "Input model (.fbx/.glb); not required if reading animation from glb or fbx")
+         "Input model (.fbx/.glb/.gltf/.urdf); not required if reading animation from glb or fbx")
       ->check(CLI::ExistingFile);
   app.add_option("-p,--parameters", opt->input_params_file, "Input model parameter file (.model)")
       ->check(CLI::ExistingFile);
@@ -40,16 +44,20 @@ std::shared_ptr<Options> setupOptions(CLI::App& app) {
   app.add_option("-d,--motion", opt->input_motion_file, "Input motion data file (.glb/.fbx)")
       ->check(CLI::ExistingFile);
 
-  app.add_option("-o,--out", opt->output_model_file, "Output file (.fbx/.glb)")->required();
+  app.add_option("-o,--out", opt->output_model_file, "Output file (.fbx/.glb/.gltf)")->required();
 
   app.add_option(
-      "--out-locator-local",
+      "--out-locators-local",
       opt->output_locator_local,
       "Output a locator file (.locators) in local space for transferring between identities");
   app.add_option(
-      "--out-locator-global",
+      "--out-locators-global",
       opt->output_locator_global,
       "Output a locator file (.locators) in global space for authoring a template");
+  app.add_option(
+      "--out-parameters",
+      opt->output_params_file,
+      "Output a model parameter file (.model) containing the parameter transform and limits");
   app.add_option("--fbx-namespace", opt->fbx_namespace, "Namespace in output fbx file");
 
   app.add_flag(
@@ -156,6 +164,23 @@ void saveLocatorFiles(const Options& options, const Character& character) {
   }
 }
 
+// Saves the character's parameter transform and limits to a .model file if an
+// output path is specified.
+void saveParameterFile(const Options& options, const Character& character) {
+  if (options.output_params_file.empty()) {
+    return;
+  }
+
+  MT_LOGI("Saving model parameter file...");
+  std::ofstream ofs(options.output_params_file);
+  MT_THROW_IF(
+      !ofs.is_open(),
+      "Cannot open output parameter file for writing: {}",
+      options.output_params_file);
+  ofs << writeModelDefinition(
+      character.skeleton, character.parameterTransform, character.parameterLimits);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -177,8 +202,7 @@ int main(int argc, char** argv) {
     const bool hasModel = !options->input_model_file.empty();
     Character character;
     if (hasModel) {
-      character = loadFullCharacter(
-          options->input_model_file, options->input_params_file, options->input_locator_file);
+      character = loadModelCharacter(*options);
     }
 
     // Load motion data
@@ -200,6 +224,9 @@ int main(int argc, char** argv) {
 
     // Save locator files
     saveLocatorFiles(*options, character);
+
+    // Save model parameter file
+    saveParameterFile(*options, character);
   } catch (std::exception& e) {
     MT_LOGE("Failed to convert model. Error: {}", e.what());
     return EXIT_FAILURE;

--- a/momentum/examples/convert_model/convert_model.cpp
+++ b/momentum/examples/convert_model/convert_model.cpp
@@ -122,12 +122,19 @@ void saveGltfOutput(
     bool hasMotion) {
   MT_LOGI("Saving gltf/glb file...");
   if (hasMotion) {
+    // Empty offsets mean "the loaded motion has no per-joint identity vector"; passing the
+    // skeleton's joint names paired with an empty identity vector would violate
+    // mapIdentityToCharacter's size precondition. Use a fully empty IdentityParameters so the
+    // glTF writer sees "no identity data" rather than a mismatched tuple.
+    const IdentityParameters offsets = motionData.offsets.size() == 0
+        ? IdentityParameters{}
+        : IdentityParameters{character.skeleton.getJointNames(), motionData.offsets};
     saveGltfCharacter(
         outputFile,
         character,
         motionData.fps,
         {character.parameterTransform.name, motionData.poses},
-        {character.skeleton.getJointNames(), motionData.offsets},
+        offsets,
         markerSequence.frames);
   } else {
     saveGltfCharacter(outputFile, character);

--- a/momentum/examples/convert_model/convert_model_helpers.cpp
+++ b/momentum/examples/convert_model/convert_model_helpers.cpp
@@ -19,6 +19,22 @@
 #include <momentum/io/skeleton/locator_io.h>
 #include <momentum/io/skeleton/parameter_transform_io.h>
 #include <momentum/io/skeleton/parameters_io.h>
+#include <momentum/io/urdf/urdf_io.h>
+
+namespace {
+
+void applyOptionalInputs(momentum::Character& character, const momentum::Options& options) {
+  if (!options.input_params_file.empty()) {
+    auto def = momentum::loadMomentumModel(options.input_params_file);
+    momentum::loadParameters(def, character);
+  }
+  if (!options.input_locator_file.empty()) {
+    character.locators = momentum::loadLocators(
+        options.input_locator_file, character.skeleton, character.parameterTransform);
+  }
+}
+
+} // namespace
 
 namespace momentum {
 
@@ -72,16 +88,23 @@ void initializeCharacterFromFbx(
     const Character& fbxCharacter,
     const Options& options) {
   character = fbxCharacter;
-  if (!options.input_params_file.empty()) {
-    auto def = loadMomentumModel(options.input_params_file);
-    loadParameters(def, character);
-  } else {
+  if (options.input_params_file.empty()) {
     character.parameterTransform = ParameterTransform::identity(character.skeleton.getJointNames());
   }
-  if (!options.input_locator_file.empty()) {
-    character.locators =
-        loadLocators(options.input_locator_file, character.skeleton, character.parameterTransform);
+  applyOptionalInputs(character, options);
+}
+
+Character loadModelCharacter(const Options& options) {
+  const filesystem::path modelPath(options.input_model_file);
+  if (modelPath.extension() != ".urdf") {
+    return loadFullCharacter(
+        options.input_model_file, options.input_params_file, options.input_locator_file);
   }
+
+  MT_LOGI("Loading URDF model...");
+  Character character = loadUrdfCharacter(modelPath);
+  applyOptionalInputs(character, options);
+  return character;
 }
 
 MatrixXf convertToModelParams(

--- a/momentum/examples/convert_model/convert_model_helpers.h
+++ b/momentum/examples/convert_model/convert_model_helpers.h
@@ -24,6 +24,7 @@ struct Options {
   std::string output_model_file;
   std::string output_locator_local;
   std::string output_locator_global;
+  std::string output_params_file;
   std::string fbx_namespace;
   bool save_markers = false;
   bool character_mesh_save = false;
@@ -55,6 +56,9 @@ MotionData loadFbxMotion(
     Character& character,
     bool hasModel,
     const Options& options);
+
+/// Loads the input model character, applying optional parameter and locator files.
+Character loadModelCharacter(const Options& options);
 
 /// Initializes the character from FBX data when no separate model was provided.
 /// Applies parameter transform and locators if specified in the options.

--- a/momentum/examples/convert_model/convert_model_integration_test.cpp
+++ b/momentum/examples/convert_model/convert_model_integration_test.cpp
@@ -10,6 +10,8 @@
 
 #include <gtest/gtest.h>
 
+#include <fstream>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -120,9 +122,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise01_Glb_Glb_Fbx_Full) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal,
        "--save-markers",
        "--character-mesh",
@@ -199,9 +201,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise06_NoModel_GlbMotion_Gltf) {
        testFile("character_with_motion.glb"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0) << "convert_model should succeed";
@@ -274,9 +276,9 @@ TEST_F(ConvertModelIntegrationTest, Pairwise10_Glb_Glb_Glb_Locators) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0) << "convert_model should succeed";
@@ -422,6 +424,34 @@ TEST_F(ConvertModelIntegrationTest, Error_UnknownMotionFormat) {
   EXPECT_EQ(rc, 0);
 }
 
+// Test: Parameter output writes a valid .model file
+TEST_F(ConvertModelIntegrationTest, ParameterOutput_WritesModelFile) {
+  const auto out = outputFile("params_test.glb");
+  const auto outParams = outputFile("exported.model");
+
+  int rc = runConvertModel(
+      {"--model",
+       testFile("character_with_motion.glb"),
+       "--parameters",
+       testFile("character.model"),
+       "--out",
+       out,
+       "--out-parameters",
+       outParams});
+
+  ASSERT_EQ(rc, 0);
+  ASSERT_TRUE(std::filesystem::exists(outParams));
+  EXPECT_GT(std::filesystem::file_size(outParams), 0u);
+
+  std::ifstream paramsFile(outParams);
+  ASSERT_TRUE(paramsFile.is_open());
+  const std::string paramsData{
+      std::istreambuf_iterator<char>{paramsFile}, std::istreambuf_iterator<char>{}};
+  EXPECT_NE(paramsData.find("[ParameterTransform]"), std::string::npos);
+  EXPECT_NE(paramsData.find("root.tx = 1*root_tx"), std::string::npos);
+  EXPECT_NE(paramsData.find("joint2.rz = 0.5*shared_rz"), std::string::npos);
+}
+
 // Test: Locator output (local and global)
 TEST_F(ConvertModelIntegrationTest, LocatorOutput_LocalAndGlobal) {
   const auto out = outputFile("locator_test.fbx");
@@ -435,9 +465,9 @@ TEST_F(ConvertModelIntegrationTest, LocatorOutput_LocalAndGlobal) {
        testFile("character.locators"),
        "--out",
        out,
-       "--out-locator-local",
+       "--out-locators-local",
        outLocLocal,
-       "--out-locator-global",
+       "--out-locators-global",
        outLocGlobal});
 
   EXPECT_EQ(rc, 0);

--- a/momentum/examples/convert_model/convert_model_test.cpp
+++ b/momentum/examples/convert_model/convert_model_test.cpp
@@ -14,8 +14,11 @@
 #include <momentum/io/character_io.h>
 #include <momentum/io/fbx/fbx_io.h>
 #include <momentum/io/gltf/gltf_io.h>
+#include <momentum/test/io/io_helpers.h>
 
 #include <gtest/gtest.h>
+
+#include <fstream>
 
 using namespace momentum;
 
@@ -145,6 +148,38 @@ TEST_F(ConvertModelTest, InitializeCharacterFromFbx_WithParamsAndLocators_LoadsB
 
   EXPECT_GT(character.parameterTransform.numAllModelParameters(), 0);
   EXPECT_GT(character.locators.size(), 0);
+}
+
+TEST_F(ConvertModelTest, LoadModelCharacter_Urdf_LoadsCharacter) {
+  auto tempDir = temporaryDirectory("convert_model_urdf");
+  const auto urdfPath = tempDir.path() / "robot.urdf";
+  {
+    std::ofstream file(urdfPath);
+    ASSERT_TRUE(file.good());
+    file << R"(
+      <?xml version="1.0"?>
+      <robot name="convert_model_robot">
+        <link name="base_link"/>
+        <link name="child_link"/>
+        <joint name="joint1" type="fixed">
+          <parent link="base_link"/>
+          <child link="child_link"/>
+          <origin xyz="0 0 0.5" rpy="0 0 0"/>
+        </joint>
+      </robot>
+    )";
+  }
+
+  Options options;
+  options.input_model_file = urdfPath.string();
+
+  const Character character = loadModelCharacter(options);
+
+  ASSERT_EQ(character.skeleton.joints.size(), 2);
+  EXPECT_EQ(character.name, "convert_model_robot");
+  EXPECT_EQ(character.skeleton.joints[0].name, "base_link");
+  EXPECT_EQ(character.skeleton.joints[1].name, "child_link");
+  EXPECT_EQ(character.skeleton.joints[1].parent, 0);
 }
 
 // ============================================================================

--- a/momentum/gui/rerun/logger.cpp
+++ b/momentum/gui/rerun/logger.cpp
@@ -477,8 +477,8 @@ void logCollisionGeometry(
       rerun::Capsules3D::from_lengths_and_radii(lengths, radii)
           .with_translations(translations)
           .with_quaternions(quaternions)
-          .with_colors(rerun::Color(128, 64, 64)));
-  // TODO: Switch to wireframe once available in Rerun
+          .with_colors(rerun::Color(128, 64, 64))
+          .with_fill_mode(rerun::FillMode::Solid));
 
   logBvh(rec, streamName + "/bvh", collisionGeometry, skeletonState);
 }

--- a/momentum/io/gltf/gltf_animation_io.cpp
+++ b/momentum/io/gltf/gltf_animation_io.cpp
@@ -222,9 +222,15 @@ std::tuple<MatrixXf, JointParameters, float> loadMotionOnCharacterCommon(
     const std::variant<filesystem::path, std::span<const std::byte>>& input,
     const Character& character) {
   const auto [loadedChar, motion, identity, fps] = loadCharacterWithMotionCommon(input);
+  // glTF files that store motion without per-joint identity offsets surface as an empty `identity`
+  // vector. Skip mapIdentityToCharacter in that case to preserve the "no identity present" signal
+  // and to avoid violating its size precondition (joint names paired with an empty values vector).
+  const JointParameters mappedIdentity = identity.size() != 0
+      ? mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character)
+      : identity;
   return {
       mapMotionToCharacter({loadedChar.parameterTransform.name, motion}, character),
-      mapIdentityToCharacter({loadedChar.skeleton.getJointNames(), identity}, character),
+      mappedIdentity,
       fps};
 }
 

--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -18,7 +18,9 @@
 #include <urdf_parser/urdf_parser.h>
 
 #include <algorithm>
+#include <array>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -49,6 +51,7 @@ struct ParsingData {
   std::vector<Eigen::Triplet<float>> triplets;
   ParameterLimits limits;
   PhysicalProperties physicalProperties;
+  CollisionGeometry collision;
   size_t totalDoFs = 0;
 
   std::vector<LinkVisualData> linkVisuals;
@@ -122,6 +125,21 @@ void addPhysicalPropertiesForUrdfLink(
     default:
       return "UNKNOWN";
   }
+}
+
+[[nodiscard]] std::string_view toString(const urdf::Geometry& geometry) {
+  switch (geometry.type) {
+    case urdf::Geometry::SPHERE:
+      return "SPHERE";
+    case urdf::Geometry::BOX:
+      return "BOX";
+    case urdf::Geometry::CYLINDER:
+      return "CYLINDER";
+    case urdf::Geometry::MESH:
+      return "MESH";
+  }
+
+  return "UNKNOWN";
 }
 
 /// Returns the principal axis index (0=X, 1=Y, 2=Z) and sign (+1/-1) for a URDF axis vector.
@@ -230,6 +248,46 @@ std::optional<Mesh> loadVisualMesh(
       MT_LOGW("Unknown URDF geometry type: {}", static_cast<int>(geometry.type));
       return std::nullopt;
   }
+}
+
+std::optional<TaperedCapsule> loadCollisionCapsule(
+    const urdf::Collision& collision,
+    std::string_view linkName,
+    size_t jointIndex) {
+  if (!collision.geometry) {
+    MT_LOGW("Ignoring URDF collision on link '{}' because it has no geometry.", linkName);
+    return std::nullopt;
+  }
+
+  const auto& geometry = *collision.geometry;
+  if (geometry.type != urdf::Geometry::CYLINDER) {
+    MT_LOGW(
+        "Ignoring unsupported URDF collision geometry '{}' on link '{}'. "
+        "Only cylinder collision geometry can be imported as Momentum tapered capsules.",
+        toString(geometry),
+        linkName);
+    return std::nullopt;
+  }
+
+  const auto& cylinder = dynamic_cast<const urdf::Cylinder&>(geometry);
+  const auto collisionOrigin = toMomentumTransform<float>(collision.origin);
+
+  // Convention conversion: URDF cylinders are centered at the origin with their axis along
+  // +Z, while Momentum TaperedCapsules start at the origin with their axis along +X.
+  //   - Rotation: compose the URDF collision origin rotation with a UnitX→UnitZ rotation so the
+  //     local +X axis of the Momentum capsule maps to the local +Z axis of the URDF cylinder.
+  //   - Translation: convert the URDF center position to centimeters, then shift along the
+  //     URDF cylinder's local +Z by -length/2 so the capsule starts where the cylinder ends.
+  TaperedCapsule capsule;
+  capsule.parent = jointIndex;
+  capsule.length = static_cast<float>(cylinder.length) * toCm<float>();
+  capsule.radius = Eigen::Vector2f::Constant(static_cast<float>(cylinder.radius) * toCm<float>());
+  capsule.transformation.rotation = collisionOrigin.rotation *
+      Eigen::Quaternionf::FromTwoVectors(Eigen::Vector3f::UnitX(), Eigen::Vector3f::UnitZ());
+  capsule.transformation.translation = collisionOrigin.translation * toCm<float>() +
+      collisionOrigin.rotation * Eigen::Vector3f(0.0f, 0.0f, -0.5f * capsule.length);
+
+  return capsule;
 }
 
 constexpr std::array<const char*, 3> kTranslationNames = {"tx", "ty", "tz"};
@@ -444,6 +502,17 @@ bool loadUrdfSkeletonRecursive(
     data.linkVisuals.push_back(std::move(visualData));
   }
 
+  for (const auto& collision : urdfLink->collision_array) {
+    if (!collision) {
+      MT_LOGW("Ignoring null URDF collision on link '{}'.", urdfLink->name);
+      continue;
+    }
+    auto capsule = loadCollisionCapsule(*collision, urdfLink->name, static_cast<size_t>(jointId));
+    if (capsule) {
+      data.collision.push_back(*capsule);
+    }
+  }
+
   // Continue parsing child links and joints
   for (const auto& childLink : urdfLink->child_links) {
     if (!loadUrdfSkeletonRecursive(data, jointId, urdfModel, childLink.get())) {
@@ -627,6 +696,7 @@ Character loadUrdfCharacterFromUrdfModel(
   data.parameterTransform.activeJointParams = data.parameterTransform.computeActiveJointParams();
 
   const std::string robotName = urdfModel->getName();
+  const CollisionGeometry* collision = data.collision.empty() ? nullptr : &data.collision;
 
   auto meshResult = buildCombinedMesh(data, urdfDir);
   if (meshResult) {
@@ -638,7 +708,7 @@ Character loadUrdfCharacterFromUrdfModel(
         LocatorList{},
         &mesh,
         &skinWeights,
-        nullptr, // collision
+        collision,
         nullptr, // poseShapes
         {}, // blendShapes
         {}, // faceExpressionBlendShapes
@@ -656,7 +726,7 @@ Character loadUrdfCharacterFromUrdfModel(
       LocatorList{},
       nullptr, // mesh
       nullptr, // skinWeights
-      nullptr, // collision
+      collision,
       nullptr, // poseShapes
       {}, // blendShapes
       {}, // faceExpressionBlendShapes

--- a/momentum/io/urdf/urdf_io.h
+++ b/momentum/io/urdf/urdf_io.h
@@ -66,9 +66,11 @@ namespace momentum {
 
 /// Loads a character from a URDF file.
 ///
-/// Parses the skeleton (joints, hierarchy, limits), parameter transform, and visual meshes.
-/// Mesh files referenced by `<visual>` elements (STL, OBJ) are resolved relative to the
-/// URDF file's directory.
+/// Parses the skeleton (joints, hierarchy, limits), parameter transform, visual meshes, and
+/// supported collision proxies. Currently only `<cylinder>` collision geometry is imported
+/// (as Momentum tapered capsules); other shapes (`<box>`, `<sphere>`, `<mesh>`) are skipped
+/// with a warning. Mesh files referenced by `<visual>` elements (STL, OBJ) are resolved
+/// relative to the URDF file's directory.
 ///
 /// @param filepath Path to the URDF file.
 /// @return The loaded character with skeleton, parameter transform, limits, and optionally

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -117,6 +117,14 @@ std::string urdfWithRevoluteMixedInertialLinks() {
   )";
 }
 
+void expectVectorNear(
+    const Eigen::Vector3f& actual,
+    const Eigen::Vector3f& expected,
+    float tolerance = 1e-5f) {
+  EXPECT_LE((actual - expected).norm(), tolerance)
+      << "actual: " << actual.transpose() << ", expected: " << expected.transpose();
+}
+
 TEST(IoUrdfTest, LoadCharacter) {
   auto urdfPath = getTestFilePath("character.urdf");
   if (!urdfPath.has_value()) {
@@ -411,6 +419,110 @@ TEST(IoUrdfTest, GltfRoundTripPreservesPhysicalProperties) {
   EXPECT_EQ(tip.jointName, "tip_link");
   EXPECT_EQ(tip.jointIndex, 2);
   expectPhysicalPropertiesJointMatches(gltfCharacter, tip);
+}
+
+TEST(IoUrdfTest, LoadUrdfWithCollisionCapsules) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="collision_robot">
+      <link name="base_link">
+        <collision name="base_capsule">
+          <origin xyz="0.01 0.02 0.03" rpy="0 1.57079632679 0"/>
+          <geometry>
+            <cylinder radius="0.04" length="0.2"/>
+          </geometry>
+        </collision>
+      </link>
+      <link name="child_link">
+        <collision name="child_capsule">
+          <origin xyz="0 0 0.05" rpy="0 0 0"/>
+          <geometry>
+            <cylinder radius="0.01" length="0.1"/>
+          </geometry>
+        </collision>
+        <collision name="unsupported_box">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="fixed_joint" type="fixed">
+        <parent link="base_link"/>
+        <child link="child_link"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_NE(character.collision, nullptr);
+  ASSERT_EQ(character.collision->size(), 2);
+
+  const auto& baseCapsule = character.collision->at(0);
+  EXPECT_EQ(baseCapsule.parent, 0);
+  EXPECT_FLOAT_EQ(baseCapsule.length, 20.0f);
+  EXPECT_TRUE(baseCapsule.radius.isApprox(Eigen::Vector2f::Constant(4.0f)));
+  expectVectorNear(baseCapsule.transformation.translation, Eigen::Vector3f(-9.0f, 2.0f, 3.0f));
+  expectVectorNear(
+      baseCapsule.transformation.translation +
+          baseCapsule.transformation.getAxisX() * baseCapsule.length,
+      Eigen::Vector3f(11.0f, 2.0f, 3.0f));
+
+  const auto& childCapsule = character.collision->at(1);
+  EXPECT_EQ(childCapsule.parent, 1);
+  EXPECT_FLOAT_EQ(childCapsule.length, 10.0f);
+  EXPECT_TRUE(childCapsule.radius.isApprox(Eigen::Vector2f::Constant(1.0f)));
+  expectVectorNear(childCapsule.transformation.translation, Eigen::Vector3f::Zero());
+  expectVectorNear(
+      childCapsule.transformation.translation +
+          childCapsule.transformation.getAxisX() * childCapsule.length,
+      Eigen::Vector3f(0.0f, 0.0f, 10.0f));
+}
+
+TEST(IoUrdfTest, LoadUrdfSkipsUnsupportedCollisionGeometries) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="unsupported_collision_robot">
+      <link name="base_link">
+        <collision name="unsupported_box">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </collision>
+        <collision name="unsupported_sphere">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </collision>
+        <collision name="unsupported_mesh">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <mesh filename="missing.stl"/>
+          </geometry>
+        </collision>
+        <collision name="supported_cylinder">
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+            <cylinder radius="0.02" length="0.1"/>
+          </geometry>
+        </collision>
+      </link>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  // Only the cylinder is imported; box, sphere, and mesh collisions are skipped with warnings.
+  ASSERT_NE(character.collision, nullptr);
+  ASSERT_EQ(character.collision->size(), 1);
+  EXPECT_FLOAT_EQ(character.collision->at(0).length, 10.0f);
+  EXPECT_TRUE(character.collision->at(0).radius.isApprox(Eigen::Vector2f::Constant(2.0f)));
 }
 
 TEST(IoUrdfTest, LoadUrdfWithSphereVisual) {

--- a/momentum/website/docs_cpp/03_examples/03_convert_model.md
+++ b/momentum/website/docs_cpp/03_examples/03_convert_model.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Convert Model
 
-The `convert_model` example demonstrates how to convert a character model and its associated animation file between FBX and GLB formats. Use the `-m` or `--model` option to specify the input model, followed by the path to the model file (`.fbx` or `.glb`). If no input model is provided, the tool will automatically read the animation from an existing GLB or FBX file.
+The `convert_model` example demonstrates how to convert a character model and its associated animation file between FBX and GLB formats. Use the `-m` or `--model` option to specify the input model, followed by the path to the model file (`.fbx`, `.glb`, `.gltf`, or `.urdf`). If no input model is provided, the tool will automatically read the animation from an existing GLB or FBX file.
 
 <FbInternalOnly>
 
@@ -19,13 +19,15 @@ convert_model [OPTIONS]
 
 Options:
   -h,--help                   Print this help message and exit
-  -m,--model TEXT:FILE        Input model (.fbx/.glb); not required if reading animation from glb or fbx
+  -m,--model TEXT:FILE        Input model (.fbx/.glb/.gltf/.urdf); not required if reading animation from glb or fbx
   -p,--parameters TEXT:FILE   Input model parameter file (.model)
   -l,--locator TEXT:FILE      Input locator file (.locators)
-  -d,--motion TEXT:FILE       Input motion data file (.mmo/.glb/.fbx)
-  -o,--out TEXT REQUIRED      Output file (.fbx/.glb)
-  --out-locator TEXT          Output a locator file (.locators)
-  --save-markers              Save marker data from motion file in output (glb only)
+  -d,--motion TEXT:FILE       Input motion data file (.glb/.fbx)
+  -o,--out TEXT REQUIRED      Output file (.fbx/.glb/.gltf)
+  --out-locators-local TEXT   Output a locator file (.locators) in local space for transferring between identities
+  --out-locators-global TEXT  Output a locator file (.locators) in global space for authoring a template
+  --out-parameters TEXT       Output a model parameter file (.model) containing the parameter transform and limits
+  --save-markers              Save marker data from input motion file in the output
   -c,--character-mesh         (FBX Output file only) Saves the Character Mesh to the output file.
 ```
 

--- a/pymomentum/quaternion_np.py
+++ b/pymomentum/quaternion_np.py
@@ -130,6 +130,37 @@ def inverse(q: NDArray) -> NDArray:
     return conjugate(q) / np.maximum((q * q).sum(axis=-1, keepdims=True), 1e-7)
 
 
+def align_z_with(direction: NDArray) -> NDArray:
+    """
+    Return an xyzw quaternion that rotates the +Z axis onto *direction*.
+
+    The returned quaternion represents the shortest-arc rotation from ``[0, 0, 1]``
+    to the normalized direction vector. Useful for orienting Z-aligned primitives
+    (capsules, cylinders) along an arbitrary world-space direction.
+
+    :param direction: A 3D direction vector. Normalized internally; a near-zero
+        vector returns the identity quaternion.
+    :return: A normalized xyzw quaternion.
+    """
+    direction = np.asarray(direction, dtype=np.float64)
+    norm = float(np.linalg.norm(direction))
+    if norm <= 1e-12:
+        return np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+
+    z_axis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    target = direction / norm
+    dot = float(np.dot(z_axis, target))
+    if dot > 1.0 - 1e-10:
+        return np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    if dot < -1.0 + 1e-10:
+        # 180-degree flip from +Z; use +X as the rotation axis.
+        return np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+    xyz = np.cross(z_axis, target)
+    q = np.array([xyz[0], xyz[1], xyz[2], 1.0 + dot], dtype=np.float64)
+    return q / np.linalg.norm(q)
+
+
 def _get_nonzero_denominator(d: NDArray, eps: float) -> NDArray:
     near_zeros = np.abs(d) < eps
     d = d * (~near_zeros)

--- a/pymomentum/rerun_vis.py
+++ b/pymomentum/rerun_vis.py
@@ -42,6 +42,7 @@ Individual logging functions are also available for finer control:
 - :func:`log_mesh` — log a :class:`~pymomentum.geometry.Mesh`
 - :func:`log_joints` — log skeleton bones and per-joint transforms
 - :func:`log_locators` — log locator world-space positions
+- :func:`log_collision_geometry` — log collision proxy capsules
 """
 
 from __future__ import annotations
@@ -50,6 +51,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from pymomentum.quaternion_np import (
+    align_z_with,
     rotate_vector_assume_normalized,
     to_rotation_matrix_assume_normalized,
 )
@@ -59,6 +61,83 @@ if TYPE_CHECKING:
 
     import rerun as rr  # @manual=fbsource//third-party/pypi/rerun-sdk:rerun-sdk
     from pymomentum.geometry import Character, Mesh  # @manual=:geometry
+
+
+_COLLISION_PROXY_COLOR: tuple[int, int, int] = (128, 64, 64)
+
+
+def _collision_capsule_segments(
+    character: Character,
+    skel_state: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    collision_geometry = character.collision_geometry
+    n_joints = skel_state.shape[0]
+    segments: list[list[np.ndarray]] = []
+    radii: list[float] = []
+    labels: list[str] = []
+
+    for i, capsule in enumerate(collision_geometry):
+        parent = int(capsule.parent)
+        if parent < 0 or parent >= n_joints:
+            continue
+
+        transform = np.asarray(capsule.transformation, dtype=np.float64)
+        length = float(capsule.length)
+        radius = float(np.max(np.asarray(capsule.radius, dtype=np.float64)))
+        if radius <= 0.0:
+            continue
+
+        local_start = transform[:3, 3]
+        local_end = local_start + transform[:3, 0] * length
+        parent_t = skel_state[parent, :3].astype(np.float64)
+        parent_q = skel_state[parent, 3:7].astype(np.float64)
+        parent_scale = float(skel_state[parent, 7])
+
+        start = parent_t + rotate_vector_assume_normalized(
+            parent_q, local_start * parent_scale
+        )
+        end = parent_t + rotate_vector_assume_normalized(
+            parent_q, local_end * parent_scale
+        )
+        segments.append([start.astype(np.float32), end.astype(np.float32)])
+        radii.append(radius * abs(parent_scale))
+        labels.append(f"collision_{i}")
+
+    if not segments:
+        return (
+            np.empty((0, 2, 3), dtype=np.float32),
+            np.empty((0,), dtype=np.float32),
+            [],
+        )
+
+    return (
+        np.asarray(segments, dtype=np.float32),
+        np.asarray(radii, dtype=np.float32),
+        labels,
+    )
+
+
+def _collision_capsules(
+    character: Character,
+    skel_state: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[str]]:
+    segments, radii, labels = _collision_capsule_segments(character, skel_state)
+    if segments.shape[0] == 0:
+        return (
+            np.empty((0, 3), dtype=np.float32),
+            np.empty((0,), dtype=np.float32),
+            np.empty((0,), dtype=np.float32),
+            np.empty((0, 4), dtype=np.float32),
+            [],
+        )
+
+    directions = segments[:, 1] - segments[:, 0]
+    lengths = np.linalg.norm(directions, axis=1).astype(np.float32)
+    quaternions = np.asarray(
+        [align_z_with(direction) for direction in directions],
+        dtype=np.float32,
+    )
+    return segments[:, 0], lengths, radii, quaternions, labels
 
 
 def log_mesh(
@@ -212,6 +291,48 @@ def log_locators(
     )
 
 
+def log_collision_geometry(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    color: tuple[int, int, int] = _COLLISION_PROXY_COLOR,
+) -> None:
+    """Log collision proxy capsules to Rerun as capsules.
+
+    Momentum collision geometry is stored as tapered capsules. Rerun renders
+    them as ordinary capsules by using the larger endpoint radius.
+
+    :param rec: The Rerun recording stream.
+    :param entity_path: Entity path for the collision proxy entity.
+    :param character: The character whose collision geometry is logged.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    :param color: RGB color tuple for the collision proxies.
+    """
+    import rerun as rr
+
+    translations, lengths, radii, quaternions, labels = _collision_capsules(
+        character,
+        skel_state,
+    )
+    if lengths.shape[0] == 0:
+        return
+
+    rec.log(
+        entity_path,
+        rr.Capsules3D(
+            lengths=lengths,
+            radii=radii,
+            translations=translations,
+            quaternions=quaternions,
+            colors=color,
+            fill_mode=rr.components.FillMode.Solid,
+            labels=labels,
+        ),
+    )
+
+
 def log_character(
     rec: rr.RecordingStream,
     entity_path: str,
@@ -220,6 +341,7 @@ def log_character(
     *,
     posed_mesh: Mesh | None = None,
     color: tuple[int, int, int] = (200, 200, 200),
+    collision_geometry: bool = False,
 ) -> None:
     """Log a complete character visualization to Rerun.
 
@@ -229,6 +351,7 @@ def log_character(
     - ``{entity_path}/mesh`` — posed mesh (if *posed_mesh* is provided)
     - ``{entity_path}/joints`` — skeleton bones and per-joint transforms
     - ``{entity_path}/locators`` — locator positions (if character has locators)
+    - ``{entity_path}/collision_proxies`` — collision capsules (when requested)
 
     This is the Python equivalent of the C++ ``momentum::logCharacter`` function.
 
@@ -244,6 +367,7 @@ def log_character(
         is logged.
     :param color: RGB color tuple for the mesh albedo.  Defaults to light grey
         ``(200, 200, 200)``.
+    :param collision_geometry: If ``True``, log collision proxy capsules.
     """
     if posed_mesh is not None:
         log_mesh(rec, f"{entity_path}/mesh", posed_mesh, color=color)
@@ -252,6 +376,14 @@ def log_character(
 
     if character.locators:
         log_locators(rec, f"{entity_path}/locators", character, skel_state)
+
+    if collision_geometry:
+        log_collision_geometry(
+            rec,
+            f"{entity_path}/collision_proxies",
+            character,
+            skel_state,
+        )
 
 
 def _make_time_columns(
@@ -448,6 +580,65 @@ def _send_locators_columns(
     rec.send_columns(entity_path, indexes=time_cols, columns=pos_cols)
 
 
+def _send_collision_geometry_columns(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    character: Character,
+    skel_states: np.ndarray,
+    time_cols: list,
+    fps: float,
+    frame_offset: int,
+    color: tuple[int, int, int],
+) -> None:
+    """Send collision proxy capsules for multiple frames via columns."""
+    import rerun as rr
+
+    n_frames = skel_states.shape[0]
+    frame_lengths: list[np.ndarray] = []
+    frame_radii: list[np.ndarray] = []
+    frame_translations: list[np.ndarray] = []
+    frame_quaternions: list[np.ndarray] = []
+    n_capsules = 0
+
+    for frame in range(n_frames):
+        translations, lengths, radii, quaternions, _labels = _collision_capsules(
+            character, skel_states[frame]
+        )
+        if frame == 0:
+            n_capsules = lengths.shape[0]
+            if n_capsules == 0:
+                return
+        elif lengths.shape[0] != n_capsules:
+            raise ValueError(
+                "Collision geometry capsule count changed mid-animation "
+                f"(frame {frame}: {lengths.shape[0]} capsules vs frame 0: "
+                f"{n_capsules} capsules); Rerun's columnar partitioning requires "
+                "a constant capsule count across frames."
+            )
+
+        frame_lengths.append(lengths)
+        frame_radii.append(radii)
+        frame_translations.append(translations)
+        frame_quaternions.append(quaternions)
+
+    first_time = _make_time_columns(1, fps, frame_offset)
+    static_cols = rr.Capsules3D.columns(
+        colors=np.tile(np.asarray(color, dtype=np.uint8), (n_capsules, 1)),
+        fill_mode=[rr.components.FillMode.Solid] * n_capsules,
+    )
+    static_cols = static_cols.partition(np.array([n_capsules]))
+    rec.send_columns(entity_path, indexes=first_time, columns=static_cols)
+
+    capsule_cols = rr.Capsules3D.columns(
+        lengths=np.concatenate(frame_lengths, axis=0),
+        radii=np.concatenate(frame_radii, axis=0),
+        translations=np.concatenate(frame_translations, axis=0),
+        quaternions=np.concatenate(frame_quaternions, axis=0),
+    )
+    capsule_cols = capsule_cols.partition(np.full(n_frames, n_capsules))
+    rec.send_columns(entity_path, indexes=time_cols, columns=capsule_cols)
+
+
 def log_animation(
     rec: rr.RecordingStream,
     entity_path: str,
@@ -458,6 +649,7 @@ def log_animation(
     fps: float = 30.0,
     color: tuple[int, int, int] = (200, 200, 200),
     frame_offset: int = 0,
+    collision_geometry: bool = False,
 ) -> None:
     """Log a multi-frame character animation using columnar batch sends.
 
@@ -489,6 +681,7 @@ def log_animation(
     :param color: RGB color for the mesh albedo factor.
     :param frame_offset: Starting frame index for the time columns.  Use when
         sending multiple chunks of the same animation.
+    :param collision_geometry: If ``True``, log collision proxy capsules.
     """
     n_frames = skel_states.shape[0]
     time_cols = _make_time_columns(n_frames, fps, frame_offset)
@@ -523,4 +716,16 @@ def log_animation(
             time_cols,
             fps,
             frame_offset,
+        )
+
+    if collision_geometry:
+        _send_collision_geometry_columns(
+            rec,
+            f"{entity_path}/collision_proxies",
+            character,
+            skel_states,
+            time_cols,
+            fps,
+            frame_offset,
+            _COLLISION_PROXY_COLOR,
         )

--- a/pymomentum/test/test_rerun_vis.py
+++ b/pymomentum/test/test_rerun_vis.py
@@ -15,6 +15,7 @@ import pymomentum.geometry_test_utils as test_utils  # @manual=:geometry_test_ut
 from pymomentum.rerun_vis import (
     log_animation,
     log_character,
+    log_collision_geometry,
     log_joints,
     log_locators,
     log_mesh,
@@ -46,7 +47,7 @@ def _is_tsan_active() -> bool:
 # load_tests() alone) so that pytest — which does not honor unittest's
 # load_tests protocol — cannot discover and instantiate it when rerun is
 # unavailable. load_tests is kept for the TSan skip path (BUCK / unittest only).
-if _HAS_RERUN:
+if _HAS_RERUN:  # noqa: C901 — gating block intentionally wraps the whole suite
 
     class TestRerunVis(unittest.TestCase):
         @classmethod
@@ -70,6 +71,25 @@ if _HAS_RERUN:
             )
             skel_state = geo.model_parameters_to_skeleton_state(character, model_params)
             self.assertEqual(skel_state.shape, (character.skeleton.size, 8))
+            return character, skel_state
+
+        def _make_collision_character_and_skel_state(
+            self,
+        ) -> tuple[geo.Character, np.ndarray]:
+            character, _ = self._make_character_and_skel_state()
+            capsule_transform = np.eye(4, dtype=np.float32)
+            capsule = geo.TaperedCapsule(
+                parent=0,
+                transformation=capsule_transform,
+                radius=np.array([1.0, 2.0], dtype=np.float32),
+                length=10.0,
+            )
+            character = character.with_collision_geometry([capsule])
+            self.assertEqual(len(character.collision_geometry), 1)
+
+            skel_state = np.zeros((character.skeleton.size, 8), dtype=np.float32)
+            skel_state[:, 6] = 1.0
+            skel_state[:, 7] = 1.0
             return character, skel_state
 
         def _posed_mesh(self, character: geo.Character) -> geo.Mesh:
@@ -116,6 +136,29 @@ if _HAS_RERUN:
             self.assertEqual(path, "locs")
             self.assertIsInstance(archetype, rr.Points3D)
 
+        def test_log_collision_geometry(self) -> None:
+            character, skel_state = self._make_collision_character_and_skel_state()
+
+            mock_rec = MagicMock()
+            log_collision_geometry(mock_rec, "collisions", character, skel_state)
+
+            mock_rec.log.assert_called_once()
+            path, archetype = mock_rec.log.call_args.args
+            self.assertEqual(path, "collisions")
+            self.assertIsInstance(archetype, rr.Capsules3D)
+            self.assertIsNotNone(archetype.colors)
+            assert archetype.colors is not None
+            expected_color = (128 << 24) | (64 << 16) | (64 << 8) | 0xFF
+            self.assertEqual(
+                archetype.colors.as_arrow_array().to_pylist(), [expected_color]
+            )
+            self.assertIsNotNone(archetype.fill_mode)
+            assert archetype.fill_mode is not None
+            self.assertEqual(
+                archetype.fill_mode.as_arrow_array().to_pylist(),
+                [rr.components.FillMode.Solid.value],
+            )
+
         def test_log_character_with_and_without_mesh(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
             posed_mesh = self._posed_mesh(character)
@@ -136,6 +179,21 @@ if _HAS_RERUN:
             paths_no_mesh = [c.args[0] for c in mock_rec.log.call_args_list]
             self.assertNotIn("ch_nm/mesh", paths_no_mesh)
             self.assertIn("ch_nm/joints", paths_no_mesh)
+
+        def test_log_character_collision_geometry_is_opt_in(self) -> None:
+            character, skel_state = self._make_collision_character_and_skel_state()
+
+            mock_rec = MagicMock()
+            log_character(mock_rec, "ch", character, skel_state)
+            paths = [c.args[0] for c in mock_rec.log.call_args_list]
+            self.assertNotIn("ch/collision_proxies", paths)
+
+            mock_rec = MagicMock()
+            log_character(
+                mock_rec, "ch", character, skel_state, collision_geometry=True
+            )
+            paths = [c.args[0] for c in mock_rec.log.call_args_list]
+            self.assertIn("ch/collision_proxies", paths)
 
         def _make_animation_inputs(
             self, n_frames: int
@@ -183,6 +241,59 @@ if _HAS_RERUN:
             self.assertEqual(len(joint_subpaths), character.skeleton.size)
             if character.locators:
                 self.assertIn("test/anim/locators", send_paths)
+
+        def test_log_animation_with_collision_geometry(self) -> None:
+            character, skel_state = self._make_collision_character_and_skel_state()
+            moved_skel_state = skel_state.copy()
+            moved_skel_state[0, 0] = 5.0
+            skel_states = np.stack([skel_state, moved_skel_state], axis=0)
+
+            mock_rec = MagicMock()
+            log_animation(
+                mock_rec,
+                "test/collision_anim",
+                character,
+                skel_states,
+                fps=30.0,
+                collision_geometry=True,
+            )
+
+            send_paths = [c.args[0] for c in mock_rec.send_columns.call_args_list]
+            self.assertIn("test/collision_anim/collision_proxies", send_paths)
+            collision_calls = [
+                c
+                for c in mock_rec.send_columns.call_args_list
+                if c.args[0] == "test/collision_anim/collision_proxies"
+            ]
+            self.assertGreaterEqual(len(collision_calls), 1)
+            static_columns = {
+                column.component_descriptor().component: column.as_arrow_array().to_pylist()
+                for column in collision_calls[0].kwargs["columns"]
+            }
+            self.assertEqual(
+                static_columns["Capsules3D:fill_mode"],
+                [[rr.components.FillMode.Solid.value]],
+            )
+
+        def test_log_animation_without_collision_geometry_does_not_send(self) -> None:
+            # Regression: a character with no collision capsules but with
+            # collision_geometry=True should silently no-op (no send_columns call to
+            # collision_proxies), not crash.
+            character, _, skel_states, _ = self._make_animation_inputs(2)
+            character = character.with_collision_geometry([])
+            self.assertEqual(len(character.collision_geometry), 0)
+
+            mock_rec = MagicMock()
+            log_animation(
+                mock_rec,
+                "test/no_collision",
+                character,
+                skel_states,
+                fps=30.0,
+                collision_geometry=True,
+            )
+            send_paths = [c.args[0] for c in mock_rec.send_columns.call_args_list]
+            self.assertNotIn("test/no_collision/collision_proxies", send_paths)
 
         def test_log_animation_without_mesh(self) -> None:
             character, _, skel_states, _ = self._make_animation_inputs(3)

--- a/pymomentum/test/test_viser_vis.py
+++ b/pymomentum/test/test_viser_vis.py
@@ -6,7 +6,6 @@
 # pyre-strict
 
 import unittest
-from typing import Any
 
 import numpy as np
 import pymomentum.geometry as geo  # @manual=:geometry
@@ -38,7 +37,6 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
         add_log_panel,
         add_mesh,
         add_skinned_mesh,
-        add_wireframe_toggle,
         CharacterHandles,
         remove_character,
         update_character,
@@ -73,14 +71,27 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             self.assertEqual(skel_state.shape, (character.skeleton.size, 8))
             return character, skel_state
 
+        def _make_collision_character_and_skel_state(
+            self,
+        ) -> tuple[geo.Character, np.ndarray]:
+            character, _ = self._make_character_and_skel_state()
+            capsule = geo.TaperedCapsule(
+                parent=0,
+                transformation=np.eye(4, dtype=np.float32),
+                radius=np.array([1.0, 2.0], dtype=np.float32),
+                length=10.0,
+            )
+            character = character.with_collision_geometry([capsule])
+            self.assertEqual(len(character.collision_geometry), 1)
+
+            skel_state = np.zeros((character.skeleton.size, 8), dtype=np.float32)
+            skel_state[:, 6] = 1.0
+            skel_state[:, 7] = 1.0
+            return character, skel_state
+
         def _posed_mesh(self, character: geo.Character) -> geo.Mesh:
             joint_params = np.zeros(character.skeleton.size * 7, dtype=np.float32)
             return character.pose_mesh(joint_params)
-
-        def _solid_mesh_visibilities(self, mesh_handle: Any) -> list[bool]:
-            if isinstance(mesh_handle, list):
-                return [bool(part.handle.visible) for part in mesh_handle]
-            return [bool(mesh_handle.visible)]
 
         def _make_uncolored_character(self, character: geo.Character) -> geo.Character:
             mesh = geo.Mesh(
@@ -348,6 +359,49 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
                 )
             remove_character(skinned)
 
+        def test_collision_proxies_track_model_revealed_via_scene_tree(self) -> None:
+            # Regression: proxy visibility is driven solely by viser's scene-tree
+            # panel, which flips the root frame's visibility directly. Because
+            # update_character repositions proxies regardless of visibility, a
+            # proxy revealed after the model moved is already at the current pose
+            # rather than stranded at the rest pose.
+            character, skel_state = self._make_collision_character_and_skel_state()
+            handles = add_character(
+                self.server,
+                "scene_tree_char",
+                character,
+                skel_state,
+                collision_geometry=True,
+                collision_geometry_visible=False,
+            )
+            root = handles.collision_root_handle
+            self.assertIsNotNone(root)
+            assert root is not None
+            self.assertFalse(root.visible)
+            capsule_handles = handles.collision_handles[0]
+
+            # Move the model while the proxies remain hidden.
+            moved = skel_state.copy()
+            moved[0, 0] = 10.0
+            update_character(self.server, handles, character, moved)
+
+            # Reveal via the scene-tree path: flip root visibility directly, with
+            # no checkbox/on_show refresh.
+            root.visible = True
+
+            # Proxy is at the moved pose, not stranded at the rest pose.
+            np.testing.assert_allclose(
+                np.asarray(capsule_handles.start_sphere.position),
+                [0.1, 0.0, 0.0],
+                atol=1e-5,
+            )
+            np.testing.assert_allclose(
+                np.asarray(capsule_handles.end_sphere.position),
+                [0.2, 0.0, 0.0],
+                atol=1e-5,
+            )
+            remove_character(handles)
+
         def test_xyzw_to_wxyz(self) -> None:
             # xyzw [0.1, 0.2, 0.3, 0.9] -> wxyz [0.9, 0.1, 0.2, 0.3]
             q_xyzw = np.array([0.1, 0.2, 0.3, 0.9])
@@ -400,96 +454,6 @@ if _HAS_VISER:  # noqa: C901 — gating block intentionally wraps the whole suit
             self.assertGreater(len(events), 0)
             for s in sliders:
                 s.remove()
-
-        def test_add_wireframe_toggle(self) -> None:
-            character, skel_state = self._make_character_and_skel_state()
-            posed_mesh = self._posed_mesh(character)
-            handles = add_character(
-                self.server, "test_wf", character, skel_state, posed_mesh=posed_mesh
-            )
-            self.assertIsNotNone(handles.mesh_handle)
-            self.assertIsNotNone(handles.wireframe_handle)
-
-            # Default initial_value=False: solid visible, wireframe hidden.
-            cb = add_wireframe_toggle(self.server, handles)
-            self.assertEqual(
-                self._solid_mesh_visibilities(handles.mesh_handle),
-                [True] * len(self._solid_mesh_visibilities(handles.mesh_handle)),
-            )
-            self.assertFalse(handles.wireframe_handle.visible)
-
-            # Flip the checkbox; visibility should swap.
-            cb.value = True
-            solid_visibilities = self._solid_mesh_visibilities(handles.mesh_handle)
-            self.assertEqual(
-                solid_visibilities,
-                [False] * len(solid_visibilities),
-            )
-            self.assertTrue(handles.wireframe_handle.visible)
-
-            cb.remove()
-            remove_character(handles)
-
-            uncolored_character = self._make_uncolored_character(character)
-            skinned = add_character(
-                self.server,
-                "test_wf_skinned",
-                uncolored_character,
-                skel_state,
-                use_skinned_mesh=True,
-            )
-            self.assertIsNotNone(skinned.mesh_handle)
-            self.assertIsNone(skinned.wireframe_handle)
-
-            skinned_cb = add_wireframe_toggle(self.server, skinned)
-            self.assertTrue(skinned.mesh_handle.visible)
-            self.assertFalse(skinned.mesh_handle.wireframe)
-
-            skinned_cb.value = True
-            self.assertTrue(skinned.mesh_handle.visible)
-            self.assertTrue(skinned.mesh_handle.wireframe)
-
-            skinned_cb.remove()
-            remove_character(skinned)
-
-            colored_character, colored_skel_state = (
-                self._make_colored_skinned_character_and_skel_state()
-            )
-            colored_skinned = add_character(
-                self.server,
-                "test_wf_color_skinned",
-                colored_character,
-                colored_skel_state,
-                use_skinned_mesh=True,
-            )
-            self.assertIsInstance(colored_skinned.mesh_handle, list)
-            self.assertIsNone(colored_skinned.wireframe_handle)
-
-            colored_skinned_cb = add_wireframe_toggle(self.server, colored_skinned)
-            for part in colored_skinned.mesh_handle:
-                self.assertTrue(part.handle.visible)
-                self.assertFalse(part.handle.wireframe)
-
-            colored_skinned_cb.value = True
-            for part in colored_skinned.mesh_handle:
-                self.assertTrue(part.handle.visible)
-                self.assertTrue(part.handle.wireframe)
-
-            moved = colored_skel_state.copy()
-            moved[:, 2] += 0.5
-            update_character(self.server, colored_skinned, colored_character, moved)
-            for part in colored_skinned.mesh_handle:
-                for i, bone in enumerate(
-                    part.handle.bones[: colored_character.skeleton.size]
-                ):
-                    np.testing.assert_allclose(
-                        np.asarray(bone.position),
-                        moved[i, :3] * 0.01,
-                        atol=1e-5,
-                    )
-
-            colored_skinned_cb.remove()
-            remove_character(colored_skinned)
 
         def test_add_log_panel(self) -> None:
             panel = add_log_panel(self.server, echo_to_stdout=False)

--- a/pymomentum/viser_vis.py
+++ b/pymomentum/viser_vis.py
@@ -38,13 +38,19 @@ Individual functions are also available:
 - :func:`add_skinned_mesh` / :func:`update_skinned_mesh` — upload mesh data once
   and update only bone transforms
 - :func:`add_joints` / :func:`update_joints` — manage skeleton joint frames
+- :func:`add_collision_geometry` / :func:`update_collision_geometry` — manage
+  collision proxy capsules
 - :func:`add_character` / :func:`update_character` / :func:`remove_character` —
   manage a complete character
+
+Mesh wireframe and collision proxy visibility are controlled through viser's
+built-in scene-tree panel (each is its own scene node), so no bespoke GUI
+toggle is provided — a single control avoids the desync between a custom
+checkbox and the scene tree's client-side visibility override.
 
 GUI widget helpers (optional, for apps building interactive viewers):
 
 - :func:`add_character_param_sliders` — one slider per model parameter
-- :func:`add_wireframe_toggle` — checkbox that toggles a character's mesh/wireframe
 - :func:`add_log_panel` — scrollable HTML log strip (returns a :class:`LogPanel`)
 """
 
@@ -55,11 +61,24 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, TYPE_CHECKING, TypeAlias
 
 import numpy as np
-from pymomentum.quaternion_np import from_rotation_matrix
+from pymomentum.quaternion_np import (
+    align_z_with,
+    from_rotation_matrix,
+    rotate_vector_assume_normalized,
+)
 
 if TYPE_CHECKING:
     import viser
     from pymomentum.geometry import Character, Mesh  # @manual=:geometry
+
+
+@dataclass
+class _CollisionCapsuleHandles:
+    """Handles for the three primitives that render one capsule."""
+
+    cylinder: Any
+    start_sphere: Any
+    end_sphere: Any
 
 
 @dataclass
@@ -74,6 +93,8 @@ class CharacterHandles:
     bones_handle: Any | None = None
     mesh_handle: Any | None = None
     wireframe_handle: Any | None = None
+    collision_root_handle: Any | None = None
+    collision_handles: list[_CollisionCapsuleHandles] = field(default_factory=list)
 
 
 @dataclass
@@ -91,6 +112,10 @@ _ColoredMeshGroups: TypeAlias = list[
 
 #: Default scale factor to convert momentum units (cm) to meters for viser.
 CM_TO_M: float = 0.01
+
+# Matches the Rerun viewer and the C++ logger so the same proxy looks identical
+# across visualization backends.
+_COLLISION_PROXY_COLOR: tuple[int, int, int] = (128, 64, 64)
 
 
 def _xyzw_to_wxyz(q: np.ndarray) -> np.ndarray:
@@ -160,11 +185,6 @@ def _solid_mesh_handles(mesh_handle: Any | None) -> list[Any]:
     if isinstance(mesh_handle, list):
         return [part.handle for part in mesh_handle]
     return [mesh_handle]
-
-
-def _set_solid_mesh_visible(mesh_handle: Any | None, visible: bool) -> None:
-    for handle in _solid_mesh_handles(mesh_handle):
-        handle.visible = visible
 
 
 def _remove_solid_mesh(mesh_handle: Any | None) -> None:
@@ -547,6 +567,211 @@ def _build_bone_segments(
     return np.array(segments, dtype=np.float32) * scale
 
 
+def _collision_capsule_segments(
+    character: Character,
+    skel_state: np.ndarray,
+    scale: float = 1.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build capsule centerline segments and radii from character collision geometry."""
+    collision_geometry = character.collision_geometry
+    n_joints = skel_state.shape[0]
+    segments: list[list[np.ndarray]] = []
+    radii: list[float] = []
+
+    for capsule in collision_geometry:
+        parent = int(capsule.parent)
+        if parent < 0 or parent >= n_joints:
+            continue
+
+        transform = np.asarray(capsule.transformation, dtype=np.float64)
+        length = float(capsule.length)
+        radius = float(np.max(np.asarray(capsule.radius, dtype=np.float64)))
+        if radius <= 0.0:
+            continue
+
+        local_start = transform[:3, 3]
+        local_end = local_start + transform[:3, 0] * length
+        parent_t = skel_state[parent, :3].astype(np.float64)
+        parent_q = skel_state[parent, 3:7].astype(np.float64)
+        parent_scale = float(skel_state[parent, 7])
+
+        start = parent_t + rotate_vector_assume_normalized(
+            parent_q, local_start * parent_scale
+        )
+        end = parent_t + rotate_vector_assume_normalized(
+            parent_q, local_end * parent_scale
+        )
+        segments.append([start.astype(np.float32), end.astype(np.float32)])
+        radii.append(radius * abs(parent_scale))
+
+    if not segments:
+        return (
+            np.empty((0, 2, 3), dtype=np.float32),
+            np.empty((0,), dtype=np.float32),
+        )
+
+    return (
+        np.asarray(segments, dtype=np.float32) * scale,
+        np.asarray(radii, dtype=np.float32) * scale,
+    )
+
+
+def _wxyz_from_z_axis(direction: np.ndarray) -> np.ndarray:
+    """Return a wxyz quaternion that rotates +Z onto *direction*."""
+    return _xyzw_to_wxyz(align_z_with(direction))
+
+
+def add_collision_geometry(
+    server: viser.ViserServer,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    scale: float = CM_TO_M,
+    color: tuple[int, int, int] = _COLLISION_PROXY_COLOR,
+    opacity: float = 0.45,
+    visible: bool = True,
+) -> tuple[Any, list[_CollisionCapsuleHandles]]:
+    """Add collision proxy capsules to the viser scene.
+
+    Momentum stores tapered capsules; viser renders each proxy as an ordinary
+    capsule using the larger endpoint radius.
+
+    :param server: The viser server instance.
+    :param entity_path: Scene-graph path for the collision proxy group.
+    :param character: The character whose collision geometry is visualized.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    :param scale: Unit conversion factor. Defaults to :data:`CM_TO_M`.
+    :param color: RGB color tuple for the collision proxies.
+    :param opacity: Material opacity for the proxies.
+    :param visible: Initial visibility for the collision proxy group.
+    :return: A tuple of (root_handle, capsule primitive handle groups).
+    """
+    segments, radii = _collision_capsule_segments(character, skel_state, scale=scale)
+    root_handle = server.scene.add_frame(
+        entity_path,
+        show_axes=False,
+        visible=visible,
+    )
+    collision_handles: list[_CollisionCapsuleHandles] = []
+    for i, (segment, radius) in enumerate(zip(segments, radii)):
+        start = segment[0].astype(np.float64)
+        end = segment[1].astype(np.float64)
+        direction = end - start
+        height = max(float(np.linalg.norm(direction)), 1e-8)
+        rendered_radius = max(float(radius), 1e-8)
+        capsule_path = f"{entity_path}/{i}"
+
+        cylinder = server.scene.add_cylinder(
+            f"{capsule_path}/body",
+            radius=rendered_radius,
+            height=height,
+            color=color,
+            radial_segments=16,
+            opacity=opacity,
+            side="double",
+            cast_shadow=False,
+            receive_shadow=False,
+            position=(start + end) * 0.5,
+            wxyz=_wxyz_from_z_axis(direction),
+            visible=True,
+        )
+        start_sphere = server.scene.add_icosphere(
+            f"{capsule_path}/start",
+            radius=rendered_radius,
+            color=color,
+            subdivisions=1,
+            opacity=opacity,
+            cast_shadow=False,
+            receive_shadow=False,
+            position=start,
+            visible=True,
+        )
+        end_sphere = server.scene.add_icosphere(
+            f"{capsule_path}/end",
+            radius=rendered_radius,
+            color=color,
+            subdivisions=1,
+            opacity=opacity,
+            cast_shadow=False,
+            receive_shadow=False,
+            position=end,
+            visible=True,
+        )
+        collision_handles.append(
+            _CollisionCapsuleHandles(
+                cylinder=cylinder,
+                start_sphere=start_sphere,
+                end_sphere=end_sphere,
+            )
+        )
+
+    return root_handle, collision_handles
+
+
+def update_collision_geometry(
+    collision_handles: list[_CollisionCapsuleHandles],
+    character: Character,
+    skel_state: np.ndarray,
+    *,
+    scale: float = CM_TO_M,
+) -> None:
+    """Update collision proxy capsule positions and sizes.
+
+    Always repositions every capsule from the current ``skel_state``, regardless
+    of visibility, so the proxies stay in sync with the model. Visibility is a
+    separate concern controlled through viser's scene-tree panel; gating updates
+    on visibility would leave proxies stranded at a stale pose when later
+    revealed through a path that does not re-run this.
+
+    :param collision_handles: Capsule primitive handles returned by
+        :func:`add_collision_geometry`.
+    :param character: The character whose collision geometry is visualized.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    :param scale: Unit conversion factor. Defaults to :data:`CM_TO_M`.
+    :return: None.
+    """
+    if not collision_handles:
+        return
+
+    segments, radii = _collision_capsule_segments(character, skel_state, scale=scale)
+    if segments.shape[0] != len(collision_handles):
+        raise ValueError(
+            "Collision geometry capsule count does not match existing handles"
+        )
+
+    for capsule_handles, segment, radius in zip(collision_handles, segments, radii):
+        start = segment[0].astype(np.float64)
+        end = segment[1].astype(np.float64)
+        direction = end - start
+        height = max(float(np.linalg.norm(direction)), 1e-8)
+        rendered_radius = max(float(radius), 1e-8)
+
+        capsule_handles.cylinder.position = (start + end) * 0.5
+        capsule_handles.cylinder.wxyz = _wxyz_from_z_axis(direction)
+        capsule_handles.cylinder.height = height
+        capsule_handles.cylinder.radius = rendered_radius
+        capsule_handles.start_sphere.position = start
+        capsule_handles.start_sphere.radius = rendered_radius
+        capsule_handles.end_sphere.position = end
+        capsule_handles.end_sphere.radius = rendered_radius
+
+
+def _remove_collision_geometry(
+    collision_root_handle: Any | None,
+    collision_handles: list[_CollisionCapsuleHandles],
+) -> None:
+    # Idempotent: clear the list as we remove so a second call (e.g. accidental
+    # double-remove during cleanup) is a no-op rather than touching freed handles.
+    while collision_handles:
+        capsule_handles = collision_handles.pop()
+        capsule_handles.cylinder.remove()
+        capsule_handles.start_sphere.remove()
+        capsule_handles.end_sphere.remove()
+    if collision_root_handle is not None:
+        collision_root_handle.remove()
+
+
 def add_joints(
     server: viser.ViserServer,
     entity_path: str,
@@ -650,6 +875,8 @@ def add_character(
     scale: float = CM_TO_M,
     axes_length: float = 0.05,
     axes_radius: float = 0.002,
+    collision_geometry: bool = False,
+    collision_geometry_visible: bool = True,
 ) -> CharacterHandles:
     """Add a complete character visualization to the viser scene.
 
@@ -658,6 +885,7 @@ def add_character(
 
     - ``{entity_path}/joints/{name}`` — per-joint coordinate frames
     - ``{entity_path}/mesh`` — posed or skinned mesh
+    - ``{entity_path}/collision_proxies`` — collision capsules, if requested
 
     :param server: The viser server instance.
     :param entity_path: Root scene-graph path for the character.
@@ -670,6 +898,8 @@ def add_character(
     :param color: RGB color tuple for the mesh.
     :param axes_length: Length of joint axis indicators.
     :param axes_radius: Radius of joint axis indicators.
+    :param collision_geometry: If true, add collision proxy capsules.
+    :param collision_geometry_visible: Initial visibility for collision proxies.
     :return: A :class:`CharacterHandles` for use with :func:`update_character`.
     """
     handles = CharacterHandles(entity_path=entity_path)
@@ -696,6 +926,19 @@ def add_character(
     elif posed_mesh is not None:
         handles.mesh_handle, handles.wireframe_handle = add_mesh(
             server, f"{entity_path}/mesh", posed_mesh, color=color, scale=scale
+        )
+
+    if collision_geometry:
+        (
+            handles.collision_root_handle,
+            handles.collision_handles,
+        ) = add_collision_geometry(
+            server,
+            f"{entity_path}/collision_proxies",
+            character,
+            skel_state,
+            scale=scale,
+            visible=collision_geometry_visible,
         )
 
     return handles
@@ -738,6 +981,13 @@ def update_character(
                 handles.mesh_handle, handles.wireframe_handle, posed_mesh, scale=scale
             )
 
+        update_collision_geometry(
+            handles.collision_handles,
+            character,
+            skel_state,
+            scale=scale,
+        )
+
         server.flush()
 
 
@@ -761,11 +1011,17 @@ def remove_character(
         _remove_solid_mesh(handles.mesh_handle)
         if handles.wireframe_handle is not None:
             handles.wireframe_handle.remove()
+        _remove_collision_geometry(
+            handles.collision_root_handle,
+            handles.collision_handles,
+        )
 
     handles.joint_frames.clear()
     handles.bones_handle = None
     handles.mesh_handle = None
     handles.wireframe_handle = None
+    handles.collision_root_handle = None
+    handles.collision_handles.clear()
 
 
 # =============================================================================
@@ -830,57 +1086,6 @@ def add_character_param_sliders(
             slider.on_update(on_change)
         sliders.append(slider)
     return sliders
-
-
-def add_wireframe_toggle(
-    server: viser.ViserServer,
-    handles: CharacterHandles,
-    *,
-    label: str = "Wireframe",
-    initial_value: bool = False,
-) -> Any:
-    """Add a checkbox that toggles between solid and wireframe for *handles*.
-
-    :func:`add_mesh` (and therefore :func:`add_character`) creates both a solid
-    and a wireframe handle; this widget flips their ``.visible`` flags so only
-    one is shown at a time. Skinned mesh handles expose ``.wireframe`` directly,
-    so the widget toggles that property instead of requiring a duplicate mesh.
-    Sets initial visibility/state to match *initial_value*.
-
-    :param server: The viser server instance.
-    :param handles: The character handles whose mesh/wireframe to toggle.
-    :param label: Checkbox label shown in the GUI.
-    :param initial_value: ``True`` shows the wireframe initially, ``False``
-        shows the solid mesh.
-    :return: The viser checkbox handle.
-    """
-    cb = server.gui.add_checkbox(label, initial_value=initial_value)
-    skinned_handles = (
-        _skinned_mesh_handles(handles.mesh_handle)
-        if handles.wireframe_handle is None
-        else []
-    )
-    if skinned_handles:
-        for handle in skinned_handles:
-            handle.visible = True
-            handle.wireframe = initial_value
-    else:
-        _set_solid_mesh_visible(handles.mesh_handle, not initial_value)
-    if handles.wireframe_handle is not None:
-        handles.wireframe_handle.visible = initial_value
-
-    @cb.on_update
-    def _(_: object) -> None:
-        if skinned_handles:
-            for handle in skinned_handles:
-                handle.visible = True
-                handle.wireframe = cb.value
-        else:
-            _set_solid_mesh_visible(handles.mesh_handle, not cb.value)
-        if handles.wireframe_handle is not None:
-            handles.wireframe_handle.visible = cb.value
-
-    return cb
 
 
 class LogPanel:


### PR DESCRIPTION
Summary:
Include collision proxy geometry in the Viser Python viewer as normal capsules derived from Momentum tapered capsules. Proxies always track the model: `update_collision_geometry` repositions every capsule from the current skeleton state regardless of visibility, so they never desync from the rest of the rig.

Visibility for both collision proxies and the mesh wireframe is controlled solely through viser's built-in scene-tree panel; the bespoke "Collision proxies" and "Wireframe" GUI checkboxes (and their helpers) are removed. A custom checkbox and the scene tree cannot be kept in sync: viser's scene-tree eye toggle sets a client-side `overrideVisibility` that takes precedence over the server value and is never reported back to the server, so once used it permanently masks the checkbox. Relying on the single scene-tree control eliminates that desync and matches how joint and locator visibility already work.

Reuses the shared `align_z_with` quaternion helper added in the Rerun viewer commit (composing it with the existing `_xyzw_to_wxyz` adapter) so both viewers share one +Z-to-direction implementation. Unifies the collision proxy color (128, 64, 64) with the Rerun viewer and the C++ logger so the same proxy looks identical across visualization backends. Makes `_remove_collision_geometry` idempotent.

Differential Revision: D106701750


