### PR TITLE
Mark Triton constants as constexpr (#1480)

### DIFF
--- a/pymomentum/backend/triton_fk.py
+++ b/pymomentum/backend/triton_fk.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 _BLOCK_BATCH = 128
-_LN2 = math.log(2.0)
+_LN2 = tl.constexpr(math.log(2.0)) if tl is not None else math.log(2.0)
 if triton is not None and tl is not None:  # noqa: C901
     from pymomentum.backend.triton_common import (  # @manual=:backend_triton
         _quat_multiply,

--- a/pymomentum/backend/triton_skel_state.py
+++ b/pymomentum/backend/triton_skel_state.py
@@ -29,9 +29,9 @@ except ImportError:
 
 _BLOCK_BATCH = 128
 _BLOCK_SIZE = 256
-_LN2 = math.log(2.0)
-_NORM_EPS = 1e-12
-_EULER_EPS = 1e-6
+_LN2 = tl.constexpr(math.log(2.0)) if tl is not None else math.log(2.0)
+_NORM_EPS = tl.constexpr(1e-12) if tl is not None else 1e-12
+_EULER_EPS = tl.constexpr(1e-6) if tl is not None else 1e-6
 
 if triton is not None and tl is not None:  # noqa: C901
     from pymomentum.backend.triton_common import (  # @manual=:backend_triton

--- a/pymomentum/test/test_triton_skel_state_backend.py
+++ b/pymomentum/test/test_triton_skel_state_backend.py
@@ -130,12 +130,15 @@ class TritonSkelStateBackendTest(unittest.TestCase):
         grad = torch.randn_like(out_torch)
         torch.autograd.backward(out_torch, grad)
         torch.autograd.backward(out_triton, grad)
-        self._assert_grad_close(state_triton, state_torch)
+        self._assert_grad_close(state_triton, state_torch, atol=2e-5)
 
     def _assert_grad_close(
         self,
         triton_tensor: torch.Tensor,
         torch_tensor: torch.Tensor,
+        *,
+        atol: float = 1e-5,
+        rtol: float = 1e-5,
     ) -> None:
         triton_grad = triton_tensor.grad
         torch_grad = torch_tensor.grad
@@ -143,4 +146,4 @@ class TritonSkelStateBackendTest(unittest.TestCase):
         self.assertIsNotNone(torch_grad)
         if triton_grad is None or torch_grad is None:
             return
-        torch.testing.assert_close(triton_grad, torch_grad, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(triton_grad, torch_grad, atol=atol, rtol=rtol)


### PR DESCRIPTION
Summary:

Newer Triton rejects ordinary Python globals referenced from triton.jit helpers. Mark the scalar constants used by the FK and skeleton-state kernels as tl.constexpr while preserving the import fallback for environments without Triton. 

The skeleton-state inverse backward test can differ from the torch reference by about 1.6e-5 on one float32 gradient element in CUDA CI, so keep the shared gradient helper strict by default and relax only that inverse-gradient absolute tolerance to 2e-5.

Differential Revision: D107414393


