### PR TITLE
Optimize GitHub CI runs

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -3,7 +3,7 @@ name: CI macOS
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore:
       - "**/website/**"
   pull_request:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install Momentum and Build hello_world
         run: |
-          pixi run install
+          pixi run install_no_build
           pixi run cmake \
             -S momentum/examples/hello_world \
             -B momentum/examples/hello_world/build \
@@ -113,7 +113,7 @@ jobs:
       - name: Build Python API Doc
         run: |
           MOMENTUM_BUILD_WITH_FBXSDK=ON \
-            pixi run doc_py
+            pixi run doc_py_no_build
 
       - name: Print ccache stats
         run: ccache -s

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -3,7 +3,7 @@ name: CI Ubuntu
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore:
       - "**/website/**"
   pull_request:
@@ -54,7 +54,7 @@ jobs:
         run: |
           MOMENTUM_BUILD_PYMOMENTUM=$MOMENTUM_BUILD_PYMOMENTUM \
             MOMENTUM_ENABLE_SIMD=$MOMENTUM_ENABLE_SIMD \
-            pixi run install
+            pixi run install_no_build
           pixi run cmake \
             -S momentum/examples/hello_world \
             -B momentum/examples/hello_world/build \
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build Python API Doc
         run: |
-          pixi run -e py312 doc_py
+          pixi run -e py312 doc_py_no_build
 
       - name: Upload Python API Doc
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -3,7 +3,7 @@ name: CI Windows
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore:
       - "**/website/**"
   pull_request:
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install Momentum and Build hello_world
         run: |
-          pixi run install
+          pixi run install_no_build
           pixi run cmake `
             -S momentum/examples/hello_world `
             -B momentum/examples/hello_world/build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build Python API Doc
         run: |
           MOMENTUM_BUILD_WITH_FBXSDK=ON \
-            pixi run doc_py
+            pixi run doc_py_no_build
 
       - name: Print ccache stats
         run: ccache -s

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -2,6 +2,8 @@ name: Publish Website
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "momentum/website/**"
       - "momentum/Doxyfile"
@@ -11,7 +13,6 @@ on:
     paths:
       - "momentum/website/**"
       - "momentum/Doxyfile"
-      - "pymomentum/**"
       - ".github/workflows/publish_website.yml"
   workflow_dispatch:
 
@@ -59,9 +60,10 @@ jobs:
         yarn install --frozen-lockfile
         yarn run build
 
-    # 3) Build Python API docs (only when pymomentum source changed)
+    # 3) Build Python API docs for main-branch deploys when pymomentum changed.
+    # PR validation happens in CI Ubuntu after the PyMomentum tests build the extension.
     - name: Free up disk space before pixi
-      if: steps.check_pymomentum.outputs.changed == 'true'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_pymomentum.outputs.changed == 'true'
       run: |
         sudo rm -rf /usr/share/dotnet || true
         sudo rm -rf /opt/ghc || true
@@ -75,26 +77,26 @@ jobs:
         df -h
 
     - name: Set up pixi
-      if: steps.check_pymomentum.outputs.changed == 'true'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_pymomentum.outputs.changed == 'true'
       uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.5
       with:
         cache: false
         environments: default
 
     - name: Build Python API Documentation
-      if: steps.check_pymomentum.outputs.changed == 'true'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_pymomentum.outputs.changed == 'true'
       run: |
         pixi run doc_py
 
     # 4) Copy Python API Documentation to Docusaurus (if built)
     - name: Copy Python API Documentation
-      if: steps.check_pymomentum.outputs.changed == 'true'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_pymomentum.outputs.changed == 'true'
       run: |
         cp -R build/python_api_doc momentum/website/build/python_api_doc
 
     # 4.5) Preserve existing Python API docs from gh-pages (when not rebuilt)
     - name: Preserve existing Python API docs from gh-pages
-      if: steps.check_pymomentum.outputs.changed != 'true'
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main' || steps.check_pymomentum.outputs.changed != 'true'
       run: |
         git fetch origin gh-pages --depth=1 || true
         if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then

--- a/pixi.toml
+++ b/pixi.toml
@@ -158,6 +158,7 @@ animate_shapes = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/release/animate_shape
 install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target install", depends-on = [
     "build",
 ], description = "Install built libraries and executables" }
+install_no_build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/release -j --target install", description = "Install libraries and executables without rebuilding first" }
 tracy = { cmd = "tracy-profiler", description = "Launch Tracy profiler GUI" }
 test_py = { cmd = "pytest pymomentum/test/", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
@@ -165,6 +166,7 @@ test_py = { cmd = "pytest pymomentum/test/", env = { MOMENTUM_MODELS_PATH = "mom
 test_py_verbose = { cmd = "pytest pymomentum/test/ -v", env = { MOMENTUM_MODELS_PATH = "momentum/" }, depends-on = [
     "build_py",
 ], description = "Run Python tests with verbose output" }
+doc_py_no_build = { cmd = "sphinx-build -a -E -W -b html pymomentum/doc build/python_api_doc", description = "Build Python API documentation without rebuilding first" }
 doc_py = { cmd = "sphinx-build -a -E -W -b html pymomentum/doc build/python_api_doc", depends-on = [
     "build_py",
 ], description = "Build Python API documentation with warnings as errors" }
@@ -494,6 +496,7 @@ animate_shapes = { cmd = "build/$PIXI_ENVIRONMENT_NAME/cpp/Release/animate_shape
 install = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp --target install --config Release --parallel", depends-on = [
     "build",
 ] }
+install_no_build = { cmd = "cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp --target install --config Release --parallel" }
 tracy = { cmd = "tracy-profiler.exe" }
 build_py = { cmd = "pip install . -v", env = { CMAKE_ARGS = """
     -DMOMENTUM_ENABLE_FBX_SAVING=$MOMENTUM_ENABLE_FBX_SAVING \


### PR DESCRIPTION
Summary: We currently duplicate github ci runs for each PR by listening to both pull_request and push. We also duplicate the same build for building docs. This diff optimizes ci to listen to `pull_request` on branches, and `push` on `main:`. And reuse already built artifacts for building docs.

Reviewed By: cstollmeta

Differential Revision: D106886771


