### PR TITLE
Add ellipsoid collision state support

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -637,12 +637,12 @@ Character replaceSkeletonHierarchy(
   if (tgtCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*tgtCharacter.collision, tgtToCombinedJoints));
+        mapParents<CollisionPrimitive>(*tgtCharacter.collision, tgtToCombinedJoints));
   }
   if (srcCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*srcCharacter.collision, srcToCombinedJoints));
+        mapParents<CollisionPrimitive>(*srcCharacter.collision, srcToCombinedJoints));
   }
 
   // Build the merged parameter transform:
@@ -807,7 +807,8 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
 
   CollisionGeometry resultCollisionGeometry;
   if (character.collision) {
-    resultCollisionGeometry = mapParents<TaperedCapsule>(*character.collision, srcToResultJoints);
+    resultCollisionGeometry =
+        mapParents<CollisionPrimitive>(*character.collision, srcToResultJoints);
   }
 
   const ParameterLimits resultParameterLimits =

--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -87,10 +87,14 @@ std::unique_ptr<CollisionGeometry> scale(
   }
 
   auto result = std::make_unique<CollisionGeometry>(*geom);
-  for (auto& capsule : (*result)) {
-    capsule.transformation.translation *= scale;
-    capsule.radius *= scale;
-    capsule.length *= scale;
+  for (auto& primitive : (*result)) {
+    primitive.transformation.translation *= scale;
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      primitive.radius *= scale;
+      primitive.length *= scale;
+    } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      primitive.ellipsoidRadii *= scale;
+    }
   }
 
   return result;
@@ -168,6 +172,10 @@ std::vector<T> mapParents(const std::vector<T>& objects, const std::vector<size_
   std::vector<T> result;
   result.reserve(objects.size());
   for (auto o : objects) {
+    if (o.parent == kInvalidIndex) {
+      result.push_back(o);
+      continue;
+    }
     MT_CHECK(
         o.parent < jointMapping.size(),
         "Parent {} exceeds joint mapping size {}",
@@ -521,6 +529,23 @@ TransformationList transformInverseBindPose(
   return result;
 }
 
+std::unique_ptr<CollisionGeometry> transformCollisionGeometry(
+    const std::unique_ptr<CollisionGeometry>& collision,
+    const Eigen::Affine3f& xf) {
+  if (!collision) {
+    return {};
+  }
+
+  auto result = std::make_unique<CollisionGeometry>(*collision);
+  const Transform xformTransform(xf);
+  for (auto& primitive : *result) {
+    if (primitive.parent == kInvalidIndex) {
+      primitive.transformation = xformTransform * primitive.transformation;
+    }
+  }
+  return result;
+}
+
 } // namespace
 
 Character transformCharacter(const Character& character, const Affine3f& xform) {
@@ -531,7 +556,7 @@ Character transformCharacter(const Character& character, const Affine3f& xform) 
       character.locators,
       transformMesh(character.mesh, xform).get(),
       character.skinWeights.get(),
-      character.collision.get(),
+      transformCollisionGeometry(character.collision, xform).get(),
       character.poseShapes.get(),
       transformBlendShape(character.blendShape, xform),
       character.faceExpressionBlendShape,
@@ -636,13 +661,11 @@ Character replaceSkeletonHierarchy(
   CollisionGeometry combinedCollisionGeometry;
   if (tgtCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
-        combinedCollisionGeometry,
-        mapParents<CollisionPrimitive>(*tgtCharacter.collision, tgtToCombinedJoints));
+        combinedCollisionGeometry, mapParents(*tgtCharacter.collision, tgtToCombinedJoints));
   }
   if (srcCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
-        combinedCollisionGeometry,
-        mapParents<CollisionPrimitive>(*srcCharacter.collision, srcToCombinedJoints));
+        combinedCollisionGeometry, mapParents(*srcCharacter.collision, srcToCombinedJoints));
   }
 
   // Build the merged parameter transform:
@@ -807,8 +830,7 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
 
   CollisionGeometry resultCollisionGeometry;
   if (character.collision) {
-    resultCollisionGeometry =
-        mapParents<CollisionPrimitive>(*character.collision, srcToResultJoints);
+    resultCollisionGeometry = mapParents(*character.collision, srcToResultJoints);
   }
 
   const ParameterLimits resultParameterLimits =

--- a/momentum/character/collision_geometry.h
+++ b/momentum/character/collision_geometry.h
@@ -8,12 +8,21 @@
 #pragma once
 
 #include <momentum/character/types.h>
+#include <momentum/common/checks.h>
 #include <momentum/common/memory.h>
 #include <momentum/math/constants.h>
 #include <momentum/math/transform.h>
 #include <momentum/math/utility.h>
 
+#include <cstdint>
+
 namespace momentum {
+
+/// Collision primitive kinds supported by character collision geometry.
+enum class CollisionPrimitiveType : uint8_t {
+  TaperedCapsule,
+  Ellipsoid,
+};
 
 /// Tapered capsule collision geometry for character collision detection.
 ///
@@ -67,9 +76,190 @@ struct TaperedCapsuleT {
   }
 };
 
-/// Collection of tapered capsules representing a character's collision geometry.
+/// Ellipsoid collision geometry for character collision detection.
+///
+/// Defined by a transformation and three local-space radii along the primitive's axes.
 template <typename S>
-using CollisionGeometryT = std::vector<TaperedCapsuleT<S>>;
+struct CollisionEllipsoidT {
+  using Scalar = S;
+
+  /// Transformation defining the ellipsoid center and orientation relative to the parent.
+  TransformT<S> transformation;
+
+  /// Radii along the local x, y, and z axes.
+  Vector3<S> radii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  CollisionEllipsoidT()
+      : transformation(TransformT<S>()), radii(Vector3<S>::Zero()), parent(kInvalidIndex) {
+    // Empty
+  }
+
+  /// Checks if the current ellipsoid is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionEllipsoidT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (!radii.isApprox(other.radii, tol)) {
+      return false;
+    }
+
+    return parent == other.parent;
+  }
+};
+
+/// Collision geometry primitive.
+///
+/// The tapered capsule fields are kept directly on the primitive so existing code that
+/// constructs capsule-only collision geometry can continue to initialize `radius`, `length`,
+/// `parent`, and `transformation` on elements of `CollisionGeometry`.
+template <typename S>
+struct CollisionPrimitiveT {
+  using Scalar = S;
+
+  /// Primitive kind.
+  CollisionPrimitiveType type;
+
+  /// Transformation defining the primitive pose relative to the parent coordinate system.
+  TransformT<S> transformation;
+
+  /// Radii at the two endpoints of a tapered capsule.
+  Vector2<S> radius;
+
+  /// Radii along the local axes of an ellipsoid.
+  Vector3<S> ellipsoidRadii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  /// Length of a tapered capsule along the x-axis.
+  S length;
+
+  CollisionPrimitiveT()
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(TransformT<S>()),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(kInvalidIndex),
+        length(S(0)) {
+    // Empty
+  }
+
+  /// Creates a collision primitive from a tapered capsule.
+  /* implicit */ CollisionPrimitiveT(const TaperedCapsuleT<S>& capsule)
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(capsule.transformation),
+        radius(capsule.radius),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(capsule.parent),
+        length(capsule.length) {}
+
+  /// Creates a collision primitive from an ellipsoid.
+  /* implicit */ CollisionPrimitiveT(const CollisionEllipsoidT<S>& ellipsoid)
+      : type(CollisionPrimitiveType::Ellipsoid),
+        transformation(ellipsoid.transformation),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(ellipsoid.radii),
+        parent(ellipsoid.parent),
+        length(S(0)) {}
+
+  /// Assigns tapered capsule data to this primitive.
+  CollisionPrimitiveT& operator=(const TaperedCapsuleT<S>& capsule) {
+    type = CollisionPrimitiveType::TaperedCapsule;
+    transformation = capsule.transformation;
+    radius = capsule.radius;
+    ellipsoidRadii.setZero();
+    parent = capsule.parent;
+    length = capsule.length;
+    return *this;
+  }
+
+  /// Assigns ellipsoid data to this primitive.
+  CollisionPrimitiveT& operator=(const CollisionEllipsoidT<S>& ellipsoid) {
+    type = CollisionPrimitiveType::Ellipsoid;
+    transformation = ellipsoid.transformation;
+    radius.setZero();
+    ellipsoidRadii = ellipsoid.radii;
+    parent = ellipsoid.parent;
+    length = S(0);
+    return *this;
+  }
+
+  /// Returns true when this primitive stores tapered capsule data.
+  [[nodiscard]] bool isTaperedCapsule() const {
+    return type == CollisionPrimitiveType::TaperedCapsule;
+  }
+
+  /// Returns true when this primitive stores ellipsoid data.
+  [[nodiscard]] bool isEllipsoid() const {
+    return type == CollisionPrimitiveType::Ellipsoid;
+  }
+
+  /// Converts this primitive to a tapered capsule.
+  ///
+  /// Requires `isTaperedCapsule()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] TaperedCapsuleT<S> toTaperedCapsule() const {
+    MT_CHECK(
+        isTaperedCapsule(),
+        "Collision primitive type {} does not store tapered capsule data",
+        static_cast<int>(type));
+
+    TaperedCapsuleT<S> capsule;
+    capsule.transformation = transformation;
+    capsule.radius = radius;
+    capsule.parent = parent;
+    capsule.length = length;
+    return capsule;
+  }
+
+  /// Converts this primitive to an ellipsoid.
+  ///
+  /// Requires `isEllipsoid()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] CollisionEllipsoidT<S> toEllipsoid() const {
+    MT_CHECK(
+        isEllipsoid(),
+        "Collision primitive type {} does not store ellipsoid data",
+        static_cast<int>(type));
+
+    CollisionEllipsoidT<S> ellipsoid;
+    ellipsoid.transformation = transformation;
+    ellipsoid.radii = ellipsoidRadii;
+    ellipsoid.parent = parent;
+    return ellipsoid;
+  }
+
+  /// Checks if the current primitive is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionPrimitiveT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (type != other.type || parent != other.parent) {
+      return false;
+    }
+
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (type == CollisionPrimitiveType::TaperedCapsule) {
+      return radius.isApprox(other.radius, tol) && ::momentum::isApprox(length, other.length, tol);
+    }
+
+    if (type == CollisionPrimitiveType::Ellipsoid) {
+      return ellipsoidRadii.isApprox(other.ellipsoidRadii, tol);
+    }
+
+    return false;
+  }
+};
+
+/// Collection of primitives representing a character's collision geometry.
+template <typename S>
+using CollisionGeometryT = std::vector<CollisionPrimitiveT<S>>;
 
 using CollisionGeometry = CollisionGeometryT<float>;
 using CollisionGeometryd = CollisionGeometryT<double>;

--- a/momentum/character/collision_geometry_state.cpp
+++ b/momentum/character/collision_geometry_state.cpp
@@ -21,18 +21,35 @@ void CollisionGeometryStateT<T>::update(
   direction.resize(numElements);
   radius.resize(numElements);
   delta.resize(numElements);
+  type.resize(numElements);
+  orientation.resize(numElements);
+  ellipsoidRadii.resize(numElements);
 
-  // TODO: This per-capsule loop is independent across iterations and could be parallelized.
+  // TODO: This per-primitive loop is independent across iterations and could be parallelized.
   for (size_t i = 0; i < numElements; ++i) {
-    const auto& tc = collisionGeometry[i];
-    const TransformT<T> parentTransform = (tc.parent == kInvalidIndex)
+    const auto& primitive = collisionGeometry[i];
+    const TransformT<T> parentTransform = (primitive.parent == kInvalidIndex)
         ? TransformT<T>()
-        : skeletonState.jointState[tc.parent].transform;
-    const TransformT<T> transform = parentTransform * tc.transformation.cast<T>();
+        : skeletonState.jointState[primitive.parent].transform;
+    const TransformT<T> transform = parentTransform * primitive.transformation.cast<T>();
+    type[i] = primitive.type;
     origin[i] = transform.translation;
-    direction[i].noalias() = transform.getAxisX() * transform.scale * tc.length;
-    radius[i].noalias() = tc.radius.cast<T>() * parentTransform.scale;
-    delta[i] = radius[i][1] - radius[i][0];
+    orientation[i] = transform.rotation;
+
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      direction[i].noalias() = transform.getAxisX() * transform.scale * primitive.length;
+      radius[i].noalias() = primitive.radius.cast<T>() * parentTransform.scale;
+      delta[i] = radius[i][1] - radius[i][0];
+      ellipsoidRadii[i].setZero();
+      continue;
+    }
+
+    if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      direction[i].setZero();
+      radius[i].setZero();
+      delta[i] = T(0);
+      ellipsoidRadii[i].noalias() = primitive.ellipsoidRadii.cast<T>() * parentTransform.scale;
+    }
   }
 }
 

--- a/momentum/character/collision_geometry_state.h
+++ b/momentum/character/collision_geometry_state.h
@@ -13,6 +13,8 @@
 
 #include <axel/BoundingBox.h>
 
+#include <algorithm>
+
 namespace momentum {
 
 /// Represents collision geometry states using a Structure of Arrays (SoA) format.
@@ -46,8 +48,42 @@ struct CollisionGeometryStateT {
   /// Signed difference between the capsule's radii (radius[1] - radius[0]).
   std::vector<T> delta;
 
+  /// Primitive types matching the source collision geometry.
+  std::vector<CollisionPrimitiveType> type;
+
+  /// Primitive orientation in global coordinates.
+  std::vector<Quaternion<T>> orientation;
+
+  /// Scaled ellipsoid radii in global coordinates.
+  std::vector<Vector3<T>> ellipsoidRadii;
+
   /// Updates the state based on a given skeleton state and collision geometry.
   void update(const SkeletonStateT<T>& skeletonState, const CollisionGeometry& collisionGeometry);
+};
+
+/// Narrow-phase collision information for a pair of primitives.
+template <typename T>
+struct CollisionOverlapResultT {
+  /// Distance between the primitive center features used by the narrow phase.
+  T distance = T(0);
+
+  /// Parametric closest-point positions. Capsule entries use [0, 1]; ellipsoid entries use 0.
+  Vector2<T> closestPoints = Vector2<T>::Zero();
+
+  /// Amount of overlap, positive when colliding.
+  T overlap = T(0);
+
+  /// Center feature position for the first primitive.
+  Vector3<T> positionA = Vector3<T>::Zero();
+
+  /// Center feature position for the second primitive.
+  Vector3<T> positionB = Vector3<T>::Zero();
+
+  /// Effective radius of the first primitive along the contact direction.
+  T radiusA = T(0);
+
+  /// Effective radius of the second primitive along the contact direction.
+  T radiusB = T(0);
 };
 
 /// Determines if two tapered capsules overlap.
@@ -108,6 +144,201 @@ bool overlaps(
   return (outOverlap > T(0)) && (closestDist >= Eps<T>(1e-8, 1e-17));
 }
 
+/// Return the clamped segment parameter for the closest point to a world-space point.
+template <typename T>
+[[nodiscard]] T closestPointOnSegmentParameter(
+    const Vector3<T>& origin,
+    const Vector3<T>& direction,
+    const Vector3<T>& point) {
+  const T directionNormSq = direction.squaredNorm();
+  if (directionNormSq <= Eps<T>(1e-8, 1e-17)) {
+    return T(0);
+  }
+
+  return std::clamp((point - origin).dot(direction) / directionNormSq, T(0), T(1));
+}
+
+/// Return the support radius of an oriented ellipsoid along a unit world-space direction.
+template <typename T>
+[[nodiscard]] T ellipsoidRadiusAlongDirection(
+    const Quaternion<T>& orientation,
+    const Vector3<T>& radii,
+    const Vector3<T>& unitDirection) {
+  const Vector3<T> localDirection = orientation.inverse() * unitDirection;
+  return radii.cwiseAbs().cwiseProduct(localDirection).norm();
+}
+
+/// Test overlap between a tapered capsule and an oriented ellipsoid.
+///
+/// The function fills the closest capsule parameter, support radii, distance,
+/// and signed overlap used by the solver when a non-degenerate overlap is found.
+///
+/// @param capsuleOrigin Origin of the capsule segment in world space.
+/// @param capsuleDirection Direction vector from capsule start to end in world space.
+/// @param capsuleRadii Radii at the capsule start and end points.
+/// @param capsuleDelta Signed difference between capsule radii (`capsuleRadii[1] -
+///   capsuleRadii[0]`).
+/// @param ellipsoidCenter Ellipsoid center in world space.
+/// @param ellipsoidOrientation Ellipsoid orientation in world space.
+/// @param ellipsoidRadii Ellipsoid radii along its local axes.
+/// @param outDistance Output: distance between the capsule centerline point and ellipsoid center.
+/// @param outCapsuleParam Output: parametric position in [0, 1] along the capsule segment.
+/// @param outOverlap Output: signed overlap amount, positive when overlapping.
+/// @param outCapsuleRadius Output: capsule support radius at `outCapsuleParam`.
+/// @param outEllipsoidRadius Output: ellipsoid support radius along the contact direction.
+/// @return True when the capsule and ellipsoid overlap with a non-degenerate contact direction.
+template <typename T>
+[[nodiscard]] bool overlapsCapsuleEllipsoid(
+    const Vector3<T>& capsuleOrigin,
+    const Vector3<T>& capsuleDirection,
+    const Vector2<T>& capsuleRadii,
+    T capsuleDelta,
+    const Vector3<T>& ellipsoidCenter,
+    const Quaternion<T>& ellipsoidOrientation,
+    const Vector3<T>& ellipsoidRadii,
+    T& outDistance,
+    T& outCapsuleParam,
+    T& outOverlap,
+    T& outCapsuleRadius,
+    T& outEllipsoidRadius) {
+  outCapsuleParam =
+      closestPointOnSegmentParameter(capsuleOrigin, capsuleDirection, ellipsoidCenter);
+  const Vector3<T> capsulePoint = capsuleOrigin + capsuleDirection * outCapsuleParam;
+  const Vector3<T> separation = capsulePoint - ellipsoidCenter;
+  outDistance = separation.norm();
+  if (outDistance < Eps<T>(1e-8, 1e-17)) {
+    return false;
+  }
+
+  const Vector3<T> normal = separation / outDistance;
+  outCapsuleRadius = capsuleRadii[0] + outCapsuleParam * capsuleDelta;
+  outEllipsoidRadius = ellipsoidRadiusAlongDirection(ellipsoidOrientation, ellipsoidRadii, normal);
+  outOverlap = outCapsuleRadius + outEllipsoidRadius - outDistance;
+  return outOverlap > T(0);
+}
+
+/// Determines whether two collision primitives overlap.
+///
+/// Capsule-capsule pairs use the existing closest-segment query. Ellipsoid pairs use a support
+/// radius along the center-feature separation direction, which gives a stable contact normal for
+/// the solver and preserves the same overlap convention used by tapered capsules.
+///
+/// @param collisionState World-space collision state for `collisionGeometry`.
+/// @param collisionGeometry Collision primitives corresponding to `collisionState`.
+/// @param indexA First primitive index.
+/// @param indexB Second primitive index.
+/// @param result Output: closest points, contact positions, support radii, distance, and overlap.
+/// @return True when the primitive pair overlaps with a non-degenerate contact direction.
+template <typename T>
+[[nodiscard]] bool overlaps(
+    const CollisionGeometryStateT<T>& collisionState,
+    const CollisionGeometry& collisionGeometry,
+    size_t indexA,
+    size_t indexB,
+    CollisionOverlapResultT<T>& result) {
+  const auto typeA = collisionGeometry[indexA].type;
+  const auto typeB = collisionGeometry[indexB].type;
+
+  if (typeA == CollisionPrimitiveType::TaperedCapsule &&
+      typeB == CollisionPrimitiveType::TaperedCapsule) {
+    if (!overlaps(
+            collisionState.origin[indexA],
+            collisionState.direction[indexA],
+            collisionState.radius[indexA],
+            collisionState.delta[indexA],
+            collisionState.origin[indexB],
+            collisionState.direction[indexB],
+            collisionState.radius[indexB],
+            collisionState.delta[indexB],
+            result.distance,
+            result.closestPoints,
+            result.overlap)) {
+      return false;
+    }
+
+    result.positionA =
+        collisionState.origin[indexA] + collisionState.direction[indexA] * result.closestPoints[0];
+    result.positionB =
+        collisionState.origin[indexB] + collisionState.direction[indexB] * result.closestPoints[1];
+    result.radiusA =
+        collisionState.radius[indexA][0] + result.closestPoints[0] * collisionState.delta[indexA];
+    result.radiusB =
+        collisionState.radius[indexB][0] + result.closestPoints[1] * collisionState.delta[indexB];
+    return true;
+  }
+
+  if (typeA == CollisionPrimitiveType::TaperedCapsule &&
+      typeB == CollisionPrimitiveType::Ellipsoid) {
+    if (!overlapsCapsuleEllipsoid(
+            collisionState.origin[indexA],
+            collisionState.direction[indexA],
+            collisionState.radius[indexA],
+            collisionState.delta[indexA],
+            collisionState.origin[indexB],
+            collisionState.orientation[indexB],
+            collisionState.ellipsoidRadii[indexB],
+            result.distance,
+            result.closestPoints[0],
+            result.overlap,
+            result.radiusA,
+            result.radiusB)) {
+      return false;
+    }
+
+    result.closestPoints[1] = T(0);
+    result.positionA =
+        collisionState.origin[indexA] + collisionState.direction[indexA] * result.closestPoints[0];
+    result.positionB = collisionState.origin[indexB];
+    return true;
+  }
+
+  if (typeA == CollisionPrimitiveType::Ellipsoid &&
+      typeB == CollisionPrimitiveType::TaperedCapsule) {
+    if (!overlapsCapsuleEllipsoid(
+            collisionState.origin[indexB],
+            collisionState.direction[indexB],
+            collisionState.radius[indexB],
+            collisionState.delta[indexB],
+            collisionState.origin[indexA],
+            collisionState.orientation[indexA],
+            collisionState.ellipsoidRadii[indexA],
+            result.distance,
+            result.closestPoints[1],
+            result.overlap,
+            result.radiusB,
+            result.radiusA)) {
+      return false;
+    }
+
+    result.closestPoints[0] = T(0);
+    result.positionA = collisionState.origin[indexA];
+    result.positionB =
+        collisionState.origin[indexB] + collisionState.direction[indexB] * result.closestPoints[1];
+    return true;
+  }
+
+  if (typeA == CollisionPrimitiveType::Ellipsoid && typeB == CollisionPrimitiveType::Ellipsoid) {
+    const Vector3<T> separation = collisionState.origin[indexA] - collisionState.origin[indexB];
+    result.distance = separation.norm();
+    if (result.distance < Eps<T>(1e-8, 1e-17)) {
+      return false;
+    }
+
+    const Vector3<T> normal = separation / result.distance;
+    result.radiusA = ellipsoidRadiusAlongDirection(
+        collisionState.orientation[indexA], collisionState.ellipsoidRadii[indexA], normal);
+    result.radiusB = ellipsoidRadiusAlongDirection(
+        collisionState.orientation[indexB], collisionState.ellipsoidRadii[indexB], normal);
+    result.overlap = result.radiusA + result.radiusB - result.distance;
+    result.positionA = collisionState.origin[indexA];
+    result.positionB = collisionState.origin[indexB];
+    result.closestPoints = Vector2<T>::Zero();
+    return result.overlap > T(0);
+  }
+
+  return false;
+}
+
 /// Updates an axis-aligned bounding box to encompass a tapered capsule.
 ///
 /// @param aabb The bounding box to update
@@ -133,19 +364,70 @@ void updateAabb(
   aabb.aabb.max() = maxA.cwiseMax(maxB);
 }
 
-/// Determines whether a pair of collision geometry capsules should be included as a valid
+/// Updates an axis-aligned bounding box to encompass an oriented ellipsoid.
+///
+/// Uses the tight ellipsoid AABB half-extent h_i = sqrt(sum_j (R_ij * radii_j)^2),
+/// i.e. the L2 norm of each rotation-matrix row scaled component-wise by the radii.
+/// This is the exact AABB of the ellipsoid, unlike the looser L1/OBB bound
+/// (sum_j |R_ij| * radii_j) which over-estimates by up to a factor of sqrt(3).
+///
+/// @param aabb The bounding box to update
+/// @param center Center of the ellipsoid
+/// @param orientation Orientation of the ellipsoid
+/// @param radii Radii along the ellipsoid's local axes
+template <typename T>
+void updateEllipsoidAabb(
+    axel::BoundingBox<T>& aabb,
+    const Vector3<T>& center,
+    const Quaternion<T>& orientation,
+    const Vector3<T>& radii) {
+  const Eigen::Matrix<T, 3, 3> rotation = orientation.toRotationMatrix();
+  const Vector3<T> absRadii = radii.cwiseAbs();
+  Vector3<T> halfExtents;
+  for (int i = 0; i < 3; ++i) {
+    halfExtents[i] = rotation.row(i).cwiseProduct(absRadii.transpose()).norm();
+  }
+  aabb.aabb.min() = center - halfExtents;
+  aabb.aabb.max() = center + halfExtents;
+}
+
+/// Updates an axis-aligned bounding box to encompass a collision primitive.
+template <typename T>
+void updateAabb(
+    axel::BoundingBox<T>& aabb,
+    const CollisionGeometryStateT<T>& collisionState,
+    size_t index) {
+  if (collisionState.type[index] == CollisionPrimitiveType::TaperedCapsule) {
+    updateAabb(
+        aabb,
+        collisionState.origin[index],
+        collisionState.direction[index],
+        collisionState.radius[index]);
+    return;
+  }
+
+  if (collisionState.type[index] == CollisionPrimitiveType::Ellipsoid) {
+    updateEllipsoidAabb(
+        aabb,
+        collisionState.origin[index],
+        collisionState.orientation[index],
+        collisionState.ellipsoidRadii[index]);
+  }
+}
+
+/// Determines whether a pair of collision geometry primitives should be included as a valid
 /// collision pair.
 ///
 /// A pair is excluded if:
-/// - The capsules overlap in rest pose (permanently overlapping, e.g. adjacent body parts),
+/// - The primitives overlap in rest pose (permanently overlapping, e.g. adjacent body parts),
 ///   unless @p filterRestPoseOverlaps is false
-/// - The capsules are attached to the same joint or directly adjacent joints
+/// - The primitives are attached to the same joint or directly adjacent joints
 ///
 /// @param collisionState The collision geometry state in rest pose
 /// @param collisionGeometry The collision geometry definition
 /// @param skeleton The skeleton used for adjacency checks
-/// @param i Index of the first capsule
-/// @param j Index of the second capsule
+/// @param i Index of the first primitive
+/// @param j Index of the second primitive
 /// @param filterRestPoseOverlaps When true, exclude pairs that overlap in rest pose
 /// @return True if the pair is a valid collision pair (should be checked for collisions)
 template <typename T, typename S>
@@ -159,7 +441,7 @@ template <typename T, typename S>
   const size_t p0 = collisionGeometry[i].parent;
   const size_t p1 = collisionGeometry[j].parent;
 
-  // World-fixed capsules (kInvalidIndex parent):
+  // World-fixed primitives (kInvalidIndex parent):
   // - If both are world-fixed, they can't collide with each other in a meaningful way.
   // - If exactly one is world-fixed, it's always a valid collision pair (no rest-pose
   //   overlap or adjacency checks apply since the world geometry is independent of
@@ -178,21 +460,8 @@ template <typename T, typename S>
   }
 
   // Check for rest-pose overlap (permanently overlapping pairs like adjacent body parts)
-  T distance;
-  Vector2<T> cp;
-  T overlap;
-  return !overlaps(
-      collisionState.origin[i],
-      collisionState.direction[i],
-      collisionState.radius[i],
-      collisionState.delta[i],
-      collisionState.origin[j],
-      collisionState.direction[j],
-      collisionState.radius[j],
-      collisionState.delta[j],
-      distance,
-      cp,
-      overlap);
+  CollisionOverlapResultT<T> overlap;
+  return !overlaps(collisionState, collisionGeometry, i, j, overlap);
 }
 
 } // namespace momentum

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -107,6 +107,25 @@ using CharacterStated_const_u = ::std::unique_ptr<const CharacterStated>;
 using CharacterStated_const_w = ::std::weak_ptr<const CharacterStated>;
 
 template <typename T>
+struct CollisionPrimitiveT;
+using CollisionPrimitive = CollisionPrimitiveT<float>;
+using CollisionPrimitived = CollisionPrimitiveT<double>;
+
+using CollisionPrimitive_p = ::std::shared_ptr<CollisionPrimitive>;
+using CollisionPrimitive_u = ::std::unique_ptr<CollisionPrimitive>;
+using CollisionPrimitive_w = ::std::weak_ptr<CollisionPrimitive>;
+using CollisionPrimitive_const_p = ::std::shared_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_u = ::std::unique_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_w = ::std::weak_ptr<const CollisionPrimitive>;
+
+using CollisionPrimitived_p = ::std::shared_ptr<CollisionPrimitived>;
+using CollisionPrimitived_u = ::std::unique_ptr<CollisionPrimitived>;
+using CollisionPrimitived_w = ::std::weak_ptr<CollisionPrimitived>;
+using CollisionPrimitived_const_p = ::std::shared_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_u = ::std::unique_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_w = ::std::weak_ptr<const CollisionPrimitived>;
+
+template <typename T>
 struct CollisionGeometryStateT;
 using CollisionGeometryState = CollisionGeometryStateT<float>;
 using CollisionGeometryStated = CollisionGeometryStateT<double>;
@@ -124,6 +143,25 @@ using CollisionGeometryStated_w = ::std::weak_ptr<CollisionGeometryStated>;
 using CollisionGeometryStated_const_p = ::std::shared_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_u = ::std::unique_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_w = ::std::weak_ptr<const CollisionGeometryStated>;
+
+template <typename T>
+struct CollisionEllipsoidT;
+using CollisionEllipsoid = CollisionEllipsoidT<float>;
+using CollisionEllipsoidd = CollisionEllipsoidT<double>;
+
+using CollisionEllipsoid_p = ::std::shared_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_u = ::std::unique_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_w = ::std::weak_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_const_p = ::std::shared_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_u = ::std::unique_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_w = ::std::weak_ptr<const CollisionEllipsoid>;
+
+using CollisionEllipsoidd_p = ::std::shared_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_u = ::std::unique_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_w = ::std::weak_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_p = ::std::shared_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_u = ::std::unique_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_w = ::std::weak_ptr<const CollisionEllipsoidd>;
 
 template <typename T>
 struct JointT;

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -145,6 +145,25 @@ using CollisionGeometryStated_const_u = ::std::unique_ptr<const CollisionGeometr
 using CollisionGeometryStated_const_w = ::std::weak_ptr<const CollisionGeometryStated>;
 
 template <typename T>
+struct CollisionOverlapResultT;
+using CollisionOverlapResult = CollisionOverlapResultT<float>;
+using CollisionOverlapResultd = CollisionOverlapResultT<double>;
+
+using CollisionOverlapResult_p = ::std::shared_ptr<CollisionOverlapResult>;
+using CollisionOverlapResult_u = ::std::unique_ptr<CollisionOverlapResult>;
+using CollisionOverlapResult_w = ::std::weak_ptr<CollisionOverlapResult>;
+using CollisionOverlapResult_const_p = ::std::shared_ptr<const CollisionOverlapResult>;
+using CollisionOverlapResult_const_u = ::std::unique_ptr<const CollisionOverlapResult>;
+using CollisionOverlapResult_const_w = ::std::weak_ptr<const CollisionOverlapResult>;
+
+using CollisionOverlapResultd_p = ::std::shared_ptr<CollisionOverlapResultd>;
+using CollisionOverlapResultd_u = ::std::unique_ptr<CollisionOverlapResultd>;
+using CollisionOverlapResultd_w = ::std::weak_ptr<CollisionOverlapResultd>;
+using CollisionOverlapResultd_const_p = ::std::shared_ptr<const CollisionOverlapResultd>;
+using CollisionOverlapResultd_const_u = ::std::unique_ptr<const CollisionOverlapResultd>;
+using CollisionOverlapResultd_const_w = ::std::weak_ptr<const CollisionOverlapResultd>;
+
+template <typename T>
 struct CollisionEllipsoidT;
 using CollisionEllipsoid = CollisionEllipsoidT<float>;
 using CollisionEllipsoidd = CollisionEllipsoidT<double>;

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -31,7 +31,9 @@ structs = [
 ]
 template_structs = [
     "CharacterState",
+    "CollisionPrimitive",
     "CollisionGeometryState",
+    "CollisionEllipsoid",
     "Joint",
     "JointState",
     "ParameterTransform",

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -33,6 +33,7 @@ template_structs = [
     "CharacterState",
     "CollisionPrimitive",
     "CollisionGeometryState",
+    "CollisionOverlapResult",
     "CollisionEllipsoid",
     "Joint",
     "JointState",

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -226,7 +226,13 @@ inline void createCollisionGeometryNodes(
 
   const auto& collisions = *character.collision;
   for (auto i = 0u; i < collisions.size(); ++i) {
-    const TaperedCapsule& collision = collisions[i];
+    const auto& collision = collisions[i];
+    if (!collision.isTaperedCapsule()) {
+      MT_LOGW(
+          "Skipping unsupported collision primitive type {} while writing FBX collision geometry",
+          static_cast<int>(collision.type));
+      continue;
+    }
 
     ::fbxsdk::FbxNode* collisionNode =
         ::fbxsdk::FbxNode::Create(scene, ("Collision " + std::to_string(i)).c_str());

--- a/momentum/io/gltf/gltf_skeleton_io.cpp
+++ b/momentum/io/gltf/gltf_skeleton_io.cpp
@@ -359,12 +359,11 @@ loadHierarchy(const fx::gltf::Document& model) {
   MT_THROW_IF(model.nodes.empty(), "No valid node found in the gltf file.");
   std::string name = model.nodes.at(0).name;
 
-  std::sort(
-      collision->begin(), collision->end(), [](const TaperedCapsule& c1, const TaperedCapsule& c2) {
-        int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
-        int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
-        return c1Parent < c2Parent;
-      });
+  std::sort(collision->begin(), collision->end(), [](const auto& c1, const auto& c2) {
+    int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
+    int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
+    return c1Parent < c2Parent;
+  });
   std::sort(locators.begin(), locators.end(), [](const Locator& l1, const Locator& l2) {
     int l1Parent = l1.parent == kInvalidIndex ? -1 : static_cast<int>(l1.parent);
     int l2Parent = l2.parent == kInvalidIndex ? -1 : static_cast<int>(l2.parent);

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -27,6 +27,18 @@ namespace momentum {
 
 namespace {
 
+template <typename LhsDerived, typename RhsDerived>
+bool lessLexicographic(
+    const Eigen::MatrixBase<LhsDerived>& lhs,
+    const Eigen::MatrixBase<RhsDerived>& rhs) {
+  for (Eigen::Index i = 0; i < lhs.size(); ++i) {
+    if (lhs[i] != rhs[i]) {
+      return lhs[i] < rhs[i];
+    }
+  }
+  return false;
+}
+
 MATCHER_P(FloatNearPointwise, tol, "Value mismatch") {
   for (int i = 0; i < std::get<0>(arg).size(); i++) {
     if (std::abs(std::get<0>(arg)[i] - std::get<1>(arg)[i]) > tol) {
@@ -147,16 +159,27 @@ void compareCollisionGeometry(
     EXPECT_EQ(refCollision->size(), collision->size());
     auto sortedRefCollision = *refCollision;
     auto sortedCollision = *collision;
-    auto compareCollisions = [](const TaperedCapsule& l1, const TaperedCapsule& l2) {
+    auto compareCollisions = [](const auto& l1, const auto& l2) {
       if (l1.parent != l2.parent) {
         return l1.parent < l2.parent;
+      }
+      if (l1.type != l2.type) {
+        return static_cast<int>(l1.type) < static_cast<int>(l2.type);
       }
       if (l1.length != l2.length) {
         return l1.length < l2.length;
       }
-      if (!l1.radius.isApprox(l2.radius)) {
-        return l1.radius.x() != l2.radius.x() ? l1.radius.x() < l2.radius.x()
-                                              : l1.radius.y() < l2.radius.y();
+      if (lessLexicographic(l1.radius, l2.radius)) {
+        return true;
+      }
+      if (lessLexicographic(l2.radius, l1.radius)) {
+        return false;
+      }
+      if (lessLexicographic(l1.ellipsoidRadii, l2.ellipsoidRadii)) {
+        return true;
+      }
+      if (lessLexicographic(l2.ellipsoidRadii, l1.ellipsoidRadii)) {
+        return false;
       }
       const auto t1 = l1.transformation.toMatrix();
       const auto t2 = l2.transformation.toMatrix();
@@ -174,21 +197,26 @@ void compareCollisionGeometry(
       const auto& collA = sortedRefCollision[i];
       const auto& collB = sortedCollision[i];
 
-      EXPECT_TRUE(collA.isApprox(collB)) << "Collision geometry mismatch at index " << i << ":\n"
-                                         << "- refCollision:\n"
-                                         << "  - radius_0 : " << collA.radius.x() << "\n"
-                                         << "  - radius_1 : " << collA.radius.y() << "\n"
-                                         << "  - length   : " << collA.length << "\n"
-                                         << "  - parent   : " << collA.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collA.transformation.toMatrix() << "\n"
-                                         << "- collision:\n"
-                                         << "  - radius_0 : " << collB.radius.x() << "\n"
-                                         << "  - radius_1 : " << collB.radius.y() << "\n"
-                                         << "  - length   : " << collB.length << "\n"
-                                         << "  - parent   : " << collB.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collB.transformation.toMatrix() << std::endl;
+      EXPECT_TRUE(collA.isApprox(collB))
+          << "Collision geometry mismatch at index " << i << ":\n"
+          << "- refCollision:\n"
+          << "  - type     : " << static_cast<int>(collA.type) << "\n"
+          << "  - radius_0 : " << collA.radius.x() << "\n"
+          << "  - radius_1 : " << collA.radius.y() << "\n"
+          << "  - radii    : " << collA.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collA.length << "\n"
+          << "  - parent   : " << collA.parent << "\n"
+          << "  - transform:\n"
+          << collA.transformation.toMatrix() << "\n"
+          << "- collision:\n"
+          << "  - type     : " << static_cast<int>(collB.type) << "\n"
+          << "  - radius_0 : " << collB.radius.x() << "\n"
+          << "  - radius_1 : " << collB.radius.y() << "\n"
+          << "  - radii    : " << collB.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collB.length << "\n"
+          << "  - parent   : " << collB.parent << "\n"
+          << "  - transform:\n"
+          << collB.transformation.toMatrix() << std::endl;
     }
   }
 }

--- a/momentum/test/character/character_helpers_gtest.h
+++ b/momentum/test/character/character_helpers_gtest.h
@@ -14,6 +14,9 @@ namespace momentum {
 
 // Matching methods
 void compareMeshes(const Mesh_u& refMesh, const Mesh_u& mesh);
+void compareCollisionGeometry(
+    const CollisionGeometry_u& refCollision,
+    const CollisionGeometry_u& collision);
 void compareChars(
     const Character& refChar,
     const Character& character,

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -132,6 +132,13 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
   setTestPhysicalProperties(this->character);
   const PhysicalProperties originalPhysicalProperties = this->character.physicalProperties;
 
+  ASSERT_TRUE(this->character.collision);
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 1;
+  ellipsoid.transformation.translation = Vector3f(0.1f, 0.2f, 0.3f);
+  ellipsoid.radii = Vector3f(0.3f, 0.2f, 0.1f);
+  this->character.collision->push_back(ellipsoid);
+
   // Store original values for comparison
   Vector3f originalTranslation = this->character.skeleton.joints[1].translationOffset;
   Vector3f originalVertex = this->character.mesh->vertices[0];
@@ -166,6 +173,11 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
         scaledCharacter.collision->at(0).radius, this->character.collision->at(0).radius * scale);
     EXPECT_EQ(
         scaledCharacter.collision->at(0).length, this->character.collision->at(0).length * scale);
+    const auto& scaledEllipsoid = scaledCharacter.collision->back();
+    EXPECT_EQ(scaledEllipsoid.type, CollisionPrimitiveType::Ellipsoid);
+    EXPECT_EQ(
+        scaledEllipsoid.transformation.translation, ellipsoid.transformation.translation * scale);
+    EXPECT_EQ(scaledEllipsoid.ellipsoidRadii, ellipsoid.radii * scale);
   }
 
   // Check that inverse bind pose was scaled
@@ -322,6 +334,48 @@ TEST_F(CharacterUtilityTest, TransformCharacter) {
   testTransformCharacter(this->characterWithBlendShapes);
 }
 
+TEST_F(CharacterUtilityTest, TransformCharacterTransformsWorldFixedCollisionGeometry) {
+  CollisionGeometry collisionGeometry;
+
+  CollisionEllipsoid parentedEllipsoid;
+  parentedEllipsoid.parent = 0;
+  parentedEllipsoid.transformation.translation = Vector3f(0.1f, 0.2f, 0.3f);
+  parentedEllipsoid.radii = Vector3f(0.2f, 0.3f, 0.4f);
+  collisionGeometry.push_back(parentedEllipsoid);
+
+  CollisionEllipsoid worldEllipsoid;
+  worldEllipsoid.parent = kInvalidIndex;
+  worldEllipsoid.transformation.translation = Vector3f(0.5f, 0.6f, 0.7f);
+  worldEllipsoid.transformation.rotation =
+      Quaternionf(Eigen::AngleAxisf(pi() / 3.0f, Vector3f::UnitZ()));
+  worldEllipsoid.radii = Vector3f(0.7f, 0.6f, 0.5f);
+  collisionGeometry.push_back(worldEllipsoid);
+
+  const Character character(
+      this->smallCharacter.skeleton,
+      this->smallCharacter.parameterTransform,
+      this->smallCharacter.parameterLimits,
+      this->smallCharacter.locators,
+      this->smallCharacter.mesh.get(),
+      this->smallCharacter.skinWeights.get(),
+      &collisionGeometry);
+
+  Affine3f transform = Affine3f::Identity();
+  transform.linear() =
+      Quaternionf(Eigen::AngleAxisf(pi() / 2.0f, Vector3f::UnitY())).toRotationMatrix();
+  transform.translation() = Vector3f(1.0f, 2.0f, 3.0f);
+
+  const Character transformedCharacter = transformCharacter(character, transform);
+
+  ASSERT_TRUE(transformedCharacter.collision);
+  ASSERT_EQ(transformedCharacter.collision->size(), 2);
+  EXPECT_TRUE(transformedCharacter.collision->at(0).transformation.isApprox(
+      parentedEllipsoid.transformation));
+  EXPECT_TRUE(transformedCharacter.collision->at(1).transformation.isApprox(
+      Transform(transform) * worldEllipsoid.transformation));
+  EXPECT_EQ(transformedCharacter.collision->at(1).ellipsoidRadii, worldEllipsoid.radii);
+}
+
 // Test removeJoints function
 TEST_F(CharacterUtilityTest, RemoveJoints) {
   // Skip if the character doesn't have enough joints
@@ -407,6 +461,38 @@ TEST_F(CharacterUtilityTest, RemoveJoints) {
   Character rootOnlyCharacter = removeJoints(this->character, allButRoot);
   EXPECT_EQ(rootOnlyCharacter.skeleton.joints.size(), 1);
   EXPECT_EQ(rootOnlyCharacter.skeleton.joints[0].name, this->character.skeleton.joints[0].name);
+}
+
+TEST_F(CharacterUtilityTest, RemoveJointsKeepsWorldFixedCollisionGeometry) {
+  CollisionGeometry collisionGeometry;
+
+  CollisionEllipsoid worldEllipsoid;
+  worldEllipsoid.parent = kInvalidIndex;
+  worldEllipsoid.radii = Vector3f(0.4f, 0.3f, 0.2f);
+  collisionGeometry.push_back(worldEllipsoid);
+
+  CollisionEllipsoid removedJointEllipsoid;
+  removedJointEllipsoid.parent = 1;
+  removedJointEllipsoid.radii = Vector3f(0.2f, 0.3f, 0.4f);
+  collisionGeometry.push_back(removedJointEllipsoid);
+
+  const Character character(
+      this->smallCharacter.skeleton,
+      this->smallCharacter.parameterTransform,
+      this->smallCharacter.parameterLimits,
+      this->smallCharacter.locators,
+      this->smallCharacter.mesh.get(),
+      this->smallCharacter.skinWeights.get(),
+      &collisionGeometry);
+
+  const std::vector<size_t> jointsToRemove = {1};
+  const Character resultCharacter = removeJoints(character, jointsToRemove);
+
+  ASSERT_TRUE(resultCharacter.collision);
+  ASSERT_EQ(resultCharacter.collision->size(), 1);
+  EXPECT_EQ(resultCharacter.collision->at(0).type, CollisionPrimitiveType::Ellipsoid);
+  EXPECT_EQ(resultCharacter.collision->at(0).parent, kInvalidIndex);
+  EXPECT_EQ(resultCharacter.collision->at(0).ellipsoidRadii, worldEllipsoid.radii);
 }
 
 // Test mapMotionToCharacter function

--- a/momentum/test/character/collision_geometry_state_test.cpp
+++ b/momentum/test/character/collision_geometry_state_test.cpp
@@ -127,6 +127,30 @@ TEST_F(CollisionGeometryStateTest, UpdateWithTransformedJoints) {
   EXPECT_FLOAT_EQ(collisionState.delta[1], -0.3f); // 0.3 - 0.6 = -0.3
 }
 
+TEST_F(CollisionGeometryStateTest, UpdateWithEllipsoid) {
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 0;
+  ellipsoid.transformation.translation = Vector3f(0.25f, 0.5f, 0.75f);
+  ellipsoid.transformation.rotation =
+      Quaternionf(Eigen::AngleAxisf(pi() / 2.0f, Vector3f::UnitZ()));
+  ellipsoid.radii = Vector3f(0.2f, 0.4f, 0.6f);
+  collisionGeometry.push_back(ellipsoid);
+
+  skeletonState.jointState[0].transform.translation = Vector3f(1.0f, 2.0f, 3.0f);
+  skeletonState.jointState[0].transform.scale = 2.0f;
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, collisionGeometry);
+
+  ASSERT_EQ(collisionState.type.size(), 3);
+  EXPECT_EQ(collisionState.type[2], CollisionPrimitiveType::Ellipsoid);
+  EXPECT_TRUE(collisionState.origin[2].isApprox(Vector3f(1.5f, 3.0f, 4.5f)));
+  EXPECT_TRUE(collisionState.direction[2].isZero());
+  EXPECT_TRUE(collisionState.radius[2].isZero());
+  EXPECT_FLOAT_EQ(collisionState.delta[2], 0.0f);
+  EXPECT_TRUE(collisionState.ellipsoidRadii[2].isApprox(Vector3f(0.4f, 0.8f, 1.2f)));
+}
+
 // Test the overlaps function with non-overlapping capsules
 TEST_F(CollisionGeometryStateTest, OverlapsNonOverlapping) {
   // Create two non-overlapping capsules
@@ -160,6 +184,58 @@ TEST_F(CollisionGeometryStateTest, OverlapsNonOverlapping) {
 
   // They should not overlap
   EXPECT_FALSE(result);
+}
+
+TEST_F(CollisionGeometryStateTest, OverlapsCapsuleEllipsoid) {
+  CollisionGeometry geometry;
+
+  TaperedCapsule capsule;
+  capsule.parent = 0;
+  capsule.length = 1.0f;
+  capsule.radius = Vector2f(0.25f, 0.25f);
+  geometry.push_back(capsule);
+
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 1;
+  ellipsoid.transformation.translation = Vector3f(0.5f, 0.45f, 0.0f);
+  ellipsoid.radii = Vector3f(0.2f, 0.3f, 0.2f);
+  geometry.push_back(ellipsoid);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 0, 1, overlap));
+  EXPECT_NEAR(overlap.distance, 0.45f, 1e-5f);
+  EXPECT_NEAR(overlap.closestPoints[0], 0.5f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusA, 0.25f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.3f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.1f, 1e-5f);
+}
+
+TEST_F(CollisionGeometryStateTest, OverlapsEllipsoidEllipsoid) {
+  CollisionGeometry geometry;
+
+  CollisionEllipsoid ellipsoidA;
+  ellipsoidA.parent = 0;
+  ellipsoidA.radii = Vector3f(0.5f, 0.2f, 0.2f);
+  geometry.push_back(ellipsoidA);
+
+  CollisionEllipsoid ellipsoidB;
+  ellipsoidB.parent = 1;
+  ellipsoidB.transformation.translation = Vector3f(0.8f, 0.0f, 0.0f);
+  ellipsoidB.radii = Vector3f(0.4f, 0.2f, 0.2f);
+  geometry.push_back(ellipsoidB);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 0, 1, overlap));
+  EXPECT_NEAR(overlap.distance, 0.8f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusA, 0.5f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.4f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.1f, 1e-5f);
 }
 
 // Test the overlaps function with overlapping capsules
@@ -313,6 +389,30 @@ TEST_F(CollisionGeometryStateTest, UpdateAabbDifferentRadii) {
   EXPECT_TRUE(aabb.aabb.min().isApprox(Vector3f(0.7f, 1.5f, 2.5f)));
   // Max should account for the larger radius at the end
   EXPECT_TRUE(aabb.aabb.max().isApprox(Vector3f(3.5f, 2.5f, 3.5f)));
+}
+
+// Test that updateEllipsoidAabb uses the tight L2 ellipsoid bound. A 45-degree rotation about
+// Z makes the tight bound (sqrt((cos45*rx)^2 + (sin45*ry)^2)) differ from the looser L1/OBB
+// bound used for boxes (cos45*rx + sin45*ry), so this exercises the ellipsoid-specific path.
+TEST_F(CollisionGeometryStateTest, UpdateEllipsoidAabb) {
+  const Vector3f center(1.0f, 2.0f, 5.0f);
+  // Unit quaternion (w, x, y, z) for a +45-degree rotation about the Z axis.
+  const Quaternionf orientation(0.9238795325f, 0.0f, 0.0f, 0.3826834324f);
+  const Vector3f radii(2.0f, 1.0f, 3.0f);
+
+  axel::BoundingBox<float> aabb;
+  updateEllipsoidAabb(aabb, center, orientation, radii);
+
+  // Tight half-extent along X and Y is sqrt((cos45*2)^2 + (sin45*1)^2) = sqrt(2.5) ~= 1.5811,
+  // whereas the box/L1 bound would be cos45*2 + sin45*1 ~= 2.1213. Z is unrotated, so 3.0.
+  const float hXy = std::sqrt(2.5f);
+  const float hZ = 3.0f;
+  EXPECT_NEAR(aabb.aabb.min().x(), center.x() - hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.min().y(), center.y() - hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.min().z(), center.z() - hZ, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().x(), center.x() + hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().y(), center.y() + hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().z(), center.z() + hZ, 1e-5f);
 }
 
 // Test the CollisionGeometryState with double precision

--- a/momentum/test/character/collision_geometry_test.cpp
+++ b/momentum/test/character/collision_geometry_test.cpp
@@ -29,6 +29,19 @@ TEST(CollisionGeometryTest, DefaultConstructor) {
   EXPECT_TRUE(capsuleDouble.radius.isApprox(Vector2<double>::Zero()));
   EXPECT_EQ(capsuleDouble.parent, kInvalidIndex);
   EXPECT_DOUBLE_EQ(capsuleDouble.length, 0.0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  EXPECT_TRUE(ellipsoidFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(ellipsoidFloat.radii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(ellipsoidFloat.parent, kInvalidIndex);
+
+  CollisionPrimitiveT<float> primitiveFloat;
+  EXPECT_EQ(primitiveFloat.type, CollisionPrimitiveType::TaperedCapsule);
+  EXPECT_TRUE(primitiveFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(primitiveFloat.radius.isApprox(Vector2<float>::Zero()));
+  EXPECT_TRUE(primitiveFloat.ellipsoidRadii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(primitiveFloat.parent, kInvalidIndex);
+  EXPECT_FLOAT_EQ(primitiveFloat.length, 0.0f);
 }
 
 // Test the isApprox method of TaperedCapsuleT
@@ -66,6 +79,25 @@ TEST(CollisionGeometryTest, IsApprox) {
       capsule1.isApprox(capsule2, 1e-4f)); // Should be approximately equal with this tolerance
   EXPECT_FALSE(
       capsule1.isApprox(capsule2, 1e-6f)); // Should not be approximately equal with this tolerance
+
+  CollisionEllipsoidT<float> ellipsoid1;
+  CollisionEllipsoidT<float> ellipsoid2;
+  EXPECT_TRUE(ellipsoid1.isApprox(ellipsoid2));
+
+  ellipsoid2.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  EXPECT_FALSE(ellipsoid1.isApprox(ellipsoid2));
+
+  CollisionPrimitiveT<float> primitive1(capsule1);
+  CollisionPrimitiveT<float> primitive2(capsule1);
+  EXPECT_TRUE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive1.isTaperedCapsule());
+  EXPECT_FALSE(primitive1.isEllipsoid());
+  EXPECT_TRUE(primitive1.toTaperedCapsule().isApprox(capsule1));
+
+  primitive2 = ellipsoid2;
+  EXPECT_FALSE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive2.isEllipsoid());
+  EXPECT_TRUE(primitive2.toEllipsoid().isApprox(ellipsoid2));
 }
 
 // Test the CollisionGeometryT type alias
@@ -85,6 +117,16 @@ TEST(CollisionGeometryTest, CollisionGeometryT) {
   EXPECT_TRUE(collisionGeometryFloat[0].radius.isApprox(Vector2<float>(1.0f, 2.0f)));
   EXPECT_FLOAT_EQ(collisionGeometryFloat[0].length, 3.0f);
   EXPECT_EQ(collisionGeometryFloat[0].parent, 0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  ellipsoidFloat.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  ellipsoidFloat.parent = 1;
+  collisionGeometryFloat.push_back(ellipsoidFloat);
+
+  EXPECT_EQ(collisionGeometryFloat.size(), 2);
+  EXPECT_TRUE(collisionGeometryFloat[1].isEllipsoid());
+  EXPECT_TRUE(collisionGeometryFloat[1].ellipsoidRadii.isApprox(Vector3<float>(1.0f, 2.0f, 3.0f)));
+  EXPECT_EQ(collisionGeometryFloat[1].parent, 1);
 
   // Create a collision geometry with double precision
   CollisionGeometryT<double> collisionGeometryDouble;

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -58,6 +58,26 @@ mm::Character withBlendShapeImpl(
   return c.withBlendShape(blendShapePtr, nShapes < 0 ? INT_MAX : nShapes);
 }
 
+std::vector<mm::TaperedCapsule> collisionGeometryToPython(
+    const mm::CollisionGeometry& collisionGeometry) {
+  std::vector<mm::TaperedCapsule> result;
+  result.reserve(collisionGeometry.size());
+  for (const auto& primitive : collisionGeometry) {
+    if (!primitive.isTaperedCapsule()) {
+      MT_THROW(
+          "Collision geometry contains unsupported primitive type for capsule-only Python binding: {}",
+          static_cast<int>(primitive.type));
+    }
+    result.push_back(primitive.toTaperedCapsule());
+  }
+  return result;
+}
+
+mm::CollisionGeometry collisionGeometryFromPython(
+    const std::vector<mm::TaperedCapsule>& collisionGeometry) {
+  return {collisionGeometry.begin(), collisionGeometry.end()};
+}
+
 } // namespace
 
 namespace pymomentum {
@@ -369,12 +389,11 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           ":return: The character's :class:`BlendShapeBase` basis, if present, or None.")
       .def_property_readonly(
           "collision_geometry",
-          [](const mm::Character& c) -> mm::CollisionGeometry {
+          [](const mm::Character& c) -> std::vector<mm::TaperedCapsule> {
             if (c.collision) {
-              return *c.collision;
-            } else {
-              return {};
+              return collisionGeometryToPython(*c.collision);
             }
+            return {};
           },
           ":return: A list of :class:`TaperedCapsule` representing the character's collision geometry.")
       .def(
@@ -407,6 +426,7 @@ It can be used to solve for facial expressions.
       .def(
           "with_collision_geometry",
           [](const mm::Character& c, const std::vector<mm::TaperedCapsule>& collision_geometry) {
+            const mm::CollisionGeometry geometry = collisionGeometryFromPython(collision_geometry);
             return mm::Character(
                 c.skeleton,
                 c.parameterTransform,
@@ -414,7 +434,7 @@ It can be used to solve for facial expressions.
                 c.locators,
                 c.mesh.get(),
                 c.skinWeights.get(),
-                &collision_geometry,
+                &geometry,
                 c.poseShapes.get(),
                 c.blendShape,
                 c.faceExpressionBlendShape,

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -15,6 +15,7 @@
 #include <momentum/character/blend_shape.h>
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>
+#include <momentum/character/collision_geometry.h>
 #include <momentum/character/skeleton.h>
 #include <momentum/character/skeleton_state.h>
 #include <momentum/io/fbx/fbx_io.h>
@@ -35,6 +36,7 @@
 #include <fmt/format.h>
 
 namespace mm = momentum;
+namespace py = pybind11;
 
 namespace {
 
@@ -58,24 +60,37 @@ mm::Character withBlendShapeImpl(
   return c.withBlendShape(blendShapePtr, nShapes < 0 ? INT_MAX : nShapes);
 }
 
-std::vector<mm::TaperedCapsule> collisionGeometryToPython(
-    const mm::CollisionGeometry& collisionGeometry) {
-  std::vector<mm::TaperedCapsule> result;
-  result.reserve(collisionGeometry.size());
+py::list collisionGeometryToPython(const mm::CollisionGeometry& collisionGeometry) {
+  py::list result;
   for (const auto& primitive : collisionGeometry) {
-    if (!primitive.isTaperedCapsule()) {
+    if (primitive.type == mm::CollisionPrimitiveType::TaperedCapsule) {
+      result.append(py::cast(primitive.toTaperedCapsule()));
+    } else if (primitive.type == mm::CollisionPrimitiveType::Ellipsoid) {
+      result.append(py::cast(primitive.toEllipsoid()));
+    } else {
       MT_THROW(
-          "Collision geometry contains unsupported primitive type for capsule-only Python binding: {}",
+          "Unsupported collision primitive type while converting collision geometry to Python: {}",
           static_cast<int>(primitive.type));
     }
-    result.push_back(primitive.toTaperedCapsule());
   }
   return result;
 }
 
-mm::CollisionGeometry collisionGeometryFromPython(
-    const std::vector<mm::TaperedCapsule>& collisionGeometry) {
-  return {collisionGeometry.begin(), collisionGeometry.end()};
+mm::CollisionGeometry collisionGeometryFromPython(const py::sequence& collisionGeometry) {
+  mm::CollisionGeometry result;
+  result.reserve(collisionGeometry.size());
+  for (const py::handle item : collisionGeometry) {
+    if (py::isinstance<mm::TaperedCapsule>(item)) {
+      result.push_back(item.cast<mm::TaperedCapsule>());
+    } else if (py::isinstance<mm::CollisionEllipsoid>(item)) {
+      result.push_back(item.cast<mm::CollisionEllipsoid>());
+    } else {
+      MT_THROW(
+          "Collision geometry entries must be TaperedCapsule or Ellipsoid; got {}",
+          py::str(py::type::handle_of(item)).cast<std::string>());
+    }
+  }
+  return result;
 }
 
 } // namespace
@@ -389,13 +404,14 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           ":return: The character's :class:`BlendShapeBase` basis, if present, or None.")
       .def_property_readonly(
           "collision_geometry",
-          [](const mm::Character& c) -> std::vector<mm::TaperedCapsule> {
+          [](const mm::Character& c) -> py::list {
             if (c.collision) {
               return collisionGeometryToPython(*c.collision);
+            } else {
+              return py::list();
             }
-            return {};
           },
-          ":return: A list of :class:`TaperedCapsule` representing the character's collision geometry.")
+          ":return: A list of :class:`TaperedCapsule` and :class:`Ellipsoid` objects representing the character's collision geometry.")
       .def(
           "with_blend_shape",
           &withBlendShapeImpl,
@@ -425,8 +441,9 @@ It can be used to solve for facial expressions.
           py::arg("n_shapes") = -1)
       .def(
           "with_collision_geometry",
-          [](const mm::Character& c, const std::vector<mm::TaperedCapsule>& collision_geometry) {
-            const mm::CollisionGeometry geometry = collisionGeometryFromPython(collision_geometry);
+          [](const mm::Character& c, const py::sequence& collision_geometry) {
+            const mm::CollisionGeometry collisionGeometry =
+                collisionGeometryFromPython(collision_geometry);
             return mm::Character(
                 c.skeleton,
                 c.parameterTransform,
@@ -434,7 +451,7 @@ It can be used to solve for facial expressions.
                 c.locators,
                 c.mesh.get(),
                 c.skinWeights.get(),
-                &geometry,
+                &collisionGeometry,
                 c.poseShapes.get(),
                 c.blendShape,
                 c.faceExpressionBlendShape,

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -31,6 +31,7 @@
 #include <momentum/character/blend_shape.h>
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>
+#include <momentum/character/collision_geometry.h>
 #include <momentum/character/fwd.h>
 #include <momentum/character/inverse_parameter_transform.h>
 #include <momentum/character/joint.h>
@@ -50,6 +51,7 @@
 #include <momentum/math/mesh.h>
 #include <momentum/math/mppca.h>
 #include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <Eigen/Core>
@@ -63,6 +65,44 @@ namespace py = pybind11;
 namespace mm = momentum;
 
 using namespace pymomentum;
+
+namespace {
+
+using OptionalTransformArray =
+    std::optional<py::array_t<float, py::array::c_style | py::array::forcecast>>;
+
+Eigen::Matrix4f collisionTransformFromPython(const OptionalTransformArray& transformation) {
+  if (!transformation.has_value()) {
+    return Eigen::Matrix4f::Identity();
+  }
+
+  const auto& array = transformation.value();
+  MT_THROW_IF(
+      array.ndim() != 2 || array.shape(0) != 4 || array.shape(1) != 4,
+      "Expected collision primitive transformation to have shape (4, 4)");
+
+  Eigen::Matrix4f matrix;
+  const auto values = array.unchecked<2>();
+  for (Eigen::Index row = 0; row < 4; ++row) {
+    for (Eigen::Index col = 0; col < 4; ++col) {
+      matrix(row, col) = values(row, col);
+    }
+  }
+  return matrix;
+}
+
+int collisionParentToPython(size_t parent) {
+  if (parent == mm::kInvalidIndex) {
+    return -1;
+  }
+  MT_THROW_IF(
+      parent > static_cast<size_t>(std::numeric_limits<int>::max()),
+      "Collision primitive parent index {} cannot be represented as a Python int",
+      parent);
+  return static_cast<int>(parent);
+}
+
+} // namespace
 
 PYBIND11_MODULE(geometry, m) {
   // TODO more explanation
@@ -178,6 +218,11 @@ PYBIND11_MODULE(geometry, m) {
       "TaperedCapsule",
       "A tapered capsule primitive used for collision detection and physics simulation. "
       "Represents a capsule with potentially different radii at each end, attached to a skeleton joint.");
+  auto ellipsoidClass = py::class_<mm::CollisionEllipsoid>(
+      m,
+      "Ellipsoid",
+      "An ellipsoid primitive used for collision detection and physics simulation. "
+      "Represents an oriented ellipsoid attached to a skeleton joint.");
   py::class_<mm::SDFColliderT<float>> sdfColliderClass = py::class_<mm::SDFColliderT<float>>(
       m,
       "SDFCollider",
@@ -428,11 +473,11 @@ The resulting arrays are as follows:
   capsuleClass
       .def(
           py::init<>([](int parent,
-                        const std::optional<Eigen::Matrix4f>& transformation,
+                        const OptionalTransformArray& transformation,
                         const std::optional<Eigen::Vector2f>& radius,
                         float length) {
             mm::TaperedCapsule capsule;
-            capsule.transformation = transformation.value_or(Eigen::Matrix4f::Identity());
+            capsule.transformation = collisionTransformFromPython(transformation);
             capsule.radius = radius.value_or(Eigen::Vector2f::Ones());
             capsule.parent = parent;
             capsule.length = length;
@@ -445,7 +490,7 @@ The resulting arrays are as follows:
 :param parent: Parent joint to which the capsule is attached.
 :param length: Length of the capsule in local space.)",
           py::arg("parent"),
-          py::arg("transformation") = std::optional<Eigen::Matrix4f>{},
+          py::arg("transformation") = py::none(),
           py::arg("radius") = std::optional<Eigen::Vector2f>{},
           py::arg("length") = 1.0f)
       .def_property_readonly(
@@ -460,14 +505,16 @@ The resulting arrays are as follows:
           "Start and end radius for the capsule.")
       .def_property_readonly(
           "parent",
-          [](const mm::TaperedCapsule& capsule) -> int { return capsule.parent; },
+          [](const mm::TaperedCapsule& capsule) -> int {
+            return collisionParentToPython(capsule.parent);
+          },
           "Parent joint to which the capsule is attached.")
       .def_property_readonly(
           "length", [](const mm::TaperedCapsule& capsule) -> float { return capsule.length; })
       .def("__repr__", [](const mm::TaperedCapsule& tc) {
         return fmt::format(
             "TaperedCapsule(parent={}, length={}, radius=[{}, {}])",
-            tc.parent,
+            collisionParentToPython(tc.parent),
             tc.length,
             tc.radius[0],
             tc.radius[1]);
@@ -504,6 +551,53 @@ The resulting arrays are as follows:
             properties.jointName,
             properties.jointIndex,
             properties.mass);
+      });
+
+  ellipsoidClass
+      .def(
+          py::init<>([](int parent,
+                        const OptionalTransformArray& transformation,
+                        const std::optional<Eigen::Vector3f>& radii) {
+            mm::CollisionEllipsoid ellipsoid;
+            ellipsoid.transformation = collisionTransformFromPython(transformation);
+            ellipsoid.radii = radii.value_or(Eigen::Vector3f::Ones());
+            ellipsoid.parent = parent;
+            return ellipsoid;
+          }),
+          R"(Create an ellipsoid using its parent, transformation, and radii.
+
+:param parent: Parent joint to which the ellipsoid is attached.
+:param transformation: Transformation defining the center and orientation relative to the parent coordinate system.
+:param radii: Radii along the local x, y, and z axes.)",
+          py::arg("parent"),
+          py::kw_only(),
+          py::arg("transformation") = py::none(),
+          py::arg("radii") = std::optional<Eigen::Vector3f>{})
+      .def_property_readonly(
+          "transformation",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> Eigen::Matrix4f {
+            return ellipsoid.transformation.toMatrix();
+          },
+          "Transformation defining the center and orientation relative to the parent coordinate system")
+      .def_property_readonly(
+          "radii",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> Eigen::Vector3f {
+            return ellipsoid.radii;
+          },
+          "Radii along the local x, y, and z axes.")
+      .def_property_readonly(
+          "parent",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> int {
+            return collisionParentToPython(ellipsoid.parent);
+          },
+          "Parent joint to which the ellipsoid is attached.")
+      .def("__repr__", [](const mm::CollisionEllipsoid& ellipsoid) {
+        return fmt::format(
+            "Ellipsoid(parent={}, radii=[{}, {}, {}])",
+            collisionParentToPython(ellipsoid.parent),
+            ellipsoid.radii[0],
+            ellipsoid.radii[1],
+            ellipsoid.radii[2]);
       });
 
   // Class Marker, defining the properties:


### PR DESCRIPTION
Summary: Track ellipsoid radii in collision state, add centered-primitive overlap and AABB support, and update character scaling utilities. Also routes `transformCharacter` through a new `transformCollisionGeometry` helper so world-fixed (parentless) collision primitives are transformed by the character transform, and adds a `kInvalidIndex` early-out in `mapParents` so world-fixed primitives are preserved by `removeJoints`/`mergeCharacters`. Extends character test helpers and adds coverage.

Reviewed By: cstollmeta

Differential Revision: D105192536


