### PR TITLE
Add Character.with_metadata() builder (#1469)

### DIFF
--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -339,6 +339,33 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           )",
           py::arg("skinned_locators"),
           py::arg("replace") = false)
+      .def(
+          "with_metadata",
+          [](const mm::Character& character, const std::string& metadata) {
+            return momentum::Character(
+                character.skeleton,
+                character.parameterTransform,
+                character.parameterLimits,
+                character.locators,
+                character.mesh.get(),
+                character.skinWeights.get(),
+                character.collision.get(),
+                character.poseShapes.get(),
+                character.blendShape,
+                character.faceExpressionBlendShape,
+                character.name,
+                character.inverseBindPose,
+                character.skinnedLocators,
+                metadata,
+                character.physicalProperties);
+          },
+          R"(Returns a new character with the passed-in metadata string.
+
+          When the character is exported to FBX, the metadata string is written as a "metadata" property on the skeleton root node, so it is a convenient channel for attaching arbitrary key/value data (e.g. JSON-encoded) to an exported clip.
+
+          :param metadata: The metadata string to attach to the character.
+          )",
+          py::arg("metadata"))
       .def_readonly("name", &mm::Character::name, "The character's name.")
       .def_readonly("metadata", &mm::Character::metadata, "The character's metadata.")
       .def_readonly(


### PR DESCRIPTION
Summary:

Adds an immutable `with_metadata(metadata: str) -> Character` builder to the geometry bindings, mirroring the existing `with_locators` / `with_parameter_limits` / `with_skinned_locators` pattern. It returns a new character with the `metadata` field replaced, leaving all other data unchanged.

Momentum already serializes `Character.metadata` as a "metadata" string property on the FBX skeleton root node, but the field was exposed to Python as `def_readonly`, so there was no way to set it from Python. This builder provides a clean, convention-matching write path (the class is otherwise immutable, so a builder is preferred over flipping the field to `def_readwrite`).

Also regenerates `geometry.pyi`.

Reviewed By: cstollmeta

Differential Revision: D106872137
