### PR TITLE
eigen 5.0.1 P1 fixes: Eigen::indexing::all sweep, unused-var cleanups, JacobiSVD options, PersistingHeapBase is_trivial relaxation (#1478)

### DIFF
--- a/momentum/character_sequence_solver/sequence_solver.cpp
+++ b/momentum/character_sequence_solver/sequence_solver.cpp
@@ -407,12 +407,7 @@ double SequenceSolverT<T>::processPerFrameErrors_parallel(
           return {
               .frameIndex = iFrame,
               .jacobian = jacRes.jacobian.topRows(jacRes.usedRows)(
-#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
-                  Eigen::placeholders::all,
-#else
-                  Eigen::all,
-#endif
-                  fn->universalParameterIndices_),
+                  Eigen::indexing::all, fn->universalParameterIndices_),
               .residual = jacRes.residual.topRows(jacRes.usedRows),
               .error = jacRes.error,
               .nFunctions = jacRes.nFunctions,


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookresearch/momentum/pull/1478

Differential Revision: D107341924


