### PR TITLE
Add box collision state support (#1455)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,6 +951,7 @@ if(MOMENTUM_BUILD_TESTING)
     SOURCES_VARS io_legacy_json_test_sources
     LINK_LIBRARIES
       character_test_helpers
+      character_test_helpers_gtest
       io_legacy_json
       io_test_helper
     ENV

--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -94,6 +94,8 @@ std::unique_ptr<CollisionGeometry> scale(
       primitive.length *= scale;
     } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
       primitive.ellipsoidRadii *= scale;
+    } else if (primitive.type == CollisionPrimitiveType::Box) {
+      primitive.boxHalfExtents *= scale;
     }
   }
 

--- a/momentum/character/collision_geometry.h
+++ b/momentum/character/collision_geometry.h
@@ -22,6 +22,7 @@ namespace momentum {
 enum class CollisionPrimitiveType : uint8_t {
   TaperedCapsule,
   Ellipsoid,
+  Box,
 };
 
 /// Tapered capsule collision geometry for character collision detection.
@@ -112,6 +113,42 @@ struct CollisionEllipsoidT {
   }
 };
 
+/// Box collision geometry for character collision detection.
+///
+/// Defined by a transformation and three local-space half extents along the primitive's axes.
+template <typename S>
+struct CollisionBoxT {
+  using Scalar = S;
+
+  /// Transformation defining the box center and orientation relative to the parent.
+  TransformT<S> transformation;
+
+  /// Half extents along the local x, y, and z axes.
+  Vector3<S> halfExtents;
+
+  /// Parent joint to which the geometry is attached.
+  size_t parent;
+
+  CollisionBoxT()
+      : transformation(TransformT<S>()), halfExtents(Vector3<S>::Zero()), parent(kInvalidIndex) {
+    // Empty
+  }
+
+  /// Checks if the current box is approximately equal to another.
+  [[nodiscard]] bool isApprox(const CollisionBoxT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
+      const {
+    if (!transformation.isApprox(other.transformation, tol)) {
+      return false;
+    }
+
+    if (!halfExtents.isApprox(other.halfExtents, tol)) {
+      return false;
+    }
+
+    return parent == other.parent;
+  }
+};
+
 /// Collision geometry primitive.
 ///
 /// The tapered capsule fields are kept directly on the primitive so existing code that
@@ -133,6 +170,9 @@ struct CollisionPrimitiveT {
   /// Radii along the local axes of an ellipsoid.
   Vector3<S> ellipsoidRadii;
 
+  /// Half extents along the local axes of a box.
+  Vector3<S> boxHalfExtents;
+
   /// Parent joint to which the geometry is attached.
   size_t parent;
 
@@ -144,6 +184,7 @@ struct CollisionPrimitiveT {
         transformation(TransformT<S>()),
         radius(Vector2<S>::Zero()),
         ellipsoidRadii(Vector3<S>::Zero()),
+        boxHalfExtents(Vector3<S>::Zero()),
         parent(kInvalidIndex),
         length(S(0)) {
     // Empty
@@ -155,6 +196,7 @@ struct CollisionPrimitiveT {
         transformation(capsule.transformation),
         radius(capsule.radius),
         ellipsoidRadii(Vector3<S>::Zero()),
+        boxHalfExtents(Vector3<S>::Zero()),
         parent(capsule.parent),
         length(capsule.length) {}
 
@@ -164,7 +206,18 @@ struct CollisionPrimitiveT {
         transformation(ellipsoid.transformation),
         radius(Vector2<S>::Zero()),
         ellipsoidRadii(ellipsoid.radii),
+        boxHalfExtents(Vector3<S>::Zero()),
         parent(ellipsoid.parent),
+        length(S(0)) {}
+
+  /// Creates a collision primitive from a box.
+  /* implicit */ CollisionPrimitiveT(const CollisionBoxT<S>& box)
+      : type(CollisionPrimitiveType::Box),
+        transformation(box.transformation),
+        radius(Vector2<S>::Zero()),
+        ellipsoidRadii(Vector3<S>::Zero()),
+        boxHalfExtents(box.halfExtents),
+        parent(box.parent),
         length(S(0)) {}
 
   /// Assigns tapered capsule data to this primitive.
@@ -173,6 +226,7 @@ struct CollisionPrimitiveT {
     transformation = capsule.transformation;
     radius = capsule.radius;
     ellipsoidRadii.setZero();
+    boxHalfExtents.setZero();
     parent = capsule.parent;
     length = capsule.length;
     return *this;
@@ -184,7 +238,20 @@ struct CollisionPrimitiveT {
     transformation = ellipsoid.transformation;
     radius.setZero();
     ellipsoidRadii = ellipsoid.radii;
+    boxHalfExtents.setZero();
     parent = ellipsoid.parent;
+    length = S(0);
+    return *this;
+  }
+
+  /// Assigns box data to this primitive.
+  CollisionPrimitiveT& operator=(const CollisionBoxT<S>& box) {
+    type = CollisionPrimitiveType::Box;
+    transformation = box.transformation;
+    radius.setZero();
+    ellipsoidRadii.setZero();
+    boxHalfExtents = box.halfExtents;
+    parent = box.parent;
     length = S(0);
     return *this;
   }
@@ -197,6 +264,11 @@ struct CollisionPrimitiveT {
   /// Returns true when this primitive stores ellipsoid data.
   [[nodiscard]] bool isEllipsoid() const {
     return type == CollisionPrimitiveType::Ellipsoid;
+  }
+
+  /// Returns true when this primitive stores box data.
+  [[nodiscard]] bool isBox() const {
+    return type == CollisionPrimitiveType::Box;
   }
 
   /// Converts this primitive to a tapered capsule.
@@ -234,6 +306,20 @@ struct CollisionPrimitiveT {
     return ellipsoid;
   }
 
+  /// Converts this primitive to a box.
+  ///
+  /// Requires `isBox()` so unhandled primitive types fail at the call site
+  /// instead of returning unrelated stale data.
+  [[nodiscard]] CollisionBoxT<S> toBox() const {
+    MT_CHECK(
+        isBox(), "Collision primitive type {} does not store box data", static_cast<int>(type));
+    CollisionBoxT<S> box;
+    box.transformation = transformation;
+    box.halfExtents = boxHalfExtents;
+    box.parent = parent;
+    return box;
+  }
+
   /// Checks if the current primitive is approximately equal to another.
   [[nodiscard]] bool isApprox(const CollisionPrimitiveT& other, const S& tol = Eps<S>(1e-4f, 1e-10))
       const {
@@ -251,6 +337,10 @@ struct CollisionPrimitiveT {
 
     if (type == CollisionPrimitiveType::Ellipsoid) {
       return ellipsoidRadii.isApprox(other.ellipsoidRadii, tol);
+    }
+
+    if (type == CollisionPrimitiveType::Box) {
+      return boxHalfExtents.isApprox(other.boxHalfExtents, tol);
     }
 
     return false;

--- a/momentum/character/collision_geometry_state.cpp
+++ b/momentum/character/collision_geometry_state.cpp
@@ -24,6 +24,7 @@ void CollisionGeometryStateT<T>::update(
   type.resize(numElements);
   orientation.resize(numElements);
   ellipsoidRadii.resize(numElements);
+  boxHalfExtents.resize(numElements);
 
   // TODO: This per-primitive loop is independent across iterations and could be parallelized.
   for (size_t i = 0; i < numElements; ++i) {
@@ -41,6 +42,7 @@ void CollisionGeometryStateT<T>::update(
       radius[i].noalias() = primitive.radius.cast<T>() * parentTransform.scale;
       delta[i] = radius[i][1] - radius[i][0];
       ellipsoidRadii[i].setZero();
+      boxHalfExtents[i].setZero();
       continue;
     }
 
@@ -49,6 +51,7 @@ void CollisionGeometryStateT<T>::update(
       radius[i].setZero();
       delta[i] = T(0);
       ellipsoidRadii[i].noalias() = primitive.ellipsoidRadii.cast<T>() * parentTransform.scale;
+      boxHalfExtents[i].setZero();
       continue;
     }
 
@@ -57,6 +60,8 @@ void CollisionGeometryStateT<T>::update(
       radius[i].setZero();
       delta[i] = T(0);
       ellipsoidRadii[i].setZero();
+      boxHalfExtents[i].noalias() = primitive.boxHalfExtents.cast<T>() * parentTransform.scale;
+      continue;
     }
   }
 }

--- a/momentum/character/collision_geometry_state.cpp
+++ b/momentum/character/collision_geometry_state.cpp
@@ -49,6 +49,14 @@ void CollisionGeometryStateT<T>::update(
       radius[i].setZero();
       delta[i] = T(0);
       ellipsoidRadii[i].noalias() = primitive.ellipsoidRadii.cast<T>() * parentTransform.scale;
+      continue;
+    }
+
+    if (primitive.type == CollisionPrimitiveType::Box) {
+      direction[i].setZero();
+      radius[i].setZero();
+      delta[i] = T(0);
+      ellipsoidRadii[i].setZero();
     }
   }
 }

--- a/momentum/character/collision_geometry_state.h
+++ b/momentum/character/collision_geometry_state.h
@@ -36,7 +36,7 @@ struct CollisionGeometryStateT {
   //
   // Note: radius[0] and radius[1] can be different.
 
-  /// Capsule's origin in global coordinates.
+  /// Primitive origin/center in global coordinates.
   std::vector<Vector3<T>> origin;
 
   /// Capsule's direction vector (representing the X-axis) in global coordinates.
@@ -57,6 +57,9 @@ struct CollisionGeometryStateT {
   /// Scaled ellipsoid radii in global coordinates.
   std::vector<Vector3<T>> ellipsoidRadii;
 
+  /// Scaled box half extents in global coordinates.
+  std::vector<Vector3<T>> boxHalfExtents;
+
   /// Updates the state based on a given skeleton state and collision geometry.
   void update(const SkeletonStateT<T>& skeletonState, const CollisionGeometry& collisionGeometry);
 };
@@ -67,7 +70,7 @@ struct CollisionOverlapResultT {
   /// Distance between the primitive center features used by the narrow phase.
   T distance = T(0);
 
-  /// Parametric closest-point positions. Capsule entries use [0, 1]; ellipsoid entries use 0.
+  /// Parametric closest-point positions. Capsule entries use [0, 1]; centered primitives use 0.
   Vector2<T> closestPoints = Vector2<T>::Zero();
 
   /// Amount of overlap, positive when colliding.
@@ -168,43 +171,81 @@ template <typename T>
   return radii.cwiseAbs().cwiseProduct(localDirection).norm();
 }
 
-/// Test overlap between a tapered capsule and an oriented ellipsoid.
+/// Return the support radius of an oriented box along a unit world-space direction.
+template <typename T>
+[[nodiscard]] T boxRadiusAlongDirection(
+    const Quaternion<T>& orientation,
+    const Vector3<T>& halfExtents,
+    const Vector3<T>& unitDirection) {
+  const Vector3<T> localDirection = orientation.inverse() * unitDirection;
+  return halfExtents.cwiseAbs().dot(localDirection.cwiseAbs());
+}
+
+/// Return whether the primitive is represented by a center, orientation, and support radius.
+[[nodiscard]] inline bool isCenteredPrimitive(CollisionPrimitiveType type) {
+  return type == CollisionPrimitiveType::Ellipsoid || type == CollisionPrimitiveType::Box;
+}
+
+/// Return the support radius of an ellipsoid or box along a unit world-space direction.
+template <typename T>
+[[nodiscard]] T centeredPrimitiveRadiusAlongDirection(
+    CollisionPrimitiveType type,
+    const Quaternion<T>& orientation,
+    const Vector3<T>& ellipsoidRadii,
+    const Vector3<T>& boxHalfExtents,
+    const Vector3<T>& unitDirection) {
+  if (type == CollisionPrimitiveType::Ellipsoid) {
+    return ellipsoidRadiusAlongDirection(orientation, ellipsoidRadii, unitDirection);
+  }
+  if (type == CollisionPrimitiveType::Box) {
+    return boxRadiusAlongDirection(orientation, boxHalfExtents, unitDirection);
+  }
+  return T(0);
+}
+
+/// Test overlap between a tapered capsule and an oriented centered primitive.
 ///
-/// The function fills the closest capsule parameter, support radii, distance,
-/// and signed overlap used by the solver when a non-degenerate overlap is found.
+/// The centered primitive can be an ellipsoid or box. The function fills the
+/// closest capsule parameter, support radii, distance, and signed overlap used
+/// by the solver when a non-degenerate overlap is found.
 ///
 /// @param capsuleOrigin Origin of the capsule segment in world space.
 /// @param capsuleDirection Direction vector from capsule start to end in world space.
 /// @param capsuleRadii Radii at the capsule start and end points.
 /// @param capsuleDelta Signed difference between capsule radii (`capsuleRadii[1] -
 ///   capsuleRadii[0]`).
-/// @param ellipsoidCenter Ellipsoid center in world space.
-/// @param ellipsoidOrientation Ellipsoid orientation in world space.
-/// @param ellipsoidRadii Ellipsoid radii along its local axes.
-/// @param outDistance Output: distance between the capsule centerline point and ellipsoid center.
+/// @param primitiveType Centered primitive type; must be ellipsoid or box.
+/// @param primitiveCenter Primitive center in world space.
+/// @param primitiveOrientation Primitive orientation in world space.
+/// @param ellipsoidRadii Ellipsoid radii along its local axes; ignored for boxes.
+/// @param boxHalfExtents Box half extents along its local axes; ignored for ellipsoids.
+/// @param outDistance Output: distance between the capsule centerline point and primitive center.
 /// @param outCapsuleParam Output: parametric position in [0, 1] along the capsule segment.
 /// @param outOverlap Output: signed overlap amount, positive when overlapping.
 /// @param outCapsuleRadius Output: capsule support radius at `outCapsuleParam`.
-/// @param outEllipsoidRadius Output: ellipsoid support radius along the contact direction.
-/// @return True when the capsule and ellipsoid overlap with a non-degenerate contact direction.
+/// @param outPrimitiveRadius Output: primitive support radius along the contact direction.
+/// @return True when the capsule and centered primitive overlap with a non-degenerate contact
+///   direction.
 template <typename T>
-[[nodiscard]] bool overlapsCapsuleEllipsoid(
+[[nodiscard]] bool overlapsCapsuleCenteredPrimitive(
     const Vector3<T>& capsuleOrigin,
     const Vector3<T>& capsuleDirection,
     const Vector2<T>& capsuleRadii,
     T capsuleDelta,
-    const Vector3<T>& ellipsoidCenter,
-    const Quaternion<T>& ellipsoidOrientation,
+    CollisionPrimitiveType primitiveType,
+    const Vector3<T>& primitiveCenter,
+    const Quaternion<T>& primitiveOrientation,
     const Vector3<T>& ellipsoidRadii,
+    const Vector3<T>& boxHalfExtents,
     T& outDistance,
     T& outCapsuleParam,
     T& outOverlap,
     T& outCapsuleRadius,
-    T& outEllipsoidRadius) {
+    T& outPrimitiveRadius) {
   outCapsuleParam =
-      closestPointOnSegmentParameter(capsuleOrigin, capsuleDirection, ellipsoidCenter);
+      closestPointOnSegmentParameter(capsuleOrigin, capsuleDirection, primitiveCenter);
   const Vector3<T> capsulePoint = capsuleOrigin + capsuleDirection * outCapsuleParam;
-  const Vector3<T> separation = capsulePoint - ellipsoidCenter;
+  const Vector3<T> separation = capsulePoint - primitiveCenter;
   outDistance = separation.norm();
   if (outDistance < Eps<T>(1e-8, 1e-17)) {
     return false;
@@ -212,16 +253,17 @@ template <typename T>
 
   const Vector3<T> normal = separation / outDistance;
   outCapsuleRadius = capsuleRadii[0] + outCapsuleParam * capsuleDelta;
-  outEllipsoidRadius = ellipsoidRadiusAlongDirection(ellipsoidOrientation, ellipsoidRadii, normal);
-  outOverlap = outCapsuleRadius + outEllipsoidRadius - outDistance;
+  outPrimitiveRadius = centeredPrimitiveRadiusAlongDirection(
+      primitiveType, primitiveOrientation, ellipsoidRadii, boxHalfExtents, normal);
+  outOverlap = outCapsuleRadius + outPrimitiveRadius - outDistance;
   return outOverlap > T(0);
 }
 
 /// Determines whether two collision primitives overlap.
 ///
-/// Capsule-capsule pairs use the existing closest-segment query. Ellipsoid pairs use a support
-/// radius along the center-feature separation direction, which gives a stable contact normal for
-/// the solver and preserves the same overlap convention used by tapered capsules.
+/// Capsule-capsule pairs use the existing closest-segment query. Centered primitive pairs use a
+/// support radius along the center-feature separation direction, which gives a stable contact
+/// normal for the solver and preserves the same overlap convention used by tapered capsules.
 ///
 /// @param collisionState World-space collision state for `collisionGeometry`.
 /// @param collisionGeometry Collision primitives corresponding to `collisionState`.
@@ -267,16 +309,17 @@ template <typename T>
     return true;
   }
 
-  if (typeA == CollisionPrimitiveType::TaperedCapsule &&
-      typeB == CollisionPrimitiveType::Ellipsoid) {
-    if (!overlapsCapsuleEllipsoid(
+  if (typeA == CollisionPrimitiveType::TaperedCapsule && isCenteredPrimitive(typeB)) {
+    if (!overlapsCapsuleCenteredPrimitive(
             collisionState.origin[indexA],
             collisionState.direction[indexA],
             collisionState.radius[indexA],
             collisionState.delta[indexA],
+            typeB,
             collisionState.origin[indexB],
             collisionState.orientation[indexB],
             collisionState.ellipsoidRadii[indexB],
+            collisionState.boxHalfExtents[indexB],
             result.distance,
             result.closestPoints[0],
             result.overlap,
@@ -292,16 +335,17 @@ template <typename T>
     return true;
   }
 
-  if (typeA == CollisionPrimitiveType::Ellipsoid &&
-      typeB == CollisionPrimitiveType::TaperedCapsule) {
-    if (!overlapsCapsuleEllipsoid(
+  if (isCenteredPrimitive(typeA) && typeB == CollisionPrimitiveType::TaperedCapsule) {
+    if (!overlapsCapsuleCenteredPrimitive(
             collisionState.origin[indexB],
             collisionState.direction[indexB],
             collisionState.radius[indexB],
             collisionState.delta[indexB],
+            typeA,
             collisionState.origin[indexA],
             collisionState.orientation[indexA],
             collisionState.ellipsoidRadii[indexA],
+            collisionState.boxHalfExtents[indexA],
             result.distance,
             result.closestPoints[1],
             result.overlap,
@@ -317,7 +361,7 @@ template <typename T>
     return true;
   }
 
-  if (typeA == CollisionPrimitiveType::Ellipsoid && typeB == CollisionPrimitiveType::Ellipsoid) {
+  if (isCenteredPrimitive(typeA) && isCenteredPrimitive(typeB)) {
     const Vector3<T> separation = collisionState.origin[indexA] - collisionState.origin[indexB];
     result.distance = separation.norm();
     if (result.distance < Eps<T>(1e-8, 1e-17)) {
@@ -325,10 +369,18 @@ template <typename T>
     }
 
     const Vector3<T> normal = separation / result.distance;
-    result.radiusA = ellipsoidRadiusAlongDirection(
-        collisionState.orientation[indexA], collisionState.ellipsoidRadii[indexA], normal);
-    result.radiusB = ellipsoidRadiusAlongDirection(
-        collisionState.orientation[indexB], collisionState.ellipsoidRadii[indexB], normal);
+    result.radiusA = centeredPrimitiveRadiusAlongDirection(
+        typeA,
+        collisionState.orientation[indexA],
+        collisionState.ellipsoidRadii[indexA],
+        collisionState.boxHalfExtents[indexA],
+        normal);
+    result.radiusB = centeredPrimitiveRadiusAlongDirection(
+        typeB,
+        collisionState.orientation[indexB],
+        collisionState.ellipsoidRadii[indexB],
+        collisionState.boxHalfExtents[indexB],
+        normal);
     result.overlap = result.radiusA + result.radiusB - result.distance;
     result.positionA = collisionState.origin[indexA];
     result.positionB = collisionState.origin[indexB];
@@ -391,6 +443,28 @@ void updateEllipsoidAabb(
   aabb.aabb.max() = center + halfExtents;
 }
 
+/// Updates an axis-aligned bounding box to encompass an oriented box.
+///
+/// Uses the exact OBB half-extent h_i = sum_j |R_ij| * halfExtents_j (L1 over the
+/// rotated extents). For a box this is the tight, correct AABB; do NOT switch it to
+/// the ellipsoid L2 row-norm, which would under-bound the box and miss collisions.
+///
+/// @param aabb The bounding box to update
+/// @param center Center of the box
+/// @param orientation Orientation of the box
+/// @param halfExtents Half extents along the box's local axes
+template <typename T>
+void updateBoxAabb(
+    axel::BoundingBox<T>& aabb,
+    const Vector3<T>& center,
+    const Quaternion<T>& orientation,
+    const Vector3<T>& halfExtents) {
+  const Eigen::Matrix<T, 3, 3> absRotation = orientation.toRotationMatrix().cwiseAbs();
+  const Vector3<T> aabbHalfExtents = absRotation * halfExtents.cwiseAbs();
+  aabb.aabb.min() = center - aabbHalfExtents;
+  aabb.aabb.max() = center + aabbHalfExtents;
+}
+
 /// Updates an axis-aligned bounding box to encompass a collision primitive.
 template <typename T>
 void updateAabb(
@@ -412,6 +486,15 @@ void updateAabb(
         collisionState.origin[index],
         collisionState.orientation[index],
         collisionState.ellipsoidRadii[index]);
+    return;
+  }
+
+  if (collisionState.type[index] == CollisionPrimitiveType::Box) {
+    updateBoxAabb(
+        aabb,
+        collisionState.origin[index],
+        collisionState.orientation[index],
+        collisionState.boxHalfExtents[index]);
   }
 }
 

--- a/momentum/character/fwd.h
+++ b/momentum/character/fwd.h
@@ -183,6 +183,25 @@ using CollisionEllipsoidd_const_u = ::std::unique_ptr<const CollisionEllipsoidd>
 using CollisionEllipsoidd_const_w = ::std::weak_ptr<const CollisionEllipsoidd>;
 
 template <typename T>
+struct CollisionBoxT;
+using CollisionBox = CollisionBoxT<float>;
+using CollisionBoxd = CollisionBoxT<double>;
+
+using CollisionBox_p = ::std::shared_ptr<CollisionBox>;
+using CollisionBox_u = ::std::unique_ptr<CollisionBox>;
+using CollisionBox_w = ::std::weak_ptr<CollisionBox>;
+using CollisionBox_const_p = ::std::shared_ptr<const CollisionBox>;
+using CollisionBox_const_u = ::std::unique_ptr<const CollisionBox>;
+using CollisionBox_const_w = ::std::weak_ptr<const CollisionBox>;
+
+using CollisionBoxd_p = ::std::shared_ptr<CollisionBoxd>;
+using CollisionBoxd_u = ::std::unique_ptr<CollisionBoxd>;
+using CollisionBoxd_w = ::std::weak_ptr<CollisionBoxd>;
+using CollisionBoxd_const_p = ::std::shared_ptr<const CollisionBoxd>;
+using CollisionBoxd_const_u = ::std::unique_ptr<const CollisionBoxd>;
+using CollisionBoxd_const_w = ::std::weak_ptr<const CollisionBoxd>;
+
+template <typename T>
 struct JointT;
 using Joint = JointT<float>;
 using Jointd = JointT<double>;

--- a/momentum/character_solver_simd/simd_collision_error_function.cpp
+++ b/momentum/character_solver_simd/simd_collision_error_function.cpp
@@ -16,9 +16,13 @@
 #include "momentum/math/constants.h"
 #include "momentum/simd/simd.h"
 
+#include <algorithm>
+
 namespace momentum {
 
 namespace {
+
+constexpr bool kFilterRestPoseOverlaps = true;
 
 template <typename T>
 [[nodiscard]] drjit::Array<T, 2> toDrJitVec(const Eigen::Vector2<T>& v) {
@@ -107,6 +111,20 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
   validPairs_.clear();
 
   const auto n = collisionGeometry_.size();
+  useScalarFallback_ =
+      std::any_of(collisionGeometry_.begin(), collisionGeometry_.end(), [](const auto& primitive) {
+        return primitive.type != CollisionPrimitiveType::TaperedCapsule;
+      });
+  if (useScalarFallback_ && !scalarFallback_) {
+    scalarFallback_.emplace(
+        this->skeleton_, this->parameterTransform_, collisionGeometry_, kFilterRestPoseOverlaps);
+  }
+  if (useScalarFallback_) {
+    commonAncestors_.clear();
+    collisionPairs_.clear();
+    aabbs_.clear();
+    return;
+  }
 
   const SkeletonStateT<T> state(
       this->parameterTransform_.zero().template cast<T>(), this->skeleton_);
@@ -115,11 +133,7 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
   aabbs_.resize(n);
   for (size_t i = 0; i < n; ++i) {
     aabbs_[i].id = gsl::narrow_cast<axel::Index>(i);
-    updateAabb(
-        aabbs_[i],
-        collisionState_.origin[i],
-        collisionState_.direction[i],
-        collisionState_.radius[i]);
+    updateAabb(aabbs_[i], collisionState_, i);
   }
 
   if (n == 0) {
@@ -131,9 +145,18 @@ void SimdCollisionErrorFunctionT<T>::updateCollisionPairs() {
 
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
-      if (isValidCollisionPair(collisionState_, collisionGeometry_, this->skeleton_, i, j)) {
-        const size_t lca = this->skeleton_.commonAncestor(
-            collisionGeometry_[i].parent, collisionGeometry_[j].parent);
+      if (isValidCollisionPair(
+              collisionState_,
+              collisionGeometry_,
+              this->skeleton_,
+              i,
+              j,
+              kFilterRestPoseOverlaps)) {
+        const size_t lca = (collisionGeometry_[i].parent == kInvalidIndex ||
+                            collisionGeometry_[j].parent == kInvalidIndex)
+            ? kInvalidIndex
+            : this->skeleton_.commonAncestor(
+                  collisionGeometry_[i].parent, collisionGeometry_[j].parent);
         validPairs_.push_back({i, j, lca});
         commonAncestors_[i * n + j] = lca;
         commonAncestors_[j * n + i] = lca;
@@ -150,11 +173,7 @@ void SimdCollisionErrorFunctionT<T>::computeBroadPhase(const SkeletonStateT<T>& 
   }
 
   for (size_t i = 0; i < aabbs_.size(); ++i) {
-    updateAabb(
-        aabbs_[i],
-        collisionState_.origin[i],
-        collisionState_.direction[i],
-        collisionState_.radius[i]);
+    updateAabb(aabbs_[i], collisionState_, i);
   }
 
   for (auto& pairs : collisionPairs_) {
@@ -168,10 +187,20 @@ void SimdCollisionErrorFunctionT<T>::computeBroadPhase(const SkeletonStateT<T>& 
 }
 
 template <typename T>
+CollisionErrorFunctionT<T>& SimdCollisionErrorFunctionT<T>::syncScalarFallback() {
+  MT_CHECK(scalarFallback_.has_value());
+  auto& fallback = scalarFallback_.value();
+  fallback.setWeight(this->weight_);
+  fallback.setActiveJoints(this->activeJointParams_);
+  fallback.setEnabledParameters(this->enabledParameters_);
+  return fallback;
+}
+
+template <typename T>
 double SimdCollisionErrorFunctionT<T>::getError(
-    const ModelParametersT<T>& /*unused*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
-    const MeshStateT<T>& /* meshState */) {
+    const MeshStateT<T>& meshState) {
   if (state.jointState.empty()) {
     return 0.0;
   }
@@ -179,6 +208,11 @@ double SimdCollisionErrorFunctionT<T>::getError(
   MT_CHECK(
       state.jointParameters.size() ==
       gsl::narrow<Eigen::Index>(this->skeleton_.joints.size() * kParametersPerJoint));
+
+  if (useScalarFallback_) {
+    auto& fallback = syncScalarFallback();
+    return fallback.getError(params, state, meshState);
+  }
 
   computeBroadPhase(state);
 
@@ -217,12 +251,17 @@ double SimdCollisionErrorFunctionT<T>::getError(
 
 template <typename T>
 double SimdCollisionErrorFunctionT<T>::getGradient(
-    const ModelParametersT<T>& /*unused*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
-    const MeshStateT<T>& /* meshState */,
+    const MeshStateT<T>& meshState,
     Ref<VectorX<T>> gradient) {
   if (state.jointState.empty()) {
     return 0.0;
+  }
+
+  if (useScalarFallback_) {
+    auto& fallback = syncScalarFallback();
+    return fallback.getGradient(params, state, meshState, gradient);
   }
 
   computeBroadPhase(state);
@@ -382,12 +421,22 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
 
 template <typename T>
 double SimdCollisionErrorFunctionT<T>::getJacobian(
-    const ModelParametersT<T>& /*unused*/,
+    const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
-    const MeshStateT<T>& /* meshState */,
+    const MeshStateT<T>& meshState,
     Ref<MatrixX<T>> jacobian,
     Ref<VectorX<T>> residual,
     int& usedRows) {
+  if (state.jointState.empty()) {
+    usedRows = 0;
+    return 0.0;
+  }
+
+  if (useScalarFallback_) {
+    auto& fallback = syncScalarFallback();
+    return fallback.getJacobian(params, state, meshState, jacobian, residual, usedRows);
+  }
+
   computeBroadPhase(state);
 
   const auto numCapsules = collisionGeometry_.size();
@@ -547,6 +596,10 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
 
 template <typename T>
 size_t SimdCollisionErrorFunctionT<T>::getJacobianSize() const {
+  if (useScalarFallback_) {
+    MT_CHECK(scalarFallback_.has_value());
+    return scalarFallback_->getJacobianSize();
+  }
   return validPairs_.size();
 }
 

--- a/momentum/character_solver_simd/simd_collision_error_function.h
+++ b/momentum/character_solver_simd/simd_collision_error_function.h
@@ -9,6 +9,7 @@
 
 #include <momentum/character/collision_geometry.h>
 #include <momentum/character/collision_geometry_state.h>
+#include <momentum/character_solver/collision_error_function.h>
 #include <momentum/character_solver/fwd.h>
 #include <momentum/character_solver/skeleton_error_function.h>
 #include <momentum/common/aligned.h>
@@ -16,6 +17,7 @@
 
 #include <axel/BoundingBox.h>
 
+#include <optional>
 #include <vector>
 
 namespace momentum {
@@ -38,18 +40,18 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   [[nodiscard]] double getError(
       const ModelParametersT<T>& params,
       const SkeletonStateT<T>& state,
-      const MeshStateT<T>& /* meshState */) final;
+      const MeshStateT<T>& meshState) final;
 
   double getGradient(
       const ModelParametersT<T>& params,
       const SkeletonStateT<T>& state,
-      const MeshStateT<T>& /* meshState */,
+      const MeshStateT<T>& meshState,
       Ref<VectorX<T>> gradient) override;
 
   double getJacobian(
-      const ModelParametersT<T>& /*unused*/,
+      const ModelParametersT<T>& params,
       const SkeletonStateT<T>& state,
-      const MeshStateT<T>& /* meshState */,
+      const MeshStateT<T>& meshState,
       Ref<MatrixX<T>> jacobian,
       Ref<VectorX<T>> residual,
       int& usedRows) override;
@@ -62,6 +64,9 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   /// Update collisionState_, aabbs_, and collisionPairs_ given the new skeleton state.
   void computeBroadPhase(const SkeletonStateT<T>& state);
 
+  /// Synchronize scalar fallback settings before delegating non-capsule collision work.
+  CollisionErrorFunctionT<T>& syncScalarFallback();
+
   /// Pre-computed valid collision pair with common ancestor.
   struct CollisionPairInfo {
     size_t indexA;
@@ -70,6 +75,11 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   };
 
   const CollisionGeometry collisionGeometry_;
+
+  /// Scalar collision error function used when any primitive is not a tapered capsule.
+  /// Constructed once because @c collisionGeometry_ is immutable; runtime solver settings are
+  /// synchronized before each delegated call.
+  std::optional<CollisionErrorFunctionT<T>> scalarFallback_;
 
   /// Pre-filtered list of valid collision pairs.
   std::vector<CollisionPairInfo> validPairs_;
@@ -84,6 +94,10 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   std::vector<axel::BoundingBox<T>> aabbs_;
 
   CollisionGeometryStateT<T> collisionState_;
+
+  /// True when the collision geometry contains a non-tapered-capsule primitive, in which case
+  /// getError/getGradient/getJacobian delegate to @c scalarFallback_ instead of the SIMD path.
+  bool useScalarFallback_ = false;
 
   // weights for the error functions
   static constexpr T kCollisionWeight = 5e-3f;

--- a/momentum/gen_fwd_input.toml
+++ b/momentum/gen_fwd_input.toml
@@ -35,6 +35,7 @@ template_structs = [
     "CollisionGeometryState",
     "CollisionOverlapResult",
     "CollisionEllipsoid",
+    "CollisionBox",
     "Joint",
     "JointState",
     "ParameterTransform",

--- a/momentum/gui/rerun/logger.cpp
+++ b/momentum/gui/rerun/logger.cpp
@@ -411,8 +411,7 @@ void logBvh(
   for (size_t i = 0; i < n; ++i) {
     auto& aabb = aabbs[i];
     aabb.id = static_cast<axel::Index>(i);
-    updateAabb(
-        aabb, collisionState.origin[i], collisionState.direction[i], collisionState.radius[i]);
+    updateAabb(aabb, collisionState, i);
   }
 
   // Construct BVH
@@ -445,40 +444,67 @@ void logCollisionGeometry(
     const std::string& streamName,
     const CollisionGeometry& collisionGeometry,
     const SkeletonState& skeletonState) {
-  // TODO: update collision geometry representation from box to capsule
+  std::vector<rerun::Position3D> capsuleTranslations;
+  std::vector<rerun::Quaternion> capsuleQuaternions;
+  std::vector<float> capsuleLengths;
+  std::vector<float> capsuleRadii;
+  std::vector<rerun::Position3D> ellipsoidCenters;
+  std::vector<rerun::HalfSize3D> ellipsoidHalfSizes;
+  std::vector<rerun::Quaternion> ellipsoidQuaternions;
 
-  std::vector<rerun::Position3D> translations;
-  std::vector<rerun::Quaternion> quaternions;
-  std::vector<float> lengths;
-  std::vector<float> radii;
-
-  translations.reserve(collisionGeometry.size());
-  quaternions.reserve(collisionGeometry.size());
-  lengths.reserve(collisionGeometry.size());
-  radii.reserve(collisionGeometry.size());
+  capsuleTranslations.reserve(collisionGeometry.size());
+  capsuleQuaternions.reserve(collisionGeometry.size());
+  capsuleLengths.reserve(collisionGeometry.size());
+  capsuleRadii.reserve(collisionGeometry.size());
+  ellipsoidCenters.reserve(collisionGeometry.size());
+  ellipsoidHalfSizes.reserve(collisionGeometry.size());
+  ellipsoidQuaternions.reserve(collisionGeometry.size());
 
   for (const auto& cg : collisionGeometry) {
-    const auto& js = skeletonState.jointState.at(cg.parent);
+    const Transform parentTransform = (cg.parent == kInvalidIndex)
+        ? Transform()
+        : skeletonState.jointState.at(cg.parent).transform;
+    const Transform tf = parentTransform * cg.transformation;
 
-    const Transform tf = js.transform * cg.transformation;
-    const Quaternionf& q = tf.rotation * Eigen::AngleAxisf(0.5f * pi(), Vector3f::UnitY());
-
-    translations.push_back(toRerunPosition3D(tf.translation));
-    quaternions.emplace_back(rerun::Quaternion::from_xyzw(q.x(), q.y(), q.z(), q.w()));
-    lengths.emplace_back(cg.length);
-    // TODO: Rerun doesn't support capsules with different radii (i.e. tapered capsule) yet
-    radii.emplace_back(cg.radius.maxCoeff());
+    if (cg.type == CollisionPrimitiveType::TaperedCapsule) {
+      const Quaternionf& q = tf.rotation * Eigen::AngleAxisf(0.5f * pi(), Vector3f::UnitY());
+      capsuleTranslations.push_back(toRerunPosition3D(tf.translation));
+      capsuleQuaternions.emplace_back(rerun::Quaternion::from_xyzw(q.x(), q.y(), q.z(), q.w()));
+      // Match CollisionGeometryStateT::update: length runs along the composed-transform
+      // X axis (scaled by the full transform scale), radius is scaled by the parent joint
+      // scale only.
+      capsuleLengths.emplace_back(cg.length * tf.scale);
+      // TODO: Rerun doesn't support capsules with different radii (i.e. tapered capsule) yet
+      capsuleRadii.emplace_back(cg.radius.maxCoeff() * parentTransform.scale);
+    } else if (cg.type == CollisionPrimitiveType::Ellipsoid) {
+      const Vector3f halfSizes = cg.ellipsoidRadii * parentTransform.scale;
+      const Quaternionf& q = tf.rotation;
+      ellipsoidCenters.push_back(toRerunPosition3D(tf.translation));
+      ellipsoidHalfSizes.push_back(toRerunHalfSizes3D(halfSizes));
+      ellipsoidQuaternions.emplace_back(rerun::Quaternion::from_xyzw(q.x(), q.y(), q.z(), q.w()));
+    }
   }
 
-  // TODO: make radius and color configurable
-  safeLog(
-      rec,
-      streamName,
-      rerun::Capsules3D::from_lengths_and_radii(lengths, radii)
-          .with_translations(translations)
-          .with_quaternions(quaternions)
-          .with_colors(rerun::Color(128, 64, 64))
-          .with_fill_mode(rerun::FillMode::Solid));
+  if (!capsuleLengths.empty()) {
+    safeLog(
+        rec,
+        streamName + "/capsules",
+        rerun::Capsules3D::from_lengths_and_radii(capsuleLengths, capsuleRadii)
+            .with_translations(capsuleTranslations)
+            .with_quaternions(capsuleQuaternions)
+            .with_colors(rerun::Color(128, 64, 64))
+            .with_fill_mode(rerun::FillMode::Solid));
+  }
+
+  if (!ellipsoidHalfSizes.empty()) {
+    safeLog(
+        rec,
+        streamName + "/ellipsoids",
+        rerun::Ellipsoids3D::from_centers_and_half_sizes(ellipsoidCenters, ellipsoidHalfSizes)
+            .with_quaternions(ellipsoidQuaternions)
+            .with_colors(rerun::Color(128, 64, 64))
+            .with_fill_mode(rerun::FillMode::Solid));
+  }
 
   logBvh(rec, streamName + "/bvh", collisionGeometry, skeletonState);
 }

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -234,6 +234,8 @@ inline void createCollisionGeometryNodes(
       case CollisionPrimitiveType::Ellipsoid:
         supportedPrimitive = true;
         break;
+      case CollisionPrimitiveType::Box:
+        break;
     }
     if (!supportedPrimitive) {
       MT_LOGW(

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -227,7 +227,15 @@ inline void createCollisionGeometryNodes(
   const auto& collisions = *character.collision;
   for (auto i = 0u; i < collisions.size(); ++i) {
     const auto& collision = collisions[i];
-    if (!collision.isTaperedCapsule()) {
+
+    bool supportedPrimitive = false;
+    switch (collision.type) {
+      case CollisionPrimitiveType::TaperedCapsule:
+      case CollisionPrimitiveType::Ellipsoid:
+        supportedPrimitive = true;
+        break;
+    }
+    if (!supportedPrimitive) {
       MT_LOGW(
           "Skipping unsupported collision primitive type {} while writing FBX collision geometry",
           static_cast<int>(collision.type));
@@ -240,12 +248,25 @@ inline void createCollisionGeometryNodes(
     collisionNode->SetNodeAttribute(nullNodeAttr);
 
     ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxBoolDT, "Col_Type").Set(true);
-    ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Length")
-        .Set(collision.length);
-    ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_A")
-        .Set(collision.radius[0]);
-    ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_B")
-        .Set(collision.radius[1]);
+    if (collision.type == CollisionPrimitiveType::TaperedCapsule) {
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxStringDT, "Col_Shape")
+          .Set(FbxString("tapered_capsule"));
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Length")
+          .Set(collision.length);
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_A")
+          .Set(collision.radius[0]);
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Rad_B")
+          .Set(collision.radius[1]);
+    } else if (collision.type == CollisionPrimitiveType::Ellipsoid) {
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxStringDT, "Col_Shape")
+          .Set(FbxString("ellipsoid"));
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Radii_X")
+          .Set(collision.ellipsoidRadii.x());
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Radii_Y")
+          .Set(collision.ellipsoidRadii.y());
+      ::fbxsdk::FbxProperty::Create(collisionNode, ::fbxsdk::FbxFloatDT, "Radii_Z")
+          .Set(collision.ellipsoidRadii.z());
+    }
 
     collisionNode->LclTranslation.Set(FbxVector4(
         collision.transformation.translation.x(),

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -167,6 +167,19 @@ bool equalsCaseInsensitive(const ofbx::DataView& data, const char* rhs) {
   return c2 == (const char*)data.end && *c == '\0';
 }
 
+bool equalsCaseInsensitive(const std::string& lhs, const char* rhs) {
+  const char* c = rhs;
+  auto it = lhs.begin();
+  while (*c && it != lhs.end()) {
+    if (tolower(static_cast<unsigned char>(*c)) != tolower(static_cast<unsigned char>(*it))) {
+      return false;
+    }
+    ++c;
+    ++it;
+  }
+  return it == lhs.end() && *c == '\0';
+}
+
 // This function is more or less copied from the OpenFBX SDK.
 ofbx::IElement* resolveProperty(const ofbx::Object& object, const char* name) {
   // This is black magic, but for some reason all the user properties are stored in an
@@ -362,6 +375,52 @@ void extractCollisionCapsule(const ofbx::Object* node, size_t parent, CollisionG
   capsules.push_back(capsule);
 }
 
+void extractCollisionEllipsoid(
+    const ofbx::Object* node,
+    size_t parent,
+    CollisionGeometry& collisionGeometry) {
+  const double radiusX = resolveDoubleProperty(*node, "radii_x");
+  const double radiusY = resolveDoubleProperty(*node, "radii_y");
+  const double radiusZ = resolveDoubleProperty(*node, "radii_z");
+
+  const auto xf = node->getLocalTransform();
+
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = parent;
+  ellipsoid.radii = Eigen::Vector3f(
+      static_cast<float>(radiusX), static_cast<float>(radiusY), static_cast<float>(radiusZ));
+  ellipsoid.transformation = toEigen(xf).cast<float>();
+  collisionGeometry.push_back(ellipsoid);
+}
+
+void extractCollisionPrimitive(
+    const ofbx::Object* node,
+    size_t parent,
+    CollisionGeometry& collisionGeometry) {
+  auto* shapeProperty = resolveProperty(*node, "col_shape");
+  if (shapeProperty != nullptr) {
+    const std::string shape = resolveStringProperty(*node, "col_shape");
+    if (equalsCaseInsensitive(shape, "ellipsoid") ||
+        equalsCaseInsensitive(shape, "collision_ellipsoid")) {
+      extractCollisionEllipsoid(node, parent, collisionGeometry);
+      return;
+    }
+    if (equalsCaseInsensitive(shape, "tapered_capsule") ||
+        equalsCaseInsensitive(shape, "capsule") ||
+        equalsCaseInsensitive(shape, "collision_capsule")) {
+      extractCollisionCapsule(node, parent, collisionGeometry);
+      return;
+    }
+
+    MT_LOGW(
+        "Unknown FBX collision shape '{}' on node '{}'; falling back to tapered capsule.",
+        shape,
+        node->name);
+  }
+
+  extractCollisionCapsule(node, parent, collisionGeometry);
+}
+
 void extractLocator(const ofbx::Object* node, size_t parent, LocatorList& locators) {
   Locator locator;
   locator.name = node->name;
@@ -440,7 +499,7 @@ void parseSkeleton(
   if (type == ofbx::Object::Type::NULL_NODE) {
     auto* res = resolveProperty(*curSkelNode, "col_type");
     if (res != nullptr) {
-      extractCollisionCapsule(curSkelNode, parent, capsules);
+      extractCollisionPrimitive(curSkelNode, parent, capsules);
     } else if (parent != kInvalidIndex) {
       extractLocator(curSkelNode, parent, locators);
     } else {

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -784,7 +784,7 @@ void addCollisionsToModel(
       model.nodes.at(jointToNodeMap.at(col.parent))
           .children.push_back(static_cast<int32_t>(nodeIndex));
 
-      // add values for the tapered capsule
+      // add values for the collision primitive
       node.name = character.skeleton.joints.at(col.parent).name + "_col";
 
       node.rotation = fromMomentumQuaternionf(col.transformation.rotation);
@@ -794,9 +794,14 @@ void addCollisionsToModel(
       // add extra properties
       if (addExtensions) {
         auto& extension = addMomentumExtension(node.extensionsAndExtras);
-        extension["type"] = "collision_capsule";
-        extension["length"] = col.length;
-        extension["radius"] = col.radius;
+        if (col.type == CollisionPrimitiveType::TaperedCapsule) {
+          extension["type"] = "collision_capsule";
+          extension["length"] = col.length;
+          extension["radius"] = col.radius;
+        } else if (col.type == CollisionPrimitiveType::Ellipsoid) {
+          extension["type"] = "collision_ellipsoid";
+          extension["radii"] = col.ellipsoidRadii;
+        }
       }
     }
   }

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -801,6 +801,10 @@ void addCollisionsToModel(
         } else if (col.type == CollisionPrimitiveType::Ellipsoid) {
           extension["type"] = "collision_ellipsoid";
           extension["radii"] = col.ellipsoidRadii;
+        } else {
+          MT_THROW(
+              "Unsupported collision primitive type {} while writing glTF collision geometry",
+              static_cast<int>(col.type));
         }
       }
     }

--- a/momentum/io/gltf/gltf_skeleton_io.cpp
+++ b/momentum/io/gltf/gltf_skeleton_io.cpp
@@ -114,6 +114,16 @@ void loadHierarchyRecursive(
     capsule.parent = parentJointId;
     collision->push_back(capsule);
     nodeToObjectMap[nodeId] = collision->size() - 1;
+  } else if (type == "collision_ellipsoid") {
+    // Found collision geometry, should be the end node
+    MT_THROW_IF(
+        parentJointId == kInvalidIndex,
+        "Invalid collision ellipsoid without a parent joint: {}",
+        node.name);
+    auto ellipsoid = createCollisionEllipsoid(node, extension);
+    ellipsoid.parent = parentJointId;
+    collision->push_back(ellipsoid);
+    nodeToObjectMap[nodeId] = collision->size() - 1;
   } else if (type == "locator") {
     // Found locator, should be the end node
     MT_THROW_IF(
@@ -174,6 +184,26 @@ TaperedCapsule createCollisionCapsule(const fx::gltf::Node& node, const nlohmann
         extension.dump());
   }
   return tc;
+}
+
+CollisionEllipsoid createCollisionEllipsoid(
+    const fx::gltf::Node& node,
+    const nlohmann::json& extension) {
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = kInvalidIndex;
+  ellipsoid.transformation = Transform();
+  ellipsoid.transformation.rotation = toMomentumQuaternionf(node.rotation);
+  ellipsoid.transformation.translation = toMomentumVec3f(node.translation);
+
+  try {
+    ellipsoid.radii = fromJson<Vector3f>(extension["radii"]);
+  } catch (const std::exception&) {
+    MT_THROW(
+        "Fail to parse json {} for collision ellipsoid {} when loading character.",
+        extension.dump(),
+        node.name);
+  }
+  return ellipsoid;
 }
 
 Locator createLocator(const fx::gltf::Node& node, const nlohmann::json& extension) {
@@ -362,7 +392,10 @@ loadHierarchy(const fx::gltf::Document& model) {
   std::sort(collision->begin(), collision->end(), [](const auto& c1, const auto& c2) {
     int c1Parent = c1.parent == kInvalidIndex ? -1 : static_cast<int>(c1.parent);
     int c2Parent = c2.parent == kInvalidIndex ? -1 : static_cast<int>(c2.parent);
-    return c1Parent < c2Parent;
+    if (c1Parent != c2Parent) {
+      return c1Parent < c2Parent;
+    }
+    return static_cast<int>(c1.type) < static_cast<int>(c2.type);
   });
   std::sort(locators.begin(), locators.end(), [](const Locator& l1, const Locator& l2) {
     int l1Parent = l1.parent == kInvalidIndex ? -1 : static_cast<int>(l1.parent);

--- a/momentum/io/gltf/gltf_skeleton_io.h
+++ b/momentum/io/gltf/gltf_skeleton_io.h
@@ -27,6 +27,15 @@ namespace momentum {
 /// @return The created TaperedCapsule object.
 TaperedCapsule createCollisionCapsule(const fx::gltf::Node& node, const nlohmann::json& extension);
 
+/// Create a collision ellipsoid from a glTF node.
+///
+/// @param[in] node The glTF node containing the collision ellipsoid data.
+/// @param[in] extension The FB_momentum extension JSON data.
+/// @return The created CollisionEllipsoid object.
+CollisionEllipsoid createCollisionEllipsoid(
+    const fx::gltf::Node& node,
+    const nlohmann::json& extension);
+
 /// Create a locator from a glTF node.
 ///
 /// @param[in] node The glTF node containing the locator data.

--- a/momentum/io/legacy_json/legacy_json_io.cpp
+++ b/momentum/io/legacy_json/legacy_json_io.cpp
@@ -464,6 +464,10 @@ nlohmann::json momentumCollisionToLegacy(const CollisionGeometry& collision) {
     } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
       primitiveJson["type"] = "ellipsoid";
       primitiveJson["radii"] = eigenToJsonArray(primitive.ellipsoidRadii);
+    } else {
+      MT_THROW(
+          "Unsupported collision primitive type {} while writing legacy JSON collision geometry",
+          static_cast<int>(primitive.type));
     }
 
     legacyCollision.push_back(primitiveJson);

--- a/momentum/io/legacy_json/legacy_json_io.cpp
+++ b/momentum/io/legacy_json/legacy_json_io.cpp
@@ -16,6 +16,7 @@
 #include <momentum/character/skin_weights.h>
 #include <momentum/character/types.h>
 #include <momentum/common/exception.h>
+#include <momentum/common/log.h>
 #include <momentum/io/common/stream_utils.h>
 #include <momentum/math/mesh.h>
 #include <momentum/math/transform.h>
@@ -392,23 +393,52 @@ CollisionGeometry legacyCollisionToMomentum(const nlohmann::json& legacyCollisio
   if (legacyCollision.is_array()) {
     collision.reserve(legacyCollision.size());
 
-    for (const auto& capsuleJson : legacyCollision) {
+    for (const auto& primitiveJson : legacyCollision) {
+      const std::string type = primitiveJson.value("type", "tapered_capsule");
+
+      if (type == "ellipsoid" || type == "collision_ellipsoid") {
+        CollisionEllipsoid ellipsoid;
+
+        if (primitiveJson.contains("transformation")) {
+          ellipsoid.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
+        }
+
+        if (primitiveJson.contains("radii")) {
+          ellipsoid.radii = jsonArrayToEigenVector3<float>(primitiveJson["radii"]);
+        } else if (primitiveJson.contains("ellipsoidRadii")) {
+          ellipsoid.radii = jsonArrayToEigenVector3<float>(primitiveJson["ellipsoidRadii"]);
+        }
+
+        if (primitiveJson.contains("parent")) {
+          ellipsoid.parent = primitiveJson["parent"].get<size_t>();
+        }
+
+        collision.push_back(ellipsoid);
+        continue;
+      }
+
+      if (type != "tapered_capsule") {
+        MT_LOGW(
+            "Unknown collision primitive type '{}' in legacy JSON; falling back to tapered capsule.",
+            type);
+      }
+
       TaperedCapsule capsule;
 
-      if (capsuleJson.contains("transformation")) {
-        capsule.transformation = jsonToTransform<float>(capsuleJson["transformation"]);
+      if (primitiveJson.contains("transformation")) {
+        capsule.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
       }
 
-      if (capsuleJson.contains("radius")) {
-        capsule.radius = jsonArrayToEigenVector2<float>(capsuleJson["radius"]);
+      if (primitiveJson.contains("radius")) {
+        capsule.radius = jsonArrayToEigenVector2<float>(primitiveJson["radius"]);
       }
 
-      if (capsuleJson.contains("parent")) {
-        capsule.parent = capsuleJson["parent"].get<size_t>();
+      if (primitiveJson.contains("parent")) {
+        capsule.parent = primitiveJson["parent"].get<size_t>();
       }
 
-      if (capsuleJson.contains("length")) {
-        capsule.length = capsuleJson["length"].get<float>();
+      if (primitiveJson.contains("length")) {
+        capsule.length = primitiveJson["length"].get<float>();
       }
 
       collision.push_back(capsule);
@@ -421,15 +451,22 @@ CollisionGeometry legacyCollisionToMomentum(const nlohmann::json& legacyCollisio
 nlohmann::json momentumCollisionToLegacy(const CollisionGeometry& collision) {
   nlohmann::json legacyCollision = nlohmann::json::array();
 
-  for (const auto& capsule : collision) {
-    nlohmann::json capsuleJson;
+  for (const auto& primitive : collision) {
+    nlohmann::json primitiveJson;
 
-    capsuleJson["transformation"] = transformToJson(capsule.transformation);
-    capsuleJson["radius"] = eigenToJsonArray(capsule.radius);
-    capsuleJson["parent"] = capsule.parent;
-    capsuleJson["length"] = capsule.length;
+    primitiveJson["transformation"] = transformToJson(primitive.transformation);
+    primitiveJson["parent"] = primitive.parent;
 
-    legacyCollision.push_back(capsuleJson);
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      primitiveJson["type"] = "tapered_capsule";
+      primitiveJson["radius"] = eigenToJsonArray(primitive.radius);
+      primitiveJson["length"] = primitive.length;
+    } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      primitiveJson["type"] = "ellipsoid";
+      primitiveJson["radii"] = eigenToJsonArray(primitive.ellipsoidRadii);
+    }
+
+    legacyCollision.push_back(primitiveJson);
   }
 
   return legacyCollision;

--- a/momentum/io/usd/usd_skeleton_io.cpp
+++ b/momentum/io/usd/usd_skeleton_io.cpp
@@ -35,13 +35,13 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (Collision)(Locators)((momentumType, "momentum:type"))((momentumParent, "momentum:parent"))(
         (momentumLength, "momentum:length"))((momentumRadius, "momentum:radius"))(
-        (momentumTranslation, "momentum:translation"))((momentumRotation, "momentum:rotation"))(
-        (momentumName, "momentum:name"))((momentumOffset, "momentum:offset"))(
-        (momentumWeight, "momentum:weight"))((momentumLocked, "momentum:locked"))(
-        (momentumLimitOrigin,
-         "momentum:limitOrigin"))((momentumLimitWeight, "momentum:limitWeight"))(
-        (momentumAttachedToSkin,
-         "momentum:attachedToSkin"))((momentumSkinOffset, "momentum:skinOffset")));
+        (momentumRadii, "momentum:radii"))((momentumTranslation, "momentum:translation"))(
+        (momentumRotation, "momentum:rotation"))((momentumName, "momentum:name"))(
+        (momentumOffset, "momentum:offset"))((momentumWeight, "momentum:weight"))(
+        (momentumLocked, "momentum:locked"))((momentumLimitOrigin, "momentum:limitOrigin"))(
+        (momentumLimitWeight,
+         "momentum:limitWeight"))((momentumAttachedToSkin, "momentum:attachedToSkin"))(
+        (momentumSkinOffset, "momentum:skinOffset")));
 
 namespace momentum {
 
@@ -67,11 +67,24 @@ Eigen::Matrix4f jointToLocalTransform(const Joint& joint) {
 
 // Compute world-space bind transform for a joint by walking up the parent chain.
 Eigen::Matrix4f computeWorldTransform(const Skeleton& skeleton, size_t jointIndex) {
-  Eigen::Matrix4f world = jointToLocalTransform(skeleton.joints[jointIndex]);
-  size_t parent = skeleton.joints[jointIndex].parent;
+  MT_THROW_IF(
+      jointIndex >= skeleton.joints.size(),
+      "Joint index {} exceeds skeleton joint count {}",
+      jointIndex,
+      skeleton.joints.size());
+
+  const auto& joint = skeleton.joints.at(jointIndex);
+  Eigen::Matrix4f world = jointToLocalTransform(joint);
+  size_t parent = joint.parent;
   while (parent != kInvalidIndex) {
-    world = jointToLocalTransform(skeleton.joints[parent]) * world;
-    parent = skeleton.joints[parent].parent;
+    MT_THROW_IF(
+        parent >= skeleton.joints.size(),
+        "Parent joint index {} exceeds skeleton joint count {}",
+        parent,
+        skeleton.joints.size());
+    const auto& parentJoint = skeleton.joints.at(parent);
+    world = jointToLocalTransform(parentJoint) * world;
+    parent = parentJoint.parent;
   }
   return world;
 }
@@ -94,16 +107,17 @@ std::string leafName(const std::string& path) {
 std::vector<std::string> buildHierarchicalPaths(const Skeleton& skeleton) {
   std::vector<std::string> paths(skeleton.joints.size());
   for (size_t i = 0; i < skeleton.joints.size(); ++i) {
-    if (skeleton.joints[i].parent == kInvalidIndex) {
-      paths[i] = skeleton.joints[i].name;
+    const auto& joint = skeleton.joints.at(i);
+    if (joint.parent == kInvalidIndex) {
+      paths.at(i) = joint.name;
     } else {
       MT_THROW_IF(
-          skeleton.joints[i].parent >= paths.size(),
+          joint.parent >= paths.size(),
           "Parent joint index {} exceeds paths size {} for joint {}",
-          skeleton.joints[i].parent,
+          joint.parent,
           paths.size(),
           i);
-      paths[i] = paths[skeleton.joints[i].parent] + "/" + skeleton.joints[i].name;
+      paths.at(i) = paths.at(joint.parent) + "/" + joint.name;
     }
   }
   return paths;
@@ -238,9 +252,20 @@ void saveCollisionGeometryToUsd(
   auto collisionScope = UsdGeomScope::Define(stage, skelRootPath.AppendChild(_tokens->Collision));
 
   for (size_t i = 0; i < collision.size(); ++i) {
-    const auto& capsule = collision[i];
-    const std::string jointName = (capsule.parent < skeleton.joints.size())
-        ? skeleton.joints.at(capsule.parent).name
+    const auto& primitive = collision[i];
+
+    std::string type;
+    switch (primitive.type) {
+      case CollisionPrimitiveType::TaperedCapsule:
+        type = "collision_capsule";
+        break;
+      case CollisionPrimitiveType::Ellipsoid:
+        type = "collision_ellipsoid";
+        break;
+    }
+
+    const std::string jointName = (primitive.parent < skeleton.joints.size())
+        ? skeleton.joints.at(primitive.parent).name
         : "unknown";
     const std::string primName = sanitizePrimName(jointName + "_col_" + std::to_string(i));
 
@@ -252,18 +277,25 @@ void saveCollisionGeometryToUsd(
         primName,
         jointName);
 
-    prim.CreateAttribute(_tokens->momentumType, SdfValueTypeNames->String)
-        .Set(std::string("collision_capsule"));
+    prim.CreateAttribute(_tokens->momentumType, SdfValueTypeNames->String).Set(type);
     prim.CreateAttribute(_tokens->momentumParent, SdfValueTypeNames->String).Set(jointName);
-    prim.CreateAttribute(_tokens->momentumLength, SdfValueTypeNames->Float).Set(capsule.length);
-    prim.CreateAttribute(_tokens->momentumRadius, SdfValueTypeNames->Float2)
-        .Set(GfVec2f(capsule.radius.x(), capsule.radius.y()));
+    if (primitive.type == CollisionPrimitiveType::TaperedCapsule) {
+      prim.CreateAttribute(_tokens->momentumLength, SdfValueTypeNames->Float).Set(primitive.length);
+      prim.CreateAttribute(_tokens->momentumRadius, SdfValueTypeNames->Float2)
+          .Set(GfVec2f(primitive.radius.x(), primitive.radius.y()));
+    } else if (primitive.type == CollisionPrimitiveType::Ellipsoid) {
+      prim.CreateAttribute(_tokens->momentumRadii, SdfValueTypeNames->Float3)
+          .Set(GfVec3f(
+              primitive.ellipsoidRadii.x(),
+              primitive.ellipsoidRadii.y(),
+              primitive.ellipsoidRadii.z()));
+    }
 
-    const auto& t = capsule.transformation.translation;
+    const auto& t = primitive.transformation.translation;
     prim.CreateAttribute(_tokens->momentumTranslation, SdfValueTypeNames->Float3)
         .Set(GfVec3f(t.x(), t.y(), t.z()));
 
-    const auto& q = capsule.transformation.rotation;
+    const auto& q = primitive.transformation.rotation;
     prim.CreateAttribute(_tokens->momentumRotation, SdfValueTypeNames->Quatf)
         .Set(GfQuatf(q.w(), q.x(), q.y(), q.z()));
   }
@@ -281,46 +313,56 @@ CollisionGeometry loadCollisionGeometryFromUsd(
     }
 
     std::string type;
-    if (!typeAttr.Get(&type) || type != "collision_capsule") {
+    if (!typeAttr.Get(&type) || (type != "collision_capsule" && type != "collision_ellipsoid")) {
       continue;
     }
 
-    TaperedCapsule capsule;
+    CollisionPrimitive primitive;
 
     std::string parentName;
     if (auto attr = prim.GetAttribute(_tokens->momentumParent); attr) {
       attr.Get(&parentName);
-      capsule.parent = skeleton.getJointIdByName(parentName);
+      primitive.parent = skeleton.getJointIdByName(parentName);
     }
 
-    if (auto attr = prim.GetAttribute(_tokens->momentumLength); attr) {
-      attr.Get(&capsule.length);
-    }
+    if (type == "collision_capsule") {
+      primitive.type = CollisionPrimitiveType::TaperedCapsule;
+      if (auto attr = prim.GetAttribute(_tokens->momentumLength); attr) {
+        attr.Get(&primitive.length);
+      }
 
-    GfVec2f radius(0.0f, 0.0f);
-    if (auto attr = prim.GetAttribute(_tokens->momentumRadius); attr) {
-      attr.Get(&radius);
-      capsule.radius = Eigen::Vector2f(radius[0], radius[1]);
+      GfVec2f radius(0.0f, 0.0f);
+      if (auto attr = prim.GetAttribute(_tokens->momentumRadius); attr) {
+        attr.Get(&radius);
+        primitive.radius = Eigen::Vector2f(radius[0], radius[1]);
+      }
+    } else if (type == "collision_ellipsoid") {
+      primitive.type = CollisionPrimitiveType::Ellipsoid;
+      GfVec3f radii(0.0f, 0.0f, 0.0f);
+      if (auto attr = prim.GetAttribute(_tokens->momentumRadii); attr) {
+        attr.Get(&radii);
+        primitive.ellipsoidRadii = Eigen::Vector3f(radii[0], radii[1], radii[2]);
+      }
     }
 
     GfVec3f translation(0.0f, 0.0f, 0.0f);
     if (auto attr = prim.GetAttribute(_tokens->momentumTranslation); attr) {
       attr.Get(&translation);
-      capsule.transformation.translation =
+      primitive.transformation.translation =
           Eigen::Vector3f(translation[0], translation[1], translation[2]);
     }
 
     GfQuatf rotation(1.0f);
     if (auto attr = prim.GetAttribute(_tokens->momentumRotation); attr) {
       attr.Get(&rotation);
-      capsule.transformation.rotation = Eigen::Quaternionf(
+      primitive.transformation.rotation = Eigen::Quaternionf(
           rotation.GetReal(),
           rotation.GetImaginary()[0],
           rotation.GetImaginary()[1],
           rotation.GetImaginary()[2]);
     }
 
-    result.push_back(capsule);
+    result.push_back(primitive);
   }
 
   return result;

--- a/momentum/io/usd/usd_skeleton_io.cpp
+++ b/momentum/io/usd/usd_skeleton_io.cpp
@@ -35,13 +35,14 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (Collision)(Locators)((momentumType, "momentum:type"))((momentumParent, "momentum:parent"))(
         (momentumLength, "momentum:length"))((momentumRadius, "momentum:radius"))(
-        (momentumRadii, "momentum:radii"))((momentumTranslation, "momentum:translation"))(
-        (momentumRotation, "momentum:rotation"))((momentumName, "momentum:name"))(
-        (momentumOffset, "momentum:offset"))((momentumWeight, "momentum:weight"))(
-        (momentumLocked, "momentum:locked"))((momentumLimitOrigin, "momentum:limitOrigin"))(
-        (momentumLimitWeight,
-         "momentum:limitWeight"))((momentumAttachedToSkin, "momentum:attachedToSkin"))(
-        (momentumSkinOffset, "momentum:skinOffset")));
+        (momentumRadii, "momentum:radii"))((momentumHalfExtents, "momentum:halfExtents"))(
+        (momentumTranslation, "momentum:translation"))((momentumRotation, "momentum:rotation"))(
+        (momentumName, "momentum:name"))((momentumOffset, "momentum:offset"))(
+        (momentumWeight, "momentum:weight"))((momentumLocked, "momentum:locked"))(
+        (momentumLimitOrigin,
+         "momentum:limitOrigin"))((momentumLimitWeight, "momentum:limitWeight"))(
+        (momentumAttachedToSkin,
+         "momentum:attachedToSkin"))((momentumSkinOffset, "momentum:skinOffset")));
 
 namespace momentum {
 
@@ -262,6 +263,9 @@ void saveCollisionGeometryToUsd(
       case CollisionPrimitiveType::Ellipsoid:
         type = "collision_ellipsoid";
         break;
+      case CollisionPrimitiveType::Box:
+        type = "collision_box";
+        break;
     }
 
     const std::string jointName = (primitive.parent < skeleton.joints.size())
@@ -289,6 +293,12 @@ void saveCollisionGeometryToUsd(
               primitive.ellipsoidRadii.x(),
               primitive.ellipsoidRadii.y(),
               primitive.ellipsoidRadii.z()));
+    } else if (primitive.type == CollisionPrimitiveType::Box) {
+      prim.CreateAttribute(_tokens->momentumHalfExtents, SdfValueTypeNames->Float3)
+          .Set(GfVec3f(
+              primitive.boxHalfExtents.x(),
+              primitive.boxHalfExtents.y(),
+              primitive.boxHalfExtents.z()));
     }
 
     const auto& t = primitive.transformation.translation;
@@ -313,7 +323,8 @@ CollisionGeometry loadCollisionGeometryFromUsd(
     }
 
     std::string type;
-    if (!typeAttr.Get(&type) || (type != "collision_capsule" && type != "collision_ellipsoid")) {
+    if (!typeAttr.Get(&type) ||
+        (type != "collision_capsule" && type != "collision_ellipsoid" && type != "collision_box")) {
       continue;
     }
 
@@ -342,6 +353,13 @@ CollisionGeometry loadCollisionGeometryFromUsd(
       if (auto attr = prim.GetAttribute(_tokens->momentumRadii); attr) {
         attr.Get(&radii);
         primitive.ellipsoidRadii = Eigen::Vector3f(radii[0], radii[1], radii[2]);
+      }
+    } else if (type == "collision_box") {
+      primitive.type = CollisionPrimitiveType::Box;
+      GfVec3f halfExtents(0.0f, 0.0f, 0.0f);
+      if (auto attr = prim.GetAttribute(_tokens->momentumHalfExtents); attr) {
+        attr.Get(&halfExtents);
+        primitive.boxHalfExtents = Eigen::Vector3f(halfExtents[0], halfExtents[1], halfExtents[2]);
       }
     }
 

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -181,6 +181,12 @@ void compareCollisionGeometry(
       if (lessLexicographic(l2.ellipsoidRadii, l1.ellipsoidRadii)) {
         return false;
       }
+      if (lessLexicographic(l1.boxHalfExtents, l2.boxHalfExtents)) {
+        return true;
+      }
+      if (lessLexicographic(l2.boxHalfExtents, l1.boxHalfExtents)) {
+        return false;
+      }
       const auto t1 = l1.transformation.toMatrix();
       const auto t2 = l2.transformation.toMatrix();
       EXPECT_EQ(t1.size(), t2.size());
@@ -204,6 +210,7 @@ void compareCollisionGeometry(
           << "  - radius_0 : " << collA.radius.x() << "\n"
           << "  - radius_1 : " << collA.radius.y() << "\n"
           << "  - radii    : " << collA.ellipsoidRadii.transpose() << "\n"
+          << "  - half_ext : " << collA.boxHalfExtents.transpose() << "\n"
           << "  - length   : " << collA.length << "\n"
           << "  - parent   : " << collA.parent << "\n"
           << "  - transform:\n"
@@ -213,6 +220,7 @@ void compareCollisionGeometry(
           << "  - radius_0 : " << collB.radius.x() << "\n"
           << "  - radius_1 : " << collB.radius.y() << "\n"
           << "  - radii    : " << collB.ellipsoidRadii.transpose() << "\n"
+          << "  - half_ext : " << collB.boxHalfExtents.transpose() << "\n"
           << "  - length   : " << collB.length << "\n"
           << "  - parent   : " << collB.parent << "\n"
           << "  - transform:\n"

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -138,6 +138,11 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
   ellipsoid.transformation.translation = Vector3f(0.1f, 0.2f, 0.3f);
   ellipsoid.radii = Vector3f(0.3f, 0.2f, 0.1f);
   this->character.collision->push_back(ellipsoid);
+  CollisionBox box;
+  box.parent = 2;
+  box.transformation.translation = Vector3f(0.4f, 0.5f, 0.6f);
+  box.halfExtents = Vector3f(0.6f, 0.5f, 0.4f);
+  this->character.collision->push_back(box);
 
   // Store original values for comparison
   Vector3f originalTranslation = this->character.skeleton.joints[1].translationOffset;
@@ -173,11 +178,16 @@ TEST_F(CharacterUtilityTest, ScaleCharacter) {
         scaledCharacter.collision->at(0).radius, this->character.collision->at(0).radius * scale);
     EXPECT_EQ(
         scaledCharacter.collision->at(0).length, this->character.collision->at(0).length * scale);
-    const auto& scaledEllipsoid = scaledCharacter.collision->back();
+    const auto& scaledEllipsoid =
+        scaledCharacter.collision->at(scaledCharacter.collision->size() - 2);
     EXPECT_EQ(scaledEllipsoid.type, CollisionPrimitiveType::Ellipsoid);
     EXPECT_EQ(
         scaledEllipsoid.transformation.translation, ellipsoid.transformation.translation * scale);
     EXPECT_EQ(scaledEllipsoid.ellipsoidRadii, ellipsoid.radii * scale);
+    const auto& scaledBox = scaledCharacter.collision->back();
+    EXPECT_EQ(scaledBox.type, CollisionPrimitiveType::Box);
+    EXPECT_EQ(scaledBox.transformation.translation, box.transformation.translation * scale);
+    EXPECT_EQ(scaledBox.boxHalfExtents, box.halfExtents * scale);
   }
 
   // Check that inverse bind pose was scaled
@@ -351,6 +361,13 @@ TEST_F(CharacterUtilityTest, TransformCharacterTransformsWorldFixedCollisionGeom
   worldEllipsoid.radii = Vector3f(0.7f, 0.6f, 0.5f);
   collisionGeometry.push_back(worldEllipsoid);
 
+  CollisionBox worldBox;
+  worldBox.parent = kInvalidIndex;
+  worldBox.transformation.translation = Vector3f(0.8f, 0.9f, 1.0f);
+  worldBox.transformation.rotation = Quaternionf(Eigen::AngleAxisf(pi() / 4.0f, Vector3f::UnitX()));
+  worldBox.halfExtents = Vector3f(0.5f, 0.4f, 0.3f);
+  collisionGeometry.push_back(worldBox);
+
   const Character character(
       this->smallCharacter.skeleton,
       this->smallCharacter.parameterTransform,
@@ -368,12 +385,15 @@ TEST_F(CharacterUtilityTest, TransformCharacterTransformsWorldFixedCollisionGeom
   const Character transformedCharacter = transformCharacter(character, transform);
 
   ASSERT_TRUE(transformedCharacter.collision);
-  ASSERT_EQ(transformedCharacter.collision->size(), 2);
+  ASSERT_EQ(transformedCharacter.collision->size(), 3);
   EXPECT_TRUE(transformedCharacter.collision->at(0).transformation.isApprox(
       parentedEllipsoid.transformation));
   EXPECT_TRUE(transformedCharacter.collision->at(1).transformation.isApprox(
       Transform(transform) * worldEllipsoid.transformation));
   EXPECT_EQ(transformedCharacter.collision->at(1).ellipsoidRadii, worldEllipsoid.radii);
+  EXPECT_TRUE(transformedCharacter.collision->at(2).transformation.isApprox(
+      Transform(transform) * worldBox.transformation));
+  EXPECT_EQ(transformedCharacter.collision->at(2).boxHalfExtents, worldBox.halfExtents);
 }
 
 // Test removeJoints function
@@ -476,6 +496,11 @@ TEST_F(CharacterUtilityTest, RemoveJointsKeepsWorldFixedCollisionGeometry) {
   removedJointEllipsoid.radii = Vector3f(0.2f, 0.3f, 0.4f);
   collisionGeometry.push_back(removedJointEllipsoid);
 
+  CollisionBox worldBox;
+  worldBox.parent = kInvalidIndex;
+  worldBox.halfExtents = Vector3f(0.6f, 0.5f, 0.4f);
+  collisionGeometry.push_back(worldBox);
+
   const Character character(
       this->smallCharacter.skeleton,
       this->smallCharacter.parameterTransform,
@@ -489,10 +514,13 @@ TEST_F(CharacterUtilityTest, RemoveJointsKeepsWorldFixedCollisionGeometry) {
   const Character resultCharacter = removeJoints(character, jointsToRemove);
 
   ASSERT_TRUE(resultCharacter.collision);
-  ASSERT_EQ(resultCharacter.collision->size(), 1);
+  ASSERT_EQ(resultCharacter.collision->size(), 2);
   EXPECT_EQ(resultCharacter.collision->at(0).type, CollisionPrimitiveType::Ellipsoid);
   EXPECT_EQ(resultCharacter.collision->at(0).parent, kInvalidIndex);
   EXPECT_EQ(resultCharacter.collision->at(0).ellipsoidRadii, worldEllipsoid.radii);
+  EXPECT_EQ(resultCharacter.collision->at(1).type, CollisionPrimitiveType::Box);
+  EXPECT_EQ(resultCharacter.collision->at(1).parent, kInvalidIndex);
+  EXPECT_EQ(resultCharacter.collision->at(1).boxHalfExtents, worldBox.halfExtents);
 }
 
 // Test mapMotionToCharacter function

--- a/momentum/test/character/collision_geometry_state_test.cpp
+++ b/momentum/test/character/collision_geometry_state_test.cpp
@@ -151,6 +151,33 @@ TEST_F(CollisionGeometryStateTest, UpdateWithEllipsoid) {
   EXPECT_TRUE(collisionState.ellipsoidRadii[2].isApprox(Vector3f(0.4f, 0.8f, 1.2f)));
 }
 
+TEST_F(CollisionGeometryStateTest, UpdateWithBox) {
+  CollisionBox box;
+  box.parent = 0;
+  box.transformation.translation = Vector3f(0.25f, 0.5f, 0.75f);
+  box.transformation.rotation = Quaternionf(Eigen::AngleAxisf(pi() / 2.0f, Vector3f::UnitZ()));
+  box.halfExtents = Vector3f(0.2f, 0.4f, 0.6f);
+  collisionGeometry.push_back(box);
+
+  skeletonState.jointState[0].transform.translation = Vector3f(1.0f, 2.0f, 3.0f);
+  skeletonState.jointState[0].transform.scale = 2.0f;
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, collisionGeometry);
+
+  ASSERT_EQ(collisionState.type.size(), 3);
+  EXPECT_EQ(collisionState.type[2], CollisionPrimitiveType::Box);
+  EXPECT_TRUE(collisionState.origin[2].isApprox(Vector3f(1.5f, 3.0f, 4.5f)));
+  EXPECT_TRUE(collisionState.direction[2].isZero());
+  EXPECT_TRUE(collisionState.radius[2].isZero());
+  EXPECT_FLOAT_EQ(collisionState.delta[2], 0.0f);
+  EXPECT_TRUE(collisionState.ellipsoidRadii[2].isZero());
+  EXPECT_TRUE(collisionState.boxHalfExtents[2].isApprox(Vector3f(0.4f, 0.8f, 1.2f)));
+  const Quaternionf expectedOrientation =
+      skeletonState.jointState[0].transform.rotation * box.transformation.rotation;
+  EXPECT_TRUE(collisionState.orientation[2].isApprox(expectedOrientation));
+}
+
 // Test the overlaps function with non-overlapping capsules
 TEST_F(CollisionGeometryStateTest, OverlapsNonOverlapping) {
   // Create two non-overlapping capsules
@@ -213,6 +240,66 @@ TEST_F(CollisionGeometryStateTest, OverlapsCapsuleEllipsoid) {
   EXPECT_NEAR(overlap.overlap, 0.1f, 1e-5f);
 }
 
+TEST_F(CollisionGeometryStateTest, OverlapsCapsuleBox) {
+  CollisionGeometry geometry;
+
+  TaperedCapsule capsule;
+  capsule.parent = 0;
+  capsule.length = 1.0f;
+  capsule.radius = Vector2f(0.25f, 0.25f);
+  geometry.push_back(capsule);
+
+  CollisionBox box;
+  box.parent = 1;
+  box.transformation.translation = Vector3f(0.5f, 0.3f, 0.3f);
+  box.halfExtents = Vector3f(0.2f, 0.3f, 0.2f);
+  geometry.push_back(box);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 0, 1, overlap));
+  EXPECT_NEAR(overlap.distance, 0.42426407f, 1e-5f);
+  EXPECT_NEAR(overlap.closestPoints[0], 0.5f, 1e-5f);
+  EXPECT_NEAR(overlap.closestPoints[1], 0.0f, 1e-5f);
+  EXPECT_TRUE(overlap.positionA.isApprox(Vector3f(0.5f, 0.0f, 0.0f), 1e-5f));
+  EXPECT_TRUE(overlap.positionB.isApprox(Vector3f(0.5f, 0.3f, 0.3f), 1e-5f));
+  EXPECT_NEAR(overlap.radiusA, 0.25f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.35355338f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.17928931f, 1e-5f);
+}
+
+TEST_F(CollisionGeometryStateTest, OverlapsBoxCapsule) {
+  CollisionGeometry geometry;
+
+  TaperedCapsule capsule;
+  capsule.parent = 0;
+  capsule.length = 1.0f;
+  capsule.radius = Vector2f(0.25f, 0.25f);
+  geometry.push_back(capsule);
+
+  CollisionBox box;
+  box.parent = 1;
+  box.transformation.translation = Vector3f(0.5f, 0.3f, 0.3f);
+  box.halfExtents = Vector3f(0.2f, 0.3f, 0.2f);
+  geometry.push_back(box);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 1, 0, overlap));
+  EXPECT_NEAR(overlap.distance, 0.42426407f, 1e-5f);
+  EXPECT_NEAR(overlap.closestPoints[0], 0.0f, 1e-5f);
+  EXPECT_NEAR(overlap.closestPoints[1], 0.5f, 1e-5f);
+  EXPECT_TRUE(overlap.positionA.isApprox(Vector3f(0.5f, 0.3f, 0.3f), 1e-5f));
+  EXPECT_TRUE(overlap.positionB.isApprox(Vector3f(0.5f, 0.0f, 0.0f), 1e-5f));
+  EXPECT_NEAR(overlap.radiusA, 0.35355338f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.25f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.17928931f, 1e-5f);
+}
+
 TEST_F(CollisionGeometryStateTest, OverlapsEllipsoidEllipsoid) {
   CollisionGeometry geometry;
 
@@ -236,6 +323,56 @@ TEST_F(CollisionGeometryStateTest, OverlapsEllipsoidEllipsoid) {
   EXPECT_NEAR(overlap.radiusA, 0.5f, 1e-5f);
   EXPECT_NEAR(overlap.radiusB, 0.4f, 1e-5f);
   EXPECT_NEAR(overlap.overlap, 0.1f, 1e-5f);
+}
+
+TEST_F(CollisionGeometryStateTest, OverlapsEllipsoidBox) {
+  CollisionGeometry geometry;
+
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 0;
+  ellipsoid.radii = Vector3f(0.5f, 0.2f, 0.2f);
+  geometry.push_back(ellipsoid);
+
+  CollisionBox box;
+  box.parent = 1;
+  box.transformation.translation = Vector3f(0.5f, 0.3f, 0.3f);
+  box.halfExtents = Vector3f(0.4f, 0.2f, 0.2f);
+  geometry.push_back(box);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 0, 1, overlap));
+  EXPECT_NEAR(overlap.distance, 0.65574385f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusA, 0.40260778f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.48799543f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.23485935f, 1e-5f);
+}
+
+TEST_F(CollisionGeometryStateTest, OverlapsBoxBox) {
+  CollisionGeometry geometry;
+
+  CollisionBox boxA;
+  boxA.parent = 0;
+  boxA.halfExtents = Vector3f(0.5f, 0.2f, 0.2f);
+  geometry.push_back(boxA);
+
+  CollisionBox boxB;
+  boxB.parent = 1;
+  boxB.transformation.translation = Vector3f(0.5f, 0.3f, 0.3f);
+  boxB.halfExtents = Vector3f(0.4f, 0.2f, 0.2f);
+  geometry.push_back(boxB);
+
+  CollisionGeometryState collisionState;
+  collisionState.update(skeletonState, geometry);
+
+  CollisionOverlapResultT<float> overlap;
+  EXPECT_TRUE(overlaps(collisionState, geometry, 0, 1, overlap));
+  EXPECT_NEAR(overlap.distance, 0.65574385f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusA, 0.56424469f, 1e-5f);
+  EXPECT_NEAR(overlap.radiusB, 0.48799543f, 1e-5f);
+  EXPECT_NEAR(overlap.overlap, 0.39649630f, 1e-5f);
 }
 
 // Test the overlaps function with overlapping capsules
@@ -406,6 +543,30 @@ TEST_F(CollisionGeometryStateTest, UpdateEllipsoidAabb) {
   // Tight half-extent along X and Y is sqrt((cos45*2)^2 + (sin45*1)^2) = sqrt(2.5) ~= 1.5811,
   // whereas the box/L1 bound would be cos45*2 + sin45*1 ~= 2.1213. Z is unrotated, so 3.0.
   const float hXy = std::sqrt(2.5f);
+  const float hZ = 3.0f;
+  EXPECT_NEAR(aabb.aabb.min().x(), center.x() - hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.min().y(), center.y() - hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.min().z(), center.z() - hZ, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().x(), center.x() + hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().y(), center.y() + hXy, 1e-5f);
+  EXPECT_NEAR(aabb.aabb.max().z(), center.z() + hZ, 1e-5f);
+}
+
+// Test that updateBoxAabb uses the exact OBB/L1 bound (cos45*hx + sin45*hy), which is the tight
+// AABB for an oriented box. It is intentionally looser than the ellipsoid L2 bound for the same
+// extents; using the ellipsoid formula here would under-bound the box and miss collisions.
+TEST_F(CollisionGeometryStateTest, UpdateBoxAabb) {
+  const Vector3f center(1.0f, 2.0f, 5.0f);
+  // Unit quaternion (w, x, y, z) for a +45-degree rotation about the Z axis.
+  const Quaternionf orientation(0.9238795325f, 0.0f, 0.0f, 0.3826834324f);
+  const Vector3f halfExtents(2.0f, 1.0f, 3.0f);
+
+  axel::BoundingBox<float> aabb;
+  updateBoxAabb(aabb, center, orientation, halfExtents);
+
+  // Exact OBB half-extent along X and Y is cos45*2 + sin45*1 = sqrt(0.5)*3 ~= 2.1213 (vs the
+  // ellipsoid L2 bound sqrt(2.5) ~= 1.5811 for the same extents). Z is unrotated, so 3.0.
+  const float hXy = std::sqrt(0.5f) * 3.0f;
   const float hZ = 3.0f;
   EXPECT_NEAR(aabb.aabb.min().x(), center.x() - hXy, 1e-5f);
   EXPECT_NEAR(aabb.aabb.min().y(), center.y() - hXy, 1e-5f);

--- a/momentum/test/character/collision_geometry_test.cpp
+++ b/momentum/test/character/collision_geometry_test.cpp
@@ -35,11 +35,17 @@ TEST(CollisionGeometryTest, DefaultConstructor) {
   EXPECT_TRUE(ellipsoidFloat.radii.isApprox(Vector3<float>::Zero()));
   EXPECT_EQ(ellipsoidFloat.parent, kInvalidIndex);
 
+  CollisionBoxT<float> boxFloat;
+  EXPECT_TRUE(boxFloat.transformation.isApprox(TransformT<float>()));
+  EXPECT_TRUE(boxFloat.halfExtents.isApprox(Vector3<float>::Zero()));
+  EXPECT_EQ(boxFloat.parent, kInvalidIndex);
+
   CollisionPrimitiveT<float> primitiveFloat;
   EXPECT_EQ(primitiveFloat.type, CollisionPrimitiveType::TaperedCapsule);
   EXPECT_TRUE(primitiveFloat.transformation.isApprox(TransformT<float>()));
   EXPECT_TRUE(primitiveFloat.radius.isApprox(Vector2<float>::Zero()));
   EXPECT_TRUE(primitiveFloat.ellipsoidRadii.isApprox(Vector3<float>::Zero()));
+  EXPECT_TRUE(primitiveFloat.boxHalfExtents.isApprox(Vector3<float>::Zero()));
   EXPECT_EQ(primitiveFloat.parent, kInvalidIndex);
   EXPECT_FLOAT_EQ(primitiveFloat.length, 0.0f);
 }
@@ -87,6 +93,30 @@ TEST(CollisionGeometryTest, IsApprox) {
   ellipsoid2.radii = Vector3<float>(1.0f, 2.0f, 3.0f);
   EXPECT_FALSE(ellipsoid1.isApprox(ellipsoid2));
 
+  CollisionBoxT<float> box1;
+  CollisionBoxT<float> box2;
+  EXPECT_TRUE(box1.isApprox(box2));
+
+  box2.halfExtents = Vector3<float>(1.0f, 2.0f, 3.0f);
+  EXPECT_FALSE(box1.isApprox(box2));
+
+  box2 = CollisionBoxT<float>();
+  box2.transformation.translation = Vector3<float>(1.0f, 0.0f, 0.0f);
+  EXPECT_FALSE(box1.isApprox(box2));
+
+  box2 = CollisionBoxT<float>();
+  box2.parent = 1;
+  EXPECT_FALSE(box1.isApprox(box2));
+
+  CollisionBoxT<float> box3;
+  box3.halfExtents = Vector3<float>(1.0f, 2.0f, 3.0f);
+  CollisionPrimitiveT<float> boxPrimitive1(box1);
+  CollisionPrimitiveT<float> boxPrimitive2(box1);
+  EXPECT_TRUE(boxPrimitive1.isApprox(boxPrimitive2));
+
+  boxPrimitive2 = box3;
+  EXPECT_FALSE(boxPrimitive1.isApprox(boxPrimitive2));
+
   CollisionPrimitiveT<float> primitive1(capsule1);
   CollisionPrimitiveT<float> primitive2(capsule1);
   EXPECT_TRUE(primitive1.isApprox(primitive2));
@@ -98,6 +128,11 @@ TEST(CollisionGeometryTest, IsApprox) {
   EXPECT_FALSE(primitive1.isApprox(primitive2));
   EXPECT_TRUE(primitive2.isEllipsoid());
   EXPECT_TRUE(primitive2.toEllipsoid().isApprox(ellipsoid2));
+
+  primitive2 = box3;
+  EXPECT_FALSE(primitive1.isApprox(primitive2));
+  EXPECT_TRUE(primitive2.isBox());
+  EXPECT_TRUE(primitive2.toBox().isApprox(box3));
 }
 
 // Test the CollisionGeometryT type alias
@@ -127,6 +162,16 @@ TEST(CollisionGeometryTest, CollisionGeometryT) {
   EXPECT_TRUE(collisionGeometryFloat[1].isEllipsoid());
   EXPECT_TRUE(collisionGeometryFloat[1].ellipsoidRadii.isApprox(Vector3<float>(1.0f, 2.0f, 3.0f)));
   EXPECT_EQ(collisionGeometryFloat[1].parent, 1);
+
+  CollisionBoxT<float> boxFloat;
+  boxFloat.halfExtents = Vector3<float>(0.5f, 1.0f, 1.5f);
+  boxFloat.parent = 2;
+  collisionGeometryFloat.push_back(boxFloat);
+
+  EXPECT_EQ(collisionGeometryFloat.size(), 3);
+  EXPECT_TRUE(collisionGeometryFloat[2].isBox());
+  EXPECT_TRUE(collisionGeometryFloat[2].boxHalfExtents.isApprox(Vector3<float>(0.5f, 1.0f, 1.5f)));
+  EXPECT_EQ(collisionGeometryFloat[2].parent, 2);
 
   // Create a collision geometry with double precision
   CollisionGeometryT<double> collisionGeometryDouble;

--- a/momentum/test/character_solver/collision_error_function_test.cpp
+++ b/momentum/test/character_solver/collision_error_function_test.cpp
@@ -376,6 +376,102 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, EllipsoidCollisionError_ProducesError) {
   ASSERT_GE(numTestedPoses, 3) << "Too few poses produced collisions";
 }
 
+TYPED_TEST(Momentum_ErrorFunctionsTest, BoxCollisionError_ProducesError) {
+  using T = typename TestFixture::Type;
+
+  const Character baseCharacter = createTestCharacter(3);
+  const auto numJointParams = baseCharacter.skeleton.joints.size() * kParametersPerJoint;
+  ParameterTransform rootYTransform;
+  rootYTransform.name = {"root_ty"};
+  rootYTransform.offsets = Eigen::VectorXf::Zero(numJointParams);
+  rootYTransform.transform.resize(numJointParams, 1);
+  std::vector<Eigen::Triplet<float>> triplets;
+  triplets.emplace_back(0 * kParametersPerJoint + 1, 0, 1.0f);
+  rootYTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
+  rootYTransform.activeJointParams = rootYTransform.computeActiveJointParams();
+
+  CollisionGeometry cg;
+
+  TaperedCapsule jointCapsule;
+  jointCapsule.parent = 0;
+  jointCapsule.length = 1.0f;
+  jointCapsule.radius = Eigen::Vector2f(0.25f, 0.25f);
+  cg.push_back(jointCapsule);
+
+  CollisionBox worldBox;
+  worldBox.parent = kInvalidIndex;
+  worldBox.transformation.translation = Eigen::Vector3f(0.5f, 0.45f, 0.0f);
+  worldBox.halfExtents = Eigen::Vector3f(0.2f, 0.3f, 0.2f);
+  cg.push_back(worldBox);
+
+  const Character character(
+      baseCharacter.skeleton,
+      rootYTransform,
+      ParameterLimits(),
+      baseCharacter.locators,
+      baseCharacter.mesh.get(),
+      baseCharacter.skinWeights.get(),
+      &cg);
+
+  // Default rest-pose filtering (matches the always-filtering stateless function so the
+  // two stay identical). The single skeleton-capsule + world-fixed box pair is kept
+  // regardless of the flag: isValidCollisionPair short-circuits world-fixed pairs as valid
+  // before the rest-pose-overlap check.
+  CollisionErrorFunctionT<T> errorFunction(character);
+  CollisionErrorFunctionStatelessT<T> errorFunctionStateless(character);
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+  const ModelParametersT<T> zeroParams =
+      ModelParametersT<T>::Zero(transform.numAllModelParameters());
+  const SkeletonStateT<T> state(transform.apply(zeroParams), character.skeleton);
+
+  const double error = errorFunction.getError(zeroParams, state, MeshStateT<T>());
+  const double statelessError = errorFunctionStateless.getError(zeroParams, state, MeshStateT<T>());
+
+  EXPECT_GT(error, 0.0);
+  EXPECT_NEAR(error, statelessError, 1e-10);
+  EXPECT_EQ(errorFunction.getCollisionPairs().size(), 1);
+  const auto debugInfo = errorFunction.getCollisionDebugInfo();
+  ASSERT_EQ(debugInfo.size(), 1);
+  EXPECT_GT(debugInfo[0].overlap, 0.0);
+
+  // The fixture already seeds the singleton RNG in SetUp(); no per-test re-seed needed.
+  size_t numTestedPoses = 0;
+  for (size_t iTrial = 0; iTrial < 10; ++iTrial) {
+    const ModelParametersT<T> mp = uniform<VectorX<T>>(
+        transform.numAllModelParameters(), static_cast<T>(-0.03), static_cast<T>(0.03));
+    const SkeletonStateT<T> trialState(transform.apply(mp), character.skeleton);
+    if (errorFunction.getError(mp, trialState, MeshStateT<T>()) <= 0.0) {
+      continue;
+    }
+    SCOPED_TRACE("trial=" + std::to_string(iTrial));
+    // Keep the perturbation on the contact normal so finite differences stay on the same smooth
+    // box support feature.
+    const T numThreshold = T(0.02);
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunction,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/true);
+    TEST_GRADIENT_AND_JACOBIAN(
+        T,
+        &errorFunctionStateless,
+        mp,
+        character,
+        numThreshold,
+        TestFixture::getJacThreshold(),
+        /*checkJacError=*/true,
+        /*checkJacobian=*/true);
+    VALIDATE_IDENTICAL(
+        T, errorFunction, errorFunctionStateless, character.skeleton, transform, mp.v);
+    ++numTestedPoses;
+  }
+  ASSERT_GE(numTestedPoses, 3) << "Too few poses produced collisions";
+}
+
 // Test capsule collision gradients on a shared skeleton with global scaling.
 // Uses a double-branch skeleton (root → joint1 → joint2, root → joint3 → joint4)
 // so that:

--- a/momentum/test/character_solver_simd/simd_collision_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_collision_error_function_test.cpp
@@ -124,6 +124,109 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, CollisionBroadphaseAccuracy) {
       << "No collisions in " << kNumRandomPoses << " random poses; test is ineffective";
 }
 
+TYPED_TEST(Momentum_ErrorFunctionsTest, SimdCollisionErrorFunctionEllipsoidFallbackIsSame) {
+#ifndef MOMENTUM_ENABLE_SIMD
+  GTEST_SKIP() << "SIMD support is required for SIMD fallback comparison.";
+#else
+  using T = typename TestFixture::Type;
+
+  const Character baseCharacter = createTestCharacter(3);
+
+  CollisionGeometry cg;
+
+  TaperedCapsule jointCapsule;
+  jointCapsule.parent = 0;
+  jointCapsule.length = 1.0f;
+  jointCapsule.radius = Eigen::Vector2f(0.25f, 0.25f);
+  cg.push_back(jointCapsule);
+
+  CollisionEllipsoid worldEllipsoid;
+  worldEllipsoid.parent = kInvalidIndex;
+  worldEllipsoid.transformation.translation = Eigen::Vector3f(0.5f, 0.45f, 0.0f);
+  worldEllipsoid.radii = Eigen::Vector3f(0.2f, 0.3f, 0.2f);
+  cg.push_back(worldEllipsoid);
+
+  const Character character(
+      baseCharacter.skeleton,
+      baseCharacter.parameterTransform,
+      baseCharacter.parameterLimits,
+      baseCharacter.locators,
+      baseCharacter.mesh.get(),
+      baseCharacter.skinWeights.get(),
+      &cg);
+
+  CollisionErrorFunctionT<T> errfBase(character, true);
+  SimdCollisionErrorFunctionT<T> errfSimd(character);
+
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+  const ModelParametersT<T> mp = ModelParametersT<T>::Zero(transform.numAllModelParameters());
+  const SkeletonStateT<T> skelState(transform.apply(mp), character.skeleton);
+
+  const double errBase = errfBase.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_GT(errBase, 0.0);
+  const double errSimd = errfSimd.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_NEAR(errBase, errSimd, 1e-10);
+  VALIDATE_IDENTICAL(T, errfBase, errfSimd, character.skeleton, transform, mp.v);
+#endif
+}
+
+// Verify scalar-fallback equivalence with MULTIPLE ellipsoids in a single character. Complements
+// SimdCollisionErrorFunctionEllipsoidFallbackIsSame (single ellipsoid) by exercising the fallback
+// path when several non-capsule primitives are present in the collision geometry.
+TYPED_TEST(
+    Momentum_ErrorFunctionsTest,
+    SimdCollisionErrorFunctionMultipleEllipsoidsFallbackIsSame) {
+#ifndef MOMENTUM_ENABLE_SIMD
+  GTEST_SKIP() << "SIMD support is required for SIMD fallback comparison.";
+#else
+  using T = typename TestFixture::Type;
+
+  const Character baseCharacter = createTestCharacter(3);
+
+  CollisionGeometry cg;
+
+  TaperedCapsule jointCapsule;
+  jointCapsule.parent = 0;
+  jointCapsule.length = 1.0f;
+  jointCapsule.radius = Eigen::Vector2f(0.25f, 0.25f);
+  cg.push_back(jointCapsule);
+
+  CollisionEllipsoid ellipsoidA;
+  ellipsoidA.parent = kInvalidIndex;
+  ellipsoidA.transformation.translation = Eigen::Vector3f(0.5f, 0.45f, 0.0f);
+  ellipsoidA.radii = Eigen::Vector3f(0.2f, 0.3f, 0.2f);
+  cg.push_back(ellipsoidA);
+
+  CollisionEllipsoid ellipsoidB;
+  ellipsoidB.parent = kInvalidIndex;
+  ellipsoidB.transformation.translation = Eigen::Vector3f(-0.5f, 0.45f, 0.0f);
+  ellipsoidB.radii = Eigen::Vector3f(0.2f, 0.3f, 0.2f);
+  cg.push_back(ellipsoidB);
+
+  const Character character(
+      baseCharacter.skeleton,
+      baseCharacter.parameterTransform,
+      baseCharacter.parameterLimits,
+      baseCharacter.locators,
+      baseCharacter.mesh.get(),
+      baseCharacter.skinWeights.get(),
+      &cg);
+
+  CollisionErrorFunctionT<T> errfBase(character, true);
+  SimdCollisionErrorFunctionT<T> errfSimd(character);
+
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+  const ModelParametersT<T> mp = ModelParametersT<T>::Zero(transform.numAllModelParameters());
+  const SkeletonStateT<T> skelState(transform.apply(mp), character.skeleton);
+
+  const double errBase = errfBase.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_GT(errBase, 0.0);
+  const double errSimd = errfSimd.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_NEAR(errBase, errSimd, 1e-10);
+  VALIDATE_IDENTICAL(T, errfBase, errfSimd, character.skeleton, transform, mp.v);
+#endif
+}
+
 // Verify that the SIMD version of the collision error function is at least as fast as the
 // multithreaded versions. Disabled by default because it's too slow to run in CI.
 TEST(Momentum_ErrorFunctions, DISABLED_SimdCollisionErrorFunctionIsFaster) {

--- a/momentum/test/character_solver_simd/simd_collision_error_function_test.cpp
+++ b/momentum/test/character_solver_simd/simd_collision_error_function_test.cpp
@@ -227,6 +227,55 @@ TYPED_TEST(
 #endif
 }
 
+TYPED_TEST(Momentum_ErrorFunctionsTest, SimdCollisionErrorFunctionBoxFallbackIsSame) {
+#ifndef MOMENTUM_ENABLE_SIMD
+  GTEST_SKIP() << "SIMD support is required for SIMD fallback comparison.";
+#else
+  using T = typename TestFixture::Type;
+
+  const Character baseCharacter = createTestCharacter(3);
+
+  CollisionGeometry cg;
+
+  TaperedCapsule jointCapsule;
+  jointCapsule.parent = 0;
+  jointCapsule.length = 1.0f;
+  jointCapsule.radius = Eigen::Vector2f(0.25f, 0.25f);
+  cg.push_back(jointCapsule);
+
+  CollisionBox worldBox;
+  worldBox.parent = kInvalidIndex;
+  worldBox.transformation.translation = Eigen::Vector3f(0.5f, 0.45f, 0.0f);
+  worldBox.halfExtents = Eigen::Vector3f(0.2f, 0.3f, 0.2f);
+  cg.push_back(worldBox);
+
+  const Character character(
+      baseCharacter.skeleton,
+      baseCharacter.parameterTransform,
+      baseCharacter.parameterLimits,
+      baseCharacter.locators,
+      baseCharacter.mesh.get(),
+      baseCharacter.skinWeights.get(),
+      &cg);
+
+  // Match the SIMD function's internal scalar fallback (kFilterRestPoseOverlaps=true) and the
+  // sibling ellipsoid fallback tests so the reference builds the same valid-pair list. (Inert
+  // here because the box is world-fixed, but keeps the comparison robust if it is reparented.)
+  CollisionErrorFunctionT<T> errfBase(character, true);
+  SimdCollisionErrorFunctionT<T> errfSimd(character);
+
+  const ParameterTransformT<T> transform = character.parameterTransform.cast<T>();
+  const ModelParametersT<T> mp = ModelParametersT<T>::Zero(transform.numAllModelParameters());
+  const SkeletonStateT<T> skelState(transform.apply(mp), character.skeleton);
+
+  const double errBase = errfBase.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_GT(errBase, 0.0);
+  const double errSimd = errfSimd.getError(mp, skelState, MeshStateT<T>());
+  EXPECT_NEAR(errBase, errSimd, 1e-10);
+  VALIDATE_IDENTICAL(T, errfBase, errfSimd, character.skeleton, transform, mp.v);
+#endif
+}
+
 // Verify that the SIMD version of the collision error function is at least as fast as the
 // multithreaded versions. Disabled by default because it's too slow to run in CI.
 TEST(Momentum_ErrorFunctions, DISABLED_SimdCollisionErrorFunctionIsFaster) {

--- a/momentum/test/io/io_legacy_json_test.cpp
+++ b/momentum/test/io/io_legacy_json_test.cpp
@@ -103,6 +103,12 @@ class LegacyJsonIOTest : public ::testing::Test {
     capsule.parent = 0;
     capsule.length = 1.0f;
     collision->push_back(capsule);
+    CollisionEllipsoid ellipsoid;
+    ellipsoid.transformation = Eigen::Affine3f::Identity();
+    ellipsoid.transformation.translation = Eigen::Vector3f(0.2f, 0.3f, 0.4f);
+    ellipsoid.radii = Eigen::Vector3f(0.3f, 0.2f, 0.1f);
+    ellipsoid.parent = 1;
+    collision->push_back(ellipsoid);
 
     // Create parameter transform
     ParameterTransform parameterTransform =
@@ -165,7 +171,7 @@ TEST_F(LegacyJsonIOTest, RoundTripConversion) {
 
   // Verify collision geometry
   ASSERT_NE(roundTripCharacter.collision, nullptr);
-  EXPECT_EQ(roundTripCharacter.collision->size(), testCharacter_.collision->size());
+  compareCollisionGeometry(testCharacter_.collision, roundTripCharacter.collision);
 }
 
 TEST_F(LegacyJsonIOTest, SkeletonOnlyConversion) {

--- a/momentum/test/io/io_usd_test.cpp
+++ b/momentum/test/io/io_usd_test.cpp
@@ -488,6 +488,12 @@ TEST_F(UsdIoTest, SaveAndLoadRoundTrip_CollisionGeometry) {
   ASSERT_TRUE(testCharacter.collision);
   ASSERT_GT(testCharacter.collision->size(), 0);
 
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = 1;
+  ellipsoid.transformation.translation = Eigen::Vector3f(0.2f, 0.3f, 0.4f);
+  ellipsoid.radii = Eigen::Vector3f(0.3f, 0.2f, 0.1f);
+  testCharacter.collision->push_back(ellipsoid);
+
   auto tempFile = temporaryFile("momentum_usd_collision", ".usda");
   saveUsd(tempFile.path(), testCharacter);
 
@@ -500,15 +506,18 @@ TEST_F(UsdIoTest, SaveAndLoadRoundTrip_CollisionGeometry) {
     const auto& orig = (*testCharacter.collision)[i];
     const auto& loaded = (*loadedCharacter.collision)[i];
 
-    EXPECT_EQ(loaded.parent, orig.parent) << "Capsule parent mismatch at index " << i;
-    EXPECT_NEAR(loaded.length, orig.length, 1e-5f) << "Capsule length mismatch at index " << i;
+    EXPECT_EQ(loaded.type, orig.type) << "Collision type mismatch at index " << i;
+    EXPECT_EQ(loaded.parent, orig.parent) << "Collision parent mismatch at index " << i;
+    EXPECT_NEAR(loaded.length, orig.length, 1e-5f) << "Collision length mismatch at index " << i;
     EXPECT_TRUE(loaded.radius.isApprox(orig.radius, 1e-5f))
-        << "Capsule radius mismatch at index " << i;
+        << "Collision radius mismatch at index " << i;
+    EXPECT_TRUE(loaded.ellipsoidRadii.isApprox(orig.ellipsoidRadii, 1e-5f))
+        << "Collision ellipsoid radii mismatch at index " << i;
     EXPECT_TRUE(loaded.transformation.translation.isApprox(orig.transformation.translation, 1e-4f))
-        << "Capsule translation mismatch at index " << i;
+        << "Collision translation mismatch at index " << i;
     EXPECT_TRUE(loaded.transformation.rotation.toRotationMatrix().isApprox(
         orig.transformation.rotation.toRotationMatrix(), 1e-4f))
-        << "Capsule rotation mismatch at index " << i;
+        << "Collision rotation mismatch at index " << i;
   }
 }
 

--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -67,6 +67,8 @@ py::list collisionGeometryToPython(const mm::CollisionGeometry& collisionGeometr
       result.append(py::cast(primitive.toTaperedCapsule()));
     } else if (primitive.type == mm::CollisionPrimitiveType::Ellipsoid) {
       result.append(py::cast(primitive.toEllipsoid()));
+    } else if (primitive.type == mm::CollisionPrimitiveType::Box) {
+      result.append(py::cast(primitive.toBox()));
     } else {
       MT_THROW(
           "Unsupported collision primitive type while converting collision geometry to Python: {}",
@@ -84,9 +86,11 @@ mm::CollisionGeometry collisionGeometryFromPython(const py::sequence& collisionG
       result.push_back(item.cast<mm::TaperedCapsule>());
     } else if (py::isinstance<mm::CollisionEllipsoid>(item)) {
       result.push_back(item.cast<mm::CollisionEllipsoid>());
+    } else if (py::isinstance<mm::CollisionBox>(item)) {
+      result.push_back(item.cast<mm::CollisionBox>());
     } else {
       MT_THROW(
-          "Collision geometry entries must be TaperedCapsule or Ellipsoid; got {}",
+          "Collision geometry entries must be TaperedCapsule, Ellipsoid, or Box; got {}",
           py::str(py::type::handle_of(item)).cast<std::string>());
     }
   }
@@ -411,7 +415,7 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
               return py::list();
             }
           },
-          ":return: A list of :class:`TaperedCapsule` and :class:`Ellipsoid` objects representing the character's collision geometry.")
+          ":return: A list of collision geometry primitives (:class:`TaperedCapsule`, :class:`Ellipsoid`, and :class:`Box` objects) representing the character's collision geometry.")
       .def(
           "with_blend_shape",
           &withBlendShapeImpl,

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -223,6 +223,11 @@ PYBIND11_MODULE(geometry, m) {
       "Ellipsoid",
       "An ellipsoid primitive used for collision detection and physics simulation. "
       "Represents an oriented ellipsoid attached to a skeleton joint.");
+  auto boxClass = py::class_<mm::CollisionBox>(
+      m,
+      "Box",
+      "A box primitive used for collision detection and physics simulation. "
+      "Represents an oriented box attached to a skeleton joint.");
   py::class_<mm::SDFColliderT<float>> sdfColliderClass = py::class_<mm::SDFColliderT<float>>(
       m,
       "SDFCollider",
@@ -598,6 +603,49 @@ The resulting arrays are as follows:
             ellipsoid.radii[0],
             ellipsoid.radii[1],
             ellipsoid.radii[2]);
+      });
+
+  boxClass
+      .def(
+          py::init<>([](int parent,
+                        const OptionalTransformArray& transformation,
+                        const std::optional<Eigen::Vector3f>& halfExtents) {
+            mm::CollisionBox box;
+            box.transformation = collisionTransformFromPython(transformation);
+            box.halfExtents = halfExtents.value_or(Eigen::Vector3f::Ones());
+            box.parent = parent;
+            return box;
+          }),
+          R"(Create a box using its parent, transformation, and half extents.
+
+:param parent: Parent joint to which the box is attached.
+:param transformation: Transformation defining the center and orientation relative to the parent coordinate system.
+:param half_extents: Half extents along the local x, y, and z axes.)",
+          py::arg("parent"),
+          py::kw_only(),
+          py::arg("transformation") = py::none(),
+          py::arg("half_extents") = std::optional<Eigen::Vector3f>{})
+      .def_property_readonly(
+          "transformation",
+          [](const mm::CollisionBox& box) -> Eigen::Matrix4f {
+            return box.transformation.toMatrix();
+          },
+          "Transformation defining the center and orientation relative to the parent coordinate system")
+      .def_property_readonly(
+          "half_extents",
+          [](const mm::CollisionBox& box) -> Eigen::Vector3f { return box.halfExtents; },
+          "Half extents along the local x, y, and z axes.")
+      .def_property_readonly(
+          "parent",
+          [](const mm::CollisionBox& box) -> int { return collisionParentToPython(box.parent); },
+          "Parent joint to which the box is attached.")
+      .def("__repr__", [](const mm::CollisionBox& box) {
+        return fmt::format(
+            "Box(parent={}, half_extents=[{}, {}, {}])",
+            collisionParentToPython(box.parent),
+            box.halfExtents[0],
+            box.halfExtents[1],
+            box.halfExtents[2]);
       });
 
   // Class Marker, defining the properties:


### PR DESCRIPTION
Summary:

Track box half extents in collision state and add box support to the centered-primitive overlap and AABB calculations. Boxes route through the shared overlap/AABB and scalar-fallback solver paths, so no dedicated box solver is needed; this commit adds focused state, overlap, AABB, scaling, and solver tests (including SIMD fallback) covering boxes. The box scaling utility itself was added in the box-primitive commit.

Reviewed By: cstollmeta

Differential Revision: D105192533
