### PR TITLE
Refactor legacy collision JSON parsing

### DIFF
--- a/momentum/character_solver_simd/simd_collision_error_function.cpp
+++ b/momentum/character_solver_simd/simd_collision_error_function.cpp
@@ -250,6 +250,62 @@ void SimdCollisionErrorFunctionT<T>::accumulateCommonAncestorScaleGradient(
 }
 
 template <typename T>
+void SimdCollisionErrorFunctionT<T>::accumulateJacobianAlongChain(
+    const SkeletonStateT<T>& state,
+    const Vector3<T>& position,
+    const Vector3<T>& direction,
+    const T factor,
+    size_t startJoint,
+    size_t stopJoint,
+    Ref<MatrixX<T>> jacobian,
+    const int row,
+    const T scaleCorrection) const {
+  size_t jointIndex = startJoint;
+  while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
+    const auto& jointState = state.jointState[jointIndex];
+    const size_t paramIndex = jointIndex * kParametersPerJoint;
+    const Vector3<T> posd = position - jointState.translation();
+
+    for (size_t d = 0; d < 3; d++) {
+      if (this->activeJointParams_[paramIndex + d]) {
+        const T val = direction.dot(jointState.getTranslationDerivative(d)) * factor;
+        jacobian_jointParams_to_modelParams(
+            val, paramIndex + d, row, this->parameterTransform_, jacobian);
+      }
+      if (this->activeJointParams_[paramIndex + 3 + d]) {
+        const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * factor;
+        jacobian_jointParams_to_modelParams(
+            val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
+      }
+    }
+    if (this->activeJointParams_[paramIndex + 6]) {
+      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * factor;
+      jacobian_jointParams_to_modelParams(
+          val, paramIndex + 6, row, this->parameterTransform_, jacobian);
+    }
+
+    jointIndex = this->skeleton_.joints[jointIndex].parent;
+  }
+}
+
+template <typename T>
+void SimdCollisionErrorFunctionT<T>::accumulateCommonAncestorScaleJacobian(
+    size_t commonAncestor,
+    const T scaleJacobian,
+    const int row,
+    Ref<MatrixX<T>> jacobian) const {
+  size_t ancestorIndex = commonAncestor;
+  while (ancestorIndex != kInvalidIndex) {
+    const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+    if (this->activeJointParams_[paramIndex + 6]) {
+      jacobian_jointParams_to_modelParams(
+          scaleJacobian, paramIndex + 6, row, this->parameterTransform_, jacobian);
+    }
+    ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+  }
+}
+
+template <typename T>
 double SimdCollisionErrorFunctionT<T>::getError(
     const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
@@ -486,85 +542,32 @@ double SimdCollisionErrorFunctionT<T>::getJacobian(
         const T scaleCorr_A = -distance_k * radiusA_at_cp_k * ln2<T>();
         const T scaleCorr_B = distance_k * radiusB_at_cp_k * ln2<T>();
 
-        // -----------------------------------
-        //  process first joint
-        // -----------------------------------
-        size_t jointIndex = iJoint;
-        while (jointIndex != kInvalidIndex && jointIndex != commonAncestor) {
-          const auto& jointState = state.jointState[jointIndex];
-          const size_t paramIndex = jointIndex * kParametersPerJoint;
-          const Eigen::Vector3<T> posd =
-              extractSingleElement(position_i, k) - jointState.translation();
+        const Vector3<T> position_ik = extractSingleElement(position_i, k);
+        const Vector3<T> position_jk = extractSingleElement(position_j, k);
+        accumulateJacobianAlongChain(
+            state,
+            position_ik,
+            direction_k,
+            -fac_k,
+            iJoint,
+            commonAncestor,
+            jacobian,
+            row,
+            scaleCorr_A);
+        accumulateJacobianAlongChain(
+            state,
+            position_jk,
+            direction_k,
+            fac_k,
+            jJoint,
+            commonAncestor,
+            jacobian,
+            row,
+            scaleCorr_B);
 
-          for (size_t d = 0; d < 3; d++) {
-            if (this->activeJointParams_[paramIndex + d]) {
-              const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * -fac_k;
-              jacobian_jointParams_to_modelParams(
-                  val, paramIndex + d, row, this->parameterTransform_, jacobian);
-            }
-            if (this->activeJointParams_[paramIndex + 3 + d]) {
-              const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * -fac_k;
-              jacobian_jointParams_to_modelParams(
-                  val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
-            }
-          }
-          if (this->activeJointParams_[paramIndex + 6]) {
-            const T val =
-                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_A) * -fac_k;
-            jacobian_jointParams_to_modelParams(
-                val, paramIndex + 6, row, this->parameterTransform_, jacobian);
-          }
-
-          jointIndex = this->skeleton_.joints[jointIndex].parent;
-        }
-
-        // -----------------------------------
-        //  process second joint
-        // -----------------------------------
-        jointIndex = jJoint;
-        while (jointIndex != kInvalidIndex && jointIndex != commonAncestor) {
-          const auto& jointState = state.jointState[jointIndex];
-          const size_t paramIndex = jointIndex * kParametersPerJoint;
-          const Vector3<T> posd = extractSingleElement(position_j, k) - jointState.translation();
-
-          for (size_t d = 0; d < 3; d++) {
-            if (this->activeJointParams_[paramIndex + d]) {
-              const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * fac_k;
-              jacobian_jointParams_to_modelParams(
-                  val, paramIndex + d, row, this->parameterTransform_, jacobian);
-            }
-            if (this->activeJointParams_[paramIndex + 3 + d]) {
-              const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * fac_k;
-              jacobian_jointParams_to_modelParams(
-                  val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
-            }
-          }
-          if (this->activeJointParams_[paramIndex + 6]) {
-            const T val =
-                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_B) * fac_k;
-            jacobian_jointParams_to_modelParams(
-                val, paramIndex + 6, row, this->parameterTransform_, jacobian);
-          }
-
-          jointIndex = this->skeleton_.joints[jointIndex].parent;
-        }
-
-        // -----------------------------------
-        //  process scale derivatives above common ancestor
-        // -----------------------------------
-        {
-          const T netScaleVal = -fac_k * ln2<T>() * direction_k.squaredNorm() +
-              wgt * (radiusA_at_cp_k + radiusB_at_cp_k) * ln2<T>();
-          size_t ancestorIndex = commonAncestor;
-          while (ancestorIndex != kInvalidIndex) {
-            const size_t paramIndex = ancestorIndex * kParametersPerJoint;
-            if (this->activeJointParams_[paramIndex + 6]) {
-              jacobian_jointParams_to_modelParams(
-                  netScaleVal, paramIndex + 6, row, this->parameterTransform_, jacobian);
-            }
-            ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
-          }
-        }
+        const T netScaleVal = -fac_k * ln2<T>() * direction_k.squaredNorm() +
+            wgt * (radiusA_at_cp_k + radiusB_at_cp_k) * ln2<T>();
+        accumulateCommonAncestorScaleJacobian(commonAncestor, netScaleVal, row, jacobian);
 
         residual(row) = overlap[k] * wgt;
         row++;

--- a/momentum/character_solver_simd/simd_collision_error_function.cpp
+++ b/momentum/character_solver_simd/simd_collision_error_function.cpp
@@ -197,6 +197,59 @@ CollisionErrorFunctionT<T>& SimdCollisionErrorFunctionT<T>::syncScalarFallback()
 }
 
 template <typename T>
+void SimdCollisionErrorFunctionT<T>::accumulateGradientAlongChain(
+    const SkeletonStateT<T>& state,
+    const Vector3<T>& position,
+    const Vector3<T>& direction,
+    const T weight,
+    size_t startJoint,
+    size_t stopJoint,
+    Ref<VectorX<T>> gradient,
+    const T scaleCorrection) const {
+  size_t jointIndex = startJoint;
+  while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
+    const auto& jointState = state.jointState[jointIndex];
+    const size_t paramIndex = jointIndex * kParametersPerJoint;
+    const Vector3<T> posd = position - jointState.translation();
+
+    for (size_t d = 0; d < 3; d++) {
+      if (this->activeJointParams_[paramIndex + d]) {
+        const T val = direction.dot(jointState.getTranslationDerivative(d)) * weight;
+        gradient_jointParams_to_modelParams(
+            val, paramIndex + d, this->parameterTransform_, gradient);
+      }
+      if (this->activeJointParams_[paramIndex + 3 + d]) {
+        const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * weight;
+        gradient_jointParams_to_modelParams(
+            val, paramIndex + 3 + d, this->parameterTransform_, gradient);
+      }
+    }
+    if (this->activeJointParams_[paramIndex + 6]) {
+      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * weight;
+      gradient_jointParams_to_modelParams(val, paramIndex + 6, this->parameterTransform_, gradient);
+    }
+
+    jointIndex = this->skeleton_.joints[jointIndex].parent;
+  }
+}
+
+template <typename T>
+void SimdCollisionErrorFunctionT<T>::accumulateCommonAncestorScaleGradient(
+    size_t commonAncestor,
+    const T scaleGradient,
+    Ref<VectorX<T>> gradient) const {
+  size_t ancestorIndex = commonAncestor;
+  while (ancestorIndex != kInvalidIndex) {
+    const size_t paramIndex = ancestorIndex * kParametersPerJoint;
+    if (this->activeJointParams_[paramIndex + 6]) {
+      gradient_jointParams_to_modelParams(
+          scaleGradient, paramIndex + 6, this->parameterTransform_, gradient);
+    }
+    ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
+  }
+}
+
+template <typename T>
 double SimdCollisionErrorFunctionT<T>::getError(
     const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
@@ -329,85 +382,15 @@ double SimdCollisionErrorFunctionT<T>::getGradient(
         const T scaleCorr_A = -distance_k * radiusA_at_cp_k * ln2<T>();
         const T scaleCorr_B = distance_k * radiusB_at_cp_k * ln2<T>();
 
-        // -----------------------------------
-        //  process first joint
-        // -----------------------------------
-        size_t jointIndex = iJoint;
-        while (jointIndex != kInvalidIndex && jointIndex != commonAncestor) {
-          const auto& jointState = state.jointState[jointIndex];
-          const size_t paramIndex = jointIndex * kParametersPerJoint;
-          const Vector3<T> posd = position_ik - jointState.translation();
+        accumulateGradientAlongChain(
+            state, position_ik, direction_k, wgt_k, iJoint, commonAncestor, gradient, scaleCorr_A);
+        accumulateGradientAlongChain(
+            state, position_jk, direction_k, -wgt_k, jJoint, commonAncestor, gradient, scaleCorr_B);
 
-          for (size_t d = 0; d < 3; d++) {
-            if (this->activeJointParams_[paramIndex + d]) {
-              const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * wgt_k;
-              gradient_jointParams_to_modelParams(
-                  val, paramIndex + d, this->parameterTransform_, gradient);
-            }
-            if (this->activeJointParams_[paramIndex + 3 + d]) {
-              const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * wgt_k;
-              gradient_jointParams_to_modelParams(
-                  val, paramIndex + 3 + d, this->parameterTransform_, gradient);
-            }
-          }
-          if (this->activeJointParams_[paramIndex + 6]) {
-            const T val =
-                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_A) * wgt_k;
-            gradient_jointParams_to_modelParams(
-                val, paramIndex + 6, this->parameterTransform_, gradient);
-          }
-
-          jointIndex = this->skeleton_.joints[jointIndex].parent;
-        }
-
-        // -----------------------------------
-        //  process second joint
-        // -----------------------------------
-        jointIndex = jJoint;
-        while (jointIndex != kInvalidIndex && jointIndex != commonAncestor) {
-          const auto& jointState = state.jointState[jointIndex];
-          const size_t paramIndex = jointIndex * kParametersPerJoint;
-          const Vector3<T> posd = position_jk - jointState.translation();
-
-          for (size_t d = 0; d < 3; d++) {
-            if (this->activeJointParams_[paramIndex + d]) {
-              const T val = direction_k.dot(jointState.getTranslationDerivative(d)) * -wgt_k;
-              gradient_jointParams_to_modelParams(
-                  val, paramIndex + d, this->parameterTransform_, gradient);
-            }
-            if (this->activeJointParams_[paramIndex + 3 + d]) {
-              const T val = direction_k.dot(jointState.getRotationDerivative(d, posd)) * -wgt_k;
-              gradient_jointParams_to_modelParams(
-                  val, paramIndex + 3 + d, this->parameterTransform_, gradient);
-            }
-          }
-          if (this->activeJointParams_[paramIndex + 6]) {
-            const T val =
-                (direction_k.dot(jointState.getScaleDerivative(posd)) + scaleCorr_B) * -wgt_k;
-            gradient_jointParams_to_modelParams(
-                val, paramIndex + 6, this->parameterTransform_, gradient);
-          }
-
-          jointIndex = this->skeleton_.joints[jointIndex].parent;
-        }
-
-        // -----------------------------------
-        //  process scale derivatives above common ancestor
-        // -----------------------------------
-        {
-          const T netScaleVal =
-              (direction_k.squaredNorm() - distance_k * (radiusA_at_cp_k + radiusB_at_cp_k)) *
-              ln2<T>() * wgt_k;
-          size_t ancestorIndex = commonAncestor;
-          while (ancestorIndex != kInvalidIndex) {
-            const size_t paramIndex = ancestorIndex * kParametersPerJoint;
-            if (this->activeJointParams_[paramIndex + 6]) {
-              gradient_jointParams_to_modelParams(
-                  netScaleVal, paramIndex + 6, this->parameterTransform_, gradient);
-            }
-            ancestorIndex = this->skeleton_.joints[ancestorIndex].parent;
-          }
-        }
+        const T netScaleVal =
+            (direction_k.squaredNorm() - distance_k * (radiusA_at_cp_k + radiusB_at_cp_k)) *
+            ln2<T>() * wgt_k;
+        accumulateCommonAncestorScaleGradient(commonAncestor, netScaleVal, gradient);
       }
     }
   }

--- a/momentum/character_solver_simd/simd_collision_error_function.h
+++ b/momentum/character_solver_simd/simd_collision_error_function.h
@@ -86,6 +86,27 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
       T scaleGradient,
       Ref<VectorX<T>> gradient) const;
 
+  /// Accumulate Jacobian contributions along a joint chain from startJoint up to (but not
+  /// including) stopJoint. The sign of factor controls the push direction.
+  /// scaleCorrection is an additive term for the scale derivative (for capsule radius correction).
+  void accumulateJacobianAlongChain(
+      const SkeletonStateT<T>& state,
+      const Vector3<T>& position,
+      const Vector3<T>& direction,
+      T factor,
+      size_t startJoint,
+      size_t stopJoint,
+      Ref<MatrixX<T>> jacobian,
+      int row,
+      T scaleCorrection = T(0)) const;
+
+  /// Accumulate the shared scale-Jacobian entry above a collision pair's common ancestor.
+  void accumulateCommonAncestorScaleJacobian(
+      size_t commonAncestor,
+      T scaleJacobian,
+      int row,
+      Ref<MatrixX<T>> jacobian) const;
+
   /// Pre-computed valid collision pair with common ancestor.
   struct CollisionPairInfo {
     size_t indexA;

--- a/momentum/character_solver_simd/simd_collision_error_function.h
+++ b/momentum/character_solver_simd/simd_collision_error_function.h
@@ -67,6 +67,25 @@ class SimdCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   /// Synchronize scalar fallback settings before delegating non-capsule collision work.
   CollisionErrorFunctionT<T>& syncScalarFallback();
 
+  /// Accumulate gradient contributions along a joint chain from startJoint up to (but not
+  /// including) stopJoint. The sign of weight controls the push direction.
+  /// scaleCorrection is an additive term for the scale derivative (for capsule radius correction).
+  void accumulateGradientAlongChain(
+      const SkeletonStateT<T>& state,
+      const Vector3<T>& position,
+      const Vector3<T>& direction,
+      T weight,
+      size_t startJoint,
+      size_t stopJoint,
+      Ref<VectorX<T>> gradient,
+      T scaleCorrection = T(0)) const;
+
+  /// Accumulate the shared scale-gradient contribution above a collision pair's common ancestor.
+  void accumulateCommonAncestorScaleGradient(
+      size_t commonAncestor,
+      T scaleGradient,
+      Ref<VectorX<T>> gradient) const;
+
   /// Pre-computed valid collision pair with common ancestor.
   struct CollisionPairInfo {
     size_t indexA;

--- a/momentum/io/legacy_json/legacy_json_io.cpp
+++ b/momentum/io/legacy_json/legacy_json_io.cpp
@@ -387,85 +387,90 @@ nlohmann::json momentumSkinnedModelToLegacy(const Mesh& mesh, const SkinWeights&
   return legacySkinnedModel;
 }
 
+void readLegacyCollisionCommonFields(
+    const nlohmann::json& primitiveJson,
+    CollisionPrimitive& primitive) {
+  if (primitiveJson.contains("transformation")) {
+    primitive.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
+  }
+
+  if (primitiveJson.contains("parent")) {
+    primitive.parent = primitiveJson["parent"].get<size_t>();
+  }
+}
+
+CollisionPrimitive legacyEllipsoidToMomentum(const nlohmann::json& primitiveJson) {
+  CollisionPrimitive ellipsoid;
+  ellipsoid.type = CollisionPrimitiveType::Ellipsoid;
+  readLegacyCollisionCommonFields(primitiveJson, ellipsoid);
+
+  const auto radii = findFieldNames(primitiveJson, {"radii", "ellipsoidRadii"});
+  if (radii != primitiveJson.end()) {
+    ellipsoid.ellipsoidRadii = jsonArrayToEigenVector3<float>(*radii);
+  }
+
+  return ellipsoid;
+}
+
+CollisionPrimitive legacyBoxToMomentum(const nlohmann::json& primitiveJson) {
+  CollisionPrimitive box;
+  box.type = CollisionPrimitiveType::Box;
+  readLegacyCollisionCommonFields(primitiveJson, box);
+
+  const auto halfExtents =
+      findFieldNames(primitiveJson, {"halfExtents", "half_extents", "boxHalfExtents"});
+  if (halfExtents != primitiveJson.end()) {
+    box.boxHalfExtents = jsonArrayToEigenVector3<float>(*halfExtents);
+  }
+
+  return box;
+}
+
+CollisionPrimitive legacyCapsuleToMomentum(const nlohmann::json& primitiveJson) {
+  CollisionPrimitive capsule;
+  readLegacyCollisionCommonFields(primitiveJson, capsule);
+
+  if (primitiveJson.contains("radius")) {
+    capsule.radius = jsonArrayToEigenVector2<float>(primitiveJson["radius"]);
+  }
+
+  if (primitiveJson.contains("length")) {
+    capsule.length = primitiveJson["length"].get<float>();
+  }
+
+  return capsule;
+}
+
+CollisionPrimitive legacyCollisionPrimitiveToMomentum(const nlohmann::json& primitiveJson) {
+  const std::string type = primitiveJson.value("type", "tapered_capsule");
+
+  if (type == "ellipsoid" || type == "collision_ellipsoid") {
+    return legacyEllipsoidToMomentum(primitiveJson);
+  }
+
+  if (type == "box" || type == "collision_box") {
+    return legacyBoxToMomentum(primitiveJson);
+  }
+
+  if (type != "tapered_capsule") {
+    MT_LOGW(
+        "Unknown collision primitive type '{}' in legacy JSON; falling back to tapered capsule.",
+        type);
+  }
+
+  return legacyCapsuleToMomentum(primitiveJson);
+}
+
 CollisionGeometry legacyCollisionToMomentum(const nlohmann::json& legacyCollision) {
   CollisionGeometry collision;
 
-  if (legacyCollision.is_array()) {
-    collision.reserve(legacyCollision.size());
+  if (!legacyCollision.is_array()) {
+    return collision;
+  }
 
-    for (const auto& primitiveJson : legacyCollision) {
-      const std::string type = primitiveJson.value("type", "tapered_capsule");
-
-      if (type == "ellipsoid" || type == "collision_ellipsoid") {
-        CollisionEllipsoid ellipsoid;
-
-        if (primitiveJson.contains("transformation")) {
-          ellipsoid.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
-        }
-
-        if (primitiveJson.contains("radii")) {
-          ellipsoid.radii = jsonArrayToEigenVector3<float>(primitiveJson["radii"]);
-        } else if (primitiveJson.contains("ellipsoidRadii")) {
-          ellipsoid.radii = jsonArrayToEigenVector3<float>(primitiveJson["ellipsoidRadii"]);
-        }
-
-        if (primitiveJson.contains("parent")) {
-          ellipsoid.parent = primitiveJson["parent"].get<size_t>();
-        }
-
-        collision.push_back(ellipsoid);
-        continue;
-      }
-
-      if (type == "box" || type == "collision_box") {
-        CollisionBox box;
-
-        if (primitiveJson.contains("transformation")) {
-          box.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
-        }
-
-        if (primitiveJson.contains("halfExtents")) {
-          box.halfExtents = jsonArrayToEigenVector3<float>(primitiveJson["halfExtents"]);
-        } else if (primitiveJson.contains("half_extents")) {
-          box.halfExtents = jsonArrayToEigenVector3<float>(primitiveJson["half_extents"]);
-        } else if (primitiveJson.contains("boxHalfExtents")) {
-          box.halfExtents = jsonArrayToEigenVector3<float>(primitiveJson["boxHalfExtents"]);
-        }
-
-        if (primitiveJson.contains("parent")) {
-          box.parent = primitiveJson["parent"].get<size_t>();
-        }
-
-        collision.push_back(box);
-        continue;
-      }
-
-      if (type != "tapered_capsule") {
-        MT_LOGW(
-            "Unknown collision primitive type '{}' in legacy JSON; falling back to tapered capsule.",
-            type);
-      }
-
-      TaperedCapsule capsule;
-
-      if (primitiveJson.contains("transformation")) {
-        capsule.transformation = jsonToTransform<float>(primitiveJson["transformation"]);
-      }
-
-      if (primitiveJson.contains("radius")) {
-        capsule.radius = jsonArrayToEigenVector2<float>(primitiveJson["radius"]);
-      }
-
-      if (primitiveJson.contains("parent")) {
-        capsule.parent = primitiveJson["parent"].get<size_t>();
-      }
-
-      if (primitiveJson.contains("length")) {
-        capsule.length = primitiveJson["length"].get<float>();
-      }
-
-      collision.push_back(capsule);
-    }
+  collision.reserve(legacyCollision.size());
+  for (const auto& primitiveJson : legacyCollision) {
+    collision.push_back(legacyCollisionPrimitiveToMomentum(primitiveJson));
   }
 
   return collision;


### PR DESCRIPTION
Summary: Split `legacyCollisionToMomentum` into per-primitive parsing helpers so the top-level legacy collision parser stays a simple array conversion while preserving the existing tapered capsule, ellipsoid, box, and unknown-type fallback behavior.

Differential Revision: D107330993


