### PR TITLE
Expose collision ellipsoids in pymomentum

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -637,12 +637,12 @@ Character replaceSkeletonHierarchy(
   if (tgtCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*tgtCharacter.collision, tgtToCombinedJoints));
+        mapParents<CollisionPrimitive>(*tgtCharacter.collision, tgtToCombinedJoints));
   }
   if (srcCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*srcCharacter.collision, srcToCombinedJoints));
+        mapParents<CollisionPrimitive>(*srcCharacter.collision, srcToCombinedJoints));
   }
 
   // Build the merged parameter transform:
@@ -807,7 +807,8 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
 
   CollisionGeometry resultCollisionGeometry;
   if (character.collision) {
-    resultCollisionGeometry = mapParents<TaperedCapsule>(*character.collision, srcToResultJoints);
+    resultCollisionGeometry =
+        mapParents<CollisionPrimitive>(*character.collision, srcToResultJoints);
   }
 
   const ParameterLimits resultParameterLimits =

--- a/momentum/character/collision_geometry.h
+++ b/momentum/character/collision_geometry.h
@@ -8,12 +8,21 @@
 #pragma once
 
 #include <momentum/character/types.h>
+#include <momentum/common/checks.h>
 #include <momentum/common/memory.h>
 #include <momentum/math/constants.h>
 #include <momentum/math/transform.h>
 #include <momentum/math/utility.h>
 
+#include <cstdint>
+
 namespace momentum {
+
+/// Collision primitive kinds supported by character collision geometry.
+enum class CollisionPrimitiveType : uint8_t {
+  TaperedCapsule,
+  Ellipsoid,
+};
 
 /// Tapered capsule collision geometry for character collision detection.
 ///
@@ -67,9 +76,190 @@ struct TaperedCapsuleT {
   }
 };
 
-/// Collection of tapered capsules representing a character's collision geometry.
+/// Ellipsoid collision geometry for character collision detection.
+///
+/// Defined by a transformation and three local-space radii along the primitive's axes.
 template <typename S>
-using CollisionGeometryT = std::vector<TaperedCapsuleT<S>>;
+struct CollisionEllipsoidT {
+  using Scalar = S;
+
+  /// Transformation defining the ellipsoid center and orientation relative to the parent.
+  TransformT<S> transformation;
+
+  /// Radii along the local x, y, and z axes.
+  Vector3<S> radii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  CollisionEllipsoidT()
+      : transformation(TransformT<S>()), radii(Vector3<S>::Zero()), parent(kInvalidIndex) {
+    // Empty
+  }
+
+  /// Checks if the current ellipsoid is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionEllipsoidT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (!radii.isApprox(other.radii, tol)) {
+      return false;
+    }
+
+    return parent == other.parent;
+  }
+};
+
+/// Collision geometry primitive.
+///
+/// The tapered capsule fields are kept directly on the primitive so existing code that
+/// constructs capsule-only collision geometry can continue to initialize `radius`, `length`,
+/// `parent`, and `transformation` on elements of `CollisionGeometry`.
+template <typename S>
+struct CollisionPrimitiveT {
+  using Scalar = S;
+
+  /// Primitive kind.
+  CollisionPrimitiveType type;
+
+  /// Transformation defining the primitive pose relative to the parent coordinate system.
+  TransformT<S> transformation;
+
+  /// Radii at the two endpoints of a tapered capsule.
+  Vector2<S> radius;
+
+  /// Radii along the local axes of an ellipsoid.
+  Vector3<S> ellipsoidRadii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  /// Length of a tapered capsule along the x-axis.
+  S length;
+
+  CollisionPrimitiveT()
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(TransformT<S>()),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(kInvalidIndex),
+        length(S(0)) {
+    // Empty
+  }
+
+  /// Creates a collision primitive from a tapered capsule.
+  /* implicit */ CollisionPrimitiveT(const TaperedCapsuleT<S>& capsule)
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(capsule.transformation),
+        radius(capsule.radius),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(capsule.parent),
+        length(capsule.length) {}
+
+  /// Creates a collision primitive from an ellipsoid.
+  /* implicit */ CollisionPrimitiveT(const CollisionEllipsoidT<S>& ellipsoid)
+      : type(CollisionPrimitiveType::Ellipsoid),
+        transformation(ellipsoid.transformation),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(ellipsoid.radii),
+        parent(ellipsoid.parent),
+        length(S(0)) {}
+
+  /// Assigns tapered capsule data to this primitive.
+  CollisionPrimitiveT& operator=(const TaperedCapsuleT<S>& capsule) {
+    type = CollisionPrimitiveType::TaperedCapsule;
+    transformation = capsule.transformation;
+    radius = capsule.radius;
+    ellipsoidRadii.setZero();
+    parent = capsule.parent;
+    length = capsule.length;
+    return *this;
+  }
+
+  /// Assigns ellipsoid data to this primitive.
+  CollisionPrimitiveT& operator=(const CollisionEllipsoidT<S>& ellipsoid) {
+    type = CollisionPrimitiveType::Ellipsoid;
+    transformation = ellipsoid.transformation;
+    radius.setZero();
+    ellipsoidRadii = ellipsoid.radii;
+    parent = ellipsoid.parent;
+    length = S(0);
+    return *this;
+  }
+
+  /// Returns true when this primitive stores tapered capsule data.
+  [[nodiscard]] bool isTaperedCapsule() const {
+    return type == CollisionPrimitiveType::TaperedCapsule;
+  }
+
+  /// Returns true when this primitive stores ellipsoid data.
+  [[nodiscard]] bool isEllipsoid() const {
+    return type == CollisionPrimitiveType::Ellipsoid;
+  }
+
+  /// Converts this primitive to a tapered capsule.
+  ///
+  /// Requires `isTaperedCapsule()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] TaperedCapsuleT<S> toTaperedCapsule() const {
+    MT_CHECK(
+        isTaperedCapsule(),
+        "Collision primitive type {} does not store tapered capsule data",
+        static_cast<int>(type));
+
+    TaperedCapsuleT<S> capsule;
+    capsule.transformation = transformation;
+    capsule.radius = radius;
+    capsule.parent = parent;
+    capsule.length = length;
+    return capsule;
+  }
+
+  /// Converts this primitive to an ellipsoid.
+  ///
+  /// Requires `isEllipsoid()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] CollisionEllipsoidT<S> toEllipsoid() const {
+    MT_CHECK(
+        isEllipsoid(),
+        "Collision primitive type {} does not store ellipsoid data",
+        static_cast<int>(type));
+
+    CollisionEllipsoidT<S> ellipsoid;
+    ellipsoid.transformation = transformation;
+    ellipsoid.radii = ellipsoidRadii;
+    ellipsoid.parent = parent;
+    return ellipsoid;
+  }
+
+  /// Checks if the current primitive is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionPrimitiveT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (type != other.type || parent != other.parent) {
+      return false;
+    }
+
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (type == CollisionPrimitiveType::TaperedCapsule) {
+      return radius.isApprox(other.radius, tol) && ::momentum::isApprox(length, other.length, tol);
+    }
+
+    if (type == CollisionPrimitiveType::Ellipsoid) {
+      return ellipsoidRadii.isApprox(other.ellipsoidRadii, tol);
+    }
+
+    return false;
+  }
+};
+
+/// Collection of primitives representing a character's collision geometry.
+template <typename S>
+using CollisionGeometryT = std::vector<CollisionPrimitiveT<S>>;
 
 using CollisionGeometry = CollisionGeometryT<float>;
 using CollisionGeometryd = CollisionGeometryT<double>;

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -107,6 +107,25 @@ using CharacterStated_const_u = ::std::unique_ptr<const CharacterStated>;
 using CharacterStated_const_w = ::std::weak_ptr<const CharacterStated>;
 
 template <typename T>
+struct CollisionPrimitiveT;
+using CollisionPrimitive = CollisionPrimitiveT<float>;
+using CollisionPrimitived = CollisionPrimitiveT<double>;
+
+using CollisionPrimitive_p = ::std::shared_ptr<CollisionPrimitive>;
+using CollisionPrimitive_u = ::std::unique_ptr<CollisionPrimitive>;
+using CollisionPrimitive_w = ::std::weak_ptr<CollisionPrimitive>;
+using CollisionPrimitive_const_p = ::std::shared_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_u = ::std::unique_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_w = ::std::weak_ptr<const CollisionPrimitive>;
+
+using CollisionPrimitived_p = ::std::shared_ptr<CollisionPrimitived>;
+using CollisionPrimitived_u = ::std::unique_ptr<CollisionPrimitived>;
+using CollisionPrimitived_w = ::std::weak_ptr<CollisionPrimitived>;
+using CollisionPrimitived_const_p = ::std::shared_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_u = ::std::unique_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_w = ::std::weak_ptr<const CollisionPrimitived>;
+
+template <typename T>
 struct CollisionGeometryStateT;
 using CollisionGeometryState = CollisionGeometryStateT<float>;
 using CollisionGeometryStated = CollisionGeometryStateT<double>;
@@ -124,6 +143,25 @@ using CollisionGeometryStated_w = ::std::weak_ptr<CollisionGeometryStated>;
 using CollisionGeometryStated_const_p = ::std::shared_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_u = ::std::unique_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_w = ::std::weak_ptr<const CollisionGeometryStated>;
+
+template <typename T>
+struct CollisionEllipsoidT;
+using CollisionEllipsoid = CollisionEllipsoidT<float>;
+using CollisionEllipsoidd = CollisionEllipsoidT<double>;
+
+using CollisionEllipsoid_p = ::std::shared_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_u = ::std::unique_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_w = ::std::weak_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_const_p = ::std::shared_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_u = ::std::unique_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_w = ::std::weak_ptr<const CollisionEllipsoid>;
+
+using CollisionEllipsoidd_p = ::std::shared_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_u = ::std::unique_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_w = ::std::weak_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_p = ::std::shared_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_u = ::std::unique_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_w = ::std::weak_ptr<const CollisionEllipsoidd>;
 
 template <typename T>
 struct JointT;

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -31,7 +31,9 @@ structs = [
 ]
 template_structs = [
     "CharacterState",
+    "CollisionPrimitive",
     "CollisionGeometryState",
+    "CollisionEllipsoid",
     "Joint",
     "JointState",
     "ParameterTransform",

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -226,7 +226,13 @@ inline void createCollisionGeometryNodes(
 
   const auto& collisions = *character.collision;
   for (auto i = 0u; i < collisions.size(); ++i) {
-    const TaperedCapsule& collision = collisions[i];
+    const auto& collision = collisions[i];
+    if (!collision.isTaperedCapsule()) {
+      MT_LOGW(
+          "Skipping unsupported collision primitive type {} while writing FBX collision geometry",
+          static_cast<int>(collision.type));
+      continue;
+    }
 
     ::fbxsdk::FbxNode* collisionNode =
         ::fbxsdk::FbxNode::Create(scene, ("Collision " + std::to_string(i)).c_str());

--- a/momentum/io/gltf/gltf_skeleton_io.cpp
+++ b/momentum/io/gltf/gltf_skeleton_io.cpp
@@ -359,12 +359,11 @@ loadHierarchy(const fx::gltf::Document& model) {
   MT_THROW_IF(model.nodes.empty(), "No valid node found in the gltf file.");
   std::string name = model.nodes.at(0).name;
 
-  std::sort(
-      collision->begin(), collision->end(), [](const TaperedCapsule& c1, const TaperedCapsule& c2) {
-        int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
-        int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
-        return c1Parent < c2Parent;
-      });
+  std::sort(collision->begin(), collision->end(), [](const auto& c1, const auto& c2) {
+    int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
+    int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
+    return c1Parent < c2Parent;
+  });
   std::sort(locators.begin(), locators.end(), [](const Locator& l1, const Locator& l2) {
     int l1Parent = l1.parent == kInvalidIndex ? -1 : static_cast<int>(l1.parent);
     int l2Parent = l2.parent == kInvalidIndex ? -1 : static_cast<int>(l2.parent);

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -27,6 +27,18 @@ namespace momentum {
 
 namespace {
 
+template <typename LhsDerived, typename RhsDerived>
+bool lessLexicographic(
+    const Eigen::MatrixBase<LhsDerived>& lhs,
+    const Eigen::MatrixBase<RhsDerived>& rhs) {
+  for (Eigen::Index i = 0; i < lhs.size(); ++i) {
+    if (lhs[i] != rhs[i]) {
+      return lhs[i] < rhs[i];
+    }
+  }
+  return false;
+}
+
 MATCHER_P(FloatNearPointwise, tol, "Value mismatch") {
   for (int i = 0; i < std::get<0>(arg).size(); i++) {
     if (std::abs(std::get<0>(arg)[i] - std::get<1>(arg)[i]) > tol) {
@@ -147,16 +159,27 @@ void compareCollisionGeometry(
     EXPECT_EQ(refCollision->size(), collision->size());
     auto sortedRefCollision = *refCollision;
     auto sortedCollision = *collision;
-    auto compareCollisions = [](const TaperedCapsule& l1, const TaperedCapsule& l2) {
+    auto compareCollisions = [](const auto& l1, const auto& l2) {
       if (l1.parent != l2.parent) {
         return l1.parent < l2.parent;
+      }
+      if (l1.type != l2.type) {
+        return static_cast<int>(l1.type) < static_cast<int>(l2.type);
       }
       if (l1.length != l2.length) {
         return l1.length < l2.length;
       }
-      if (!l1.radius.isApprox(l2.radius)) {
-        return l1.radius.x() != l2.radius.x() ? l1.radius.x() < l2.radius.x()
-                                              : l1.radius.y() < l2.radius.y();
+      if (lessLexicographic(l1.radius, l2.radius)) {
+        return true;
+      }
+      if (lessLexicographic(l2.radius, l1.radius)) {
+        return false;
+      }
+      if (lessLexicographic(l1.ellipsoidRadii, l2.ellipsoidRadii)) {
+        return true;
+      }
+      if (lessLexicographic(l2.ellipsoidRadii, l1.ellipsoidRadii)) {
+        return false;
       }
       const auto t1 = l1.transformation.toMatrix();
       const auto t2 = l2.transformation.toMatrix();
@@ -174,21 +197,26 @@ void compareCollisionGeometry(
       const auto& collA = sortedRefCollision[i];
       const auto& collB = sortedCollision[i];
 
-      EXPECT_TRUE(collA.isApprox(collB)) << "Collision geometry mismatch at index " << i << ":\n"
-                                         << "- refCollision:\n"
-                                         << "  - radius_0 : " << collA.radius.x() << "\n"
-                                         << "  - radius_1 : " << collA.radius.y() << "\n"
-                                         << "  - length   : " << collA.length << "\n"
-                                         << "  - parent   : " << collA.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collA.transformation.toMatrix() << "\n"
-                                         << "- collision:\n"
-                                         << "  - radius_0 : " << collB.radius.x() << "\n"
-                                         << "  - radius_1 : " << collB.radius.y() << "\n"
-                                         << "  - length   : " << collB.length << "\n"
-                                         << "  - parent   : " << collB.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collB.transformation.toMatrix() << std::endl;
+      EXPECT_TRUE(collA.isApprox(collB))
+          << "Collision geometry mismatch at index " << i << ":\n"
+          << "- refCollision:\n"
+          << "  - type     : " << static_cast<int>(collA.type) << "\n"
+          << "  - radius_0 : " << collA.radius.x() << "\n"
+          << "  - radius_1 : " << collA.radius.y() << "\n"
+          << "  - radii    : " << collA.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collA.length << "\n"
+          << "  - parent   : " << collA.parent << "\n"
+          << "  - transform:\n"
+          << collA.transformation.toMatrix() << "\n"
+          << "- collision:\n"
+          << "  - type     : " << static_cast<int>(collB.type) << "\n"
+          << "  - radius_0 : " << collB.radius.x() << "\n"
+          << "  - radius_1 : " << collB.radius.y() << "\n"
+          << "  - radii    : " << collB.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collB.length << "\n"
+          << "  - parent   : " << collB.parent << "\n"
+          << "  - transform:\n"
+          << collB.transformation.toMatrix() << std::endl;
     }
   }
 }

--- a/momentum/test/character/collision_geometry_test.cpp
+++ b/momentum/test/character/collision_geometry_test.cpp
@@ -29,6 +29,19 @@ TEST(CollisionGeometryTest, DefaultConstructor) {
   EXPECT_TRUE(capsuleDouble.radius.isApprox(Vector2<double>::Zero()));
   EXPECT_EQ(capsuleDouble.parent, kInvalidIndex);
   EXPECT_DOUBLE_EQ(capsuleDouble.length, 0.0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  EXPECT_TRUE(ellipsoidFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(ellipsoidFloat.radii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(ellipsoidFloat.parent, kInvalidIndex);
+
+  CollisionPrimitiveT<float> primitiveFloat;
+  EXPECT_EQ(primitiveFloat.type, CollisionPrimitiveType::TaperedCapsule);
+  EXPECT_TRUE(primitiveFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(primitiveFloat.radius.isApprox(Vector2<float>::Zero()));
+  EXPECT_TRUE(primitiveFloat.ellipsoidRadii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(primitiveFloat.parent, kInvalidIndex);
+  EXPECT_FLOAT_EQ(primitiveFloat.length, 0.0f);
 }
 
 // Test the isApprox method of TaperedCapsuleT
@@ -66,6 +79,25 @@ TEST(CollisionGeometryTest, IsApprox) {
       capsule1.isApprox(capsule2, 1e-4f)); // Should be approximately equal with this tolerance
   EXPECT_FALSE(
       capsule1.isApprox(capsule2, 1e-6f)); // Should not be approximately equal with this tolerance
+
+  CollisionEllipsoidT<float> ellipsoid1;
+  CollisionEllipsoidT<float> ellipsoid2;
+  EXPECT_TRUE(ellipsoid1.isApprox(ellipsoid2));
+
+  ellipsoid2.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  EXPECT_FALSE(ellipsoid1.isApprox(ellipsoid2));
+
+  CollisionPrimitiveT<float> primitive1(capsule1);
+  CollisionPrimitiveT<float> primitive2(capsule1);
+  EXPECT_TRUE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive1.isTaperedCapsule());
+  EXPECT_FALSE(primitive1.isEllipsoid());
+  EXPECT_TRUE(primitive1.toTaperedCapsule().isApprox(capsule1));
+
+  primitive2 = ellipsoid2;
+  EXPECT_FALSE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive2.isEllipsoid());
+  EXPECT_TRUE(primitive2.toEllipsoid().isApprox(ellipsoid2));
 }
 
 // Test the CollisionGeometryT type alias
@@ -85,6 +117,16 @@ TEST(CollisionGeometryTest, CollisionGeometryT) {
   EXPECT_TRUE(collisionGeometryFloat[0].radius.isApprox(Vector2<float>(1.0f, 2.0f)));
   EXPECT_FLOAT_EQ(collisionGeometryFloat[0].length, 3.0f);
   EXPECT_EQ(collisionGeometryFloat[0].parent, 0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  ellipsoidFloat.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  ellipsoidFloat.parent = 1;
+  collisionGeometryFloat.push_back(ellipsoidFloat);
+
+  EXPECT_EQ(collisionGeometryFloat.size(), 2);
+  EXPECT_TRUE(collisionGeometryFloat[1].isEllipsoid());
+  EXPECT_TRUE(collisionGeometryFloat[1].ellipsoidRadii.isApprox(Vector3<float>(1.0f, 2.0f, 3.0f)));
+  EXPECT_EQ(collisionGeometryFloat[1].parent, 1);
 
   // Create a collision geometry with double precision
   CollisionGeometryT<double> collisionGeometryDouble;

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -58,6 +58,26 @@ mm::Character withBlendShapeImpl(
   return c.withBlendShape(blendShapePtr, nShapes < 0 ? INT_MAX : nShapes);
 }
 
+std::vector<mm::TaperedCapsule> collisionGeometryToPython(
+    const mm::CollisionGeometry& collisionGeometry) {
+  std::vector<mm::TaperedCapsule> result;
+  result.reserve(collisionGeometry.size());
+  for (const auto& primitive : collisionGeometry) {
+    if (!primitive.isTaperedCapsule()) {
+      MT_THROW(
+          "Collision geometry contains unsupported primitive type for capsule-only Python binding: {}",
+          static_cast<int>(primitive.type));
+    }
+    result.push_back(primitive.toTaperedCapsule());
+  }
+  return result;
+}
+
+mm::CollisionGeometry collisionGeometryFromPython(
+    const std::vector<mm::TaperedCapsule>& collisionGeometry) {
+  return {collisionGeometry.begin(), collisionGeometry.end()};
+}
+
 } // namespace
 
 namespace pymomentum {
@@ -369,12 +389,11 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           ":return: The character's :class:`BlendShapeBase` basis, if present, or None.")
       .def_property_readonly(
           "collision_geometry",
-          [](const mm::Character& c) -> mm::CollisionGeometry {
+          [](const mm::Character& c) -> std::vector<mm::TaperedCapsule> {
             if (c.collision) {
-              return *c.collision;
-            } else {
-              return {};
+              return collisionGeometryToPython(*c.collision);
             }
+            return {};
           },
           ":return: A list of :class:`TaperedCapsule` representing the character's collision geometry.")
       .def(
@@ -407,6 +426,7 @@ It can be used to solve for facial expressions.
       .def(
           "with_collision_geometry",
           [](const mm::Character& c, const std::vector<mm::TaperedCapsule>& collision_geometry) {
+            const mm::CollisionGeometry geometry = collisionGeometryFromPython(collision_geometry);
             return mm::Character(
                 c.skeleton,
                 c.parameterTransform,
@@ -414,7 +434,7 @@ It can be used to solve for facial expressions.
                 c.locators,
                 c.mesh.get(),
                 c.skinWeights.get(),
-                &collision_geometry,
+                &geometry,
                 c.poseShapes.get(),
                 c.blendShape,
                 c.faceExpressionBlendShape,

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -15,6 +15,7 @@
 #include <momentum/character/blend_shape.h>
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>
+#include <momentum/character/collision_geometry.h>
 #include <momentum/character/skeleton.h>
 #include <momentum/character/skeleton_state.h>
 #include <momentum/io/fbx/fbx_io.h>
@@ -35,6 +36,7 @@
 #include <fmt/format.h>
 
 namespace mm = momentum;
+namespace py = pybind11;
 
 namespace {
 
@@ -58,24 +60,37 @@ mm::Character withBlendShapeImpl(
   return c.withBlendShape(blendShapePtr, nShapes < 0 ? INT_MAX : nShapes);
 }
 
-std::vector<mm::TaperedCapsule> collisionGeometryToPython(
-    const mm::CollisionGeometry& collisionGeometry) {
-  std::vector<mm::TaperedCapsule> result;
-  result.reserve(collisionGeometry.size());
+py::list collisionGeometryToPython(const mm::CollisionGeometry& collisionGeometry) {
+  py::list result;
   for (const auto& primitive : collisionGeometry) {
-    if (!primitive.isTaperedCapsule()) {
+    if (primitive.type == mm::CollisionPrimitiveType::TaperedCapsule) {
+      result.append(py::cast(primitive.toTaperedCapsule()));
+    } else if (primitive.type == mm::CollisionPrimitiveType::Ellipsoid) {
+      result.append(py::cast(primitive.toEllipsoid()));
+    } else {
       MT_THROW(
-          "Collision geometry contains unsupported primitive type for capsule-only Python binding: {}",
+          "Unsupported collision primitive type while converting collision geometry to Python: {}",
           static_cast<int>(primitive.type));
     }
-    result.push_back(primitive.toTaperedCapsule());
   }
   return result;
 }
 
-mm::CollisionGeometry collisionGeometryFromPython(
-    const std::vector<mm::TaperedCapsule>& collisionGeometry) {
-  return {collisionGeometry.begin(), collisionGeometry.end()};
+mm::CollisionGeometry collisionGeometryFromPython(const py::sequence& collisionGeometry) {
+  mm::CollisionGeometry result;
+  result.reserve(collisionGeometry.size());
+  for (const py::handle item : collisionGeometry) {
+    if (py::isinstance<mm::TaperedCapsule>(item)) {
+      result.push_back(item.cast<mm::TaperedCapsule>());
+    } else if (py::isinstance<mm::CollisionEllipsoid>(item)) {
+      result.push_back(item.cast<mm::CollisionEllipsoid>());
+    } else {
+      MT_THROW(
+          "Collision geometry entries must be TaperedCapsule or Ellipsoid; got {}",
+          py::str(py::type::handle_of(item)).cast<std::string>());
+    }
+  }
+  return result;
 }
 
 } // namespace
@@ -389,13 +404,14 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           ":return: The character's :class:`BlendShapeBase` basis, if present, or None.")
       .def_property_readonly(
           "collision_geometry",
-          [](const mm::Character& c) -> std::vector<mm::TaperedCapsule> {
+          [](const mm::Character& c) -> py::list {
             if (c.collision) {
               return collisionGeometryToPython(*c.collision);
+            } else {
+              return py::list();
             }
-            return {};
           },
-          ":return: A list of :class:`TaperedCapsule` representing the character's collision geometry.")
+          ":return: A list of :class:`TaperedCapsule` and :class:`Ellipsoid` objects representing the character's collision geometry.")
       .def(
           "with_blend_shape",
           &withBlendShapeImpl,
@@ -425,8 +441,9 @@ It can be used to solve for facial expressions.
           py::arg("n_shapes") = -1)
       .def(
           "with_collision_geometry",
-          [](const mm::Character& c, const std::vector<mm::TaperedCapsule>& collision_geometry) {
-            const mm::CollisionGeometry geometry = collisionGeometryFromPython(collision_geometry);
+          [](const mm::Character& c, const py::sequence& collision_geometry) {
+            const mm::CollisionGeometry collisionGeometry =
+                collisionGeometryFromPython(collision_geometry);
             return mm::Character(
                 c.skeleton,
                 c.parameterTransform,
@@ -434,7 +451,7 @@ It can be used to solve for facial expressions.
                 c.locators,
                 c.mesh.get(),
                 c.skinWeights.get(),
-                &geometry,
+                &collisionGeometry,
                 c.poseShapes.get(),
                 c.blendShape,
                 c.faceExpressionBlendShape,

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -31,6 +31,7 @@
 #include <momentum/character/blend_shape.h>
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>
+#include <momentum/character/collision_geometry.h>
 #include <momentum/character/fwd.h>
 #include <momentum/character/inverse_parameter_transform.h>
 #include <momentum/character/joint.h>
@@ -50,6 +51,7 @@
 #include <momentum/math/mesh.h>
 #include <momentum/math/mppca.h>
 #include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <Eigen/Core>
@@ -63,6 +65,44 @@ namespace py = pybind11;
 namespace mm = momentum;
 
 using namespace pymomentum;
+
+namespace {
+
+using OptionalTransformArray =
+    std::optional<py::array_t<float, py::array::c_style | py::array::forcecast>>;
+
+Eigen::Matrix4f collisionTransformFromPython(const OptionalTransformArray& transformation) {
+  if (!transformation.has_value()) {
+    return Eigen::Matrix4f::Identity();
+  }
+
+  const auto& array = transformation.value();
+  MT_THROW_IF(
+      array.ndim() != 2 || array.shape(0) != 4 || array.shape(1) != 4,
+      "Expected collision primitive transformation to have shape (4, 4)");
+
+  Eigen::Matrix4f matrix;
+  const auto values = array.unchecked<2>();
+  for (Eigen::Index row = 0; row < 4; ++row) {
+    for (Eigen::Index col = 0; col < 4; ++col) {
+      matrix(row, col) = values(row, col);
+    }
+  }
+  return matrix;
+}
+
+int collisionParentToPython(size_t parent) {
+  if (parent == mm::kInvalidIndex) {
+    return -1;
+  }
+  MT_THROW_IF(
+      parent > static_cast<size_t>(std::numeric_limits<int>::max()),
+      "Collision primitive parent index {} cannot be represented as a Python int",
+      parent);
+  return static_cast<int>(parent);
+}
+
+} // namespace
 
 PYBIND11_MODULE(geometry, m) {
   // TODO more explanation
@@ -178,6 +218,11 @@ PYBIND11_MODULE(geometry, m) {
       "TaperedCapsule",
       "A tapered capsule primitive used for collision detection and physics simulation. "
       "Represents a capsule with potentially different radii at each end, attached to a skeleton joint.");
+  auto ellipsoidClass = py::class_<mm::CollisionEllipsoid>(
+      m,
+      "Ellipsoid",
+      "An ellipsoid primitive used for collision detection and physics simulation. "
+      "Represents an oriented ellipsoid attached to a skeleton joint.");
   py::class_<mm::SDFColliderT<float>> sdfColliderClass = py::class_<mm::SDFColliderT<float>>(
       m,
       "SDFCollider",
@@ -428,11 +473,11 @@ The resulting arrays are as follows:
   capsuleClass
       .def(
           py::init<>([](int parent,
-                        const std::optional<Eigen::Matrix4f>& transformation,
+                        const OptionalTransformArray& transformation,
                         const std::optional<Eigen::Vector2f>& radius,
                         float length) {
             mm::TaperedCapsule capsule;
-            capsule.transformation = transformation.value_or(Eigen::Matrix4f::Identity());
+            capsule.transformation = collisionTransformFromPython(transformation);
             capsule.radius = radius.value_or(Eigen::Vector2f::Ones());
             capsule.parent = parent;
             capsule.length = length;
@@ -445,7 +490,7 @@ The resulting arrays are as follows:
 :param parent: Parent joint to which the capsule is attached.
 :param length: Length of the capsule in local space.)",
           py::arg("parent"),
-          py::arg("transformation") = std::optional<Eigen::Matrix4f>{},
+          py::arg("transformation") = py::none(),
           py::arg("radius") = std::optional<Eigen::Vector2f>{},
           py::arg("length") = 1.0f)
       .def_property_readonly(
@@ -460,14 +505,16 @@ The resulting arrays are as follows:
           "Start and end radius for the capsule.")
       .def_property_readonly(
           "parent",
-          [](const mm::TaperedCapsule& capsule) -> int { return capsule.parent; },
+          [](const mm::TaperedCapsule& capsule) -> int {
+            return collisionParentToPython(capsule.parent);
+          },
           "Parent joint to which the capsule is attached.")
       .def_property_readonly(
           "length", [](const mm::TaperedCapsule& capsule) -> float { return capsule.length; })
       .def("__repr__", [](const mm::TaperedCapsule& tc) {
         return fmt::format(
             "TaperedCapsule(parent={}, length={}, radius=[{}, {}])",
-            tc.parent,
+            collisionParentToPython(tc.parent),
             tc.length,
             tc.radius[0],
             tc.radius[1]);
@@ -504,6 +551,53 @@ The resulting arrays are as follows:
             properties.jointName,
             properties.jointIndex,
             properties.mass);
+      });
+
+  ellipsoidClass
+      .def(
+          py::init<>([](int parent,
+                        const OptionalTransformArray& transformation,
+                        const std::optional<Eigen::Vector3f>& radii) {
+            mm::CollisionEllipsoid ellipsoid;
+            ellipsoid.transformation = collisionTransformFromPython(transformation);
+            ellipsoid.radii = radii.value_or(Eigen::Vector3f::Ones());
+            ellipsoid.parent = parent;
+            return ellipsoid;
+          }),
+          R"(Create an ellipsoid using its parent, transformation, and radii.
+
+:param parent: Parent joint to which the ellipsoid is attached.
+:param transformation: Transformation defining the center and orientation relative to the parent coordinate system.
+:param radii: Radii along the local x, y, and z axes.)",
+          py::arg("parent"),
+          py::kw_only(),
+          py::arg("transformation") = py::none(),
+          py::arg("radii") = std::optional<Eigen::Vector3f>{})
+      .def_property_readonly(
+          "transformation",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> Eigen::Matrix4f {
+            return ellipsoid.transformation.toMatrix();
+          },
+          "Transformation defining the center and orientation relative to the parent coordinate system")
+      .def_property_readonly(
+          "radii",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> Eigen::Vector3f {
+            return ellipsoid.radii;
+          },
+          "Radii along the local x, y, and z axes.")
+      .def_property_readonly(
+          "parent",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> int {
+            return collisionParentToPython(ellipsoid.parent);
+          },
+          "Parent joint to which the ellipsoid is attached.")
+      .def("__repr__", [](const mm::CollisionEllipsoid& ellipsoid) {
+        return fmt::format(
+            "Ellipsoid(parent={}, radii=[{}, {}, {}])",
+            collisionParentToPython(ellipsoid.parent),
+            ellipsoid.radii[0],
+            ellipsoid.radii[1],
+            ellipsoid.radii[2]);
       });
 
   // Class Marker, defining the properties:


### PR DESCRIPTION
Summary: Add the `pymomentum.geometry.Ellipsoid` binding and allow `Character.collision_geometry` and `with_collision_geometry` to round-trip mixed tapered capsule and ellipsoid primitives. Regenerate `geometry.pyi` so the new class is exported in the checked-in typing surface.

Reviewed By: cstollmeta

Differential Revision: D105192543


