### PR TITLE
Add Rerun collision geometry viewer support

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -637,12 +637,12 @@ Character replaceSkeletonHierarchy(
   if (tgtCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*tgtCharacter.collision, tgtToCombinedJoints));
+        mapParents<CollisionPrimitive>(*tgtCharacter.collision, tgtToCombinedJoints));
   }
   if (srcCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
         combinedCollisionGeometry,
-        mapParents<TaperedCapsule>(*srcCharacter.collision, srcToCombinedJoints));
+        mapParents<CollisionPrimitive>(*srcCharacter.collision, srcToCombinedJoints));
   }
 
   // Build the merged parameter transform:
@@ -807,7 +807,8 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
 
   CollisionGeometry resultCollisionGeometry;
   if (character.collision) {
-    resultCollisionGeometry = mapParents<TaperedCapsule>(*character.collision, srcToResultJoints);
+    resultCollisionGeometry =
+        mapParents<CollisionPrimitive>(*character.collision, srcToResultJoints);
   }
 
   const ParameterLimits resultParameterLimits =

--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -87,10 +87,14 @@ std::unique_ptr<CollisionGeometry> scale(
   }
 
   auto result = std::make_unique<CollisionGeometry>(*geom);
-  for (auto& capsule : (*result)) {
-    capsule.transformation.translation *= scale;
-    capsule.radius *= scale;
-    capsule.length *= scale;
+  for (auto& primitive : (*result)) {
+    primitive.transformation.translation *= scale;
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      primitive.radius *= scale;
+      primitive.length *= scale;
+    } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      primitive.ellipsoidRadii *= scale;
+    }
   }
 
   return result;
@@ -168,6 +172,10 @@ std::vector<T> mapParents(const std::vector<T>& objects, const std::vector<size_
   std::vector<T> result;
   result.reserve(objects.size());
   for (auto o : objects) {
+    if (o.parent == kInvalidIndex) {
+      result.push_back(o);
+      continue;
+    }
     MT_CHECK(
         o.parent < jointMapping.size(),
         "Parent {} exceeds joint mapping size {}",
@@ -521,6 +529,23 @@ TransformationList transformInverseBindPose(
   return result;
 }
 
+std::unique_ptr<CollisionGeometry> transformCollisionGeometry(
+    const std::unique_ptr<CollisionGeometry>& collision,
+    const Eigen::Affine3f& xf) {
+  if (!collision) {
+    return {};
+  }
+
+  auto result = std::make_unique<CollisionGeometry>(*collision);
+  const Transform xformTransform(xf);
+  for (auto& primitive : *result) {
+    if (primitive.parent == kInvalidIndex) {
+      primitive.transformation = xformTransform * primitive.transformation;
+    }
+  }
+  return result;
+}
+
 } // namespace
 
 Character transformCharacter(const Character& character, const Affine3f& xform) {
@@ -531,7 +556,7 @@ Character transformCharacter(const Character& character, const Affine3f& xform) 
       character.locators,
       transformMesh(character.mesh, xform).get(),
       character.skinWeights.get(),
-      character.collision.get(),
+      transformCollisionGeometry(character.collision, xform).get(),
       character.poseShapes.get(),
       transformBlendShape(character.blendShape, xform),
       character.faceExpressionBlendShape,
@@ -636,13 +661,11 @@ Character replaceSkeletonHierarchy(
   CollisionGeometry combinedCollisionGeometry;
   if (tgtCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
-        combinedCollisionGeometry,
-        mapParents<CollisionPrimitive>(*tgtCharacter.collision, tgtToCombinedJoints));
+        combinedCollisionGeometry, mapParents(*tgtCharacter.collision, tgtToCombinedJoints));
   }
   if (srcCharacter.collision) {
     combinedCollisionGeometry = mergeVectors(
-        combinedCollisionGeometry,
-        mapParents<CollisionPrimitive>(*srcCharacter.collision, srcToCombinedJoints));
+        combinedCollisionGeometry, mapParents(*srcCharacter.collision, srcToCombinedJoints));
   }
 
   // Build the merged parameter transform:
@@ -807,8 +830,7 @@ Character removeJoints(const Character& character, momentum::span<const size_t> 
 
   CollisionGeometry resultCollisionGeometry;
   if (character.collision) {
-    resultCollisionGeometry =
-        mapParents<CollisionPrimitive>(*character.collision, srcToResultJoints);
+    resultCollisionGeometry = mapParents(*character.collision, srcToResultJoints);
   }
 
   const ParameterLimits resultParameterLimits =

--- a/momentum/character/collision_geometry.h
+++ b/momentum/character/collision_geometry.h
@@ -8,12 +8,21 @@
 #pragma once
 
 #include <momentum/character/types.h>
+#include <momentum/common/checks.h>
 #include <momentum/common/memory.h>
 #include <momentum/math/constants.h>
 #include <momentum/math/transform.h>
 #include <momentum/math/utility.h>
 
+#include <cstdint>
+
 namespace momentum {
+
+/// Collision primitive kinds supported by character collision geometry.
+enum class CollisionPrimitiveType : uint8_t {
+  TaperedCapsule,
+  Ellipsoid,
+};
 
 /// Tapered capsule collision geometry for character collision detection.
 ///
@@ -67,9 +76,190 @@ struct TaperedCapsuleT {
   }
 };
 
-/// Collection of tapered capsules representing a character's collision geometry.
+/// Ellipsoid collision geometry for character collision detection.
+///
+/// Defined by a transformation and three local-space radii along the primitive's axes.
 template <typename S>
-using CollisionGeometryT = std::vector<TaperedCapsuleT<S>>;
+struct CollisionEllipsoidT {
+  using Scalar = S;
+
+  /// Transformation defining the ellipsoid center and orientation relative to the parent.
+  TransformT<S> transformation;
+
+  /// Radii along the local x, y, and z axes.
+  Vector3<S> radii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  CollisionEllipsoidT()
+      : transformation(TransformT<S>()), radii(Vector3<S>::Zero()), parent(kInvalidIndex) {
+    // Empty
+  }
+
+  /// Checks if the current ellipsoid is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionEllipsoidT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (!radii.isApprox(other.radii, tol)) {
+      return false;
+    }
+
+    return parent == other.parent;
+  }
+};
+
+/// Collision geometry primitive.
+///
+/// The tapered capsule fields are kept directly on the primitive so existing code that
+/// constructs capsule-only collision geometry can continue to initialize `radius`, `length`,
+/// `parent`, and `transformation` on elements of `CollisionGeometry`.
+template <typename S>
+struct CollisionPrimitiveT {
+  using Scalar = S;
+
+  /// Primitive kind.
+  CollisionPrimitiveType type;
+
+  /// Transformation defining the primitive pose relative to the parent coordinate system.
+  TransformT<S> transformation;
+
+  /// Radii at the two endpoints of a tapered capsule.
+  Vector2<S> radius;
+
+  /// Radii along the local axes of an ellipsoid.
+  Vector3<S> ellipsoidRadii;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  /// Length of a tapered capsule along the x-axis.
+  S length;
+
+  CollisionPrimitiveT()
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(TransformT<S>()),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(kInvalidIndex),
+        length(S(0)) {
+    // Empty
+  }
+
+  /// Creates a collision primitive from a tapered capsule.
+  /* implicit */ CollisionPrimitiveT(const TaperedCapsuleT<S>& capsule)
+      : type(CollisionPrimitiveType::TaperedCapsule),
+        transformation(capsule.transformation),
+        radius(capsule.radius),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        parent(capsule.parent),
+        length(capsule.length) {}
+
+  /// Creates a collision primitive from an ellipsoid.
+  /* implicit */ CollisionPrimitiveT(const CollisionEllipsoidT<S>& ellipsoid)
+      : type(CollisionPrimitiveType::Ellipsoid),
+        transformation(ellipsoid.transformation),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(ellipsoid.radii),
+        parent(ellipsoid.parent),
+        length(S(0)) {}
+
+  /// Assigns tapered capsule data to this primitive.
+  CollisionPrimitiveT& operator=(const TaperedCapsuleT<S>& capsule) {
+    type = CollisionPrimitiveType::TaperedCapsule;
+    transformation = capsule.transformation;
+    radius = capsule.radius;
+    ellipsoidRadii.setZero();
+    parent = capsule.parent;
+    length = capsule.length;
+    return *this;
+  }
+
+  /// Assigns ellipsoid data to this primitive.
+  CollisionPrimitiveT& operator=(const CollisionEllipsoidT<S>& ellipsoid) {
+    type = CollisionPrimitiveType::Ellipsoid;
+    transformation = ellipsoid.transformation;
+    radius.setZero();
+    ellipsoidRadii = ellipsoid.radii;
+    parent = ellipsoid.parent;
+    length = S(0);
+    return *this;
+  }
+
+  /// Returns true when this primitive stores tapered capsule data.
+  [[nodiscard]] bool isTaperedCapsule() const {
+    return type == CollisionPrimitiveType::TaperedCapsule;
+  }
+
+  /// Returns true when this primitive stores ellipsoid data.
+  [[nodiscard]] bool isEllipsoid() const {
+    return type == CollisionPrimitiveType::Ellipsoid;
+  }
+
+  /// Converts this primitive to a tapered capsule.
+  ///
+  /// Requires `isTaperedCapsule()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] TaperedCapsuleT<S> toTaperedCapsule() const {
+    MT_CHECK(
+        isTaperedCapsule(),
+        "Collision primitive type {} does not store tapered capsule data",
+        static_cast<int>(type));
+
+    TaperedCapsuleT<S> capsule;
+    capsule.transformation = transformation;
+    capsule.radius = radius;
+    capsule.parent = parent;
+    capsule.length = length;
+    return capsule;
+  }
+
+  /// Converts this primitive to an ellipsoid.
+  ///
+  /// Requires `isEllipsoid()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated default-initialized fields.
+  [[nodiscard]] CollisionEllipsoidT<S> toEllipsoid() const {
+    MT_CHECK(
+        isEllipsoid(),
+        "Collision primitive type {} does not store ellipsoid data",
+        static_cast<int>(type));
+
+    CollisionEllipsoidT<S> ellipsoid;
+    ellipsoid.transformation = transformation;
+    ellipsoid.radii = ellipsoidRadii;
+    ellipsoid.parent = parent;
+    return ellipsoid;
+  }
+
+  /// Checks if the current primitive is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionPrimitiveT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (type != other.type || parent != other.parent) {
+      return false;
+    }
+
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (type == CollisionPrimitiveType::TaperedCapsule) {
+      return radius.isApprox(other.radius, tol) && ::momentum::isApprox(length, other.length, tol);
+    }
+
+    if (type == CollisionPrimitiveType::Ellipsoid) {
+      return ellipsoidRadii.isApprox(other.ellipsoidRadii, tol);
+    }
+
+    return false;
+  }
+};
+
+/// Collection of primitives representing a character's collision geometry.
+template <typename S>
+using CollisionGeometryT = std::vector<CollisionPrimitiveT<S>>;
 
 using CollisionGeometry = CollisionGeometryT<float>;
 using CollisionGeometryd = CollisionGeometryT<double>;

--- a/momentum/character/collision_geometry_state.cpp
+++ b/momentum/character/collision_geometry_state.cpp
@@ -21,18 +21,35 @@ void CollisionGeometryStateT<T>::update(
   direction.resize(numElements);
   radius.resize(numElements);
   delta.resize(numElements);
+  type.resize(numElements);
+  orientation.resize(numElements);
+  ellipsoidRadii.resize(numElements);
 
-  // TODO: This per-capsule loop is independent across iterations and could be parallelized.
+  // TODO: This per-primitive loop is independent across iterations and could be parallelized.
   for (size_t i = 0; i < numElements; ++i) {
-    const auto& tc = collisionGeometry[i];
-    const TransformT<T> parentTransform = (tc.parent == kInvalidIndex)
+    const auto& primitive = collisionGeometry[i];
+    const TransformT<T> parentTransform = (primitive.parent == kInvalidIndex)
         ? TransformT<T>()
-        : skeletonState.jointState[tc.parent].transform;
-    const TransformT<T> transform = parentTransform * tc.transformation.cast<T>();
+        : skeletonState.jointState[primitive.parent].transform;
+    const TransformT<T> transform = parentTransform * primitive.transformation.cast<T>();
+    type[i] = primitive.type;
     origin[i] = transform.translation;
-    direction[i].noalias() = transform.getAxisX() * transform.scale * tc.length;
-    radius[i].noalias() = tc.radius.cast<T>() * parentTransform.scale;
-    delta[i] = radius[i][1] - radius[i][0];
+    orientation[i] = transform.rotation;
+
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      direction[i].noalias() = transform.getAxisX() * transform.scale * primitive.length;
+      radius[i].noalias() = primitive.radius.cast<T>() * parentTransform.scale;
+      delta[i] = radius[i][1] - radius[i][0];
+      ellipsoidRadii[i].setZero();
+      continue;
+    }
+
+    if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      direction[i].setZero();
+      radius[i].setZero();
+      delta[i] = T(0);
+      ellipsoidRadii[i].noalias() = primitive.ellipsoidRadii.cast<T>() * parentTransform.scale;
+    }
   }
 }
 

--- a/momentum/character/collision_geometry_state.h
+++ b/momentum/character/collision_geometry_state.h
@@ -13,6 +13,8 @@
 
 #include <axel/BoundingBox.h>
 
+#include <algorithm>
+
 namespace momentum {
 
 /// Represents collision geometry states using a Structure of Arrays (SoA) format.
@@ -46,8 +48,42 @@ struct CollisionGeometryStateT {
   /// Signed difference between the capsule's radii (radius[1] - radius[0]).
   std::vector<T> delta;
 
+  /// Primitive types matching the source collision geometry.
+  std::vector<CollisionPrimitiveType> type;
+
+  /// Primitive orientation in global coordinates.
+  std::vector<Quaternion<T>> orientation;
+
+  /// Scaled ellipsoid radii in global coordinates.
+  std::vector<Vector3<T>> ellipsoidRadii;
+
   /// Updates the state based on a given skeleton state and collision geometry.
   void update(const SkeletonStateT<T>& skeletonState, const CollisionGeometry& collisionGeometry);
+};
+
+/// Narrow-phase collision information for a pair of primitives.
+template <typename T>
+struct CollisionOverlapResultT {
+  /// Distance between the primitive center features used by the narrow phase.
+  T distance = T(0);
+
+  /// Parametric closest-point positions. Capsule entries use [0, 1]; ellipsoid entries use 0.
+  Vector2<T> closestPoints = Vector2<T>::Zero();
+
+  /// Amount of overlap, positive when colliding.
+  T overlap = T(0);
+
+  /// Center feature position for the first primitive.
+  Vector3<T> positionA = Vector3<T>::Zero();
+
+  /// Center feature position for the second primitive.
+  Vector3<T> positionB = Vector3<T>::Zero();
+
+  /// Effective radius of the first primitive along the contact direction.
+  T radiusA = T(0);
+
+  /// Effective radius of the second primitive along the contact direction.
+  T radiusB = T(0);
 };
 
 /// Determines if two tapered capsules overlap.
@@ -108,6 +144,201 @@ bool overlaps(
   return (outOverlap > T(0)) && (closestDist >= Eps<T>(1e-8, 1e-17));
 }
 
+/// Return the clamped segment parameter for the closest point to a world-space point.
+template <typename T>
+[[nodiscard]] T closestPointOnSegmentParameter(
+    const Vector3<T>& origin,
+    const Vector3<T>& direction,
+    const Vector3<T>& point) {
+  const T directionNormSq = direction.squaredNorm();
+  if (directionNormSq <= Eps<T>(1e-8, 1e-17)) {
+    return T(0);
+  }
+
+  return std::clamp((point - origin).dot(direction) / directionNormSq, T(0), T(1));
+}
+
+/// Return the support radius of an oriented ellipsoid along a unit world-space direction.
+template <typename T>
+[[nodiscard]] T ellipsoidRadiusAlongDirection(
+    const Quaternion<T>& orientation,
+    const Vector3<T>& radii,
+    const Vector3<T>& unitDirection) {
+  const Vector3<T> localDirection = orientation.inverse() * unitDirection;
+  return radii.cwiseAbs().cwiseProduct(localDirection).norm();
+}
+
+/// Test overlap between a tapered capsule and an oriented ellipsoid.
+///
+/// The function fills the closest capsule parameter, support radii, distance,
+/// and signed overlap used by the solver when a non-degenerate overlap is found.
+///
+/// @param capsuleOrigin Origin of the capsule segment in world space.
+/// @param capsuleDirection Direction vector from capsule start to end in world space.
+/// @param capsuleRadii Radii at the capsule start and end points.
+/// @param capsuleDelta Signed difference between capsule radii (`capsuleRadii[1] -
+///   capsuleRadii[0]`).
+/// @param ellipsoidCenter Ellipsoid center in world space.
+/// @param ellipsoidOrientation Ellipsoid orientation in world space.
+/// @param ellipsoidRadii Ellipsoid radii along its local axes.
+/// @param outDistance Output: distance between the capsule centerline point and ellipsoid center.
+/// @param outCapsuleParam Output: parametric position in [0, 1] along the capsule segment.
+/// @param outOverlap Output: signed overlap amount, positive when overlapping.
+/// @param outCapsuleRadius Output: capsule support radius at `outCapsuleParam`.
+/// @param outEllipsoidRadius Output: ellipsoid support radius along the contact direction.
+/// @return True when the capsule and ellipsoid overlap with a non-degenerate contact direction.
+template <typename T>
+[[nodiscard]] bool overlapsCapsuleEllipsoid(
+    const Vector3<T>& capsuleOrigin,
+    const Vector3<T>& capsuleDirection,
+    const Vector2<T>& capsuleRadii,
+    T capsuleDelta,
+    const Vector3<T>& ellipsoidCenter,
+    const Quaternion<T>& ellipsoidOrientation,
+    const Vector3<T>& ellipsoidRadii,
+    T& outDistance,
+    T& outCapsuleParam,
+    T& outOverlap,
+    T& outCapsuleRadius,
+    T& outEllipsoidRadius) {
+  outCapsuleParam =
+      closestPointOnSegmentParameter(capsuleOrigin, capsuleDirection, ellipsoidCenter);
+  const Vector3<T> capsulePoint = capsuleOrigin + capsuleDirection * outCapsuleParam;
+  const Vector3<T> separation = capsulePoint - ellipsoidCenter;
+  outDistance = separation.norm();
+  if (outDistance < Eps<T>(1e-8, 1e-17)) {
+    return false;
+  }
+
+  const Vector3<T> normal = separation / outDistance;
+  outCapsuleRadius = capsuleRadii[0] + outCapsuleParam * capsuleDelta;
+  outEllipsoidRadius = ellipsoidRadiusAlongDirection(ellipsoidOrientation, ellipsoidRadii, normal);
+  outOverlap = outCapsuleRadius + outEllipsoidRadius - outDistance;
+  return outOverlap > T(0);
+}
+
+/// Determines whether two collision primitives overlap.
+///
+/// Capsule-capsule pairs use the existing closest-segment query. Ellipsoid pairs use a support
+/// radius along the center-feature separation direction, which gives a stable contact normal for
+/// the solver and preserves the same overlap convention used by tapered capsules.
+///
+/// @param collisionState World-space collision state for `collisionGeometry`.
+/// @param collisionGeometry Collision primitives corresponding to `collisionState`.
+/// @param indexA First primitive index.
+/// @param indexB Second primitive index.
+/// @param result Output: closest points, contact positions, support radii, distance, and overlap.
+/// @return True when the primitive pair overlaps with a non-degenerate contact direction.
+template <typename T>
+[[nodiscard]] bool overlaps(
+    const CollisionGeometryStateT<T>& collisionState,
+    const CollisionGeometry& collisionGeometry,
+    size_t indexA,
+    size_t indexB,
+    CollisionOverlapResultT<T>& result) {
+  const auto typeA = collisionGeometry[indexA].type;
+  const auto typeB = collisionGeometry[indexB].type;
+
+  if (typeA == CollisionPrimitiveType::TaperedCapsule &&
+      typeB == CollisionPrimitiveType::TaperedCapsule) {
+    if (!overlaps(
+            collisionState.origin[indexA],
+            collisionState.direction[indexA],
+            collisionState.radius[indexA],
+            collisionState.delta[indexA],
+            collisionState.origin[indexB],
+            collisionState.direction[indexB],
+            collisionState.radius[indexB],
+            collisionState.delta[indexB],
+            result.distance,
+            result.closestPoints,
+            result.overlap)) {
+      return false;
+    }
+
+    result.positionA =
+        collisionState.origin[indexA] + collisionState.direction[indexA] * result.closestPoints[0];
+    result.positionB =
+        collisionState.origin[indexB] + collisionState.direction[indexB] * result.closestPoints[1];
+    result.radiusA =
+        collisionState.radius[indexA][0] + result.closestPoints[0] * collisionState.delta[indexA];
+    result.radiusB =
+        collisionState.radius[indexB][0] + result.closestPoints[1] * collisionState.delta[indexB];
+    return true;
+  }
+
+  if (typeA == CollisionPrimitiveType::TaperedCapsule &&
+      typeB == CollisionPrimitiveType::Ellipsoid) {
+    if (!overlapsCapsuleEllipsoid(
+            collisionState.origin[indexA],
+            collisionState.direction[indexA],
+            collisionState.radius[indexA],
+            collisionState.delta[indexA],
+            collisionState.origin[indexB],
+            collisionState.orientation[indexB],
+            collisionState.ellipsoidRadii[indexB],
+            result.distance,
+            result.closestPoints[0],
+            result.overlap,
+            result.radiusA,
+            result.radiusB)) {
+      return false;
+    }
+
+    result.closestPoints[1] = T(0);
+    result.positionA =
+        collisionState.origin[indexA] + collisionState.direction[indexA] * result.closestPoints[0];
+    result.positionB = collisionState.origin[indexB];
+    return true;
+  }
+
+  if (typeA == CollisionPrimitiveType::Ellipsoid &&
+      typeB == CollisionPrimitiveType::TaperedCapsule) {
+    if (!overlapsCapsuleEllipsoid(
+            collisionState.origin[indexB],
+            collisionState.direction[indexB],
+            collisionState.radius[indexB],
+            collisionState.delta[indexB],
+            collisionState.origin[indexA],
+            collisionState.orientation[indexA],
+            collisionState.ellipsoidRadii[indexA],
+            result.distance,
+            result.closestPoints[1],
+            result.overlap,
+            result.radiusB,
+            result.radiusA)) {
+      return false;
+    }
+
+    result.closestPoints[0] = T(0);
+    result.positionA = collisionState.origin[indexA];
+    result.positionB =
+        collisionState.origin[indexB] + collisionState.direction[indexB] * result.closestPoints[1];
+    return true;
+  }
+
+  if (typeA == CollisionPrimitiveType::Ellipsoid && typeB == CollisionPrimitiveType::Ellipsoid) {
+    const Vector3<T> separation = collisionState.origin[indexA] - collisionState.origin[indexB];
+    result.distance = separation.norm();
+    if (result.distance < Eps<T>(1e-8, 1e-17)) {
+      return false;
+    }
+
+    const Vector3<T> normal = separation / result.distance;
+    result.radiusA = ellipsoidRadiusAlongDirection(
+        collisionState.orientation[indexA], collisionState.ellipsoidRadii[indexA], normal);
+    result.radiusB = ellipsoidRadiusAlongDirection(
+        collisionState.orientation[indexB], collisionState.ellipsoidRadii[indexB], normal);
+    result.overlap = result.radiusA + result.radiusB - result.distance;
+    result.positionA = collisionState.origin[indexA];
+    result.positionB = collisionState.origin[indexB];
+    result.closestPoints = Vector2<T>::Zero();
+    return result.overlap > T(0);
+  }
+
+  return false;
+}
+
 /// Updates an axis-aligned bounding box to encompass a tapered capsule.
 ///
 /// @param aabb The bounding box to update
@@ -133,19 +364,70 @@ void updateAabb(
   aabb.aabb.max() = maxA.cwiseMax(maxB);
 }
 
-/// Determines whether a pair of collision geometry capsules should be included as a valid
+/// Updates an axis-aligned bounding box to encompass an oriented ellipsoid.
+///
+/// Uses the tight ellipsoid AABB half-extent h_i = sqrt(sum_j (R_ij * radii_j)^2),
+/// i.e. the L2 norm of each rotation-matrix row scaled component-wise by the radii.
+/// This is the exact AABB of the ellipsoid, unlike the looser L1/OBB bound
+/// (sum_j |R_ij| * radii_j) which over-estimates by up to a factor of sqrt(3).
+///
+/// @param aabb The bounding box to update
+/// @param center Center of the ellipsoid
+/// @param orientation Orientation of the ellipsoid
+/// @param radii Radii along the ellipsoid's local axes
+template <typename T>
+void updateEllipsoidAabb(
+    axel::BoundingBox<T>& aabb,
+    const Vector3<T>& center,
+    const Quaternion<T>& orientation,
+    const Vector3<T>& radii) {
+  const Eigen::Matrix<T, 3, 3> rotation = orientation.toRotationMatrix();
+  const Vector3<T> absRadii = radii.cwiseAbs();
+  Vector3<T> halfExtents;
+  for (int i = 0; i < 3; ++i) {
+    halfExtents[i] = rotation.row(i).cwiseProduct(absRadii.transpose()).norm();
+  }
+  aabb.aabb.min() = center - halfExtents;
+  aabb.aabb.max() = center + halfExtents;
+}
+
+/// Updates an axis-aligned bounding box to encompass a collision primitive.
+template <typename T>
+void updateAabb(
+    axel::BoundingBox<T>& aabb,
+    const CollisionGeometryStateT<T>& collisionState,
+    size_t index) {
+  if (collisionState.type[index] == CollisionPrimitiveType::TaperedCapsule) {
+    updateAabb(
+        aabb,
+        collisionState.origin[index],
+        collisionState.direction[index],
+        collisionState.radius[index]);
+    return;
+  }
+
+  if (collisionState.type[index] == CollisionPrimitiveType::Ellipsoid) {
+    updateEllipsoidAabb(
+        aabb,
+        collisionState.origin[index],
+        collisionState.orientation[index],
+        collisionState.ellipsoidRadii[index]);
+  }
+}
+
+/// Determines whether a pair of collision geometry primitives should be included as a valid
 /// collision pair.
 ///
 /// A pair is excluded if:
-/// - The capsules overlap in rest pose (permanently overlapping, e.g. adjacent body parts),
+/// - The primitives overlap in rest pose (permanently overlapping, e.g. adjacent body parts),
 ///   unless @p filterRestPoseOverlaps is false
-/// - The capsules are attached to the same joint or directly adjacent joints
+/// - The primitives are attached to the same joint or directly adjacent joints
 ///
 /// @param collisionState The collision geometry state in rest pose
 /// @param collisionGeometry The collision geometry definition
 /// @param skeleton The skeleton used for adjacency checks
-/// @param i Index of the first capsule
-/// @param j Index of the second capsule
+/// @param i Index of the first primitive
+/// @param j Index of the second primitive
 /// @param filterRestPoseOverlaps When true, exclude pairs that overlap in rest pose
 /// @return True if the pair is a valid collision pair (should be checked for collisions)
 template <typename T, typename S>
@@ -159,7 +441,7 @@ template <typename T, typename S>
   const size_t p0 = collisionGeometry[i].parent;
   const size_t p1 = collisionGeometry[j].parent;
 
-  // World-fixed capsules (kInvalidIndex parent):
+  // World-fixed primitives (kInvalidIndex parent):
   // - If both are world-fixed, they can't collide with each other in a meaningful way.
   // - If exactly one is world-fixed, it's always a valid collision pair (no rest-pose
   //   overlap or adjacency checks apply since the world geometry is independent of
@@ -178,21 +460,8 @@ template <typename T, typename S>
   }
 
   // Check for rest-pose overlap (permanently overlapping pairs like adjacent body parts)
-  T distance;
-  Vector2<T> cp;
-  T overlap;
-  return !overlaps(
-      collisionState.origin[i],
-      collisionState.direction[i],
-      collisionState.radius[i],
-      collisionState.delta[i],
-      collisionState.origin[j],
-      collisionState.direction[j],
-      collisionState.radius[j],
-      collisionState.delta[j],
-      distance,
-      cp,
-      overlap);
+  CollisionOverlapResultT<T> overlap;
+  return !overlaps(collisionState, collisionGeometry, i, j, overlap);
 }
 
 } // namespace momentum

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -107,6 +107,25 @@ using CharacterStated_const_u = ::std::unique_ptr<const CharacterStated>;
 using CharacterStated_const_w = ::std::weak_ptr<const CharacterStated>;
 
 template <typename T>
+struct CollisionPrimitiveT;
+using CollisionPrimitive = CollisionPrimitiveT<float>;
+using CollisionPrimitived = CollisionPrimitiveT<double>;
+
+using CollisionPrimitive_p = ::std::shared_ptr<CollisionPrimitive>;
+using CollisionPrimitive_u = ::std::unique_ptr<CollisionPrimitive>;
+using CollisionPrimitive_w = ::std::weak_ptr<CollisionPrimitive>;
+using CollisionPrimitive_const_p = ::std::shared_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_u = ::std::unique_ptr<const CollisionPrimitive>;
+using CollisionPrimitive_const_w = ::std::weak_ptr<const CollisionPrimitive>;
+
+using CollisionPrimitived_p = ::std::shared_ptr<CollisionPrimitived>;
+using CollisionPrimitived_u = ::std::unique_ptr<CollisionPrimitived>;
+using CollisionPrimitived_w = ::std::weak_ptr<CollisionPrimitived>;
+using CollisionPrimitived_const_p = ::std::shared_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_u = ::std::unique_ptr<const CollisionPrimitived>;
+using CollisionPrimitived_const_w = ::std::weak_ptr<const CollisionPrimitived>;
+
+template <typename T>
 struct CollisionGeometryStateT;
 using CollisionGeometryState = CollisionGeometryStateT<float>;
 using CollisionGeometryStated = CollisionGeometryStateT<double>;
@@ -124,6 +143,25 @@ using CollisionGeometryStated_w = ::std::weak_ptr<CollisionGeometryStated>;
 using CollisionGeometryStated_const_p = ::std::shared_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_u = ::std::unique_ptr<const CollisionGeometryStated>;
 using CollisionGeometryStated_const_w = ::std::weak_ptr<const CollisionGeometryStated>;
+
+template <typename T>
+struct CollisionEllipsoidT;
+using CollisionEllipsoid = CollisionEllipsoidT<float>;
+using CollisionEllipsoidd = CollisionEllipsoidT<double>;
+
+using CollisionEllipsoid_p = ::std::shared_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_u = ::std::unique_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_w = ::std::weak_ptr<CollisionEllipsoid>;
+using CollisionEllipsoid_const_p = ::std::shared_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_u = ::std::unique_ptr<const CollisionEllipsoid>;
+using CollisionEllipsoid_const_w = ::std::weak_ptr<const CollisionEllipsoid>;
+
+using CollisionEllipsoidd_p = ::std::shared_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_u = ::std::unique_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_w = ::std::weak_ptr<CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_p = ::std::shared_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_u = ::std::unique_ptr<const CollisionEllipsoidd>;
+using CollisionEllipsoidd_const_w = ::std::weak_ptr<const CollisionEllipsoidd>;
 
 template <typename T>
 struct JointT;

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -145,6 +145,25 @@ using CollisionGeometryStated_const_u = ::std::unique_ptr<const CollisionGeometr
 using CollisionGeometryStated_const_w = ::std::weak_ptr<const CollisionGeometryStated>;
 
 template <typename T>
+struct CollisionOverlapResultT;
+using CollisionOverlapResult = CollisionOverlapResultT<float>;
+using CollisionOverlapResultd = CollisionOverlapResultT<double>;
+
+using CollisionOverlapResult_p = ::std::shared_ptr<CollisionOverlapResult>;
+using CollisionOverlapResult_u = ::std::unique_ptr<CollisionOverlapResult>;
+using CollisionOverlapResult_w = ::std::weak_ptr<CollisionOverlapResult>;
+using CollisionOverlapResult_const_p = ::std::shared_ptr<const CollisionOverlapResult>;
+using CollisionOverlapResult_const_u = ::std::unique_ptr<const CollisionOverlapResult>;
+using CollisionOverlapResult_const_w = ::std::weak_ptr<const CollisionOverlapResult>;
+
+using CollisionOverlapResultd_p = ::std::shared_ptr<CollisionOverlapResultd>;
+using CollisionOverlapResultd_u = ::std::unique_ptr<CollisionOverlapResultd>;
+using CollisionOverlapResultd_w = ::std::weak_ptr<CollisionOverlapResultd>;
+using CollisionOverlapResultd_const_p = ::std::shared_ptr<const CollisionOverlapResultd>;
+using CollisionOverlapResultd_const_u = ::std::unique_ptr<const CollisionOverlapResultd>;
+using CollisionOverlapResultd_const_w = ::std::weak_ptr<const CollisionOverlapResultd>;
+
+template <typename T>
 struct CollisionEllipsoidT;
 using CollisionEllipsoid = CollisionEllipsoidT<float>;
 using CollisionEllipsoidd = CollisionEllipsoidT<double>;

--- a/momentum/character_solver/collision_error_function.cpp
+++ b/momentum/character_solver/collision_error_function.cpp
@@ -57,11 +57,7 @@ void CollisionErrorFunctionT<T>::updateCollisionPairs(bool filterRestPoseOverlap
   aabbs_.resize(n);
   for (size_t i = 0; i < n; ++i) {
     aabbs_[i].id = gsl::narrow_cast<axel::Index>(i);
-    updateAabb(
-        aabbs_[i],
-        collisionState_.origin[i],
-        collisionState_.direction[i],
-        collisionState_.radius[i]);
+    updateAabb(aabbs_[i], collisionState_, i);
   }
 
   if (n == 0) {
@@ -88,11 +84,7 @@ void CollisionErrorFunctionT<T>::computeBroadPhase(const SkeletonStateT<T>& stat
   }
 
   for (size_t i = 0; i < aabbs_.size(); ++i) {
-    updateAabb(
-        aabbs_[i],
-        collisionState_.origin[i],
-        collisionState_.direction[i],
-        collisionState_.radius[i]);
+    updateAabb(aabbs_[i], collisionState_, i);
   }
 }
 
@@ -101,24 +93,11 @@ bool CollisionErrorFunctionT<T>::checkCollision(
     const CollisionGeometryStateT<T>& colState,
     size_t indexA,
     size_t indexB,
-    T& distance,
-    Vector2<T>& cp,
-    T& overlap) const {
+    CollisionOverlapResultT<T>& result) const {
   if (!aabbs_[indexA].intersects(aabbs_[indexB])) {
     return false;
   }
-  return overlaps(
-      colState.origin[indexA],
-      colState.direction[indexA],
-      colState.radius[indexA],
-      colState.delta[indexA],
-      colState.origin[indexB],
-      colState.direction[indexB],
-      colState.radius[indexB],
-      colState.delta[indexB],
-      distance,
-      cp,
-      overlap);
+  return overlaps(colState, collisionGeometry_, indexA, indexB, result);
 }
 
 template <typename T>
@@ -201,10 +180,8 @@ template <typename T>
 std::vector<Vector2i> CollisionErrorFunctionT<T>::getCollisionPairs() const {
   std::vector<Vector2i> collidingPairs;
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (checkCollision(collisionState_, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (checkCollision(collisionState_, pair.indexA, pair.indexB, result)) {
       collidingPairs.emplace_back(static_cast<int>(pair.indexA), static_cast<int>(pair.indexB));
     }
   }
@@ -229,14 +206,12 @@ double CollisionErrorFunctionT<T>::getError(
   double error = 0;
   size_t collidingCount = 0;
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (!checkCollision(collisionState_, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (!checkCollision(collisionState_, pair.indexA, pair.indexB, result)) {
       continue;
     }
     collidingCount++;
-    error += sqr(overlap) * kCollisionWeight * this->weight_;
+    error += sqr(result.overlap) * kCollisionWeight * this->weight_;
   }
 
   MT_LOGD(
@@ -267,46 +242,34 @@ double CollisionErrorFunctionT<T>::getGradient(
 
   double error = 0;
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (!checkCollision(collisionState_, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (!checkCollision(collisionState_, pair.indexA, pair.indexB, result)) {
       continue;
     }
 
-    error += sqr(overlap) * kCollisionWeight * this->weight_;
+    error += sqr(result.overlap) * kCollisionWeight * this->weight_;
 
-    const Vector3<T> position_i =
-        collisionState_.origin[pair.indexA] + collisionState_.direction[pair.indexA] * cp[0];
-    const Vector3<T> position_j =
-        collisionState_.origin[pair.indexB] + collisionState_.direction[pair.indexB] * cp[1];
-    const Vector3<T> direction = position_i - position_j;
-    const T wgt = -T(2) * kCollisionWeight * this->weight_ * (overlap / distance);
-
-    // Effective radii at the closest points (for scale derivative correction)
-    const T radiusA_at_cp =
-        collisionState_.radius[pair.indexA][0] + cp[0] * collisionState_.delta[pair.indexA];
-    const T radiusB_at_cp =
-        collisionState_.radius[pair.indexB][0] + cp[1] * collisionState_.delta[pair.indexB];
+    const Vector3<T> direction = result.positionA - result.positionB;
+    const T wgt = -T(2) * kCollisionWeight * this->weight_ * (result.overlap / result.distance);
 
     accumulateGradientAlongChain(
         state,
-        position_i,
+        result.positionA,
         direction,
         wgt,
         collisionGeometry_[pair.indexA].parent,
         pair.commonAncestor,
         gradient,
-        -distance * radiusA_at_cp * ln2<T>());
+        -result.distance * result.radiusA * ln2<T>());
     accumulateGradientAlongChain(
         state,
-        position_j,
+        result.positionB,
         direction,
         -wgt,
         collisionGeometry_[pair.indexB].parent,
         pair.commonAncestor,
         gradient,
-        distance * radiusB_at_cp * ln2<T>());
+        result.distance * result.radiusB * ln2<T>());
 
     // Scale derivatives above the common ancestor: translation and rotation derivatives cancel
     // above the LCA (both capsule endpoints move identically), but scale derivatives do not
@@ -314,7 +277,8 @@ double CollisionErrorFunctionT<T>::getGradient(
     // also changes capsule radii.
     {
       const T netScaleVal =
-          (direction.squaredNorm() - distance * (radiusA_at_cp + radiusB_at_cp)) * ln2<T>() * wgt;
+          (direction.squaredNorm() - result.distance * (result.radiusA + result.radiusB)) *
+          ln2<T>() * wgt;
       size_t ancestorIndex = pair.commonAncestor;
       while (ancestorIndex != kInvalidIndex) {
         const size_t paramIndex = ancestorIndex * kParametersPerJoint;
@@ -365,54 +329,42 @@ double CollisionErrorFunctionT<T>::getJacobian(
   double error = 0;
 
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (!checkCollision(collisionState_, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (!checkCollision(collisionState_, pair.indexA, pair.indexB, result)) {
       continue;
     }
 
-    error += sqr(overlap) * kCollisionWeight * this->weight_;
+    error += sqr(result.overlap) * kCollisionWeight * this->weight_;
 
-    const Vector3<T> position_i =
-        collisionState_.origin[pair.indexA] + collisionState_.direction[pair.indexA] * cp[0];
-    const Vector3<T> position_j =
-        collisionState_.origin[pair.indexB] + collisionState_.direction[pair.indexB] * cp[1];
-    const Vector3<T> direction = position_i - position_j;
-    const T fac = wgt / distance;
+    const Vector3<T> direction = result.positionA - result.positionB;
+    const T fac = wgt / result.distance;
     const int row = pos++;
-
-    // Effective radii at the closest points (for scale derivative correction)
-    const T radiusA_at_cp =
-        collisionState_.radius[pair.indexA][0] + cp[0] * collisionState_.delta[pair.indexA];
-    const T radiusB_at_cp =
-        collisionState_.radius[pair.indexB][0] + cp[1] * collisionState_.delta[pair.indexB];
 
     accumulateJacobianAlongChain(
         state,
-        position_i,
+        result.positionA,
         direction,
         -fac,
         collisionGeometry_[pair.indexA].parent,
         pair.commonAncestor,
         jacobian,
         row,
-        -distance * radiusA_at_cp * ln2<T>());
+        -result.distance * result.radiusA * ln2<T>());
     accumulateJacobianAlongChain(
         state,
-        position_j,
+        result.positionB,
         direction,
         fac,
         collisionGeometry_[pair.indexB].parent,
         pair.commonAncestor,
         jacobian,
         row,
-        distance * radiusB_at_cp * ln2<T>());
+        result.distance * result.radiusB * ln2<T>());
 
     // Scale derivatives above the common ancestor
     {
       const T netScaleVal = -fac * ln2<T>() * direction.squaredNorm() +
-          wgt * (radiusA_at_cp + radiusB_at_cp) * ln2<T>();
+          wgt * (result.radiusA + result.radiusB) * ln2<T>();
       size_t ancestorIndex = pair.commonAncestor;
       while (ancestorIndex != kInvalidIndex) {
         const size_t paramIndex = ancestorIndex * kParametersPerJoint;
@@ -424,7 +376,7 @@ double CollisionErrorFunctionT<T>::getJacobian(
       }
     }
 
-    residual(row) = overlap * wgt;
+    residual(row) = result.overlap * wgt;
   }
 
   usedRows = pos;
@@ -435,17 +387,15 @@ template <typename T>
 std::vector<CollisionDebugEntryT<T>> CollisionErrorFunctionT<T>::getCollisionDebugInfo() const {
   std::vector<CollisionDebugEntryT<T>> entries;
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (checkCollision(collisionState_, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (checkCollision(collisionState_, pair.indexA, pair.indexB, result)) {
       entries.push_back(
           {pair.indexA,
            pair.indexB,
            collisionGeometry_[pair.indexA].parent,
            collisionGeometry_[pair.indexB].parent,
-           overlap,
-           distance});
+           result.overlap,
+           result.distance});
     }
   }
   return entries;

--- a/momentum/character_solver/collision_error_function.h
+++ b/momentum/character_solver/collision_error_function.h
@@ -83,15 +83,13 @@ class CollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   /// Update collisionState_ and aabbs_ given the new skeleton state.
   void computeBroadPhase(const SkeletonStateT<T>& state);
 
-  /// AABB broadphase pre-check followed by narrow-phase capsule overlap test.
-  /// Returns true if the pair collides, filling distance, cp, and overlap.
+  /// AABB broadphase pre-check followed by narrow-phase collision overlap test.
+  /// Returns true when the pair collides, filling result with contact details.
   [[nodiscard]] bool checkCollision(
       const CollisionGeometryStateT<T>& colState,
       size_t indexA,
       size_t indexB,
-      T& distance,
-      Vector2<T>& cp,
-      T& overlap) const;
+      CollisionOverlapResultT<T>& result) const;
 
   /// Accumulate gradient contributions along a joint chain from startJoint up to (but not
   /// including) stopJoint. The sign of weight controls the push direction.

--- a/momentum/character_solver/collision_error_function_stateless.cpp
+++ b/momentum/character_solver/collision_error_function_stateless.cpp
@@ -52,8 +52,7 @@ void CollisionErrorFunctionStatelessT<T>::updateCollisionPairs() {
   aabbs_.resize(n);
   for (size_t i = 0; i < n; ++i) {
     aabbs_[i].id = gsl::narrow_cast<axel::Index>(i);
-    updateAabb(
-        aabbs_[i], collisionState.origin[i], collisionState.direction[i], collisionState.radius[i]);
+    updateAabb(aabbs_[i], collisionState, i);
   }
 
   if (n == 0) {
@@ -79,8 +78,7 @@ void CollisionErrorFunctionStatelessT<T>::computeBroadPhase(const SkeletonStateT
   }
 
   for (size_t i = 0; i < aabbs_.size(); ++i) {
-    updateAabb(
-        aabbs_[i], collisionState.origin[i], collisionState.direction[i], collisionState.radius[i]);
+    updateAabb(aabbs_[i], collisionState, i);
   }
 }
 
@@ -89,24 +87,11 @@ bool CollisionErrorFunctionStatelessT<T>::checkCollision(
     const CollisionGeometryStateT<T>& colState,
     size_t indexA,
     size_t indexB,
-    T& distance,
-    Vector2<T>& cp,
-    T& overlap) const {
+    CollisionOverlapResultT<T>& result) const {
   if (!aabbs_[indexA].intersects(aabbs_[indexB])) {
     return false;
   }
-  return overlaps(
-      colState.origin[indexA],
-      colState.direction[indexA],
-      colState.radius[indexA],
-      colState.delta[indexA],
-      colState.origin[indexB],
-      colState.direction[indexB],
-      colState.radius[indexB],
-      colState.delta[indexB],
-      distance,
-      cp,
-      overlap);
+  return overlaps(colState, collisionGeometry, indexA, indexB, result);
 }
 
 template <typename T>
@@ -189,10 +174,8 @@ template <typename T>
 std::vector<Vector2i> CollisionErrorFunctionStatelessT<T>::getCollisionPairs() const {
   std::vector<Vector2i> collidingPairs;
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (checkCollision(collisionState, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (checkCollision(collisionState, pair.indexA, pair.indexB, result)) {
       collidingPairs.emplace_back(pair.indexA, pair.indexB);
     }
   }
@@ -216,13 +199,11 @@ double CollisionErrorFunctionStatelessT<T>::getError(
 
   double error = 0;
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (!checkCollision(collisionState, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (!checkCollision(collisionState, pair.indexA, pair.indexB, result)) {
       continue;
     }
-    error += sqr(overlap) * kCollisionWeight * this->weight_;
+    error += sqr(result.overlap) * kCollisionWeight * this->weight_;
   }
 
   return error;
@@ -246,51 +227,40 @@ double CollisionErrorFunctionStatelessT<T>::getGradient(
 
   double error = 0;
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (!checkCollision(collisionState, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (!checkCollision(collisionState, pair.indexA, pair.indexB, result)) {
       continue;
     }
 
-    error += sqr(overlap) * kCollisionWeight * this->weight_;
+    error += sqr(result.overlap) * kCollisionWeight * this->weight_;
 
-    const Vector3<T> position_i =
-        collisionState.origin[pair.indexA] + collisionState.direction[pair.indexA] * cp[0];
-    const Vector3<T> position_j =
-        collisionState.origin[pair.indexB] + collisionState.direction[pair.indexB] * cp[1];
-    const Vector3<T> direction = position_i - position_j;
-    const T wgt = -T(2) * kCollisionWeight * this->weight_ * (overlap / distance);
-
-    // Effective radii at the closest points (for scale derivative correction)
-    const T radiusA_at_cp =
-        collisionState.radius[pair.indexA][0] + cp[0] * collisionState.delta[pair.indexA];
-    const T radiusB_at_cp =
-        collisionState.radius[pair.indexB][0] + cp[1] * collisionState.delta[pair.indexB];
+    const Vector3<T> direction = result.positionA - result.positionB;
+    const T wgt = -T(2) * kCollisionWeight * this->weight_ * (result.overlap / result.distance);
 
     accumulateGradientAlongChain(
         state,
-        position_i,
+        result.positionA,
         direction,
         wgt,
         collisionGeometry[pair.indexA].parent,
         pair.commonAncestor,
         gradient,
-        -distance * radiusA_at_cp * ln2<T>());
+        -result.distance * result.radiusA * ln2<T>());
     accumulateGradientAlongChain(
         state,
-        position_j,
+        result.positionB,
         direction,
         -wgt,
         collisionGeometry[pair.indexB].parent,
         pair.commonAncestor,
         gradient,
-        distance * radiusB_at_cp * ln2<T>());
+        result.distance * result.radiusB * ln2<T>());
 
     // Scale derivatives above the common ancestor
     {
       const T netScaleVal =
-          (direction.squaredNorm() - distance * (radiusA_at_cp + radiusB_at_cp)) * ln2<T>() * wgt;
+          (direction.squaredNorm() - result.distance * (result.radiusA + result.radiusB)) *
+          ln2<T>() * wgt;
       size_t ancestorIndex = pair.commonAncestor;
       while (ancestorIndex != kInvalidIndex) {
         const size_t paramIndex = ancestorIndex * kParametersPerJoint;
@@ -341,54 +311,42 @@ double CollisionErrorFunctionStatelessT<T>::getJacobian(
   double error = 0;
 
   for (const auto& pair : validPairs_) {
-    T distance;
-    Vector2<T> cp;
-    T overlap;
-    if (!checkCollision(collisionState, pair.indexA, pair.indexB, distance, cp, overlap)) {
+    CollisionOverlapResultT<T> result;
+    if (!checkCollision(collisionState, pair.indexA, pair.indexB, result)) {
       continue;
     }
 
-    error += sqr(overlap) * kCollisionWeight * this->weight_;
+    error += sqr(result.overlap) * kCollisionWeight * this->weight_;
 
-    const Vector3<T> position_i =
-        collisionState.origin[pair.indexA] + collisionState.direction[pair.indexA] * cp[0];
-    const Vector3<T> position_j =
-        collisionState.origin[pair.indexB] + collisionState.direction[pair.indexB] * cp[1];
-    const Vector3<T> direction = position_i - position_j;
-    const T fac = wgt / distance;
+    const Vector3<T> direction = result.positionA - result.positionB;
+    const T fac = wgt / result.distance;
     const int row = pos++;
-
-    // Effective radii at the closest points (for scale derivative correction)
-    const T radiusA_at_cp =
-        collisionState.radius[pair.indexA][0] + cp[0] * collisionState.delta[pair.indexA];
-    const T radiusB_at_cp =
-        collisionState.radius[pair.indexB][0] + cp[1] * collisionState.delta[pair.indexB];
 
     accumulateJacobianAlongChain(
         state,
-        position_i,
+        result.positionA,
         direction,
         -fac,
         collisionGeometry[pair.indexA].parent,
         pair.commonAncestor,
         jacobian,
         row,
-        -distance * radiusA_at_cp * ln2<T>());
+        -result.distance * result.radiusA * ln2<T>());
     accumulateJacobianAlongChain(
         state,
-        position_j,
+        result.positionB,
         direction,
         fac,
         collisionGeometry[pair.indexB].parent,
         pair.commonAncestor,
         jacobian,
         row,
-        distance * radiusB_at_cp * ln2<T>());
+        result.distance * result.radiusB * ln2<T>());
 
     // Scale derivatives above the common ancestor
     {
       const T netScaleVal = -fac * ln2<T>() * direction.squaredNorm() +
-          wgt * (radiusA_at_cp + radiusB_at_cp) * ln2<T>();
+          wgt * (result.radiusA + result.radiusB) * ln2<T>();
       size_t ancestorIndex = pair.commonAncestor;
       while (ancestorIndex != kInvalidIndex) {
         const size_t paramIndex = ancestorIndex * kParametersPerJoint;
@@ -400,7 +358,7 @@ double CollisionErrorFunctionStatelessT<T>::getJacobian(
       }
     }
 
-    residual(row) = overlap * wgt;
+    residual(row) = result.overlap * wgt;
   }
 
   usedRows = pos;

--- a/momentum/character_solver/collision_error_function_stateless.h
+++ b/momentum/character_solver/collision_error_function_stateless.h
@@ -65,14 +65,13 @@ class CollisionErrorFunctionStatelessT : public SkeletonErrorFunctionT<T> {
   /// Update collisionState and aabbs_ given the new skeleton state.
   void computeBroadPhase(const SkeletonStateT<T>& state);
 
-  /// AABB broadphase pre-check followed by narrow-phase capsule overlap test.
+  /// AABB broadphase pre-check followed by narrow-phase collision overlap test.
+  /// Returns true when the pair collides, filling result with contact details.
   [[nodiscard]] bool checkCollision(
       const CollisionGeometryStateT<T>& colState,
       size_t indexA,
       size_t indexB,
-      T& distance,
-      Vector2<T>& cp,
-      T& overlap) const;
+      CollisionOverlapResultT<T>& result) const;
 
   /// Accumulate gradient contributions along a joint chain.
   /// scaleCorrection is an additive term for the scale derivative (for capsule radius correction).

--- a/momentum/character_solver_simd/simd_collision_error_function.cpp
+++ b/momentum/character_solver_simd/simd_collision_error_function.cpp
@@ -16,6 +16,8 @@
 #include "momentum/math/constants.h"
 #include "momentum/simd/simd.h"
 
+#include <algorithm>
+
 namespace momentum {
 
 namespace {
@@ -107,6 +109,19 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
   validPairs_.clear();
 
   const auto n = collisionGeometry_.size();
+  useScalarFallback_ =
+      std::any_of(collisionGeometry_.begin(), collisionGeometry_.end(), [](const auto& primitive) {
+        return primitive.type != CollisionPrimitiveType::TaperedCapsule;
+      });
+  if (useScalarFallback_ && !scalarFallback_) {
+    scalarFallback_.emplace(this->skeleton_, this->parameterTransform_, collisionGeometry_);
+  }
+  if (useScalarFallback_) {
+    commonAncestors_.clear();
+    collisionPairs_.clear();
+    aabbs_.clear();
+    return;
+  }
 
   const SkeletonStateT<T> state(
       this->parameterTransform_.zero().template cast<T>(), this->skeleton_);
@@ -115,11 +130,7 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
   aabbs_.resize(n);
   for (size_t i = 0; i < n; ++i) {
     aabbs_[i].id = gsl::narrow_cast<axel::Index>(i);
-    updateAabb(
-        aabbs_[i],
-        collisionState_.origin[i],
-        collisionState_.direction[i],
-        collisionState_.radius[i]);
+    updateAabb(aabbs_[i], collisionState_, i);
   }
 
   if (n == 0) {
@@ -132,8 +143,11 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
       if (isValidCollisionPair(collisionState_, collisionGeometry_, this->skeleton_, i, j)) {
-        const size_t lca = this->skeleton_.commonAncestor(
-            collisionGeometry_[i].parent, collisionGeometry_[j].parent);
+        const size_t lca = (collisionGeometry_[i].parent == kInvalidIndex ||
+                            collisionGeometry_[j].parent == kInvalidIndex)
+            ? kInvalidIndex
+            : this->skeleton_.commonAncestor(
+                  collisionGeometry_[i].parent, collisionGeometry_[j].parent);
         validPairs_.push_back({i, j, lca});
         commonAncestors_[i * n + j] = lca;
         commonAncestors_[j * n + i] = lca;
@@ -150,11 +164,7 @@ void SimdCollisionErrorFunctionT<T>::computeBroadPhase(const SkeletonStateT<T>& 
   }
 
   for (size_t i = 0; i < aabbs_.size(); ++i) {
-    updateAabb(
-        aabbs_[i],
-        collisionState_.origin[i],
-        collisionState_.direction[i],
-        collisionState_.radius[i]);
+    updateAabb(aabbs_[i], collisionState_, i);
   }
 
   for (auto& pairs : collisionPairs_) {
@@ -168,10 +178,20 @@ void SimdCollisionErrorFunctionT<T>::computeBroadPhase(const SkeletonStateT<T>& 
 }
 
 template <typename T>
+CollisionErrorFunctionT<T>& SimdCollisionErrorFunctionT<T>::syncScalarFallback() {
+  MT_CHECK(scalarFallback_.has_value());
+  auto& fallback = scalarFallback_.value();
+  fallback.setWeight(this->weight_);
+  fallback.setActiveJoints(this->activeJointParams_);
+  fallback.setEnabledParameters(this->enabledParameters_);
+  return fallback;
+}
+
+template <typename T>
 double SimdCollisionErrorFunctionT<T>::getError(
-    const ModelParametersT<T>& /*unused*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
-    const MeshStateT<T>& /* meshState */) {
+    const MeshStateT<T>& meshState) {
   if (state.jointState.empty()) {
     return 0.0;
   }
@@ -179,6 +199,11 @@ double SimdCollisionErrorFunctionT<T>::getError(
   MT_CHECK(
       state.jointParameters.size() ==
       gsl::narrow<Eigen::Index>(this->skeleton_.joints.size() * kParametersPerJoint));
+
+  if (useScalarFallback_) {
+    auto& fallback = syncScalarFallback();
+    return fallback.getError(params, state, meshState);
+  }
 
   computeBroadPhase(state);
 
@@ -217,12 +242,17 @@ double SimdCollisionErrorFunctionT<T>::getError(
 
 template <typename T>
 double SimdCollisionErrorFunctionT<T>::getGradient(
-    const ModelParametersT<T>& /*unused*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
-    const MeshStateT<T>& /* meshState */,
+    const MeshStateT<T>& meshState,
     Ref<VectorX<T>> gradient) {
   if (state.jointState.empty()) {
     return 0.0;
+  }
+
+  if (useScalarFallback_) {
+    auto& fallback = syncScalarFallback();
+    return fallback.getGradient(params, state, meshState, gradient);
   }
 
   computeBroadPhase(state);
@@ -382,12 +412,22 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
 
 template <typename T>
 double SimdCollisionErrorFunctionT<T>::getJacobian(
-    const ModelParametersT<T>& /*unused*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
-    const MeshStateT<T>& /* meshState */,
+    const MeshStateT<T>& meshState,
     Ref<MatrixX<T>> jacobian,
     Ref<VectorX<T>> residual,
     int& usedRows) {
+  if (state.jointState.empty()) {
+    usedRows = 0;
+    return 0.0;
+  }
+
+  if (useScalarFallback_) {
+    auto& fallback = syncScalarFallback();
+    return fallback.getJacobian(params, state, meshState, jacobian, residual, usedRows);
+  }
+
   computeBroadPhase(state);
 
   const auto numCapsules = collisionGeometry_.size();
@@ -547,6 +587,10 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
 
 template <typename T>
 size_t SimdCollisionErrorFunctionT<T>::getJacobianSize() const {
+  if (useScalarFallback_) {
+    MT_CHECK(scalarFallback_.has_value());
+    return scalarFallback_->getJacobianSize();
+  }
   return validPairs_.size();
 }
 

--- a/momentum/character_solver_simd/simd_collision_error_function.h
+++ b/momentum/character_solver_simd/simd_collision_error_function.h
@@ -9,6 +9,7 @@
 
 #include <momentum/character/collision_geometry.h>
 #include <momentum/character/collision_geometry_state.h>
+#include <momentum/character_solver/collision_error_function.h>
 #include <momentum/character_solver/fwd.h>
 #include <momentum/character_solver/skeleton_error_function.h>
 #include <momentum/common/aligned.h>
@@ -16,6 +17,7 @@
 
 #include <axel/BoundingBox.h>
 
+#include <optional>
 #include <vector>
 
 namespace momentum {
@@ -62,6 +64,9 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   /// Update collisionState_, aabbs_, and collisionPairs_ given the new skeleton state.
   void computeBroadPhase(const SkeletonStateT<T>& state);
 
+  /// Synchronize scalar fallback settings before delegating non-capsule collision work.
+  CollisionErrorFunctionT<T>& syncScalarFallback();
+
   /// Pre-computed valid collision pair with common ancestor.
   struct CollisionPairInfo {
     size_t indexA;
@@ -70,6 +75,11 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   };
 
   const CollisionGeometry collisionGeometry_;
+
+  /// Scalar collision error function used to evaluate non-tapered-capsule primitives (e.g.
+  /// ellipsoids and boxes). Lazily created and re-synced from the SIMD inputs whenever
+  /// @c useScalarFallback_ is set.
+  std::optional<CollisionErrorFunctionT<T>> scalarFallback_;
 
   /// Pre-filtered list of valid collision pairs.
   std::vector<CollisionPairInfo> validPairs_;
@@ -84,6 +94,10 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   std::vector<axel::BoundingBox<T>> aabbs_;
 
   CollisionGeometryStateT<T> collisionState_;
+
+  /// True when the collision geometry contains a non-tapered-capsule primitive, in which case
+  /// getError/getGradient/getJacobian delegate to @c scalarFallback_ instead of the SIMD path.
+  bool useScalarFallback_ = false;
 
   // weights for the error functions
   static constexpr T kCollisionWeight = 5e-3f;

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -31,7 +31,9 @@ structs = [
 ]
 template_structs = [
     "CharacterState",
+    "CollisionPrimitive",
     "CollisionGeometryState",
+    "CollisionEllipsoid",
     "Joint",
     "JointState",
     "ParameterTransform",

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -33,6 +33,7 @@ template_structs = [
     "CharacterState",
     "CollisionPrimitive",
     "CollisionGeometryState",
+    "CollisionOverlapResult",
     "CollisionEllipsoid",
     "Joint",
     "JointState",

--- a/momentum/gui/rerun/logger.cpp
+++ b/momentum/gui/rerun/logger.cpp
@@ -411,8 +411,7 @@ void logBvh(
   for (size_t i = 0; i < n; ++i) {
     auto& aabb = aabbs[i];
     aabb.id = static_cast<axel::Index>(i);
-    updateAabb(
-        aabb, collisionState.origin[i], collisionState.direction[i], collisionState.radius[i]);
+    updateAabb(aabb, collisionState, i);
   }
 
   // Construct BVH
@@ -445,40 +444,62 @@ void logCollisionGeometry(
     const std::string& streamName,
     const CollisionGeometry& collisionGeometry,
     const SkeletonState& skeletonState) {
-  // TODO: update collision geometry representation from box to capsule
+  std::vector<rerun::Position3D> capsuleTranslations;
+  std::vector<rerun::Quaternion> capsuleQuaternions;
+  std::vector<float> capsuleLengths;
+  std::vector<float> capsuleRadii;
+  std::vector<rerun::Position3D> ellipsoidCenters;
+  std::vector<rerun::HalfSize3D> ellipsoidHalfSizes;
+  std::vector<rerun::Quaternion> ellipsoidQuaternions;
 
-  std::vector<rerun::Position3D> translations;
-  std::vector<rerun::Quaternion> quaternions;
-  std::vector<float> lengths;
-  std::vector<float> radii;
-
-  translations.reserve(collisionGeometry.size());
-  quaternions.reserve(collisionGeometry.size());
-  lengths.reserve(collisionGeometry.size());
-  radii.reserve(collisionGeometry.size());
+  capsuleTranslations.reserve(collisionGeometry.size());
+  capsuleQuaternions.reserve(collisionGeometry.size());
+  capsuleLengths.reserve(collisionGeometry.size());
+  capsuleRadii.reserve(collisionGeometry.size());
+  ellipsoidCenters.reserve(collisionGeometry.size());
+  ellipsoidHalfSizes.reserve(collisionGeometry.size());
+  ellipsoidQuaternions.reserve(collisionGeometry.size());
 
   for (const auto& cg : collisionGeometry) {
-    const auto& js = skeletonState.jointState.at(cg.parent);
+    const Transform parentTransform = (cg.parent == kInvalidIndex)
+        ? Transform()
+        : skeletonState.jointState.at(cg.parent).transform;
+    const Transform tf = parentTransform * cg.transformation;
 
-    const Transform tf = js.transform * cg.transformation;
-    const Quaternionf& q = tf.rotation * Eigen::AngleAxisf(0.5f * pi(), Vector3f::UnitY());
-
-    translations.push_back(toRerunPosition3D(tf.translation));
-    quaternions.emplace_back(rerun::Quaternion::from_xyzw(q.x(), q.y(), q.z(), q.w()));
-    lengths.emplace_back(cg.length);
-    // TODO: Rerun doesn't support capsules with different radii (i.e. tapered capsule) yet
-    radii.emplace_back(cg.radius.maxCoeff());
+    if (cg.type == CollisionPrimitiveType::TaperedCapsule) {
+      const Quaternionf& q = tf.rotation * Eigen::AngleAxisf(0.5f * pi(), Vector3f::UnitY());
+      capsuleTranslations.push_back(toRerunPosition3D(tf.translation));
+      capsuleQuaternions.emplace_back(rerun::Quaternion::from_xyzw(q.x(), q.y(), q.z(), q.w()));
+      capsuleLengths.emplace_back(cg.length);
+      // TODO: Rerun doesn't support capsules with different radii (i.e. tapered capsule) yet
+      capsuleRadii.emplace_back(cg.radius.maxCoeff());
+    } else if (cg.type == CollisionPrimitiveType::Ellipsoid) {
+      const Vector3f halfSizes = cg.ellipsoidRadii * parentTransform.scale;
+      const Quaternionf& q = tf.rotation;
+      ellipsoidCenters.push_back(toRerunPosition3D(tf.translation));
+      ellipsoidHalfSizes.push_back(toRerunHalfSizes3D(halfSizes));
+      ellipsoidQuaternions.emplace_back(rerun::Quaternion::from_xyzw(q.x(), q.y(), q.z(), q.w()));
+    }
   }
 
-  // TODO: make radius and color configurable
-  safeLog(
-      rec,
-      streamName,
-      rerun::Capsules3D::from_lengths_and_radii(lengths, radii)
-          .with_translations(translations)
-          .with_quaternions(quaternions)
-          .with_colors(rerun::Color(128, 64, 64)));
-  // TODO: Switch to wireframe once available in Rerun
+  if (!capsuleLengths.empty()) {
+    safeLog(
+        rec,
+        streamName + "/capsules",
+        rerun::Capsules3D::from_lengths_and_radii(capsuleLengths, capsuleRadii)
+            .with_translations(capsuleTranslations)
+            .with_quaternions(capsuleQuaternions)
+            .with_colors(rerun::Color(128, 64, 64)));
+  }
+
+  if (!ellipsoidHalfSizes.empty()) {
+    safeLog(
+        rec,
+        streamName + "/ellipsoids",
+        rerun::Ellipsoids3D::from_centers_and_half_sizes(ellipsoidCenters, ellipsoidHalfSizes)
+            .with_quaternions(ellipsoidQuaternions)
+            .with_colors(rerun::Color(128, 64, 64)));
+  }
 
   logBvh(rec, streamName + "/bvh", collisionGeometry, skeletonState);
 }

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -227,7 +227,15 @@ inline void createCollisionGeometryNodes(
   const auto& collisions = *character.collision;
   for (auto i = 0u; i < collisions.size(); ++i) {
     const auto& collision = collisions[i];
-    if (!collision.isTaperedCapsule()) {
+
+    bool supportedPrimitive = false;
+    switch (collision.type) {
+      case CollisionPrimitiveType::TaperedCapsule:
+      case CollisionPrimitiveType::Ellipsoid:
+        supportedPrimitive = true;
+        break;
+    }
+    if (!supportedPrimitive) {
       MT_LOGW(
           "Skipping unsupported collision primitive type {} while writing FBX collision geometry",
           static_cast<int>(collision.type));
@@ -240,12 +248,25 @@ inline void createCollisionGeometryNodes(
     collisionNode->SetNodeAttribute(nullNodeAttr);
 
     ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxBoolDT, "Col_Type").Set(true);
-    ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Length")
-        .Set(collision.length);
-    ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_A")
-        .Set(collision.radius[0]);
-    ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_B")
-        .Set(collision.radius[1]);
+    if (collision.type == CollisionPrimitiveType::TaperedCapsule) {
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxStringDT, "Col_Shape")
+          .Set(FbxString("tapered_capsule"));
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Length")
+          .Set(collision.length);
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_A")
+          .Set(collision.radius[0]);
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_B")
+          .Set(collision.radius[1]);
+    } else if (collision.type == CollisionPrimitiveType::Ellipsoid) {
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxStringDT, "Col_Shape")
+          .Set(FbxString("ellipsoid"));
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Radii_X")
+          .Set(collision.ellipsoidRadii.x());
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Radii_Y")
+          .Set(collision.ellipsoidRadii.y());
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Radii_Z")
+          .Set(collision.ellipsoidRadii.z());
+    }
 
     collisionNode->LclTranslation.Set(FbxVector4(
         collision.transformation.translation.x(),

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -226,7 +226,13 @@ inline void createCollisionGeometryNodes(
 
   const auto& collisions = *character.collision;
   for (auto i = 0u; i < collisions.size(); ++i) {
-    const TaperedCapsule& collision = collisions[i];
+    const auto& collision = collisions[i];
+    if (!collision.isTaperedCapsule()) {
+      MT_LOGW(
+          "Skipping unsupported collision primitive type {} while writing FBX collision geometry",
+          static_cast<int>(collision.type));
+      continue;
+    }
 
     ::fbxsdk::FbxNode* collisionNode =
         ::fbxsdk::FbxNode::Create(scene, ("Collision " + std::to_string(i)).c_str());

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -167,6 +167,19 @@ bool equalsCaseInsensitive(const ofbx::DataView& data, const char* rhs) {
   return c2 == (const char*)data.end && *c == '\0';
 }
 
+bool equalsCaseInsensitive(const std::string& lhs, const char* rhs) {
+  const char* c = rhs;
+  auto it = lhs.begin();
+  while (*c && it != lhs.end()) {
+    if (tolower(static_cast<unsigned char>(*c)) != tolower(static_cast<unsigned char>(*it))) {
+      return false;
+    }
+    ++c;
+    ++it;
+  }
+  return it == lhs.end() && *c == '\0';
+}
+
 // This function is more or less copied from the OpenFBX SDK.
 ofbx::IElement* resolveProperty(const ofbx::Object& object, const char* name) {
   // This is black magic, but for some reason all the user properties are stored in an
@@ -362,6 +375,52 @@ void extractCollisionCapsule(const ofbx::Object* node, size_t parent, CollisionG
   capsules.push_back(capsule);
 }
 
+void extractCollisionEllipsoid(
+    const ofbx::Object* node,
+    size_t parent,
+    CollisionGeometry& collisionGeometry) {
+  const double radiusX = resolveDoubleProperty(*node, "radii_x");
+  const double radiusY = resolveDoubleProperty(*node, "radii_y");
+  const double radiusZ = resolveDoubleProperty(*node, "radii_z");
+
+  const auto xf = node->getLocalTransform();
+
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = parent;
+  ellipsoid.radii = Eigen::Vector3f(
+      static_cast<float>(radiusX), static_cast<float>(radiusY), static_cast<float>(radiusZ));
+  ellipsoid.transformation = toEigen(xf).cast<float>();
+  collisionGeometry.push_back(ellipsoid);
+}
+
+void extractCollisionPrimitive(
+    const ofbx::Object* node,
+    size_t parent,
+    CollisionGeometry& collisionGeometry) {
+  auto* shapeProperty = resolveProperty(*node, "col_shape");
+  if (shapeProperty != nullptr) {
+    const std::string shape = resolveStringProperty(*node, "col_shape");
+    if (equalsCaseInsensitive(shape, "ellipsoid") ||
+        equalsCaseInsensitive(shape, "collision_ellipsoid")) {
+      extractCollisionEllipsoid(node, parent, collisionGeometry);
+      return;
+    }
+    if (equalsCaseInsensitive(shape, "tapered_capsule") ||
+        equalsCaseInsensitive(shape, "capsule") ||
+        equalsCaseInsensitive(shape, "collision_capsule")) {
+      extractCollisionCapsule(node, parent, collisionGeometry);
+      return;
+    }
+
+    MT_LOGW(
+        "Unknown FBX collision shape '{}' on node '{}'; falling back to tapered capsule.",
+        shape,
+        node->name);
+  }
+
+  extractCollisionCapsule(node, parent, collisionGeometry);
+}
+
 void extractLocator(const ofbx::Object* node, size_t parent, LocatorList& locators) {
   Locator locator;
   locator.name = node->name;
@@ -440,7 +499,7 @@ void parseSkeleton(
   if (type == ofbx::Object::Type::NULL_NODE) {
     auto* res = resolveProperty(*curSkelNode, "col_type");
     if (res != nullptr) {
-      extractCollisionCapsule(curSkelNode, parent, capsules);
+      extractCollisionPrimitive(curSkelNode, parent, capsules);
     } else if (parent != kInvalidIndex) {
       extractLocator(curSkelNode, parent, locators);
     } else {

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -784,7 +784,7 @@ void addCollisionsToModel(
       model.nodes.at(jointToNodeMap.at(col.parent))
           .children.push_back(static_cast<int32_t>(nodeIndex));
 
-      // add values for the tapered capsule
+      // add values for the collision primitive
       node.name = character.skeleton.joints.at(col.parent).name + "_col";
 
       node.rotation = fromMomentumQuaternionf(col.transformation.rotation);
@@ -794,9 +794,14 @@ void addCollisionsToModel(
       // add extra properties
       if (addExtensions) {
         auto& extension = addMomentumExtension(node.extensionsAndExtras);
-        extension["type"] = "collision_capsule";
-        extension["length"] = col.length;
-        extension["radius"] = col.radius;
+        if (col.type == CollisionPrimitiveType::TaperedCapsule) {
+          extension["type"] = "collision_capsule";
+          extension["length"] = col.length;
+          extension["radius"] = col.radius;
+        } else if (col.type == CollisionPrimitiveType::Ellipsoid) {
+          extension["type"] = "collision_ellipsoid";
+          extension["radii"] = col.ellipsoidRadii;
+        }
       }
     }
   }

--- a/momentum/io/gltf/gltf_skeleton_io.cpp
+++ b/momentum/io/gltf/gltf_skeleton_io.cpp
@@ -359,12 +359,11 @@ loadHierarchy(const fx::gltf::Document& model) {
   MT_THROW_IF(model.nodes.empty(), "No valid node found in the gltf file.");
   std::string name = model.nodes.at(0).name;
 
-  std::sort(
-      collision->begin(), collision->end(), [](const TaperedCapsule& c1, const TaperedCapsule& c2) {
-        int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
-        int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
-        return c1Parent < c2Parent;
-      });
+  std::sort(collision->begin(), collision->end(), [](const auto& c1, const auto& c2) {
+    int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
+    int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
+    return c1Parent < c2Parent;
+  });
   std::sort(locators.begin(), locators.end(), [](const Locator& l1, const Locator& l2) {
     int l1Parent = l1.parent == kInvalidIndex ? -1 : static_cast<int>(l1.parent);
     int l2Parent = l2.parent == kInvalidIndex ? -1 : static_cast<int>(l2.parent);

--- a/momentum/io/gltf/gltf_skeleton_io.cpp
+++ b/momentum/io/gltf/gltf_skeleton_io.cpp
@@ -114,6 +114,16 @@ void loadHierarchyRecursive(
     capsule.parent = parentJointId;
     collision->push_back(capsule);
     nodeToObjectMap[nodeId] = collision->size() - 1;
+  } else if (type == "collision_ellipsoid") {
+    // Found collision geometry, should be the end node
+    MT_THROW_IF(
+        parentJointId == kInvalidIndex,
+        "Invalid collision ellipsoid without a parent joint: {}",
+        node.name);
+    auto ellipsoid = createCollisionEllipsoid(node, extension);
+    ellipsoid.parent = parentJointId;
+    collision->push_back(ellipsoid);
+    nodeToObjectMap[nodeId] = collision->size() - 1;
   } else if (type == "locator") {
     // Found locator, should be the end node
     MT_THROW_IF(
@@ -174,6 +184,26 @@ TaperedCapsule createCollisionCapsule(const fx::gltf::Node& node, const nlohmann
         extension.dump());
   }
   return tc;
+}
+
+CollisionEllipsoid createCollisionEllipsoid(
+    const fx::gltf::Node& node,
+    const nlohmann::json& extension) {
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = kInvalidIndex;
+  ellipsoid.transformation = Transform();
+  ellipsoid.transformation.rotation = toMomentumQuaternionf(node.rotation);
+  ellipsoid.transformation.translation = toMomentumVec3f(node.translation);
+
+  try {
+    ellipsoid.radii = fromJson<Vector3f>(extension["radii"]);
+  } catch (const std::exception&) {
+    MT_THROW(
+        "Fail to parse json {} for collision ellipsoid {} when loading character.",
+        extension.dump(),
+        node.name);
+  }
+  return ellipsoid;
 }
 
 Locator createLocator(const fx::gltf::Node& node, const nlohmann::json& extension) {
@@ -362,7 +392,10 @@ loadHierarchy(const fx::gltf::Document& model) {
   std::sort(collision->begin(), collision->end(), [](const auto& c1, const auto& c2) {
     int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
     int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
-    return c1Parent < c2Parent;
+    if (c1Parent != c2Parent) {
+      return c1Parent < c2Parent;
+    }
+    return static_cast<int>(c1.type) < static_cast<int>(c2.type);
   });
   std::sort(locators.begin(), locators.end(), [](const Locator& l1, const Locator& l2) {
     int l1Parent = l1.parent == kInvalidIndex ? -1 : static_cast<int>(l1.parent);

--- a/momentum/io/gltf/gltf_skeleton_io.h
+++ b/momentum/io/gltf/gltf_skeleton_io.h
@@ -27,6 +27,15 @@ namespace momentum {
 /// @return The created TaperedCapsule object.
 TaperedCapsule createCollisionCapsule(const fx::gltf::Node& node, const nlohmann::json& extension);
 
+/// Create a collision ellipsoid from a glTF node.
+///
+/// @param[in] node The glTF node containing the collision ellipsoid data.
+/// @param[in] extension The FB_momentum extension JSON data.
+/// @return The created CollisionEllipsoid object.
+CollisionEllipsoid createCollisionEllipsoid(
+    const fx::gltf::Node& node,
+    const nlohmann::json& extension);
+
 /// Create a locator from a glTF node.
 ///
 /// @param[in] node The glTF node containing the locator data.

--- a/momentum/io/legacy_json/legacy_json_io.cpp
+++ b/momentum/io/legacy_json/legacy_json_io.cpp
@@ -16,6 +16,7 @@
 #include <momentum/character/skin_weights.h>
 #include <momentum/character/types.h>
 #include <momentum/common/exception.h>
+#include <momentum/common/log.h>
 #include <momentum/io/common/stream_utils.h>
 #include <momentum/math/mesh.h>
 #include <momentum/math/transform.h>
@@ -392,23 +393,52 @@ CollisionGeometry legacyCollisionToMomentum(const nlohmann::json& legacyCollisio
   if (legacyCollision.is_array()) {
     collision.reserve(legacyCollision.size());
 
-    for (const auto& capsuleJson : legacyCollision) {
+    for (const auto& primitiveJson : legacyCollision) {
+      const std::string type = primitiveJson.value("type", "tapered_capsule");
+
+      if (type == "ellipsoid" || type == "collision_ellipsoid") {
+        CollisionEllipsoid ellipsoid;
+
+        if (primitiveJson.contains("transformation")) {
+          ellipsoid.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
+        }
+
+        if (primitiveJson.contains("radii")) {
+          ellipsoid.radii = jsonArrayToEigenVector3<float>(primitiveJson["radii"]);
+        } else if (primitiveJson.contains("ellipsoidRadii")) {
+          ellipsoid.radii = jsonArrayToEigenVector3<float>(primitiveJson["ellipsoidRadii"]);
+        }
+
+        if (primitiveJson.contains("parent")) {
+          ellipsoid.parent = primitiveJson["parent"].get<size_t>();
+        }
+
+        collision.push_back(ellipsoid);
+        continue;
+      }
+
+      if (type != "tapered_capsule") {
+        MT_LOGW(
+            "Unknown collision primitive type '{}' in legacy JSON; falling back to tapered capsule.",
+            type);
+      }
+
       TaperedCapsule capsule;
 
-      if (capsuleJson.contains("transformation")) {
-        capsule.transformation = jsonToTransform<float>(capsuleJson["transformation"]);
+      if (primitiveJson.contains("transformation")) {
+        capsule.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
       }
 
-      if (capsuleJson.contains("radius")) {
-        capsule.radius = jsonArrayToEigenVector2<float>(capsuleJson["radius"]);
+      if (primitiveJson.contains("radius")) {
+        capsule.radius = jsonArrayToEigenVector2<float>(primitiveJson["radius"]);
       }
 
-      if (capsuleJson.contains("parent")) {
-        capsule.parent = capsuleJson["parent"].get<size_t>();
+      if (primitiveJson.contains("parent")) {
+        capsule.parent = primitiveJson["parent"].get<size_t>();
       }
 
-      if (capsuleJson.contains("length")) {
-        capsule.length = capsuleJson["length"].get<float>();
+      if (primitiveJson.contains("length")) {
+        capsule.length = primitiveJson["length"].get<float>();
       }
 
       collision.push_back(capsule);
@@ -421,15 +451,22 @@ CollisionGeometry legacyCollisionToMomentum(const nlohmann::json& legacyCollisio
 nlohmann::json momentumCollisionToLegacy(const CollisionGeometry& collision) {
   nlohmann::json legacyCollision = nlohmann::json::array();
 
-  for (const auto& capsule : collision) {
-    nlohmann::json capsuleJson;
+  for (const auto& primitive : collision) {
+    nlohmann::json primitiveJson;
 
-    capsuleJson["transformation"] = transformToJson(capsule.transformation);
-    capsuleJson["radius"] = eigenToJsonArray(capsule.radius);
-    capsuleJson["parent"] = capsule.parent;
-    capsuleJson["length"] = capsule.length;
+    primitiveJson["transformation"] = transformToJson(primitive.transformation);
+    primitiveJson["parent"] = primitive.parent;
 
-    legacyCollision.push_back(capsuleJson);
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      primitiveJson["type"] = "tapered_capsule";
+      primitiveJson["radius"] = eigenToJsonArray(primitive.radius);
+      primitiveJson["length"] = primitive.length;
+    } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      primitiveJson["type"] = "ellipsoid";
+      primitiveJson["radii"] = eigenToJsonArray(primitive.ellipsoidRadii);
+    }
+
+    legacyCollision.push_back(primitiveJson);
   }
 
   return legacyCollision;

--- a/momentum/io/usd/usd_skeleton_io.cpp
+++ b/momentum/io/usd/usd_skeleton_io.cpp
@@ -35,13 +35,13 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (Collision)(Locators)((momentumType, "momentum:type"))((momentumParent, "momentum:parent"))(
         (momentumLength, "momentum:length"))((momentumRadius, "momentum:radius"))(
-        (momentumTranslation, "momentum:translation"))((momentumRotation, "momentum:rotation"))(
-        (momentumName, "momentum:name"))((momentumOffset, "momentum:offset"))(
-        (momentumWeight, "momentum:weight"))((momentumLocked, "momentum:locked"))(
-        (momentumLimitOrigin,
-         "momentum:limitOrigin"))((momentumLimitWeight, "momentum:limitWeight"))(
-        (momentumAttachedToSkin,
-         "momentum:attachedToSkin"))((momentumSkinOffset, "momentum:skinOffset")));
+        (momentumRadii, "momentum:radii"))((momentumTranslation, "momentum:translation"))(
+        (momentumRotation, "momentum:rotation"))((momentumName, "momentum:name"))(
+        (momentumOffset, "momentum:offset"))((momentumWeight, "momentum:weight"))(
+        (momentumLocked, "momentum:locked"))((momentumLimitOrigin, "momentum:limitOrigin"))(
+        (momentumLimitWeight,
+         "momentum:limitWeight"))((momentumAttachedToSkin, "momentum:attachedToSkin"))(
+        (momentumSkinOffset, "momentum:skinOffset")));
 
 namespace momentum {
 
@@ -67,11 +67,24 @@ Eigen::Matrix4f jointToLocalTransform(const Joint& joint) {
 
 // Compute world-space bind transform for a joint by walking up the parent chain.
 Eigen::Matrix4f computeWorldTransform(const Skeleton& skeleton, size_t jointIndex) {
-  Eigen::Matrix4f world = jointToLocalTransform(skeleton.joints[jointIndex]);
-  size_t parent = skeleton.joints[jointIndex].parent;
+  MT_THROW_IF(
+      jointIndex >= skeleton.joints.size(),
+      "Joint index {} exceeds skeleton joint count {}",
+      jointIndex,
+      skeleton.joints.size());
+
+  const auto& joint = skeleton.joints.at(jointIndex);
+  Eigen::Matrix4f world = jointToLocalTransform(joint);
+  size_t parent = joint.parent;
   while (parent != kInvalidIndex) {
-    world = jointToLocalTransform(skeleton.joints[parent]) * world;
-    parent = skeleton.joints[parent].parent;
+    MT_THROW_IF(
+        parent >= skeleton.joints.size(),
+        "Parent joint index {} exceeds skeleton joint count {}",
+        parent,
+        skeleton.joints.size());
+    const auto& parentJoint = skeleton.joints.at(parent);
+    world = jointToLocalTransform(parentJoint) * world;
+    parent = parentJoint.parent;
   }
   return world;
 }
@@ -94,16 +107,17 @@ std::string leafName(const std::string& path) {
 std::vector<std::string> buildHierarchicalPaths(const Skeleton& skeleton) {
   std::vector<std::string> paths(skeleton.joints.size());
   for (size_t i = 0; i < skeleton.joints.size(); ++i) {
-    if (skeleton.joints[i].parent == kInvalidIndex) {
-      paths[i] = skeleton.joints[i].name;
+    const auto& joint = skeleton.joints.at(i);
+    if (joint.parent == kInvalidIndex) {
+      paths.at(i) = joint.name;
     } else {
       MT_THROW_IF(
-          skeleton.joints[i].parent >= paths.size(),
+          joint.parent >= paths.size(),
           "Parent joint index {} exceeds paths size {} for joint {}",
-          skeleton.joints[i].parent,
+          joint.parent,
           paths.size(),
           i);
-      paths[i] = paths[skeleton.joints[i].parent] + "/" + skeleton.joints[i].name;
+      paths.at(i) = paths.at(joint.parent) + "/" + joint.name;
     }
   }
   return paths;
@@ -238,9 +252,26 @@ void saveCollisionGeometryToUsd(
   auto collisionScope = UsdGeomScope::Define(stage, skelRootPath.AppendChild(_tokens->Collision));
 
   for (size_t i = 0; i < collision.size(); ++i) {
-    const auto& capsule = collision[i];
-    const std::string jointName = (capsule.parent < skeleton.joints.size())
-        ? skeleton.joints.at(capsule.parent).name
+    const auto& primitive = collision[i];
+
+    std::string type;
+    switch (primitive.type) {
+      case CollisionPrimitiveType::TaperedCapsule:
+        type = "collision_capsule";
+        break;
+      case CollisionPrimitiveType::Ellipsoid:
+        type = "collision_ellipsoid";
+        break;
+    }
+    if (type.empty()) {
+      MT_LOGW(
+          "Skipping unsupported collision primitive type {} when saving USD collision geometry.",
+          static_cast<int>(primitive.type));
+      continue;
+    }
+
+    const std::string jointName = (primitive.parent < skeleton.joints.size())
+        ? skeleton.joints.at(primitive.parent).name
         : "unknown";
     const std::string primName = sanitizePrimName(jointName + "_col_" + std::to_string(i));
 
@@ -252,18 +283,25 @@ void saveCollisionGeometryToUsd(
         primName,
         jointName);
 
-    prim.CreateAttribute(_tokens->momentumType, SdfValueTypeNames->String)
-        .Set(std::string("collision_capsule"));
+    prim.CreateAttribute(_tokens->momentumType, SdfValueTypeNames->String).Set(type);
     prim.CreateAttribute(_tokens->momentumParent, SdfValueTypeNames->String).Set(jointName);
-    prim.CreateAttribute(_tokens->momentumLength, SdfValueTypeNames->Float).Set(capsule.length);
-    prim.CreateAttribute(_tokens->momentumRadius, SdfValueTypeNames->Float2)
-        .Set(GfVec2f(capsule.radius.x(), capsule.radius.y()));
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      prim.CreateAttribute(_tokens->momentumLength, SdfValueTypeNames->Float).Set(primitive.length);
+      prim.CreateAttribute(_tokens->momentumRadius, SdfValueTypeNames->Float2)
+          .Set(GfVec2f(primitive.radius.x(), primitive.radius.y()));
+    } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      prim.CreateAttribute(_tokens->momentumRadii, SdfValueTypeNames->Float3)
+          .Set(GfVec3f(
+              primitive.ellipsoidRadii.x(),
+              primitive.ellipsoidRadii.y(),
+              primitive.ellipsoidRadii.z()));
+    }
 
-    const auto& t = capsule.transformation.translation;
+    const auto& t = primitive.transformation.translation;
     prim.CreateAttribute(_tokens->momentumTranslation, SdfValueTypeNames->Float3)
         .Set(GfVec3f(t.x(), t.y(), t.z()));
 
-    const auto& q = capsule.transformation.rotation;
+    const auto& q = primitive.transformation.rotation;
     prim.CreateAttribute(_tokens->momentumRotation, SdfValueTypeNames->Quatf)
         .Set(GfQuatf(q.w(), q.x(), q.y(), q.z()));
   }
@@ -281,46 +319,56 @@ CollisionGeometry loadCollisionGeometryFromUsd(
     }
 
     std::string type;
-    if (!typeAttr.Get(&type) || type != "collision_capsule") {
+    if (!typeAttr.Get(&type) || (type != "collision_capsule" && type != "collision_ellipsoid")) {
       continue;
     }
 
-    TaperedCapsule capsule;
+    CollisionPrimitive primitive;
 
     std::string parentName;
     if (auto attr = prim.GetAttribute(_tokens->momentumParent); attr) {
       attr.Get(&parentName);
-      capsule.parent = skeleton.getJointIdByName(parentName);
+      primitive.parent = skeleton.getJointIdByName(parentName);
     }
 
-    if (auto attr = prim.GetAttribute(_tokens->momentumLength); attr) {
-      attr.Get(&capsule.length);
-    }
+    if (type == "collision_capsule") {
+      primitive.type = CollisionPrimitiveType::TaperedCapsule;
+      if (auto attr = prim.GetAttribute(_tokens->momentumLength); attr) {
+        attr.Get(&primitive.length);
+      }
 
-    GfVec2f radius(0.0f, 0.0f);
-    if (auto attr = prim.GetAttribute(_tokens->momentumRadius); attr) {
-      attr.Get(&radius);
-      capsule.radius = Eigen::Vector2f(radius[0], radius[1]);
+      GfVec2f radius(0.0f, 0.0f);
+      if (auto attr = prim.GetAttribute(_tokens->momentumRadius); attr) {
+        attr.Get(&radius);
+        primitive.radius = Eigen::Vector2f(radius[0], radius[1]);
+      }
+    } else if (type == "collision_ellipsoid") {
+      primitive.type = CollisionPrimitiveType::Ellipsoid;
+      GfVec3f radii(0.0f, 0.0f, 0.0f);
+      if (auto attr = prim.GetAttribute(_tokens->momentumRadii); attr) {
+        attr.Get(&radii);
+        primitive.ellipsoidRadii = Eigen::Vector3f(radii[0], radii[1], radii[2]);
+      }
     }
 
     GfVec3f translation(0.0f, 0.0f, 0.0f);
     if (auto attr = prim.GetAttribute(_tokens->momentumTranslation); attr) {
       attr.Get(&translation);
-      capsule.transformation.translation =
+      primitive.transformation.translation =
           Eigen::Vector3f(translation[0], translation[1], translation[2]);
     }
 
     GfQuatf rotation(1.0f);
     if (auto attr = prim.GetAttribute(_tokens->momentumRotation); attr) {
       attr.Get(&rotation);
-      capsule.transformation.rotation = Eigen::Quaternionf(
+      primitive.transformation.rotation = Eigen::Quaternionf(
           rotation.GetReal(),
           rotation.GetImaginary()[0],
           rotation.GetImaginary()[1],
           rotation.GetImaginary()[2]);
     }
 
-    result.push_back(capsule);
+    result.push_back(primitive);
   }
 
   return result;

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -27,6 +27,18 @@ namespace momentum {
 
 namespace {
 
+template <typename LhsDerived, typename RhsDerived>
+bool lessLexicographic(
+    const Eigen::MatrixBase<LhsDerived>& lhs,
+    const Eigen::MatrixBase<RhsDerived>& rhs) {
+  for (Eigen::Index i = 0; i < lhs.size(); ++i) {
+    if (lhs[i] != rhs[i]) {
+      return lhs[i] < rhs[i];
+    }
+  }
+  return false;
+}
+
 MATCHER_P(FloatNearPointwise, tol, "Value mismatch") {
   for (int i = 0; i < std::get<0>(arg).size(); i++) {
     if (std::abs(std::get<0>(arg)[i] - std::get<1>(arg)[i]) > tol) {
@@ -147,16 +159,27 @@ void compareCollisionGeometry(
     EXPECT_EQ(refCollision->size(), collision->size());
     auto sortedRefCollision = *refCollision;
     auto sortedCollision = *collision;
-    auto compareCollisions = [](const TaperedCapsule& l1, const TaperedCapsule& l2) {
+    auto compareCollisions = [](const auto& l1, const auto& l2) {
       if (l1.parent != l2.parent) {
         return l1.parent < l2.parent;
+      }
+      if (l1.type != l2.type) {
+        return static_cast<int>(l1.type) < static_cast<int>(l2.type);
       }
       if (l1.length != l2.length) {
         return l1.length < l2.length;
       }
-      if (!l1.radius.isApprox(l2.radius)) {
-        return l1.radius.x() != l2.radius.x() ? l1.radius.x() < l2.radius.x()
-                                              : l1.radius.y() < l2.radius.y();
+      if (lessLexicographic(l1.radius, l2.radius)) {
+        return true;
+      }
+      if (lessLexicographic(l2.radius, l1.radius)) {
+        return false;
+      }
+      if (lessLexicographic(l1.ellipsoidRadii, l2.ellipsoidRadii)) {
+        return true;
+      }
+      if (lessLexicographic(l2.ellipsoidRadii, l1.ellipsoidRadii)) {
+        return false;
       }
       const auto t1 = l1.transformation.toMatrix();
       const auto t2 = l2.transformation.toMatrix();
@@ -174,21 +197,26 @@ void compareCollisionGeometry(
       const auto& collA = sortedRefCollision[i];
       const auto& collB = sortedCollision[i];
 
-      EXPECT_TRUE(collA.isApprox(collB)) << "Collision geometry mismatch at index " << i << ":\n"
-                                         << "- refCollision:\n"
-                                         << "  - radius_0 : " << collA.radius.x() << "\n"
-                                         << "  - radius_1 : " << collA.radius.y() << "\n"
-                                         << "  - length   : " << collA.length << "\n"
-                                         << "  - parent   : " << collA.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collA.transformation.toMatrix() << "\n"
-                                         << "- collision:\n"
-                                         << "  - radius_0 : " << collB.radius.x() << "\n"
-                                         << "  - radius_1 : " << collB.radius.y() << "\n"
-                                         << "  - length   : " << collB.length << "\n"
-                                         << "  - parent   : " << collB.parent << "\n"
-                                         << "  - transform:\n"
-                                         << collB.transformation.toMatrix() << std::endl;
+      EXPECT_TRUE(collA.isApprox(collB))
+          << "Collision geometry mismatch at index " << i << ":\n"
+          << "- refCollision:\n"
+          << "  - type     : " << static_cast<int>(collA.type) << "\n"
+          << "  - radius_0 : " << collA.radius.x() << "\n"
+          << "  - radius_1 : " << collA.radius.y() << "\n"
+          << "  - radii    : " << collA.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collA.length << "\n"
+          << "  - parent   : " << collA.parent << "\n"
+          << "  - transform:\n"
+          << collA.transformation.toMatrix() << "\n"
+          << "- collision:\n"
+          << "  - type     : " << static_cast<int>(collB.type) << "\n"
+          << "  - radius_0 : " << collB.radius.x() << "\n"
+          << "  - radius_1 : " << collB.radius.y() << "\n"
+          << "  - radii    : " << collB.ellipsoidRadii.transpose() << "\n"
+          << "  - length   : " << collB.length << "\n"
+          << "  - parent   : " << collB.parent << "\n"
+          << "  - transform:\n"
+          << collB.transformation.toMatrix() << std::endl;
     }
   }
 }

--- a/momentum/test/character/character_helpers_gtest.h
+++ b/momentum/test/character/character_helpers_gtest.h
@@ -14,6 +14,9 @@ namespace momentum {
 
 // Matching methods
 void compareMeshes(const Mesh_u& refMesh, const Mesh_u& mesh);
+void compareCollisionGeometry(
+    const CollisionGeometry_u& refCollision,
+    const CollisionGeometry_u& collision);
 void compareChars(
     const Character& refChar,
     const Character& character,

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -132,6 +132,13 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
   setTestPhysicalProperties(this->character);
   const PhysicalProperties originalPhysicalProperties = this->character.physicalProperties;
 
+  ASSERT_TRUE(this->character.collision);
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 1;
+  ellipsoid.transformation.translation = Vector3f(0.1f, 0.2f, 0.3f);
+  ellipsoid.radii = Vector3f(0.3f, 0.2f, 0.1f);
+  this->character.collision->push_back(ellipsoid);
+
   // Store original values for comparison
   Vector3f originalTranslation = this->character.skeleton.joints[1].translationOffset;
   Vector3f originalVertex = this->character.mesh->vertices[0];
@@ -166,6 +173,11 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
         scaledCharacter.collision->at(0).radius, this->character.collision->at(0).radius * scale);
     EXPECT_EQ(
         scaledCharacter.collision->at(0).length, this->character.collision->at(0).length * scale);
+    const auto& scaledEllipsoid = scaledCharacter.collision->back();
+    EXPECT_EQ(scaledEllipsoid.type, CollisionPrimitiveType::Ellipsoid);
+    EXPECT_EQ(
+        scaledEllipsoid.transformation.translation, ellipsoid.transformation.translation * scale);
+    EXPECT_EQ(scaledEllipsoid.ellipsoidRadii, ellipsoid.radii * scale);
   }
 
   // Check that inverse bind pose was scaled
@@ -322,6 +334,48 @@ TEST_F(CharacterUtilityTest, TransformCharacter) {
   testTransformCharacter(this->characterWithBlendShapes);
 }
 
+TEST_F(CharacterUtilityTest, TransformCharacterTransformsWorldFixedCollisionGeometry) {
+  CollisionGeometry collisionGeometry;
+
+  CollisionEllipsoid parentedEllipsoid;
+  parentedEllipsoid.parent = 0;
+  parentedEllipsoid.transformation.translation = Vector3f(0.1f, 0.2f, 0.3f);
+  parentedEllipsoid.radii = Vector3f(0.2f, 0.3f, 0.4f);
+  collisionGeometry.push_back(parentedEllipsoid);
+
+  CollisionEllipsoid worldEllipsoid;
+  worldEllipsoid.parent = kInvalidIndex;
+  worldEllipsoid.transformation.translation = Vector3f(0.5f, 0.6f, 0.7f);
+  worldEllipsoid.transformation.rotation =
+      Quaternionf(Eigen::AngleAxisf(pi() / 3.0f, Vector3f::UnitZ()));
+  worldEllipsoid.radii = Vector3f(0.7f, 0.6f, 0.5f);
+  collisionGeometry.push_back(worldEllipsoid);
+
+  const Character character(
+      this->smallCharacter.skeleton,
+      this->smallCharacter.parameterTransform,
+      this->smallCharacter.parameterLimits,
+      this->smallCharacter.locators,
+      this->smallCharacter.mesh.get(),
+      this->smallCharacter.skinWeights.get(),
+      &collisionGeometry);
+
+  Affine3f transform = Affine3f::Identity();
+  transform.linear() =
+      Quaternionf(Eigen::AngleAxisf(pi() / 2.0f, Vector3f::UnitY())).toRotationMatrix();
+  transform.translation() = Vector3f(1.0f, 2.0f, 3.0f);
+
+  const Character transformedCharacter = transformCharacter(character, transform);
+
+  ASSERT_TRUE(transformedCharacter.collision);
+  ASSERT_EQ(transformedCharacter.collision->size(), 2);
+  EXPECT_TRUE(transformedCharacter.collision->at(0).transformation.isApprox(
+      parentedEllipsoid.transformation));
+  EXPECT_TRUE(transformedCharacter.collision->at(1).transformation.isApprox(
+      Transform(transform) * worldEllipsoid.transformation));
+  EXPECT_EQ(transformedCharacter.collision->at(1).ellipsoidRadii, worldEllipsoid.radii);
+}
+
 // Test removeJoints function
 TEST_F(CharacterUtilityTest, RemoveJoints) {
   // Skip if the character doesn't have enough joints
@@ -407,6 +461,38 @@ TEST_F(CharacterUtilityTest, RemoveJoints) {
   Character rootOnlyCharacter = removeJoints(this->character, allButRoot);
   EXPECT_EQ(rootOnlyCharacter.skeleton.joints.size(), 1);
   EXPECT_EQ(rootOnlyCharacter.skeleton.joints[0].name, this->character.skeleton.joints[0].name);
+}
+
+TEST_F(CharacterUtilityTest, RemoveJointsKeepsWorldFixedCollisionGeometry) {
+  CollisionGeometry collisionGeometry;
+
+  CollisionEllipsoid worldEllipsoid;
+  worldEllipsoid.parent = kInvalidIndex;
+  worldEllipsoid.radii = Vector3f(0.4f, 0.3f, 0.2f);
+  collisionGeometry.push_back(worldEllipsoid);
+
+  CollisionEllipsoid removedJointEllipsoid;
+  removedJointEllipsoid.parent = 1;
+  removedJointEllipsoid.radii = Vector3f(0.2f, 0.3f, 0.4f);
+  collisionGeometry.push_back(removedJointEllipsoid);
+
+  const Character character(
+      this->smallCharacter.skeleton,
+      this->smallCharacter.parameterTransform,
+      this->smallCharacter.parameterLimits,
+      this->smallCharacter.locators,
+      this->smallCharacter.mesh.get(),
+      this->smallCharacter.skinWeights.get(),
+      &collisionGeometry);
+
+  const std::vector<size_t> jointsToRemove = {1};
+  const Character resultCharacter = removeJoints(character, jointsToRemove);
+
+  ASSERT_TRUE(resultCharacter.collision);
+  ASSERT_EQ(resultCharacter.collision->size(), 1);
+  EXPECT_EQ(resultCharacter.collision->at(0).type, CollisionPrimitiveType::Ellipsoid);
+  EXPECT_EQ(resultCharacter.collision->at(0).parent, kInvalidIndex);
+  EXPECT_EQ(resultCharacter.collision->at(0).ellipsoidRadii, worldEllipsoid.radii);
 }
 
 // Test mapMotionToCharacter function

--- a/momentum/test/character/collision_geometry_state_test.cpp
+++ b/momentum/test/character/collision_geometry_state_test.cpp
@@ -127,6 +127,30 @@ TEST_F(CollisionGeometryStateTest, UpdateWithTransformedJoints) {
   EXPECT_FLOAT_EQ(collisionState.delta[1], -0.3f); // 0.3 - 0.6 = -0.3
 }
 
+TEST_F(CollisionGeometryStateTest, UpdateWithEllipsoid) {
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 0;
+  ellipsoid.transformation.translation = Vector3f(0.25f, 0.5f, 0.75f);
+  ellipsoid.transformation.rotation =
+      Quaternionf(Eigen::AngleAxisf(pi() / 2.0f, Vector3f::UnitZ()));
+  ellipsoid.radii = Vector3f(0.2f, 0.4f, 0.6f);
+  collisionGeometry.push_back(ellipsoid);
+
+  skeletonState.jointState[0].transform.translation = Vector3f(1.0f, 2.0f, 3.0f);
+  skeletonState.jointState[0].transform.scale = 2.0f;
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, collisionGeometry);
+
+  ASSERT_EQ(collisionState.type.size(), 3);
+  EXPECT_EQ(collisionState.type[2], CollisionPrimitiveType::Ellipsoid);
+  EXPECT_TRUE(collisionState.origin[2].isApprox(Vector3f(1.5f, 3.0f, 4.5f)));
+  EXPECT_TRUE(collisionState.direction[2].isZero());
+  EXPECT_TRUE(collisionState.radius[2].isZero());
+  EXPECT_FLOAT_EQ(collisionState.delta[2], 0.0f);
+  EXPECT_TRUE(collisionState.ellipsoidRadii[2].isApprox(Vector3f(0.4f, 0.8f, 1.2f)));
+}
+
 // Test the overlaps function with non-overlapping capsules
 TEST_F(CollisionGeometryStateTest, OverlapsNonOverlapping) {
   // Create two non-overlapping capsules
@@ -160,6 +184,58 @@ TEST_F(CollisionGeometryStateTest, OverlapsNonOverlapping) {
 
   // They should not overlap
   EXPECT_FALSE(result);
+}
+
+TEST_F(CollisionGeometryStateTest, OverlapsCapsuleEllipsoid) {
+  CollisionGeometry geometry;
+
+  TaperedCapsule capsule;
+  capsule.parent = 0;
+  capsule.length = 1.0f;
+  capsule.radius = Vector2f(0.25f, 0.25f);
+  geometry.push_back(capsule);
+
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 1;
+  ellipsoid.transformation.translation = Vector3f(0.5f, 0.45f, 0.0f);
+  ellipsoid.radii = Vector3f(0.2f, 0.3f, 0.2f);
+  geometry.push_back(ellipsoid);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 0, 1, overlap));
+  EXPECT_NEAR(overlap.distance, 0.45f, 1e-5f);
+  EXPECT_NEAR(overlap.closestPoints[0], 0.5f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusA, 0.25f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.3f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.1f, 1e-5f);
+}
+
+TEST_F(CollisionGeometryStateTest, OverlapsEllipsoidEllipsoid) {
+  CollisionGeometry geometry;
+
+  CollisionEllipsoid ellipsoidA;
+  ellipsoidA.parent = 0;
+  ellipsoidA.radii = Vector3f(0.5f, 0.2f, 0.2f);
+  geometry.push_back(ellipsoidA);
+
+  CollisionEllipsoid ellipsoidB;
+  ellipsoidB.parent = 1;
+  ellipsoidB.transformation.translation = Vector3f(0.8f, 0.0f, 0.0f);
+  ellipsoidB.radii = Vector3f(0.4f, 0.2f, 0.2f);
+  geometry.push_back(ellipsoidB);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 0, 1, overlap));
+  EXPECT_NEAR(overlap.distance, 0.8f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusA, 0.5f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.4f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.1f, 1e-5f);
 }
 
 // Test the overlaps function with overlapping capsules
@@ -313,6 +389,30 @@ TEST_F(CollisionGeometryStateTest, UpdateAabbDifferentRadii) {
   EXPECT_TRUE(aabb.aabb.min().isApprox(Vector3f(0.7f, 1.5f, 2.5f)));
   // Max should account for the larger radius at the end
   EXPECT_TRUE(aabb.aabb.max().isApprox(Vector3f(3.5f, 2.5f, 3.5f)));
+}
+
+// Test that updateEllipsoidAabb uses the tight L2 ellipsoid bound. A 45-degree rotation about
+// Z makes the tight bound (sqrt((cos45*rx)^2 + (sin45*ry)^2)) differ from the looser L1/OBB
+// bound used for boxes (cos45*rx + sin45*ry), so this exercises the ellipsoid-specific path.
+TEST_F(CollisionGeometryStateTest, UpdateEllipsoidAabb) {
+  const Vector3f center(1.0f, 2.0f, 5.0f);
+  // Unit quaternion (w, x, y, z) for a +45-degree rotation about the Z axis.
+  const Quaternionf orientation(0.9238795325f, 0.0f, 0.0f, 0.3826834324f);
+  const Vector3f radii(2.0f, 1.0f, 3.0f);
+
+  axel::BoundingBox<float> aabb;
+  updateEllipsoidAabb(aabb, center, orientation, radii);
+
+  // Tight half-extent along X and Y is sqrt((cos45*2)^2 + (sin45*1)^2) = sqrt(2.5) ~= 1.5811,
+  // whereas the box/L1 bound would be cos45*2 + sin45*1 ~= 2.1213. Z is unrotated, so 3.0.
+  const float hXy = std::sqrt(2.5f);
+  const float hZ = 3.0f;
+  EXPECT_NEAR(aabb.aabb.min().x(), center.x() - hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.min().y(), center.y() - hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.min().z(), center.z() - hZ, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().x(), center.x() + hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().y(), center.y() + hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().z(), center.z() + hZ, 1e-5f);
 }
 
 // Test the CollisionGeometryState with double precision

--- a/momentum/test/character/collision_geometry_test.cpp
+++ b/momentum/test/character/collision_geometry_test.cpp
@@ -29,6 +29,19 @@ TEST(CollisionGeometryTest, DefaultConstructor) {
   EXPECT_TRUE(capsuleDouble.radius.isApprox(Vector2<double>::Zero()));
   EXPECT_EQ(capsuleDouble.parent, kInvalidIndex);
   EXPECT_DOUBLE_EQ(capsuleDouble.length, 0.0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  EXPECT_TRUE(ellipsoidFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(ellipsoidFloat.radii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(ellipsoidFloat.parent, kInvalidIndex);
+
+  CollisionPrimitiveT<float> primitiveFloat;
+  EXPECT_EQ(primitiveFloat.type, CollisionPrimitiveType::TaperedCapsule);
+  EXPECT_TRUE(primitiveFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(primitiveFloat.radius.isApprox(Vector2<float>::Zero()));
+  EXPECT_TRUE(primitiveFloat.ellipsoidRadii.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(primitiveFloat.parent, kInvalidIndex);
+  EXPECT_FLOAT_EQ(primitiveFloat.length, 0.0f);
 }
 
 // Test the isApprox method of TaperedCapsuleT
@@ -66,6 +79,25 @@ TEST(CollisionGeometryTest, IsApprox) {
       capsule1.isApprox(capsule2, 1e-4f)); // Should be approximately equal with this tolerance
   EXPECT_FALSE(
       capsule1.isApprox(capsule2, 1e-6f)); // Should not be approximately equal with this tolerance
+
+  CollisionEllipsoidT<float> ellipsoid1;
+  CollisionEllipsoidT<float> ellipsoid2;
+  EXPECT_TRUE(ellipsoid1.isApprox(ellipsoid2));
+
+  ellipsoid2.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  EXPECT_FALSE(ellipsoid1.isApprox(ellipsoid2));
+
+  CollisionPrimitiveT<float> primitive1(capsule1);
+  CollisionPrimitiveT<float> primitive2(capsule1);
+  EXPECT_TRUE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive1.isTaperedCapsule());
+  EXPECT_FALSE(primitive1.isEllipsoid());
+  EXPECT_TRUE(primitive1.toTaperedCapsule().isApprox(capsule1));
+
+  primitive2 = ellipsoid2;
+  EXPECT_FALSE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive2.isEllipsoid());
+  EXPECT_TRUE(primitive2.toEllipsoid().isApprox(ellipsoid2));
 }
 
 // Test the CollisionGeometryT type alias
@@ -85,6 +117,16 @@ TEST(CollisionGeometryTest, CollisionGeometryT) {
   EXPECT_TRUE(collisionGeometryFloat[0].radius.isApprox(Vector2<float>(1.0f, 2.0f)));
   EXPECT_FLOAT_EQ(collisionGeometryFloat[0].length, 3.0f);
   EXPECT_EQ(collisionGeometryFloat[0].parent, 0);
+
+  CollisionEllipsoidT<float> ellipsoidFloat;
+  ellipsoidFloat.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
+  ellipsoidFloat.parent = 1;
+  collisionGeometryFloat.push_back(ellipsoidFloat);
+
+  EXPECT_EQ(collisionGeometryFloat.size(), 2);
+  EXPECT_TRUE(collisionGeometryFloat[1].isEllipsoid());
+  EXPECT_TRUE(collisionGeometryFloat[1].ellipsoidRadii.isApprox(Vector3<float>(1.0f, 2.0f, 3.0f)));
+  EXPECT_EQ(collisionGeometryFloat[1].parent, 1);
 
   // Create a collision geometry with double precision
   CollisionGeometryT<double> collisionGeometryDouble;

--- a/momentum/test/character_solver/collision_error_function_test.cpp
+++ b/momentum/test/character_solver/collision_error_function_test.cpp
@@ -290,6 +290,91 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, CapsuleCollisionError_GradientsAndJacobi
   ASSERT_GE(numTestedPoses, 3) << "Too few poses produced collisions";
 }
 
+TYPED_TEST(Momentum_ErrorFunctionsTest, EllipsoidCollisionError_ProducesError) {
+  using T = typename TestFixture::Type;
+
+  const Character baseCharacter = createTestCharacter(3);
+
+  CollisionGeometry cg;
+
+  TaperedCapsule jointCapsule;
+  jointCapsule.parent = 0;
+  jointCapsule.length = 1.0f;
+  jointCapsule.radius = Eigen::Vector2f(0.25f, 0.25f);
+  cg.push_back(jointCapsule);
+
+  CollisionEllipsoid worldEllipsoid;
+  worldEllipsoid.parent = kInvalidIndex;
+  worldEllipsoid.transformation.translation = Eigen::Vector3f(0.5f, 0.45f, 0.0f);
+  worldEllipsoid.radii = Eigen::Vector3f(0.2f, 0.3f, 0.2f);
+  cg.push_back(worldEllipsoid);
+
+  const Character character(
+      baseCharacter.skeleton,
+      baseCharacter.parameterTransform,
+      baseCharacter.parameterLimits,
+      baseCharacter.locators,
+      baseCharacter.mesh.get(),
+      baseCharacter.skinWeights.get(),
+      &cg);
+
+  CollisionErrorFunctionT<T> errorFunction(character, false);
+  CollisionErrorFunctionStatelessT<T> errorFunctionStateless(character);
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+  const ModelParametersT<T> zeroParams =
+      ModelParametersT<T>::Zero(transform.numAllModelParameters());
+  const SkeletonStateT<T> state(transform.apply(zeroParams), character.skeleton);
+
+  const double error = errorFunction.getError(zeroParams, state, MeshStateT<T>());
+  const double statelessError = errorFunctionStateless.getError(zeroParams, state, MeshStateT<T>());
+
+  EXPECT_GT(error, 0.0);
+  EXPECT_NEAR(error, statelessError, 1e-10);
+  EXPECT_EQ(errorFunction.getCollisionPairs().size(), 1);
+  const auto debugInfo = errorFunction.getCollisionDebugInfo();
+  ASSERT_EQ(debugInfo.size(), 1);
+  EXPECT_GT(debugInfo[0].overlap, 0.0);
+
+  Random<>::GetSingleton().setSeed(TestFixture::kTestSeed);
+  size_t numTestedPoses = 0;
+  for (size_t iTrial = 0; iTrial < 10; ++iTrial) {
+    const ModelParametersT<T> mp = uniform<VectorX<T>>(
+        transform.numAllModelParameters(), static_cast<T>(-0.03), static_cast<T>(0.03));
+    const SkeletonStateT<T> trialState(transform.apply(mp), character.skeleton);
+    if (errorFunction.getError(mp, trialState, MeshStateT<T>()) <= 0.0) {
+      continue;
+    }
+    SCOPED_TRACE("trial=" + std::to_string(iTrial));
+    // Ellipsoid contact finite differences are less stable than capsule contact even for double:
+    // the closest point and normal both move under perturbation, and these shallow overlaps have
+    // small gradient/Jacobian norms. Keep a relative 2% tolerance while checking analytical and
+    // stateless implementations against the same numerical result.
+    const T numThreshold = T(0.02);
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunction,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/true);
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunctionStateless,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/true);
+    VALIDATE_IDENTICAL(
+        T, errorFunction, errorFunctionStateless, character.skeleton, transform, mp.v);
+    ++numTestedPoses;
+  }
+  ASSERT_GE(numTestedPoses, 3) << "Too few poses produced collisions";
+}
+
 // Test capsule collision gradients on a shared skeleton with global scaling.
 // Uses a double-branch skeleton (root → joint1 → joint2, root → joint3 → joint4)
 // so that:

--- a/momentum/test/character_solver_simd/simd_collision_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_collision_error_function_test.cpp
@@ -124,6 +124,52 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, CollisionBroadphaseAccuracy) {
       << "No collisions in " << kNumRandomPoses << " random poses; test is ineffective";
 }
 
+TYPED_TEST(Momentum_ErrorFunctionsTest, SimdCollisionErrorFunctionEllipsoidFallbackIsSame) {
+#ifndef MOMENTUM_ENABLE_SIMD
+  GTEST_SKIP() << "SIMD support is required for SIMD fallback comparison.";
+#else
+  using T = typename TestFixture::Type;
+
+  const Character baseCharacter = createTestCharacter(3);
+
+  CollisionGeometry cg;
+
+  TaperedCapsule jointCapsule;
+  jointCapsule.parent = 0;
+  jointCapsule.length = 1.0f;
+  jointCapsule.radius = Eigen::Vector2f(0.25f, 0.25f);
+  cg.push_back(jointCapsule);
+
+  CollisionEllipsoid worldEllipsoid;
+  worldEllipsoid.parent = kInvalidIndex;
+  worldEllipsoid.transformation.translation = Eigen::Vector3f(0.5f, 0.45f, 0.0f);
+  worldEllipsoid.radii = Eigen::Vector3f(0.2f, 0.3f, 0.2f);
+  cg.push_back(worldEllipsoid);
+
+  const Character character(
+      baseCharacter.skeleton,
+      baseCharacter.parameterTransform,
+      baseCharacter.parameterLimits,
+      baseCharacter.locators,
+      baseCharacter.mesh.get(),
+      baseCharacter.skinWeights.get(),
+      &cg);
+
+  CollisionErrorFunctionT<T> errfBase(character, false);
+  SimdCollisionErrorFunctionT<T> errfSimd(character);
+
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+  const ModelParametersT<T> mp = ModelParametersT<T>::Zero(transform.numAllModelParameters());
+  const SkeletonStateT<T> skelState(transform.apply(mp), character.skeleton);
+
+  const double errBase = errfBase.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_GT(errBase, 0.0);
+  const double errSimd = errfSimd.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_NEAR(errBase, errSimd, 1e-10);
+  VALIDATE_IDENTICAL(T, errfBase, errfSimd, character.skeleton, transform, mp.v);
+#endif
+}
+
 // Verify that the SIMD version of the collision error function is at least as fast as the
 // multithreaded versions. Disabled by default because it's too slow to run in CI.
 TEST(Momentum_ErrorFunctions, DISABLED_SimdCollisionErrorFunctionIsFaster) {

--- a/momentum/test/io/io_legacy_json_test.cpp
+++ b/momentum/test/io/io_legacy_json_test.cpp
@@ -103,6 +103,12 @@ class LegacyJsonIOTest : public ::testing::Test {
     capsule.parent = 0;
     capsule.length = 1.0f;
     collision->push_back(capsule);
+    CollisionEllipsoid ellipsoid;
+    ellipsoid.transformation = Eigen::Affine3f::Identity();
+    ellipsoid.transformation.translation = Eigen::Vector3f(0.2f, 0.3f, 0.4f);
+    ellipsoid.radii = Eigen::Vector3f(0.3f, 0.2f, 0.1f);
+    ellipsoid.parent = 1;
+    collision->push_back(ellipsoid);
 
     // Create parameter transform
     ParameterTransform parameterTransform =
@@ -165,7 +171,7 @@ TEST_F(LegacyJsonIOTest, RoundTripConversion) {
 
   // Verify collision geometry
   ASSERT_NE(roundTripCharacter.collision, nullptr);
-  EXPECT_EQ(roundTripCharacter.collision->size(), testCharacter_.collision->size());
+  compareCollisionGeometry(testCharacter_.collision, roundTripCharacter.collision);
 }
 
 TEST_F(LegacyJsonIOTest, SkeletonOnlyConversion) {

--- a/momentum/test/io/io_usd_test.cpp
+++ b/momentum/test/io/io_usd_test.cpp
@@ -488,6 +488,12 @@ TEST_F(UsdIoTest, SaveAndLoadRoundTrip_CollisionGeometry) {
   ASSERT_TRUE(testCharacter.collision);
   ASSERT_GT(testCharacter.collision->size(), 0);
 
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 1;
+  ellipsoid.transformation.translation = Eigen::Vector3f(0.2f, 0.3f, 0.4f);
+  ellipsoid.radii = Eigen::Vector3f(0.3f, 0.2f, 0.1f);
+  testCharacter.collision->push_back(ellipsoid);
+
   auto tempFile = temporaryFile("momentum_usd_collision", ".usda");
   saveUsd(tempFile.path(), testCharacter);
 
@@ -500,15 +506,18 @@ TEST_F(UsdIoTest, SaveAndLoadRoundTrip_CollisionGeometry) {
     const auto& orig = (*testCharacter.collision)[i];
     const auto& loaded = (*loadedCharacter.collision)[i];
 
-    EXPECT_EQ(loaded.parent, orig.parent) << "Capsule parent mismatch at index " << i;
-    EXPECT_NEAR(loaded.length, orig.length, 1e-5f) << "Capsule length mismatch at index " << i;
+    EXPECT_EQ(loaded.type, orig.type) << "Collision type mismatch at index " << i;
+    EXPECT_EQ(loaded.parent, orig.parent) << "Collision parent mismatch at index " << i;
+    EXPECT_NEAR(loaded.length, orig.length, 1e-5f) << "Collision length mismatch at index " << i;
     EXPECT_TRUE(loaded.radius.isApprox(orig.radius, 1e-5f))
-        << "Capsule radius mismatch at index " << i;
+        << "Collision radius mismatch at index " << i;
+    EXPECT_TRUE(loaded.ellipsoidRadii.isApprox(orig.ellipsoidRadii, 1e-5f))
+        << "Collision ellipsoid radii mismatch at index " << i;
     EXPECT_TRUE(loaded.transformation.translation.isApprox(orig.transformation.translation, 1e-4f))
-        << "Capsule translation mismatch at index " << i;
+        << "Collision translation mismatch at index " << i;
     EXPECT_TRUE(loaded.transformation.rotation.toRotationMatrix().isApprox(
         orig.transformation.rotation.toRotationMatrix(), 1e-4f))
-        << "Capsule rotation mismatch at index " << i;
+        << "Collision rotation mismatch at index " << i;
   }
 }
 

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -58,6 +58,26 @@ mm::Character withBlendShapeImpl(
   return c.withBlendShape(blendShapePtr, nShapes < 0 ? INT_MAX : nShapes);
 }
 
+std::vector<mm::TaperedCapsule> collisionGeometryToPython(
+    const mm::CollisionGeometry& collisionGeometry) {
+  std::vector<mm::TaperedCapsule> result;
+  result.reserve(collisionGeometry.size());
+  for (const auto& primitive : collisionGeometry) {
+    if (!primitive.isTaperedCapsule()) {
+      MT_THROW(
+          "Collision geometry contains unsupported primitive type for capsule-only Python binding: {}",
+          static_cast<int>(primitive.type));
+    }
+    result.push_back(primitive.toTaperedCapsule());
+  }
+  return result;
+}
+
+mm::CollisionGeometry collisionGeometryFromPython(
+    const std::vector<mm::TaperedCapsule>& collisionGeometry) {
+  return {collisionGeometry.begin(), collisionGeometry.end()};
+}
+
 } // namespace
 
 namespace pymomentum {
@@ -369,12 +389,11 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           ":return: The character's :class:`BlendShapeBase` basis, if present, or None.")
       .def_property_readonly(
           "collision_geometry",
-          [](const mm::Character& c) -> mm::CollisionGeometry {
+          [](const mm::Character& c) -> std::vector<mm::TaperedCapsule> {
             if (c.collision) {
-              return *c.collision;
-            } else {
-              return {};
+              return collisionGeometryToPython(*c.collision);
             }
+            return {};
           },
           ":return: A list of :class:`TaperedCapsule` representing the character's collision geometry.")
       .def(
@@ -407,6 +426,7 @@ It can be used to solve for facial expressions.
       .def(
           "with_collision_geometry",
           [](const mm::Character& c, const std::vector<mm::TaperedCapsule>& collision_geometry) {
+            const mm::CollisionGeometry geometry = collisionGeometryFromPython(collision_geometry);
             return mm::Character(
                 c.skeleton,
                 c.parameterTransform,
@@ -414,7 +434,7 @@ It can be used to solve for facial expressions.
                 c.locators,
                 c.mesh.get(),
                 c.skinWeights.get(),
-                &collision_geometry,
+                &geometry,
                 c.poseShapes.get(),
                 c.blendShape,
                 c.faceExpressionBlendShape,

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -15,6 +15,7 @@
 #include <momentum/character/blend_shape.h>
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>
+#include <momentum/character/collision_geometry.h>
 #include <momentum/character/skeleton.h>
 #include <momentum/character/skeleton_state.h>
 #include <momentum/io/fbx/fbx_io.h>
@@ -35,6 +36,7 @@
 #include <fmt/format.h>
 
 namespace mm = momentum;
+namespace py = pybind11;
 
 namespace {
 
@@ -58,24 +60,37 @@ mm::Character withBlendShapeImpl(
   return c.withBlendShape(blendShapePtr, nShapes < 0 ? INT_MAX : nShapes);
 }
 
-std::vector<mm::TaperedCapsule> collisionGeometryToPython(
-    const mm::CollisionGeometry& collisionGeometry) {
-  std::vector<mm::TaperedCapsule> result;
-  result.reserve(collisionGeometry.size());
+py::list collisionGeometryToPython(const mm::CollisionGeometry& collisionGeometry) {
+  py::list result;
   for (const auto& primitive : collisionGeometry) {
-    if (!primitive.isTaperedCapsule()) {
+    if (primitive.type == mm::CollisionPrimitiveType::TaperedCapsule) {
+      result.append(py::cast(primitive.toTaperedCapsule()));
+    } else if (primitive.type == mm::CollisionPrimitiveType::Ellipsoid) {
+      result.append(py::cast(primitive.toEllipsoid()));
+    } else {
       MT_THROW(
-          "Collision geometry contains unsupported primitive type for capsule-only Python binding: {}",
+          "Unsupported collision primitive type while converting collision geometry to Python: {}",
           static_cast<int>(primitive.type));
     }
-    result.push_back(primitive.toTaperedCapsule());
   }
   return result;
 }
 
-mm::CollisionGeometry collisionGeometryFromPython(
-    const std::vector<mm::TaperedCapsule>& collisionGeometry) {
-  return {collisionGeometry.begin(), collisionGeometry.end()};
+mm::CollisionGeometry collisionGeometryFromPython(const py::sequence& collisionGeometry) {
+  mm::CollisionGeometry result;
+  result.reserve(collisionGeometry.size());
+  for (const py::handle item : collisionGeometry) {
+    if (py::isinstance<mm::TaperedCapsule>(item)) {
+      result.push_back(item.cast<mm::TaperedCapsule>());
+    } else if (py::isinstance<mm::CollisionEllipsoid>(item)) {
+      result.push_back(item.cast<mm::CollisionEllipsoid>());
+    } else {
+      MT_THROW(
+          "Collision geometry entries must be TaperedCapsule or Ellipsoid; got {}",
+          py::str(py::type::handle_of(item)).cast<std::string>());
+    }
+  }
+  return result;
 }
 
 } // namespace
@@ -389,13 +404,14 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           ":return: The character's :class:`BlendShapeBase` basis, if present, or None.")
       .def_property_readonly(
           "collision_geometry",
-          [](const mm::Character& c) -> std::vector<mm::TaperedCapsule> {
+          [](const mm::Character& c) -> py::list {
             if (c.collision) {
               return collisionGeometryToPython(*c.collision);
+            } else {
+              return py::list();
             }
-            return {};
           },
-          ":return: A list of :class:`TaperedCapsule` representing the character's collision geometry.")
+          ":return: A list of :class:`TaperedCapsule` and :class:`Ellipsoid` objects representing the character's collision geometry.")
       .def(
           "with_blend_shape",
           &withBlendShapeImpl,
@@ -425,8 +441,9 @@ It can be used to solve for facial expressions.
           py::arg("n_shapes") = -1)
       .def(
           "with_collision_geometry",
-          [](const mm::Character& c, const std::vector<mm::TaperedCapsule>& collision_geometry) {
-            const mm::CollisionGeometry geometry = collisionGeometryFromPython(collision_geometry);
+          [](const mm::Character& c, const py::sequence& collision_geometry) {
+            const mm::CollisionGeometry collisionGeometry =
+                collisionGeometryFromPython(collision_geometry);
             return mm::Character(
                 c.skeleton,
                 c.parameterTransform,
@@ -434,7 +451,7 @@ It can be used to solve for facial expressions.
                 c.locators,
                 c.mesh.get(),
                 c.skinWeights.get(),
-                &geometry,
+                &collisionGeometry,
                 c.poseShapes.get(),
                 c.blendShape,
                 c.faceExpressionBlendShape,

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -31,6 +31,7 @@
 #include <momentum/character/blend_shape.h>
 #include <momentum/character/character.h>
 #include <momentum/character/character_utility.h>
+#include <momentum/character/collision_geometry.h>
 #include <momentum/character/fwd.h>
 #include <momentum/character/inverse_parameter_transform.h>
 #include <momentum/character/joint.h>
@@ -50,6 +51,7 @@
 #include <momentum/math/mesh.h>
 #include <momentum/math/mppca.h>
 #include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <Eigen/Core>
@@ -63,6 +65,44 @@ namespace py = pybind11;
 namespace mm = momentum;
 
 using namespace pymomentum;
+
+namespace {
+
+using OptionalTransformArray =
+    std::optional<py::array_t<float, py::array::c_style | py::array::forcecast>>;
+
+Eigen::Matrix4f collisionTransformFromPython(const OptionalTransformArray& transformation) {
+  if (!transformation.has_value()) {
+    return Eigen::Matrix4f::Identity();
+  }
+
+  const auto& array = transformation.value();
+  MT_THROW_IF(
+      array.ndim() != 2 || array.shape(0) != 4 || array.shape(1) != 4,
+      "Expected collision primitive transformation to have shape (4, 4)");
+
+  Eigen::Matrix4f matrix;
+  const auto values = array.unchecked<2>();
+  for (Eigen::Index row = 0; row < 4; ++row) {
+    for (Eigen::Index col = 0; col < 4; ++col) {
+      matrix(row, col) = values(row, col);
+    }
+  }
+  return matrix;
+}
+
+int collisionParentToPython(size_t parent) {
+  if (parent == mm::kInvalidIndex) {
+    return -1;
+  }
+  MT_THROW_IF(
+      parent > static_cast<size_t>(std::numeric_limits<int>::max()),
+      "Collision primitive parent index {} cannot be represented as a Python int",
+      parent);
+  return static_cast<int>(parent);
+}
+
+} // namespace
 
 PYBIND11_MODULE(geometry, m) {
   // TODO more explanation
@@ -178,6 +218,11 @@ PYBIND11_MODULE(geometry, m) {
       "TaperedCapsule",
       "A tapered capsule primitive used for collision detection and physics simulation. "
       "Represents a capsule with potentially different radii at each end, attached to a skeleton joint.");
+  auto ellipsoidClass = py::class_<mm::CollisionEllipsoid>(
+      m,
+      "Ellipsoid",
+      "An ellipsoid primitive used for collision detection and physics simulation. "
+      "Represents an oriented ellipsoid attached to a skeleton joint.");
   py::class_<mm::SDFColliderT<float>> sdfColliderClass = py::class_<mm::SDFColliderT<float>>(
       m,
       "SDFCollider",
@@ -428,11 +473,11 @@ The resulting arrays are as follows:
   capsuleClass
       .def(
           py::init<>([](int parent,
-                        const std::optional<Eigen::Matrix4f>& transformation,
+                        const OptionalTransformArray& transformation,
                         const std::optional<Eigen::Vector2f>& radius,
                         float length) {
             mm::TaperedCapsule capsule;
-            capsule.transformation = transformation.value_or(Eigen::Matrix4f::Identity());
+            capsule.transformation = collisionTransformFromPython(transformation);
             capsule.radius = radius.value_or(Eigen::Vector2f::Ones());
             capsule.parent = parent;
             capsule.length = length;
@@ -445,7 +490,7 @@ The resulting arrays are as follows:
 :param parent: Parent joint to which the capsule is attached.
 :param length: Length of the capsule in local space.)",
           py::arg("parent"),
-          py::arg("transformation") = std::optional<Eigen::Matrix4f>{},
+          py::arg("transformation") = py::none(),
           py::arg("radius") = std::optional<Eigen::Vector2f>{},
           py::arg("length") = 1.0f)
       .def_property_readonly(
@@ -460,14 +505,16 @@ The resulting arrays are as follows:
           "Start and end radius for the capsule.")
       .def_property_readonly(
           "parent",
-          [](const mm::TaperedCapsule& capsule) -> int { return capsule.parent; },
+          [](const mm::TaperedCapsule& capsule) -> int {
+            return collisionParentToPython(capsule.parent);
+          },
           "Parent joint to which the capsule is attached.")
       .def_property_readonly(
           "length", [](const mm::TaperedCapsule& capsule) -> float { return capsule.length; })
       .def("__repr__", [](const mm::TaperedCapsule& tc) {
         return fmt::format(
             "TaperedCapsule(parent={}, length={}, radius=[{}, {}])",
-            tc.parent,
+            collisionParentToPython(tc.parent),
             tc.length,
             tc.radius[0],
             tc.radius[1]);
@@ -504,6 +551,53 @@ The resulting arrays are as follows:
             properties.jointName,
             properties.jointIndex,
             properties.mass);
+      });
+
+  ellipsoidClass
+      .def(
+          py::init<>([](int parent,
+                        const OptionalTransformArray& transformation,
+                        const std::optional<Eigen::Vector3f>& radii) {
+            mm::CollisionEllipsoid ellipsoid;
+            ellipsoid.transformation = collisionTransformFromPython(transformation);
+            ellipsoid.radii = radii.value_or(Eigen::Vector3f::Ones());
+            ellipsoid.parent = parent;
+            return ellipsoid;
+          }),
+          R"(Create an ellipsoid using its parent, transformation, and radii.
+
+:param parent: Parent joint to which the ellipsoid is attached.
+:param transformation: Transformation defining the center and orientation relative to the parent coordinate system.
+:param radii: Radii along the local x, y, and z axes.)",
+          py::arg("parent"),
+          py::kw_only(),
+          py::arg("transformation") = py::none(),
+          py::arg("radii") = std::optional<Eigen::Vector3f>{})
+      .def_property_readonly(
+          "transformation",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> Eigen::Matrix4f {
+            return ellipsoid.transformation.toMatrix();
+          },
+          "Transformation defining the center and orientation relative to the parent coordinate system")
+      .def_property_readonly(
+          "radii",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> Eigen::Vector3f {
+            return ellipsoid.radii;
+          },
+          "Radii along the local x, y, and z axes.")
+      .def_property_readonly(
+          "parent",
+          [](const mm::CollisionEllipsoid& ellipsoid) -> int {
+            return collisionParentToPython(ellipsoid.parent);
+          },
+          "Parent joint to which the ellipsoid is attached.")
+      .def("__repr__", [](const mm::CollisionEllipsoid& ellipsoid) {
+        return fmt::format(
+            "Ellipsoid(parent={}, radii=[{}, {}, {}])",
+            collisionParentToPython(ellipsoid.parent),
+            ellipsoid.radii[0],
+            ellipsoid.radii[1],
+            ellipsoid.radii[2]);
       });
 
   // Class Marker, defining the properties:

--- a/pymomentum/rerun_vis.py
+++ b/pymomentum/rerun_vis.py
@@ -15,7 +15,7 @@ the C++ ``momentum::logCharacter`` family of functions in
 ``momentum/gui/rerun/logger.h``.
 
 The primary entry point is :func:`log_character`, which logs the skeleton,
-mesh, and locators of a character in a structured entity tree::
+mesh, collision geometry, and locators of a character in a structured entity tree::
 
     import rerun as rr
     import pymomentum.geometry as geo
@@ -41,15 +41,19 @@ Individual logging functions are also available for finer control:
 
 - :func:`log_mesh` — log a :class:`~pymomentum.geometry.Mesh`
 - :func:`log_joints` — log skeleton bones and per-joint transforms
+- :func:`log_collision_geometry` — log tapered capsule and ellipsoid collision primitives
 - :func:`log_locators` — log locator world-space positions
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
 from pymomentum.quaternion_np import (
+    from_rotation_matrix,
+    multiply_assume_normalized,
     rotate_vector_assume_normalized,
     to_rotation_matrix_assume_normalized,
 )
@@ -59,6 +63,133 @@ if TYPE_CHECKING:
 
     import rerun as rr  # @manual=fbsource//third-party/pypi/rerun-sdk:rerun-sdk
     from pymomentum.geometry import Character, Mesh  # @manual=:geometry
+
+
+_COLLISION_COLOR: tuple[int, int, int] = (128, 64, 64)
+_Z_TO_X_QUAT_XYZW: np.ndarray = np.array(
+    [0.0, np.sqrt(0.5), 0.0, np.sqrt(0.5)], dtype=np.float64
+)
+
+
+@dataclass(frozen=True)
+class _CollisionGeometryArrays:
+    capsule_translations: np.ndarray
+    capsule_quaternions: np.ndarray
+    capsule_lengths: np.ndarray
+    capsule_radii: np.ndarray
+    ellipsoid_centers: np.ndarray
+    ellipsoid_quaternions: np.ndarray
+    ellipsoid_half_sizes: np.ndarray
+
+
+def _empty_array(shape: tuple[int, ...], dtype: Any = np.float32) -> np.ndarray:
+    return np.empty((0, *shape), dtype=dtype)
+
+
+def _is_valid_parent(parent: int, skel_state: np.ndarray) -> bool:
+    return 0 <= parent < skel_state.shape[0]
+
+
+def _uniform_scale(linear: np.ndarray) -> float:
+    scale = float(np.linalg.norm(linear[:, 0]))
+    return scale if scale > 1e-8 else 1.0
+
+
+def _collision_world_transform(
+    primitive: Any,
+    skel_state: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, float, float]:
+    local = np.asarray(primitive.transformation, dtype=np.float64)
+    parent_scale = 1.0
+    parent_transform = np.eye(4, dtype=np.float64)
+    parent = int(primitive.parent)
+    if _is_valid_parent(parent, skel_state):
+        parent_scale = float(skel_state[parent, 7])
+        parent_rotation = to_rotation_matrix_assume_normalized(
+            skel_state[parent, 3:7][None, :]
+        )[0]
+        parent_transform[:3, :3] = parent_rotation * parent_scale
+        parent_transform[:3, 3] = skel_state[parent, :3]
+
+    world = parent_transform @ local
+    world_scale = _uniform_scale(world[:3, :3])
+    rotation = world[:3, :3] / world_scale
+    world_quat = from_rotation_matrix(rotation[None, :, :])[0].astype(np.float64)
+    return world[:3, 3], world_quat, parent_scale, world_scale
+
+
+def _collision_geometry_arrays(
+    character: Character,
+    skel_state: np.ndarray,
+) -> _CollisionGeometryArrays:
+    capsule_translations: list[np.ndarray] = []
+    capsule_quaternions: list[np.ndarray] = []
+    capsule_lengths: list[float] = []
+    capsule_radii: list[float] = []
+    ellipsoid_centers: list[np.ndarray] = []
+    ellipsoid_quaternions: list[np.ndarray] = []
+    ellipsoid_half_sizes: list[np.ndarray] = []
+
+    for primitive in character.collision_geometry:
+        translation, quaternion, parent_scale, world_scale = _collision_world_transform(
+            primitive, skel_state
+        )
+        if hasattr(primitive, "length"):
+            capsule_translations.append(translation)
+            capsule_quaternions.append(
+                multiply_assume_normalized(quaternion, _Z_TO_X_QUAT_XYZW)
+            )
+            # Intentional scale asymmetry, mirroring momentum's C++ collision
+            # convention (CollisionGeometryStateT::update in
+            # collision_geometry_state.cpp): the capsule length runs along the
+            # composed-transform X axis and so is scaled by the full world scale
+            # (direction = getAxisX() * transform.scale * length), while the
+            # radius is scaled by the parent joint scale only
+            # (radius = primitive.radius * parentTransform.scale). Do not collapse
+            # these to a single factor; that would diverge from the geometry the
+            # solver actually uses.
+            capsule_lengths.append(float(primitive.length) * world_scale)
+            capsule_radii.append(
+                float(np.max(np.asarray(primitive.radius))) * parent_scale
+            )
+        elif hasattr(primitive, "radii"):
+            ellipsoid_centers.append(translation)
+            ellipsoid_quaternions.append(quaternion)
+            ellipsoid_half_sizes.append(np.asarray(primitive.radii) * parent_scale)
+
+    return _CollisionGeometryArrays(
+        capsule_translations=np.asarray(capsule_translations, dtype=np.float32).reshape(
+            (-1, 3)
+        )
+        if capsule_translations
+        else _empty_array((3,)),
+        capsule_quaternions=np.asarray(capsule_quaternions, dtype=np.float32).reshape(
+            (-1, 4)
+        )
+        if capsule_quaternions
+        else _empty_array((4,)),
+        capsule_lengths=np.asarray(capsule_lengths, dtype=np.float32),
+        capsule_radii=np.asarray(capsule_radii, dtype=np.float32),
+        ellipsoid_centers=np.asarray(ellipsoid_centers, dtype=np.float32).reshape(
+            (-1, 3)
+        )
+        if ellipsoid_centers
+        else _empty_array((3,)),
+        ellipsoid_quaternions=np.asarray(
+            ellipsoid_quaternions, dtype=np.float32
+        ).reshape((-1, 4))
+        if ellipsoid_quaternions
+        else _empty_array((4,)),
+        ellipsoid_half_sizes=np.asarray(ellipsoid_half_sizes, dtype=np.float32).reshape(
+            (-1, 3)
+        )
+        if ellipsoid_half_sizes
+        else _empty_array((3,)),
+    )
+
+
+def _colors(count: int) -> np.ndarray:
+    return np.tile(np.asarray([_COLLISION_COLOR], dtype=np.uint8), (count, 1))
 
 
 def log_mesh(
@@ -212,6 +343,48 @@ def log_locators(
     )
 
 
+def log_collision_geometry(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    character: Character,
+    skel_state: np.ndarray,
+) -> None:
+    """Log character collision geometry to Rerun.
+
+    Tapered capsules are visualized as regular capsules using their maximum endpoint
+    radius because Rerun does not currently expose tapered capsule geometry.
+
+    :param rec: The Rerun recording stream.
+    :param entity_path: Entity path for the collision-geometry root.
+    :param character: The character whose collision primitives are logged.
+    :param skel_state: Skeleton state array of shape ``(n_joints, 8)``.
+    """
+    import rerun as rr
+
+    arrays = _collision_geometry_arrays(character, skel_state)
+    if arrays.capsule_lengths.size > 0:
+        rec.log(
+            f"{entity_path}/capsules",
+            rr.Capsules3D(
+                lengths=arrays.capsule_lengths,
+                radii=arrays.capsule_radii,
+                translations=arrays.capsule_translations,
+                quaternions=arrays.capsule_quaternions,
+                colors=_colors(arrays.capsule_lengths.shape[0]),
+            ),
+        )
+    if arrays.ellipsoid_half_sizes.shape[0] > 0:
+        rec.log(
+            f"{entity_path}/ellipsoids",
+            rr.Ellipsoids3D(
+                half_sizes=arrays.ellipsoid_half_sizes,
+                centers=arrays.ellipsoid_centers,
+                quaternions=arrays.ellipsoid_quaternions,
+                colors=_colors(arrays.ellipsoid_half_sizes.shape[0]),
+            ),
+        )
+
+
 def log_character(
     rec: rr.RecordingStream,
     entity_path: str,
@@ -224,10 +397,11 @@ def log_character(
     """Log a complete character visualization to Rerun.
 
     This is the top-level convenience function that logs the skeleton,
-    optionally the mesh, and locators as a structured entity tree:
+    optionally the mesh, collision geometry, and locators as a structured entity tree:
 
     - ``{entity_path}/mesh`` — posed mesh (if *posed_mesh* is provided)
     - ``{entity_path}/joints`` — skeleton bones and per-joint transforms
+    - ``{entity_path}/collision_geometry`` — collision primitives (if present)
     - ``{entity_path}/locators`` — locator positions (if character has locators)
 
     This is the Python equivalent of the C++ ``momentum::logCharacter`` function.
@@ -252,6 +426,11 @@ def log_character(
 
     if character.locators:
         log_locators(rec, f"{entity_path}/locators", character, skel_state)
+
+    if character.collision_geometry:
+        log_collision_geometry(
+            rec, f"{entity_path}/collision_geometry", character, skel_state
+        )
 
 
 def _make_time_columns(
@@ -448,6 +627,67 @@ def _send_locators_columns(
     rec.send_columns(entity_path, indexes=time_cols, columns=pos_cols)
 
 
+def _send_collision_geometry_columns(
+    rec: rr.RecordingStream,
+    entity_path: str,
+    character: Character,
+    skel_states: np.ndarray,
+    time_cols: list,
+) -> None:
+    """Send collision geometry for multiple frames via :meth:`rec.send_columns`."""
+    import rerun as rr
+
+    if not character.collision_geometry:
+        return
+
+    n_frames = skel_states.shape[0]
+    if n_frames == 0:
+        return
+
+    arrays_by_frame = [
+        _collision_geometry_arrays(character, skel_states[i]) for i in range(n_frames)
+    ]
+
+    n_capsules = arrays_by_frame[0].capsule_lengths.shape[0]
+    if n_capsules > 0:
+        capsule_cols = rr.Capsules3D.columns(
+            lengths=np.concatenate(
+                [arrays.capsule_lengths for arrays in arrays_by_frame]
+            ),
+            radii=np.concatenate([arrays.capsule_radii for arrays in arrays_by_frame]),
+            translations=np.concatenate(
+                [arrays.capsule_translations for arrays in arrays_by_frame]
+            ),
+            quaternions=np.concatenate(
+                [arrays.capsule_quaternions for arrays in arrays_by_frame]
+            ),
+            colors=_colors(n_frames * n_capsules),
+        )
+        capsule_cols = capsule_cols.partition(np.full(n_frames, n_capsules))
+        rec.send_columns(
+            f"{entity_path}/capsules", indexes=time_cols, columns=capsule_cols
+        )
+
+    n_ellipsoids = arrays_by_frame[0].ellipsoid_half_sizes.shape[0]
+    if n_ellipsoids > 0:
+        ellipsoid_cols = rr.Ellipsoids3D.columns(
+            half_sizes=np.concatenate(
+                [arrays.ellipsoid_half_sizes for arrays in arrays_by_frame]
+            ),
+            centers=np.concatenate(
+                [arrays.ellipsoid_centers for arrays in arrays_by_frame]
+            ),
+            quaternions=np.concatenate(
+                [arrays.ellipsoid_quaternions for arrays in arrays_by_frame]
+            ),
+            colors=_colors(n_frames * n_ellipsoids),
+        )
+        ellipsoid_cols = ellipsoid_cols.partition(np.full(n_frames, n_ellipsoids))
+        rec.send_columns(
+            f"{entity_path}/ellipsoids", indexes=time_cols, columns=ellipsoid_cols
+        )
+
+
 def log_animation(
     rec: rr.RecordingStream,
     entity_path: str,
@@ -523,4 +763,13 @@ def log_animation(
             time_cols,
             fps,
             frame_offset,
+        )
+
+    if character.collision_geometry:
+        _send_collision_geometry_columns(
+            rec,
+            f"{entity_path}/collision_geometry",
+            character,
+            skel_states,
+            time_cols,
         )

--- a/pymomentum/test/test_rerun_vis.py
+++ b/pymomentum/test/test_rerun_vis.py
@@ -7,6 +7,7 @@
 
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -15,6 +16,7 @@ import pymomentum.geometry_test_utils as test_utils  # @manual=:geometry_test_ut
 from pymomentum.rerun_vis import (
     log_animation,
     log_character,
+    log_collision_geometry,
     log_joints,
     log_locators,
     log_mesh,
@@ -76,6 +78,27 @@ if _HAS_RERUN:
             joint_params = np.zeros(character.skeleton.size * 7, dtype=np.float32)
             return character.pose_mesh(joint_params)
 
+        def _with_mixed_collision_geometry(
+            self, character: geo.Character
+        ) -> geo.Character:
+            return character.with_collision_geometry(
+                [
+                    geo.TaperedCapsule(
+                        parent=0,
+                        radius=np.array([0.1, 0.2], dtype=np.float32),
+                        length=1.0,
+                    ),
+                    geo.Ellipsoid(
+                        parent=1,
+                        radii=np.array([0.3, 0.2, 0.1], dtype=np.float32),
+                    ),
+                ]
+            )
+
+        def _component_batch_array(self, component_batch: Any) -> np.ndarray:
+            self.assertIsNotNone(component_batch)
+            return np.asarray(component_batch.as_arrow_array().to_pylist())
+
         def test_log_joints_uses_skeleton_state(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
             # Smoke check: the call should consume the full skel_state and not
@@ -115,6 +138,50 @@ if _HAS_RERUN:
             path, archetype = mock_rec.log.call_args.args
             self.assertEqual(path, "locs")
             self.assertIsInstance(archetype, rr.Points3D)
+
+        def test_log_collision_geometry(self) -> None:
+            character, skel_state = self._make_character_and_skel_state()
+            character = self._with_mixed_collision_geometry(character)
+
+            mock_rec = MagicMock()
+            log_collision_geometry(mock_rec, "collision", character, skel_state)
+            logged = {c.args[0]: c.args[1] for c in mock_rec.log.call_args_list}
+            capsules = logged["collision/capsules"]
+            ellipsoids = logged["collision/ellipsoids"]
+            self.assertIsInstance(capsules, rr.Capsules3D)
+            self.assertIsInstance(ellipsoids, rr.Ellipsoids3D)
+
+            capsule_parent_scale = skel_state[0, 7]
+            capsule_translations = self._component_batch_array(capsules.translations)
+            self.assertEqual(capsule_translations.shape, (1, 3))
+            np.testing.assert_allclose(capsule_translations[0], skel_state[0, :3])
+            np.testing.assert_allclose(
+                self._component_batch_array(capsules.lengths),
+                np.array([1.0 * capsule_parent_scale], dtype=np.float32),
+            )
+            np.testing.assert_allclose(
+                self._component_batch_array(capsules.radii),
+                np.array([0.2 * capsule_parent_scale], dtype=np.float32),
+            )
+
+            ellipsoid_parent_scale = skel_state[1, 7]
+            ellipsoid_centers = self._component_batch_array(ellipsoids.centers)
+            self.assertEqual(ellipsoid_centers.shape, (1, 3))
+            np.testing.assert_allclose(ellipsoid_centers[0], skel_state[1, :3])
+            np.testing.assert_allclose(
+                self._component_batch_array(ellipsoids.half_sizes),
+                np.array([[0.3, 0.2, 0.1]], dtype=np.float32) * ellipsoid_parent_scale,
+            )
+
+        def test_log_character_includes_collision_geometry(self) -> None:
+            character, skel_state = self._make_character_and_skel_state()
+            character = self._with_mixed_collision_geometry(character)
+
+            mock_rec = MagicMock()
+            log_character(mock_rec, "ch_collision", character, skel_state)
+            paths = [c.args[0] for c in mock_rec.log.call_args_list]
+            self.assertIn("ch_collision/collision_geometry/capsules", paths)
+            self.assertIn("ch_collision/collision_geometry/ellipsoids", paths)
 
         def test_log_character_with_and_without_mesh(self) -> None:
             character, skel_state = self._make_character_and_skel_state()
@@ -156,6 +223,7 @@ if _HAS_RERUN:
 
         def test_log_animation_sends_columns(self) -> None:
             character, _, skel_states, posed_meshes = self._make_animation_inputs(5)
+            character = self._with_mixed_collision_geometry(character)
 
             mock_rec = MagicMock()
             log_animation(
@@ -183,6 +251,8 @@ if _HAS_RERUN:
             self.assertEqual(len(joint_subpaths), character.skeleton.size)
             if character.locators:
                 self.assertIn("test/anim/locators", send_paths)
+            self.assertIn("test/anim/collision_geometry/capsules", send_paths)
+            self.assertIn("test/anim/collision_geometry/ellipsoids", send_paths)
 
         def test_log_animation_without_mesh(self) -> None:
             character, _, skel_states, _ = self._make_animation_inputs(3)


### PR DESCRIPTION
Summary: Add Python Rerun helpers for logging capsule and ellipsoid collision geometry on characters and animations, and update the Rerun example to show collision geometry.

Reviewed By: cstollmeta

Differential Revision: D105192535
