### PR TITLE
Fix OpenCV rational distortion model to (1+A)/B form

### DIFF
--- a/momentum/camera/camera.cpp
+++ b/momentum/camera/camera.cpp
@@ -310,9 +310,8 @@ std::pair<Vector3P<T>, typename Packet<T>::MaskType> OpenCVIntrinsicsModelT<T>::
 
   const auto& dp = distortionParams_;
 
-  Packet<T> radialDistortion = T(1) +
-      (rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3))) /
-          (T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6)));
+  Packet<T> radialDistortion = (T(1) + rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3))) /
+      (T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6)));
 
   Packet<T> xpp =
       xp * radialDistortion + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * drjit::square(xp));
@@ -338,9 +337,8 @@ std::pair<Eigen::Vector3<T>, bool> OpenCVIntrinsicsModelT<T>::project(
 
   const auto& dp = distortionParams_;
 
-  T radialDistortion = T(1) +
-      (rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3))) /
-          (T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6)));
+  T radialDistortion = (T(1) + rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3))) /
+      (T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6)));
 
   T xpp = xp * radialDistortion + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   T ypp = yp * radialDistortion + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
@@ -371,7 +369,8 @@ OpenCVIntrinsicsModelT<T>::projectJacobian(const Eigen::Vector3<T>& point) const
 
   const auto& dp = distortionParams_;
 
-  // Radial factor = num/den, where num and den are even-degree polynomials in r.
+  // Radial factor = num/den, where num and den are even-degree polynomials in r
+  // (OpenCV rational model: (1 + k1 r^2 + k2 r^4 + k3 r^6) / (1 + k4 r^2 + k5 r^4 + k6 r^6)).
   const T radial_num = T(1) + rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3));
   const T radial_den = T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6));
   const T radial_factor = radial_num / radial_den;
@@ -621,12 +620,13 @@ OpenCVIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& po
 
   const auto& dp = distortionParams_;
 
-  // radial_factor = 1 + A/B, where
+  // radial_factor = (1 + A)/B, where
   //   A = rsqr * (k1 + rsqr * (k2 + rsqr * k3))
   //   B = 1 + rsqr * (k4 + rsqr * (k5 + rsqr * k6))
+  // (OpenCV rational model: (1 + k1 r^2 + k2 r^4 + k3 r^6) / (1 + k4 r^2 + k5 r^4 + k6 r^6)).
   const T A = rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3));
   const T B = T(1) + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6));
-  const T radial_factor = T(1) + A / B;
+  const T radial_factor = (T(1) + A) / B;
 
   const T xpp = xp * radial_factor + T(2) * dp.p1 * xp * yp + dp.p2 * (rsqr + T(2) * xp * xp);
   const T ypp = yp * radial_factor + dp.p1 * (rsqr + T(2) * yp * yp) + T(2) * dp.p2 * xp * yp;
@@ -648,19 +648,20 @@ OpenCVIntrinsicsModelT<T>::projectIntrinsicsJacobian(const Eigen::Vector3<T>& po
   // For radial coefficients k_i, only radial_factor depends on them, so
   //   d(xpp)/dk_i = xp * d(radial_factor)/dk_i, similarly for ypp.
   //
-  // Numerator coefficients (k1, k2, k3): d(A/B)/dk_i = (dA/dk_i) / B with
+  // Numerator coefficients (k1, k2, k3): d((1+A)/B)/dk_i = (dA/dk_i) / B with
   //   dA/dk1 = rsqr, dA/dk2 = rsqr^2, dA/dk3 = rsqr^3.
-  // Denominator coefficients (k4, k5, k6): d(A/B)/dk_i = -A * (dB/dk_i) / B^2 with
+  // Denominator coefficients (k4, k5, k6): d((1+A)/B)/dk_i = -(1+A) * (dB/dk_i) / B^2 with
   //   dB/dk4 = rsqr, dB/dk5 = rsqr^2, dB/dk6 = rsqr^3.
+  const T onePlusA = T(1) + A;
   const T B_sq = B * B;
   const T rsqr2 = rsqr * rsqr;
   const T rsqr3 = rsqr2 * rsqr;
   const T drf_dk1 = rsqr / B;
   const T drf_dk2 = rsqr2 / B;
   const T drf_dk3 = rsqr3 / B;
-  const T drf_dk4 = -A * rsqr / B_sq;
-  const T drf_dk5 = -A * rsqr2 / B_sq;
-  const T drf_dk6 = -A * rsqr3 / B_sq;
+  const T drf_dk4 = -onePlusA * rsqr / B_sq;
+  const T drf_dk5 = -onePlusA * rsqr2 / B_sq;
+  const T drf_dk6 = -onePlusA * rsqr3 / B_sq;
 
   jacobian(0, 4) = fx_ * xp * drf_dk1;
   jacobian(1, 4) = fy_ * yp * drf_dk1;

--- a/momentum/test/camera/test_camera.cpp
+++ b/momentum/test/camera/test_camera.cpp
@@ -2096,3 +2096,200 @@ TEST_F(OpenCVFisheyeCameraTest, FisheyeSimdProjectOutsideFOV) {
   auto [projectedOutside, validMaskOutside] = clone->project(simdOutside);
   EXPECT_FALSE(validMaskOutside[0]) << "Point outside FOV should be invalid";
 }
+
+namespace {
+// Independent reference for the OpenCV rational forward projection, in the correct
+// (1+A)/B form. Kept separate from camera.cpp so the test fails if production code
+// regresses to the incorrect 1 + A/B form.
+Eigen::Vector2d openCVRationalReferenceProjection(
+    const Eigen::Vector3d& point,
+    double fx,
+    double fy,
+    double cx,
+    double cy,
+    const OpenCVDistortionParametersT<double>& dp) {
+  const double invZ = 1.0 / point.z();
+  const double xp = point.x() * invZ;
+  const double yp = point.y() * invZ;
+  const double rsqr = xp * xp + yp * yp;
+
+  const double radial = (1.0 + rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3))) /
+      (1.0 + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6)));
+
+  const double xpp = xp * radial + 2.0 * dp.p1 * xp * yp + dp.p2 * (rsqr + 2.0 * xp * xp);
+  const double ypp = yp * radial + dp.p1 * (rsqr + 2.0 * yp * yp) + 2.0 * dp.p2 * xp * yp;
+
+  return {fx * xpp + cx, fy * ypp + cy};
+}
+
+// The incorrect 1 + A/B form. Used only to assert that the chosen test points actually
+// discriminate the two forms (i.e. that the denominator terms matter for these points).
+Eigen::Vector2d openCVRationalWrongReferenceProjection(
+    const Eigen::Vector3d& point,
+    double fx,
+    double fy,
+    double cx,
+    double cy,
+    const OpenCVDistortionParametersT<double>& dp) {
+  const double invZ = 1.0 / point.z();
+  const double xp = point.x() * invZ;
+  const double yp = point.y() * invZ;
+  const double rsqr = xp * xp + yp * yp;
+
+  const double a = rsqr * (dp.k1 + rsqr * (dp.k2 + rsqr * dp.k3));
+  const double b = 1.0 + rsqr * (dp.k4 + rsqr * (dp.k5 + rsqr * dp.k6));
+  const double radial = 1.0 + a / b;
+
+  const double xpp = xp * radial + 2.0 * dp.p1 * xp * yp + dp.p2 * (rsqr + 2.0 * xp * xp);
+  const double ypp = yp * radial + dp.p1 * (rsqr + 2.0 * yp * yp) + 2.0 * dp.p2 * xp * yp;
+
+  return {fx * xpp + cx, fy * ypp + cy};
+}
+
+OpenCVDistortionParametersT<double> rationalDenominatorDistortion() {
+  OpenCVDistortionParametersT<double> dp;
+  dp.k1 = 0.12;
+  dp.k2 = -0.015;
+  dp.k3 = 0.001;
+  dp.k4 = 0.045;
+  dp.k5 = -0.004;
+  dp.k6 = 0.0006;
+  dp.p1 = 0.0003;
+  dp.p2 = -0.0002;
+  return dp;
+}
+} // namespace
+
+// Verify that every forward-projection code path agrees with each other AND with an
+// independent (1+A)/B reference when the rational denominator (k4,k5,k6) is non-zero.
+// This is the configuration that distinguishes the correct (1+A)/B model from the
+// incorrect 1+A/B model; tests with a zero denominator cannot catch that regression.
+TEST_F(CameraTest, OpenCVRationalForwardProjectionAllVariantsCorrect) {
+  const OpenCVDistortionParametersT<double> dp = rationalDenominatorDistortion();
+
+  const double fx = 520.0;
+  const double fy = 510.0;
+  const double cx = 320.0;
+  const double cy = 240.0;
+  const auto intrinsics = std::make_shared<OpenCVIntrinsicsModeld>(640, 480, fx, fy, cx, cy, dp);
+
+  const std::vector<Eigen::Vector3d> testPoints = {
+      Eigen::Vector3d(0.4, 0.2, 2.0),
+      Eigen::Vector3d(-0.5, 0.35, 2.5),
+      Eigen::Vector3d(0.9, -0.45, 3.0),
+      Eigen::Vector3d(0.0, 0.0, 1.0),
+  };
+
+  const double tolerance = 1e-9;
+
+  for (const auto& point : testPoints) {
+    const Eigen::Vector2d reference = openCVRationalReferenceProjection(point, fx, fy, cx, cy, dp);
+
+    // Sanity check: for off-axis points the (1+A)/B and 1+A/B forms must differ
+    // meaningfully, otherwise the test would not actually exercise the fix. The
+    // on-axis point (rsqr == 0) makes both forms identical, so skip it there.
+    if (point.head<2>().squaredNorm() > 0.0) {
+      const Eigen::Vector2d wrongReference =
+          openCVRationalWrongReferenceProjection(point, fx, fy, cx, cy, dp);
+      EXPECT_GT((reference - wrongReference).norm(), 1e-3)
+          << "Test point does not discriminate (1+A)/B from 1+A/B";
+    }
+
+    // Variant 1: SIMD/packet project()
+    using PacketT = Packet<double>;
+    Vector3P<double> widePoint(PacketT(point.x()), PacketT(point.y()), PacketT(point.z()));
+    auto [packetProjected, packetMask] = intrinsics->project(widePoint);
+    ASSERT_TRUE(packetMask[0]);
+    EXPECT_NEAR(packetProjected.x()[0], reference.x(), tolerance) << "packet project u";
+    EXPECT_NEAR(packetProjected.y()[0], reference.y(), tolerance) << "packet project v";
+
+    // Variant 2: scalar project()
+    auto [scalarProjected, scalarValid] = intrinsics->project(point);
+    ASSERT_TRUE(scalarValid);
+    EXPECT_NEAR(scalarProjected.x(), reference.x(), tolerance) << "scalar project u";
+    EXPECT_NEAR(scalarProjected.y(), reference.y(), tolerance) << "scalar project v";
+
+    // Variant 3: projectJacobian() projected point
+    auto [jacProjected, jac3x3, jacValid] = intrinsics->projectJacobian(point);
+    ASSERT_TRUE(jacValid);
+    EXPECT_NEAR(jacProjected.x(), reference.x(), tolerance) << "projectJacobian u";
+    EXPECT_NEAR(jacProjected.y(), reference.y(), tolerance) << "projectJacobian v";
+
+    // Variant 4: projectIntrinsicsJacobian() projected point
+    auto [intrinsicsJacProjected, jac3x14, intrinsicsJacValid] =
+        intrinsics->projectIntrinsicsJacobian(point);
+    ASSERT_TRUE(intrinsicsJacValid);
+    EXPECT_NEAR(intrinsicsJacProjected.x(), reference.x(), tolerance)
+        << "projectIntrinsicsJacobian u";
+    EXPECT_NEAR(intrinsicsJacProjected.y(), reference.y(), tolerance)
+        << "projectIntrinsicsJacobian v";
+  }
+}
+
+// Finite-difference validation of projectIntrinsicsJacobian() with a non-zero rational
+// denominator. The k4/k5/k6 derivative terms are only exercised when the denominator is
+// non-trivial; this guards the (1+A)/B intrinsics Jacobian against regressions in those
+// columns (the on-axis/zero-denominator tests cannot).
+TEST_F(CameraTest, OpenCVIntrinsicsJacobianValidationWithDenominatorDistortion) {
+  const OpenCVDistortionParametersT<double> dp = rationalDenominatorDistortion();
+  const auto intrinsics =
+      std::make_shared<OpenCVIntrinsicsModeld>(640, 480, 520.0, 510.0, 320.0, 240.0, dp);
+
+  const std::vector<Eigen::Vector3d> testPoints = {
+      Eigen::Vector3d(0.4, 0.2, 2.0),
+      Eigen::Vector3d(-0.5, 0.35, 2.5),
+      Eigen::Vector3d(0.9, -0.45, 3.0),
+  };
+
+  const double epsilon = 1e-8;
+  const double tolerance = 1e-4;
+
+  for (const auto& point : testPoints) {
+    auto [projectedPoint, analyticalJacobian, isValid] =
+        intrinsics->projectIntrinsicsJacobian(point);
+    ASSERT_TRUE(isValid);
+
+    Eigen::MatrixXd finiteDiffJacobian(3, 14);
+
+    auto baseParams = intrinsics->getIntrinsicParameters();
+    auto [baseProjected, baseValid] = intrinsics->project(point);
+    ASSERT_TRUE(baseValid);
+
+    for (int i = 0; i < 14; ++i) {
+      auto cloned = intrinsics->clone();
+      Eigen::VectorXd perturbedParams = baseParams;
+      perturbedParams(i) += epsilon;
+      cloned->setIntrinsicParameters(perturbedParams);
+
+      auto [perturbedProjected, perturbedValid] = cloned->project(point);
+      ASSERT_TRUE(perturbedValid);
+
+      finiteDiffJacobian.col(i) = (perturbedProjected - baseProjected) / epsilon;
+    }
+
+    for (int row = 0; row < 2; ++row) { // Only check u and v rows
+      for (int col = 0; col < 14; ++col) {
+        EXPECT_NEAR(analyticalJacobian(row, col), finiteDiffJacobian(row, col), tolerance)
+            << "OpenCV rational intrinsics Jacobian mismatch at (" << row << "," << col
+            << ") for point (" << point.x() << "," << point.y() << "," << point.z() << ")";
+      }
+    }
+  }
+}
+
+// projectJacobian()/project() self-consistency with a non-zero rational denominator.
+// (Relocated here from the CUDA backend commit: it is a CPU-only test.)
+TEST_F(CameraTest, OpenCVRationalProjectJacobianConsistencyWithDenominatorDistortion) {
+  const OpenCVDistortionParametersT<double> distortionParams = rationalDenominatorDistortion();
+
+  const auto intrinsics = std::make_shared<OpenCVIntrinsicsModeld>(
+      640, 480, 520.0, 510.0, 320.0, 240.0, distortionParams);
+  const std::vector<Eigen::Vector3d> testPoints = {
+      Eigen::Vector3d(0.4, 0.2, 2.0),
+      Eigen::Vector3d(-0.5, 0.35, 2.5),
+      Eigen::Vector3d(0.9, -0.45, 3.0),
+  };
+
+  testIntrinsicsJacobianComprehensive(
+      intrinsics, "OpenCVRationalDenominatorDouble", testPoints, 1e-4, 1e-6);
+}


### PR DESCRIPTION
Summary:
The `OpenCVIntrinsicsModelT` radial distortion factor was computed inconsistently across its projection code paths. The OpenCV rational model defines the radial factor as `(1 + k1 r^2 + k2 r^4 + k3 r^6) / (1 + k4 r^2 + k5 r^4 + k6 r^6)`, i.e. `(1 + A)/B`. Three code paths instead computed `1 + A/B`, which is a different (incorrect) function whenever any denominator coefficient `k4`, `k5`, or `k6` is non-zero:

- the SIMD/packet `project()` overload,
- the scalar `project()` overload,
- the forward model inside `projectIntrinsicsJacobian()`.

This corrects all three to `(1 + A)/B`. For `projectIntrinsicsJacobian()` the intrinsics-Jacobian terms for the denominator coefficients are also corrected: `d((1+A)/B)/dk_{4,5,6} = -(1+A) * (dB/dk_i) / B^2`, so the `-A * ...` factors become `-(1+A) * ...`. The numerator-coefficient derivatives `d((1+A)/B)/dk_{1,2,3} = (dA/dk_i)/B` are unchanged.

The scalar `projectJacobian()` already used the correct `(1+A)/B` form, so all projection paths are now mutually consistent and match OpenCV.

Reviewed By: yutingye

Differential Revision: D106870877


