### PR TITLE
Add collision ellipsoid primitive type

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -637,12 +637,12 @@ Character replaceSkeletonHierarchy(
   if (tgtCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*tgtCharacter.collision, tgtToCombinedJoints));
+        mapParents<CollisionPrimitive>(*tgtCharacter.collision, tgtToCombinedJoints));
   }
   if (srcCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*srcCharacter.collision, srcToCombinedJoints));
+        mapParents<CollisionPrimitive>(*srcCharacter.collision, srcToCombinedJoints));
   }
 
   // Build the merged parameter transform:
@@ -807,7 +807,8 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
 
   CollisionGeometry resultCollisionGeometry;
   if (character.collision) {
-    resultCollisionGeometry = mapParents<TaperedCapsule>(*character.collision, srcToResultJoints);
+    resultCollisionGeometry =
+        mapParents<CollisionPrimitive>(*character.collision, srcToResultJoints);
   }
 
   const ParameterLimits resultParameterLimits =

--- a/momentum/character/collision_geometry.h
+++ b/momentum/character/collision_geometry.h
@@ -8,12 +8,21 @@
 #pragma once
 
 #include <momentum/character/types.h>
+#include <momentum/common/checks.h>
 #include <momentum/common/memory.h>
 #include <momentum/math/constants.h>
 #include <momentum/math/transform.h>
 #include <momentum/math/utility.h>
 
+#include <cstdint>
+
 namespace momentum {
+
+/// Collision primitive kinds supported by character collision geometry.
+enum class CollisionPrimitiveType : uint8_t {
+  TaperedCapsule,
+  Ellipsoid,
+};
 
 /// Tapered capsule collision geometry for character collision detection.
 ///
@@ -67,9 +76,190 @@ struct TaperedCapsuleT {
   }
 };
 
-/// Collection of tapered capsules representing a character's collision geometry.
+/// Ellipsoid collision geometry for character collision detection.
+///
+/// Defined by a transformation and three local-space radii along the primitive's axes.
 template <typename S>
-using CollisionGeometryT = std::vector<TaperedCapsuleT<S>>;
+struct CollisionEllipsoidT {
+  using Scalar = S;
+
+  /// Transformation defining the ellipsoid center and orientation relative to the parent.
+  TransformT<S> transformation;
+
+  /// Radii along the local x, y, and z axes.
+  Vector3<S> radii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  CollisionEllipsoidT()
+      : transformation(TransformT<S>()), radii(Vector3<S>::Zero()), parent(kInvalidIndex) {
+    // Empty
+  }
+
+  /// Checks if the current ellipsoid is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionEllipsoidT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (!radii.isApprox(other.radii, tol)) {
+      return false;
+    }
+
+    return parent == other.parent;
+  }
+};
+
+/// Collision geometry primitive.
+///
+/// The tapered capsule fields are kept directly on the primitive so existing code that
+/// constructs capsule-only collision geometry can continue to initialize `radius`, `length`,
+/// `parent`, and `transformation` on elements of `CollisionGeometry`.
+template <typename S>
+struct CollisionPrimitiveT {
+  using Scalar = S;
+
+  /// Primitive kind.
+  CollisionPrimitiveType type;
+
+  /// Transformation defining the primitive pose relative to the parent coordinate system.
+  TransformT<S> transformation;
+
+  /// Radii at the two endpoints of a tapered capsule.
+  Vector2<S> radius;
+
+  /// Radii along the local axes of an ellipsoid.
+  Vector3<S> ellipsoidRadii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  /// Length of a tapered capsule along the x-axis.
+  S length;
+
+  CollisionPrimitiveT()
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(TransformT<S>()),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(kInvalidIndex),
+        length(S(0)) {
+    // Empty
+  }
+
+  /// Creates a collision primitive from a tapered capsule.
+  /* implicit */ CollisionPrimitiveT(const TaperedCapsuleT<S>& capsule)
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(capsule.transformation),
+        radius(capsule.radius),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(capsule.parent),
+        length(capsule.length) {}
+
+  /// Creates a collision primitive from an ellipsoid.
+  /* implicit */ CollisionPrimitiveT(const CollisionEllipsoidT<S>& ellipsoid)
+      : type(CollisionPrimitiveType::Ellipsoid),
+        transformation(ellipsoid.transformation),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(ellipsoid.radii),
+        parent(ellipsoid.parent),
+        length(S(0)) {}
+
+  /// Assigns tapered capsule data to this primitive.
+  CollisionPrimitiveT& operator=(const TaperedCapsuleT<S>& capsule) {
+    type = CollisionPrimitiveType::TaperedCapsule;
+    transformation = capsule.transformation;
+    radius = capsule.radius;
+    ellipsoidRadii.setZero();
+    parent = capsule.parent;
+    length = capsule.length;
+    return *this;
+  }
+
+  /// Assigns ellipsoid data to this primitive.
+  CollisionPrimitiveT& operator=(const CollisionEllipsoidT<S>& ellipsoid) {
+    type = CollisionPrimitiveType::Ellipsoid;
+    transformation = ellipsoid.transformation;
+    radius.setZero();
+    ellipsoidRadii = ellipsoid.radii;
+    parent = ellipsoid.parent;
+    length = S(0);
+    return *this;
+  }
+
+  /// Returns true when this primitive stores tapered capsule data.
+  [[nodiscard]] bool isTaperedCapsule() const {
+    return type == CollisionPrimitiveType::TaperedCapsule;
+  }
+
+  /// Returns true when this primitive stores ellipsoid data.
+  [[nodiscard]] bool isEllipsoid() const {
+    return type == CollisionPrimitiveType::Ellipsoid;
+  }
+
+  /// Converts this primitive to a tapered capsule.
+  ///
+  /// Requires `isTaperedCapsule()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] TaperedCapsuleT<S> toTaperedCapsule() const {
+    MT_CHECK(
+        isTaperedCapsule(),
+        "Collision primitive type {} does not store tapered capsule data",
+        static_cast<int>(type));
+
+    TaperedCapsuleT<S> capsule;
+    capsule.transformation = transformation;
+    capsule.radius = radius;
+    capsule.parent = parent;
+    capsule.length = length;
+    return capsule;
+  }
+
+  /// Converts this primitive to an ellipsoid.
+  ///
+  /// Requires `isEllipsoid()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] CollisionEllipsoidT<S> toEllipsoid() const {
+    MT_CHECK(
+        isEllipsoid(),
+        "Collision primitive type {} does not store ellipsoid data",
+        static_cast<int>(type));
+
+    CollisionEllipsoidT<S> ellipsoid;
+    ellipsoid.transformation = transformation;
+    ellipsoid.radii = ellipsoidRadii;
+    ellipsoid.parent = parent;
+    return ellipsoid;
+  }
+
+  /// Checks if the current primitive is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionPrimitiveT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (type != other.type || parent != other.parent) {
+      return false;
+    }
+
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (type == CollisionPrimitiveType::TaperedCapsule) {
+      return radius.isApprox(other.radius, tol) && ::momentum::isApprox(length, other.length, tol);
+    }
+
+    if (type == CollisionPrimitiveType::Ellipsoid) {
+      return ellipsoidRadii.isApprox(other.ellipsoidRadii, tol);
+    }
+
+    return false;
+  }
+};
+
+/// Collection of primitives representing a character's collision geometry.
+template <typename S>
+using CollisionGeometryT = std::vector<CollisionPrimitiveT<S>>;
 
 using CollisionGeometry = CollisionGeometryT<float>;
 using CollisionGeometryd = CollisionGeometryT<double>;

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -107,6 +107,25 @@ using CharacterStated_const_u = ::std::unique_ptr<const CharacterStated>;
 using CharacterStated_const_w = ::std::weak_ptr<const CharacterStated>;
 
 template <typename T>
+struct CollisionPrimitiveT;
+using CollisionPrimitive = CollisionPrimitiveT<float>;
+using CollisionPrimitived = CollisionPrimitiveT<double>;
+
+using CollisionPrimitive_p = ::std::shared_ptr<CollisionPrimitive>;
+using CollisionPrimitive_u = ::std::unique_ptr<CollisionPrimitive>;
+using CollisionPrimitive_w = ::std::weak_ptr<CollisionPrimitive>;
+using CollisionPrimitive_const_p = ::std::shared_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_u = ::std::unique_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_w = ::std::weak_ptr<const CollisionPrimitive>;
+
+using CollisionPrimitived_p = ::std::shared_ptr<CollisionPrimitived>;
+using CollisionPrimitived_u = ::std::unique_ptr<CollisionPrimitived>;
+using CollisionPrimitived_w = ::std::weak_ptr<CollisionPrimitived>;
+using CollisionPrimitived_const_p = ::std::shared_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_u = ::std::unique_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_w = ::std::weak_ptr<const CollisionPrimitived>;
+
+template <typename T>
 struct CollisionGeometryStateT;
 using CollisionGeometryState = CollisionGeometryStateT<float>;
 using CollisionGeometryStated = CollisionGeometryStateT<double>;
@@ -124,6 +143,25 @@ using CollisionGeometryStated_w = ::std::weak_ptr<CollisionGeometryStated>;
 using CollisionGeometryStated_const_p = ::std::shared_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_u = ::std::unique_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_w = ::std::weak_ptr<const CollisionGeometryStated>;
+
+template <typename T>
+struct CollisionEllipsoidT;
+using CollisionEllipsoid = CollisionEllipsoidT<float>;
+using CollisionEllipsoidd = CollisionEllipsoidT<double>;
+
+using CollisionEllipsoid_p = ::std::shared_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_u = ::std::unique_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_w = ::std::weak_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_const_p = ::std::shared_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_u = ::std::unique_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_w = ::std::weak_ptr<const CollisionEllipsoid>;
+
+using CollisionEllipsoidd_p = ::std::shared_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_u = ::std::unique_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_w = ::std::weak_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_p = ::std::shared_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_u = ::std::unique_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_w = ::std::weak_ptr<const CollisionEllipsoidd>;
 
 template <typename T>
 struct JointT;

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -31,7 +31,9 @@ structs = [
 ]
 template_structs = [
     "CharacterState",
+    "CollisionPrimitive",
     "CollisionGeometryState",
+    "CollisionEllipsoid",
     "Joint",
     "JointState",
     "ParameterTransform",

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -226,7 +226,13 @@ inline void createCollisionGeometryNodes(
 
   const auto& collisions = *character.collision;
   for (auto i = 0u; i < collisions.size(); ++i) {
-    const TaperedCapsule& collision = collisions[i];
+    const auto& collision = collisions[i];
+    if (!collision.isTaperedCapsule()) {
+      MT_LOGW(
+          "Skipping unsupported collision primitive type {} while writing FBX collision geometry",
+          static_cast<int>(collision.type));
+      continue;
+    }
 
     ::fbxsdk::FbxNode* collisionNode =
         ::fbxsdk::FbxNode::Create(scene, ("Collision " + std::to_string(i)).c_str());

--- a/momentum/io/gltf/gltf_skeleton_io.cpp
+++ b/momentum/io/gltf/gltf_skeleton_io.cpp
@@ -359,12 +359,11 @@ loadHierarchy(const fx::gltf::Document& model) {
   MT_THROW_IF(model.nodes.empty(), "No valid node found in the gltf file.");
   std::string name = model.nodes.at(0).name;
 
-  std::sort(
-      collision->begin(), collision->end(), [](const TaperedCapsule& c1, const TaperedCapsule& c2) {
-        int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
-        int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
-        return c1Parent < c2Parent;
-      });
+  std::sort(collision->begin(), collision->end(), [](const auto& c1, const auto& c2) {
+    int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
+    int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
+    return c1Parent < c2Parent;
+  });
   std::sort(locators.begin(), locators.end(), [](const Locator& l1, const Locator& l2) {
     int l1Parent = l1.parent == kInvalidIndex ? -1 : static_cast<int>(l1.parent);
     int l2Parent = l2.parent == kInvalidIndex ? -1 : static_cast<int>(l2.parent);

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -27,6 +27,18 @@ namespace momentum {
 
 namespace {
 
+template <typename LhsDerived, typename RhsDerived>
+bool lessLexicographic(
+    const Eigen::MatrixBase<LhsDerived>& lhs,
+    const Eigen::MatrixBase<RhsDerived>& rhs) {
+  for (Eigen::Index i = 0; i < lhs.size(); ++i) {
+    if (lhs[i] != rhs[i]) {
+      return lhs[i] < rhs[i];
+    }
+  }
+  return false;
+}
+
 MATCHER_P(FloatNearPointwise, tol, "Value mismatch") {
   for (int i = 0; i < std::get<0>(arg).size(); i++) {
     if (std::abs(std::get<0>(arg)[i] - std::get<1>(arg)[i]) > tol) {
@@ -147,16 +159,27 @@ void compareCollisionGeometry(
     EXPECT_EQ(refCollision->size(), collision->size());
     auto sortedRefCollision = *refCollision;
     auto sortedCollision = *collision;
-    auto compareCollisions = [](const TaperedCapsule& l1, const TaperedCapsule& l2) {
+    auto compareCollisions = [](const auto& l1, const auto& l2) {
       if (l1.parent != l2.parent) {
         return l1.parent < l2.parent;
+      }
+      if (l1.type != l2.type) {
+        return static_cast<int>(l1.type) < static_cast<int>(l2.type);
       }
       if (l1.length != l2.length) {
         return l1.length < l2.length;
       }
-      if (!l1.radius.isApprox(l2.radius)) {
-        return l1.radius.x() != l2.radius.x() ? l1.radius.x() < l2.radius.x()
-                                              : l1.radius.y() < l2.radius.y();
+      if (lessLexicographic(l1.radius, l2.radius)) {
+        return true;
+      }
+      if (lessLexicographic(l2.radius, l1.radius)) {
+        return false;
+      }
+      if (lessLexicographic(l1.ellipsoidRadii, l2.ellipsoidRadii)) {
+        return true;
+      }
+      if (lessLexicographic(l2.ellipsoidRadii, l1.ellipsoidRadii)) {
+        return false;
       }
       const auto t1 = l1.transformation.toMatrix();
       const auto t2 = l2.transformation.toMatrix();
@@ -174,21 +197,26 @@ void compareCollisionGeometry(
       const auto& collA = sortedRefCollision[i];
       const auto& collB = sortedCollision[i];
 
-      EXPECT_TRUE(collA.isApprox(collB)) << "Collision geometry mismatch at index " << i << ":\n"
-                                         << "- refCollision:\n"
-                                         << "  - radius_0 : " << collA.radius.x() << "\n"
-                                         << "  - radius_1 : " << collA.radius.y() << "\n"
-                                         << "  - length   : " << collA.length << "\n"
-                                         << "  - parent   : " << collA.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collA.transformation.toMatrix() << "\n"
-                                         << "- collision:\n"
-                                         << "  - radius_0 : " << collB.radius.x() << "\n"
-                                         << "  - radius_1 : " << collB.radius.y() << "\n"
-                                         << "  - length   : " << collB.length << "\n"
-                                         << "  - parent   : " << collB.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collB.transformation.toMatrix() << std::endl;
+      EXPECT_TRUE(collA.isApprox(collB))
+          << "Collision geometry mismatch at index " << i << ":\n"
+          << "- refCollision:\n"
+          << "  - type     : " << static_cast<int>(collA.type) << "\n"
+          << "  - radius_0 : " << collA.radius.x() << "\n"
+          << "  - radius_1 : " << collA.radius.y() << "\n"
+          << "  - radii    : " << collA.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collA.length << "\n"
+          << "  - parent   : " << collA.parent << "\n"
+          << "  - transform:\n"
+          << collA.transformation.toMatrix() << "\n"
+          << "- collision:\n"
+          << "  - type     : " << static_cast<int>(collB.type) << "\n"
+          << "  - radius_0 : " << collB.radius.x() << "\n"
+          << "  - radius_1 : " << collB.radius.y() << "\n"
+          << "  - radii    : " << collB.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collB.length << "\n"
+          << "  - parent   : " << collB.parent << "\n"
+          << "  - transform:\n"
+          << collB.transformation.toMatrix() << std::endl;
     }
   }
 }

--- a/momentum/test/character/collision_geometry_test.cpp
+++ b/momentum/test/character/collision_geometry_test.cpp
@@ -29,6 +29,19 @@ TEST(CollisionGeometryTest, DefaultConstructor) {
   EXPECT_TRUE(capsuleDouble.radius.isApprox(Vector2<double>::Zero()));
   EXPECT_EQ(capsuleDouble.parent, kInvalidIndex);
   EXPECT_DOUBLE_EQ(capsuleDouble.length, 0.0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  EXPECT_TRUE(ellipsoidFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(ellipsoidFloat.radii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(ellipsoidFloat.parent, kInvalidIndex);
+
+  CollisionPrimitiveT<float> primitiveFloat;
+  EXPECT_EQ(primitiveFloat.type, CollisionPrimitiveType::TaperedCapsule);
+  EXPECT_TRUE(primitiveFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(primitiveFloat.radius.isApprox(Vector2<float>::Zero()));
+  EXPECT_TRUE(primitiveFloat.ellipsoidRadii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(primitiveFloat.parent, kInvalidIndex);
+  EXPECT_FLOAT_EQ(primitiveFloat.length, 0.0f);
 }
 
 // Test the isApprox method of TaperedCapsuleT
@@ -66,6 +79,25 @@ TEST(CollisionGeometryTest, IsApprox) {
       capsule1.isApprox(capsule2, 1e-4f)); // Should be approximately equal with this tolerance
   EXPECT_FALSE(
       capsule1.isApprox(capsule2, 1e-6f)); // Should not be approximately equal with this tolerance
+
+  CollisionEllipsoidT<float> ellipsoid1;
+  CollisionEllipsoidT<float> ellipsoid2;
+  EXPECT_TRUE(ellipsoid1.isApprox(ellipsoid2));
+
+  ellipsoid2.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  EXPECT_FALSE(ellipsoid1.isApprox(ellipsoid2));
+
+  CollisionPrimitiveT<float> primitive1(capsule1);
+  CollisionPrimitiveT<float> primitive2(capsule1);
+  EXPECT_TRUE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive1.isTaperedCapsule());
+  EXPECT_FALSE(primitive1.isEllipsoid());
+  EXPECT_TRUE(primitive1.toTaperedCapsule().isApprox(capsule1));
+
+  primitive2 = ellipsoid2;
+  EXPECT_FALSE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive2.isEllipsoid());
+  EXPECT_TRUE(primitive2.toEllipsoid().isApprox(ellipsoid2));
 }
 
 // Test the CollisionGeometryT type alias
@@ -85,6 +117,16 @@ TEST(CollisionGeometryTest, CollisionGeometryT) {
   EXPECT_TRUE(collisionGeometryFloat[0].radius.isApprox(Vector2<float>(1.0f, 2.0f)));
   EXPECT_FLOAT_EQ(collisionGeometryFloat[0].length, 3.0f);
   EXPECT_EQ(collisionGeometryFloat[0].parent, 0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  ellipsoidFloat.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  ellipsoidFloat.parent = 1;
+  collisionGeometryFloat.push_back(ellipsoidFloat);
+
+  EXPECT_EQ(collisionGeometryFloat.size(), 2);
+  EXPECT_TRUE(collisionGeometryFloat[1].isEllipsoid());
+  EXPECT_TRUE(collisionGeometryFloat[1].ellipsoidRadii.isApprox(Vector3<float>(1.0f, 2.0f, 3.0f)));
+  EXPECT_EQ(collisionGeometryFloat[1].parent, 1);
 
   // Create a collision geometry with double precision
   CollisionGeometryT<double> collisionGeometryDouble;

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -58,6 +58,26 @@ mm::Character withBlendShapeImpl(
   return c.withBlendShape(blendShapePtr, nShapes < 0 ? INT_MAX : nShapes);
 }
 
+std::vector<mm::TaperedCapsule> collisionGeometryToPython(
+    const mm::CollisionGeometry& collisionGeometry) {
+  std::vector<mm::TaperedCapsule> result;
+  result.reserve(collisionGeometry.size());
+  for (const auto& primitive : collisionGeometry) {
+    if (!primitive.isTaperedCapsule()) {
+      MT_THROW(
+          "Collision geometry contains unsupported primitive type for capsule-only Python binding: {}",
+          static_cast<int>(primitive.type));
+    }
+    result.push_back(primitive.toTaperedCapsule());
+  }
+  return result;
+}
+
+mm::CollisionGeometry collisionGeometryFromPython(
+    const std::vector<mm::TaperedCapsule>& collisionGeometry) {
+  return {collisionGeometry.begin(), collisionGeometry.end()};
+}
+
 } // namespace
 
 namespace pymomentum {
@@ -369,12 +389,11 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           ":return: The character's :class:`BlendShapeBase` basis, if present, or None.")
       .def_property_readonly(
           "collision_geometry",
-          [](const mm::Character& c) -> mm::CollisionGeometry {
+          [](const mm::Character& c) -> std::vector<mm::TaperedCapsule> {
             if (c.collision) {
-              return *c.collision;
-            } else {
-              return {};
+              return collisionGeometryToPython(*c.collision);
             }
+            return {};
           },
           ":return: A list of :class:`TaperedCapsule` representing the character's collision geometry.")
       .def(
@@ -407,6 +426,7 @@ It can be used to solve for facial expressions.
       .def(
           "with_collision_geometry",
           [](const mm::Character& c, const std::vector<mm::TaperedCapsule>& collision_geometry) {
+            const mm::CollisionGeometry geometry = collisionGeometryFromPython(collision_geometry);
             return mm::Character(
                 c.skeleton,
                 c.parameterTransform,
@@ -414,7 +434,7 @@ It can be used to solve for facial expressions.
                 c.locators,
                 c.mesh.get(),
                 c.skinWeights.get(),
-                &collision_geometry,
+                &geometry,
                 c.poseShapes.get(),
                 c.blendShape,
                 c.faceExpressionBlendShape,


### PR DESCRIPTION
Summary: Introduce the unified `CollisionPrimitive` type and `CollisionPrimitiveType` enum (`TaperedCapsule`, `Ellipsoid`), add the `CollisionEllipsoid` primitive with conversion helpers (`toTaperedCapsule`/`toEllipsoid`) and generated forward declarations, and migrate `CollisionGeometry` to store `CollisionPrimitive`. Updates the callers affected by the type change: `character_utility` `mapParents`, glTF/FBX collision serialization, the pymomentum `character_pybind` collision-geometry binding, and a downstream `MomentumUtils` body-tracking consumer. Adds focused primitive unit tests.

Reviewed By: cstollmeta

Differential Revision: D105192539


