### PR TITLE
Seed Random::uniformQuaternion from the instance generator

### DIFF
--- a/momentum/math/random-inl.h
+++ b/momentum/math/random-inl.h
@@ -8,9 +8,12 @@
 #pragma once
 
 #include <momentum/math/random.h>
+
+#include <momentum/math/constants.h>
 #include <momentum/math/types.h>
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 
 namespace momentum {
@@ -232,7 +235,16 @@ DynamicMatrix Random<Generator>::uniform(
 template <typename Generator>
 template <typename T>
 Quaternion<T> Random<Generator>::uniformQuaternion() {
-  return Quaternion<T>::UnitRandom();
+  // Shoemake's method for a uniformly distributed unit quaternion (Haar measure on SO(3)). This
+  // matches the distribution of Eigen::Quaternion::UnitRandom() but draws from this instance's
+  // generator, so the result is controlled by setSeed(). Eigen's UnitRandom() instead uses the
+  // unseeded global std::rand(), which is not reproducible and is invisible to setSeed().
+  const T u1 = this->template uniform<T>(T(0), T(1));
+  const T u2 = this->template uniform<T>(T(0), twopi<T>());
+  const T u3 = this->template uniform<T>(T(0), twopi<T>());
+  const T a = std::sqrt(T(1) - u1);
+  const T b = std::sqrt(u1);
+  return Quaternion<T>(a * std::sin(u2), a * std::cos(u2), b * std::sin(u3), b * std::cos(u3));
 }
 
 template <typename Generator>

--- a/momentum/math/random-inl.h
+++ b/momentum/math/random-inl.h
@@ -314,9 +314,10 @@ uint32_t Random<Generator>::getSeed() const {
 
 template <typename Generator>
 void Random<Generator>::setSeed(uint32_t seed) {
-  if (seed == seed_) {
-    return;
-  }
+  // Always re-seed the engine, even when the value is unchanged. Callers (e.g. test fixtures that
+  // re-seed before every case) rely on setSeed() resetting the generator to the start of the
+  // deterministic sequence for `seed`; skipping the reset when seed == seed_ would silently leave
+  // the engine advanced by previous draws and make consumers order-dependent.
   seed_ = seed;
   generator_.seed(seed_);
 }

--- a/momentum/test/math/random_test.cpp
+++ b/momentum/test/math/random_test.cpp
@@ -453,6 +453,29 @@ TYPED_TEST(RandomTest, UniformQuaternion) {
   }
 }
 
+// Regression test: uniformQuaternion() must draw from the instance generator so it is reproducible
+// under a fixed seed. It previously delegated to Eigen::Quaternion::UnitRandom(), which uses the
+// unseeded global std::rand() and is therefore order-dependent and invisible to setSeed().
+TYPED_TEST(RandomTest, UniformQuaternionIsReproducibleFromSeed) {
+  using T = typename TestFixture::Type;
+
+  Random<> r0(777);
+  Random<> r1(777);
+  for (int i = 0; i < 16; ++i) {
+    const Quaternion<T> q0 = r0.template uniformQuaternion<T>();
+    const Quaternion<T> q1 = r1.template uniformQuaternion<T>();
+    EXPECT_TRUE(q0.coeffs().isApprox(q1.coeffs()))
+        << "q0=" << q0.coeffs().transpose() << " q1=" << q1.coeffs().transpose();
+  }
+
+  // Re-seeding restarts the quaternion sequence.
+  r0.setSeed(777);
+  const Quaternion<T> qFirstAgain = r0.template uniformQuaternion<T>();
+  Random<> rFresh(777);
+  const Quaternion<T> qFresh = rFresh.template uniformQuaternion<T>();
+  EXPECT_TRUE(qFirstAgain.coeffs().isApprox(qFresh.coeffs()));
+}
+
 TEST(RandomTest, ScalarNormal) {
   const auto numTests = 1000;
   const float mean = 2.5f;

--- a/momentum/test/math/random_test.cpp
+++ b/momentum/test/math/random_test.cpp
@@ -82,6 +82,23 @@ TEST(RandomTest, DeterministicBySeed) {
   }
 }
 
+// Regression test: setSeed() must reset the engine even when the new seed equals the current
+// seed. A previous early-return optimization skipped re-seeding in that case, which silently
+// defeated per-test reseeding (e.g. fixture SetUp()) and made whole test suites order-dependent
+// when run in a single process.
+TEST(RandomTest, SetSeedAlwaysResetsStream) {
+  Random<> rng(12345);
+  const double first = rng.uniform<double>(0.0, 1.0);
+  const double second = rng.uniform<double>(0.0, 1.0);
+  ASSERT_NE(first, second) << "sanity: drawing should advance the engine";
+
+  // Re-seed with the SAME value that is already stored; this must restart the sequence.
+  rng.setSeed(12345);
+  const double afterReset = rng.uniform<double>(0.0, 1.0);
+  EXPECT_EQ(first, afterReset)
+      << "setSeed(currentSeed) must reset the engine to the start of the sequence";
+}
+
 TEST(RandomTest, ScalarUniform) {
   const auto numTests = 1000;
 


### PR DESCRIPTION
Summary:
`Random::uniformQuaternion()` (and therefore `uniformRotationMatrix()`, `uniformIsometry3()`, and `uniformAffine3()`, which all delegate to it) returned `Eigen::Quaternion::UnitRandom()`. Eigen's `UnitRandom()` draws from the unseeded global `std::rand()`, so the result ignored both the instance seed and `setSeed()`. Tests that switched from `Quaternion::UnitRandom()` to `rng.uniformQuaternion<T>()` for reproducibility therefore gained nothing, and any single-process test run that drew random rotations stayed order-dependent (the rotations depended on cumulative `std::rand()` calls across the whole binary).

Reimplement `uniformQuaternion()` with Shoemake's method, drawing three uniforms from the instance generator. This produces the same uniform (Haar) distribution on SO(3) as Eigen's `UnitRandom()` but is fully controlled by the seed. Add a regression test (`UniformQuaternionIsReproducibleFromSeed`) verifying two equally-seeded generators produce identical quaternion sequences and that re-seeding restarts the sequence.

Differential Revision: D106961073


