### PR TITLE
Remove default `EulerConvention` parameter from momentum math rotation functions

### DIFF
--- a/momentum/character/skeleton_state.cpp
+++ b/momentum/character/skeleton_state.cpp
@@ -338,7 +338,8 @@ localTransformToJointParametersRespectingConstraints(
   } else if (numActiveAxes == 3) {
     // ZYX-then-reverse matches the (Rx * Ry * Rz) convention used elsewhere in momentum and
     // produces the same parameters as the unconstrained quaternionToEuler path.
-    result.template segment<3>(3) = rotationMatrixToEulerZYX(rotationMatrix).reverse();
+    result.template segment<3>(3) =
+        rotationMatrixToEulerZYX(rotationMatrix, EulerConvention::Intrinsic).reverse();
   } else {
     // numActiveAxes == 0: leave rotation parameters at zero.
   }

--- a/momentum/character/types.h
+++ b/momentum/character/types.h
@@ -130,17 +130,6 @@ struct JointParametersT : public EigenStrongType<JointParametersT, ::Eigen::Vect
   using t = ::Eigen::VectorX<T>;
   using EigenStrongType<JointParametersT, t>::EigenStrongType;
   using EigenStrongType<JointParametersT, t>::operator=;
-
-  [[nodiscard]] static ::Eigen::Vector3<T> fromRotationMatrix(const ::Eigen::Matrix3<T>& m) {
-    // From JointState::set(), we can see that localRotation = rz * ry * rx, but the order in
-    // JointParameters is [rx, ry, rz]. Therefore, the conversion should be
-    // rotationMatrixToEulerZYX.reverse.
-    return rotationMatrixToEulerZYX(m).reverse();
-  }
-
-  [[nodiscard]] static ::Eigen::Vector3<T> fromQuaternion(const ::Eigen::Quaternion<T>& q) {
-    return fromRotationMatrix(q.toRotationMatrix());
-  }
 };
 
 using JointParameters = JointParametersT<float>;

--- a/momentum/io/bvh/bvh_io.cpp
+++ b/momentum/io/bvh/bvh_io.cpp
@@ -340,7 +340,8 @@ void mapBvhJointToModelParams(
     // Decompose to Momentum's ZYX convention: [rx, ry, rz]
     // Momentum applies rotations as R = Rz(rz) * Ry(ry) * Rx(rx)
     // so we decompose as ZYX and reverse to get [rx, ry, rz]
-    const Vector3f eulerAngles = rotationMatrixToEulerZYX(q.toRotationMatrix()).reverse();
+    const Vector3f eulerAngles =
+        rotationMatrixToEulerZYX(q.toRotationMatrix(), EulerConvention::Intrinsic).reverse();
     motion(jointParamBase + RX, frameIdx) = eulerAngles[0];
     motion(jointParamBase + RY, frameIdx) = eulerAngles[1];
     motion(jointParamBase + RZ, frameIdx) = eulerAngles[2];

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -149,7 +149,8 @@ inline SkeletonNodeResult createSkeletonNodes(
     skeletonNode->LclTranslation.Set(FbxDouble3(
         joint.translationOffset[0], joint.translationOffset[1], joint.translationOffset[2]));
 
-    const auto angles = rotationMatrixToEulerZYX(joint.preRotation.toRotationMatrix());
+    const auto angles =
+        rotationMatrixToEulerZYX(joint.preRotation.toRotationMatrix(), EulerConvention::Intrinsic);
     skeletonNode->SetPivotState(FbxNode::eSourcePivot, FbxNode::ePivotActive);
     skeletonNode->SetRotationActive(true);
     skeletonNode->SetPreRotation(

--- a/momentum/math/utility.h
+++ b/momentum/math/utility.h
@@ -189,21 +189,17 @@ template <typename T>
     int axis0,
     int axis1,
     int axis2,
-    EulerConvention convention = EulerConvention::Intrinsic);
+    EulerConvention convention);
 
 /// An optimized version of rotationMatrixToEuler(m, 0, 1, 2, convention) or
 /// rotationMatrixToEuler(m, 2, 1, 0, convention).reverse().
 template <typename T>
-[[nodiscard]] Vector3<T> rotationMatrixToEulerXYZ(
-    const Matrix3<T>& m,
-    EulerConvention convention = EulerConvention::Intrinsic);
+[[nodiscard]] Vector3<T> rotationMatrixToEulerXYZ(const Matrix3<T>& m, EulerConvention convention);
 
 /// An optimized version of rotationMatrixToEuler(m, 2, 1, 0, convention) or
 /// rotationMatrixToEuler(m, 0, 1, 2, convention).reverse().
 template <typename T>
-[[nodiscard]] Vector3<T> rotationMatrixToEulerZYX(
-    const Matrix3<T>& m,
-    EulerConvention convention = EulerConvention::Intrinsic);
+[[nodiscard]] Vector3<T> rotationMatrixToEulerZYX(const Matrix3<T>& m, EulerConvention convention);
 
 /// Fits a two-axis Euler rotation to a rotation matrix
 ///
@@ -250,7 +246,7 @@ template <typename T>
     int axis0,
     int axis1,
     int axis2,
-    EulerConvention convention = EulerConvention::Intrinsic);
+    EulerConvention convention);
 
 /// Converts Euler angles to rotation matrix
 ///
@@ -266,21 +262,21 @@ template <typename T>
     int axis0,
     int axis1,
     int axis2,
-    EulerConvention convention = EulerConvention::Intrinsic);
+    EulerConvention convention);
 
 /// An optimized version of eulerToRotationMatrix(angles, 0, 1, 2, convention) or
 /// eulerToRotationMatrix(angles.reverse(), 2, 1, 0, convention).
 template <typename T>
 [[nodiscard]] Matrix3<T> eulerXYZToRotationMatrix(
     const Vector3<T>& angles,
-    EulerConvention convention = EulerConvention::Intrinsic);
+    EulerConvention convention);
 
 /// An optimized version of eulerToRotationMatrix(angles, 2, 1, 0, convention) or
 /// eulerToRotationMatrix(angles.reverse(), 0, 1, 2, convention).
 template <typename T>
 [[nodiscard]] Matrix3<T> eulerZYXToRotationMatrix(
     const Vector3<T>& angles,
-    EulerConvention convention = EulerConvention::Intrinsic);
+    EulerConvention convention);
 
 /// Converts a quaternion to Euler angles using the Extrinsic XYZ convention
 ///


### PR DESCRIPTION
Summary:
The momentum math library rotation conversion functions (`rotationMatrixToEuler`, `rotationMatrixToEulerXYZ`, `rotationMatrixToEulerZYX`, `eulerToQuaternion`, `eulerToRotationMatrix`, `eulerXYZToRotationMatrix`, `eulerZYXToRotationMatrix`) all defaulted to `EulerConvention::Intrinsic`, while the skeleton system uses Extrinsic XYZ throughout. This implicit default was confusing and error-prone.

This diff removes the default parameter value, forcing every caller to explicitly specify the convention. All existing callers that relied on the default now pass `EulerConvention::Intrinsic` explicitly, preserving behavior.

This is phase 1 of a cleanup. Phase 2 (future diff) will audit each call site and migrate to Extrinsic where appropriate, with the goal of eventually removing the `EulerConvention` parameter entirely and standardizing on Extrinsic.

Also adds `#include <momentum/math/utility.h>` to `types.h` so it is self-contained (it already used `rotationMatrixToEulerZYX` from that header via transitive includes).

Reviewed By: fbogo

Differential Revision: D106719932


