### PR TITLE
Replace `rotationMatrixToEulerZYX(m, Intrinsic).reverse()` with `rotationMatrixToEulerXYZ(m, Extrinsic)` (#1471)

### DIFF
--- a/momentum/character/skeleton_state.cpp
+++ b/momentum/character/skeleton_state.cpp
@@ -336,10 +336,10 @@ localTransformToJointParametersRespectingConstraints(
     result(3 + activeAxes[0]) = angles[0];
     result(3 + activeAxes[1]) = angles[1];
   } else if (numActiveAxes == 3) {
-    // ZYX-then-reverse matches the (Rx * Ry * Rz) convention used elsewhere in momentum and
-    // produces the same parameters as the unconstrained quaternionToEuler path.
+    // Decompose into Extrinsic XYZ angles [rx, ry, rz], matching the convention used by
+    // JointStateT::set() and the unconstrained quaternionToEuler path.
     result.template segment<3>(3) =
-        rotationMatrixToEulerZYX(rotationMatrix, EulerConvention::Intrinsic).reverse();
+        rotationMatrixToEulerXYZ(rotationMatrix, EulerConvention::Extrinsic);
   } else {
     // numActiveAxes == 0: leave rotation parameters at zero.
   }

--- a/momentum/io/bvh/bvh_io.cpp
+++ b/momentum/io/bvh/bvh_io.cpp
@@ -337,11 +337,9 @@ void mapBvhJointToModelParams(
   // Convert BVH rotation to Momentum's ZYX convention
   const Quaternionf q = convertBvhRotationToQuaternion(bvhJoint, frameData);
   if (!q.isApprox(Quaternionf::Identity())) {
-    // Decompose to Momentum's ZYX convention: [rx, ry, rz]
-    // Momentum applies rotations as R = Rz(rz) * Ry(ry) * Rx(rx)
-    // so we decompose as ZYX and reverse to get [rx, ry, rz]
+    // Decompose into Momentum's Extrinsic XYZ convention: [rx, ry, rz]
     const Vector3f eulerAngles =
-        rotationMatrixToEulerZYX(q.toRotationMatrix(), EulerConvention::Intrinsic).reverse();
+        rotationMatrixToEulerXYZ(q.toRotationMatrix(), EulerConvention::Extrinsic);
     motion(jointParamBase + RX, frameIdx) = eulerAngles[0];
     motion(jointParamBase + RY, frameIdx) = eulerAngles[1];
     motion(jointParamBase + RZ, frameIdx) = eulerAngles[2];


### PR DESCRIPTION
Summary:

The `rotationMatrixToEulerZYX(m, Intrinsic).reverse()` idiom is mathematically equivalent to `rotationMatrixToEulerXYZ(m, Extrinsic)`, but the latter directly expresses the intent: decompose a rotation matrix into Extrinsic XYZ Euler angles matching momentum's skeleton convention.

This diff replaces all 10 call sites that used the ZYX+reverse trick with the direct Extrinsic XYZ call. No behavior change.

The one `rotationMatrixToEulerZYX` call without `.reverse()` (`fbx_io_internal.h`) is left as-is since it genuinely needs ZYX decomposition for FBX pre-rotation export.

Reviewed By: cstollmeta

Differential Revision: D106722162


