### PR TITLE
Enable projected center-of-mass support constraint (#1468)

### DIFF
--- a/momentum/character_solver/center_of_mass_error_function.cpp
+++ b/momentum/character_solver/center_of_mass_error_function.cpp
@@ -12,7 +12,10 @@
 #include "momentum/common/checks.h"
 #include "momentum/common/profile.h"
 
+#include <array>
+#include <cmath>
 #include <numeric>
+#include <utility>
 #include <vector>
 
 namespace momentum {
@@ -28,6 +31,51 @@ Eigen::Vector3<T> worldMassPosition(
     return jointState.translation();
   }
   return jointState.transform * constraint.offsets[index];
+}
+
+template <typename T>
+Eigen::Vector3<T> centerOfMass(
+    const CenterOfMassConstraintT<T>& constraint,
+    const JointStateListT<T>& jointStates) {
+  const T invTotalMass = T(1) / constraint.totalMass();
+
+  Eigen::Vector3<T> com = Eigen::Vector3<T>::Zero();
+  for (size_t i = 0; i < constraint.jointIndices.size(); ++i) {
+    const Eigen::Vector3<T> worldPos =
+        worldMassPosition(jointStates[constraint.jointIndices[i]], constraint, i);
+    com += constraint.masses[i] * worldPos;
+  }
+  return com * invTotalMass;
+}
+
+template <typename T>
+Eigen::Vector3<T> projectToPlane(
+    const Eigen::Vector3<T>& position,
+    const CenterOfMassConstraintT<T>& constraint) {
+  return position -
+      constraint.projectionNormal *
+      (position.dot(constraint.projectionNormal) - constraint.projectionD);
+}
+
+template <typename T>
+Eigen::Matrix<T, 3, 3> residualDerivative(const CenterOfMassConstraintT<T>& constraint) {
+  if (!constraint.projectToPlane) {
+    return Eigen::Matrix<T, 3, 3>::Identity();
+  }
+
+  return Eigen::Matrix<T, 3, 3>::Identity() -
+      constraint.projectionNormal * constraint.projectionNormal.transpose();
+}
+
+template <typename T>
+Eigen::Vector3<T> centerOfMassResidual(
+    const Eigen::Vector3<T>& com,
+    const CenterOfMassConstraintT<T>& constraint) {
+  if (!constraint.projectToPlane) {
+    return com - constraint.target;
+  }
+
+  return projectToPlane(com, constraint) - constraint.target;
 }
 
 } // namespace
@@ -69,7 +117,20 @@ void CenterOfMassErrorFunctionT<T>::addConstraint(const ConstraintType& constrai
     MT_CHECK(jointIdx < this->skeleton_.joints.size(), "Invalid joint index: {}", jointIdx);
   }
 
-  constraints_.push_back(constraint);
+  ConstraintType normalizedConstraint = constraint;
+  if (normalizedConstraint.projectToPlane) {
+    MT_CHECK(
+        normalizedConstraint.projectionNormal.allFinite(),
+        "Projection plane normal must contain only finite values");
+    MT_CHECK(
+        std::isfinite(normalizedConstraint.projectionD), "Projection plane offset must be finite");
+    const T normalNorm = normalizedConstraint.projectionNormal.norm();
+    MT_CHECK(normalNorm > T(1e-6), "Projection plane normal must be non-zero");
+    normalizedConstraint.projectionNormal /= normalNorm;
+    normalizedConstraint.projectionD /= normalNorm;
+  }
+
+  constraints_.push_back(std::move(normalizedConstraint));
 }
 
 template <typename T>
@@ -109,20 +170,9 @@ double CenterOfMassErrorFunctionT<T>::getError(
   double error = 0.0;
 
   for (const auto& constr : constraints_) {
-    const T invTotalMass = T(1) / constr.totalMass();
-
-    // Compute center of mass: CoM = (sum m_k * p_k) / (sum m_k)
-    Eigen::Vector3<T> com = Eigen::Vector3<T>::Zero();
-    for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
-      const Eigen::Vector3<T> worldPos =
-          worldMassPosition(state.jointState[constr.jointIndices[i]], constr, i);
-      com += constr.masses[i] * worldPos;
-    }
-    com *= invTotalMass;
-
-    // Residual: f = CoM - target
-    const Eigen::Vector3<T> residual = com - constr.target;
-    error += constr.weight * residual.squaredNorm() * this->weight_;
+    const Eigen::Vector3<T> com = centerOfMass(constr, state.jointState);
+    const Eigen::Vector3<T> res = centerOfMassResidual(com, constr);
+    error += constr.weight * res.squaredNorm() * this->weight_;
   }
 
   return error;
@@ -166,16 +216,17 @@ double CenterOfMassErrorFunctionT<T>::getGradient(
     }
     com *= invTotalMass;
 
-    // Residual: f = CoM - target
-    const Eigen::Vector3<T> residual = com - constr.target;
+    // Residual: f = project(CoM) - target (projection applied when configured)
+    const Eigen::Vector3<T> residual = centerOfMassResidual(com, constr);
     error += constr.weight * residual.squaredNorm() * this->weight_;
 
     const T wgt = T(2) * constr.weight * this->weight_;
 
     // The weighted residual for accumulateJointGradient is 2 * weight * f.
-    // The dfdv encodes the normalizedMass factor: dfdv = (m_k / totalMass) * I_3x3
+    // The dfdv encodes the normalizedMass factor and optional projection derivative.
     // accumulateJointGradient computes: gradient += weightedResidual^T * dfdv * d(worldPos)/dq
     const Eigen::Vector3<T> weightedRes = wgt * residual;
+    const Eigen::Matrix<T, 3, 3> dResidualDCom = residualDerivative(constr);
 
     for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
       const size_t jointIdx = constr.jointIndices[i];
@@ -183,7 +234,7 @@ double CenterOfMassErrorFunctionT<T>::getGradient(
       const Eigen::Vector3<T> worldPos =
           hasOffsets ? worldPositions[i] : state.jointState[jointIdx].translation();
 
-      const Eigen::Matrix<T, 3, 3> dfdv = normalizedMass * Eigen::Matrix<T, 3, 3>::Identity();
+      const Eigen::Matrix<T, 3, 3> dfdv = normalizedMass * dResidualDCom;
       std::array<Eigen::Vector3<T>, 1> worldVecs = {worldPos};
       std::array<Eigen::Matrix<T, 3, 3>, 1> dfdvArr = {dfdv};
       std::array<uint8_t, 1> isPoints = {1};
@@ -241,12 +292,13 @@ double CenterOfMassErrorFunctionT<T>::getJacobian(
     }
     com *= invTotalMass;
 
-    // Residual: f = CoM - target
-    const Eigen::Vector3<T> res = com - constr.target;
+    // Residual: f = project(CoM) - target (projection applied when configured)
+    const Eigen::Vector3<T> res = centerOfMassResidual(com, constr);
     error += constr.weight * res.squaredNorm() * this->weight_;
 
     const T wgt = std::sqrt(constr.weight * this->weight_);
     residual.template segment<3>(rowIndex) = wgt * res;
+    const Eigen::Matrix<T, 3, 3> dResidualDCom = residualDerivative(constr);
 
     // For each joint, accumulate Jacobian
     for (size_t i = 0; i < constr.jointIndices.size(); ++i) {
@@ -255,7 +307,7 @@ double CenterOfMassErrorFunctionT<T>::getJacobian(
       const Eigen::Vector3<T> worldPos =
           hasOffsets ? worldPositions[i] : state.jointState[jointIdx].translation();
 
-      const Eigen::Matrix<T, 3, 3> dfdv = normalizedMass * Eigen::Matrix<T, 3, 3>::Identity();
+      const Eigen::Matrix<T, 3, 3> dfdv = normalizedMass * dResidualDCom;
       std::array<Eigen::Vector3<T>, 1> worldVecs = {worldPos};
       std::array<Eigen::Matrix<T, 3, 3>, 1> dfdvArr = {dfdv};
       std::array<uint8_t, 1> isPoints = {1};

--- a/momentum/character_solver/center_of_mass_error_function.h
+++ b/momentum/character_solver/center_of_mass_error_function.h
@@ -55,6 +55,18 @@ struct CenterOfMassConstraintT {
   /// Target position for the center of mass
   Eigen::Vector3<T> target = Eigen::Vector3<T>::Zero();
 
+  /// If true, project the computed center of mass to @p projectionNormal dot x - @p projectionD = 0
+  /// before comparing it to @p target.
+  ///
+  /// The target is expected to already lie on the same projection plane.
+  bool projectToPlane = false;
+
+  /// Normal for the optional projection plane.
+  Eigen::Vector3<T> projectionNormal = Eigen::Vector3<T>::UnitY();
+
+  /// Offset for the optional projection plane in the equation normal dot x - d = 0.
+  T projectionD = T(0);
+
   /// Weight of this constraint
   T weight = T(1);
 
@@ -74,6 +86,9 @@ struct CenterOfMassConstraintT {
 ///
 /// The residual is:
 ///   f = CoM - target
+/// or, when projection is enabled:
+///   f = project(CoM) - target
+/// where project(x) orthogonally projects x to the configured plane.
 ///
 /// This uses SkeletonDerivativeT for efficient hierarchy walks, similar to
 /// CameraProjectionErrorFunctionT.

--- a/momentum/test/character_solver/center_of_mass_error_function_test.cpp
+++ b/momentum/test/character_solver/center_of_mass_error_function_test.cpp
@@ -65,6 +65,49 @@ TYPED_TEST(CenterOfMassErrorFunctionTest, GradientsAndJacobians) {
       false);
 }
 
+TYPED_TEST(CenterOfMassErrorFunctionTest, ProjectedGradientsAndJacobians) {
+  using T = typename TestFixture::Type;
+  Random<>::GetSingleton().setSeed(12345);
+
+  const Character character = createTestCharacter();
+  const auto& skeleton = character.skeleton;
+  const auto& parameterTransform = character.parameterTransform;
+
+  const Eigen::VectorX<T> refParams =
+      0.25 * uniform<VectorX<T>>(parameterTransform.numAllModelParameters(), -1, 1);
+  const ModelParametersT<T> modelParams = refParams;
+
+  CenterOfMassErrorFunctionT<T> errorFunction(skeleton, parameterTransform);
+
+  const Eigen::Vector3<T> planeNormal = Eigen::Vector3<T>(T(1), T(2), T(-1)).normalized();
+  const T planeD = T(0.25);
+  const auto targetSeed = uniform<Vector3<T>>(-1, 1);
+
+  CenterOfMassConstraintT<T> constraint;
+  const size_t numJoints = std::min<size_t>(4, skeleton.joints.size());
+  for (size_t j = 0; j < numJoints; ++j) {
+    constraint.jointIndices.push_back(j);
+    constraint.masses.push_back(T(1) + T(j) * T(0.5));
+    constraint.offsets.push_back(uniform<Vector3<T>>(-0.25, 0.25));
+  }
+  constraint.target = targetSeed - planeNormal * (targetSeed.dot(planeNormal) - planeD);
+  constraint.projectToPlane = true;
+  constraint.projectionNormal = T(2) * planeNormal;
+  constraint.projectionD = T(2) * planeD;
+  constraint.weight = T(1.5);
+  errorFunction.addConstraint(constraint);
+
+  TEST_GRADIENT_AND_JACOBIAN(
+      T,
+      &errorFunction,
+      modelParams,
+      character,
+      Eps<T>(5e-2f, 5e-4),
+      Eps<T>(1e-4f, 1e-8),
+      false,
+      false);
+}
+
 TYPED_TEST(CenterOfMassErrorFunctionTest, ZeroError) {
   using T = typename TestFixture::Type;
 
@@ -93,6 +136,39 @@ TYPED_TEST(CenterOfMassErrorFunctionTest, ZeroError) {
   }
   actualCoM /= totalMass;
   constraint.target = actualCoM;
+  constraint.weight = T(1);
+  errorFunction.addConstraint(constraint);
+
+  const double error = errorFunction.getError(
+      modelParams, skelState, MeshStateT<T>(modelParams, skelState, character));
+  EXPECT_NEAR(error, 0.0, Eps<T>(1e-5f, 1e-10));
+}
+
+TYPED_TEST(CenterOfMassErrorFunctionTest, ProjectedZeroErrorIgnoresHeightAbovePlane) {
+  using T = typename TestFixture::Type;
+  Random<>::GetSingleton().setSeed(12345);
+
+  const Character character = createTestCharacter();
+  const auto& skeleton = character.skeleton;
+  const auto& parameterTransform = character.parameterTransform;
+  const ParameterTransformT<T> transform = parameterTransform.cast<T>();
+
+  ModelParametersT<T> modelParams =
+      ModelParametersT<T>::Zero(parameterTransform.numAllModelParameters());
+  modelParams(0) = T(1);
+  modelParams(1) = T(2);
+  modelParams(2) = T(3);
+  const SkeletonStateT<T> skelState(transform.apply(modelParams), skeleton);
+
+  CenterOfMassErrorFunctionT<T> errorFunction(skeleton, parameterTransform);
+
+  CenterOfMassConstraintT<T> constraint;
+  constraint.jointIndices = {0};
+  constraint.masses = {T(1)};
+  constraint.target = Eigen::Vector3<T>(T(1), T(0), T(3));
+  constraint.projectToPlane = true;
+  constraint.projectionNormal = Eigen::Vector3<T>(T(0), T(2), T(0));
+  constraint.projectionD = T(0);
   constraint.weight = T(1);
   errorFunction.addConstraint(constraint);
 


### PR DESCRIPTION
Summary:

Adds an optional plane-projected residual to `CenterOfMassErrorFunction` and uses it to keep the projected center of mass over a support polygon, improving balance.

`CenterOfMassConstraintT` gains `projectToPlane`, `projectionNormal`, and `projectionD` fields whose defaults preserve existing behavior. The projection-plane normal is normalized in `addConstraint`, and `getError`, `getGradient`, and `getJacobian` all compute the same projected residual with the projection derivative `(I - n n^T)`, so the analytic gradient and Jacobian stay consistent.

Differential Revision: D106968643


