### PR TITLE
Exclude Triton backend tests on CPU pytest runs

### DIFF
--- a/pymomentum/test/conftest.py
+++ b/pymomentum/test/conftest.py
@@ -22,6 +22,13 @@ import os
 collect_ignore: list[str] = []
 
 try:
+    import torch
+
+    cuda_available = torch.cuda.is_available()
+except ImportError:
+    cuda_available = False
+
+try:
     import pymomentum.io_usd as _io_usd  # noqa: F401  # @manual=:io_usd
 
     usd_available = True
@@ -30,3 +37,12 @@ except ImportError:
 
 if not usd_available:
     collect_ignore.append(os.path.join(os.path.dirname(__file__), "test_usd.py"))
+
+if not cuda_available:
+    for test_file in (
+        "test_triton_fk_backend.py",
+        "test_triton_quaternion_backend.py",
+        "test_triton_skel_state_backend.py",
+        "test_triton_skinning_backend.py",
+    ):
+        collect_ignore.append(os.path.join(os.path.dirname(__file__), test_file))


### PR DESCRIPTION
Summary: Updates pytest collection to ignore the Triton backend test modules when CUDA is not available. This keeps CPU-only open-source test runs from collecting GPU-only backend tests while preserving collection on CUDA-enabled environments.

Differential Revision: D106873774


