### PR TITLE
Add generalized loss support to LimitErrorFunction (#1491)

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -369,6 +369,7 @@ character_solver_test_sources = [
     "test/character_solver/joint_to_joint_distance_error_function_test.cpp",
     "test/character_solver/joint_to_joint_orientation_error_function_test.cpp",
     "test/character_solver/joint_to_joint_position_error_function_test.cpp",
+    "test/character_solver/limit_error_function_loss_test.cpp",
     "test/character_solver/limit_error_function_test.cpp",
     "test/character_solver/normal_error_function_test.cpp",
     "test/character_solver/orientation_error_function_test.cpp",

--- a/momentum/character_solver/limit_error_function.cpp
+++ b/momentum/character_solver/limit_error_function.cpp
@@ -20,11 +20,20 @@ namespace {
 
 constexpr float kPositionWeight = 1e-4f;
 
-template <typename T>
+// Each constraint contributes `w * loss(s)` where `s` is the raw squared residual and `w` is the
+// product of the weighting terms. The helpers below are templated on whether the loss is a plain
+// L2 loss:
+//   - IsL2 == true:  the squared error is used directly. `invC2` (the loss scale, 1 for the default
+//     c = 1) is folded into the surrounding weight by the caller, so these helpers do no
+//     loss-function calls at all and match the original hand-optimized quadratic penalty.
+//   - IsL2 == false: the squared error is transformed by GeneralizedLossT::value/deriv.
+
+template <typename T, bool IsL2>
 T computeMinMaxError(
     const LimitMinMax& data,
     const ModelParametersT<T>& params,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters) {
   if (!enabledParameters.test(data.parameterIndex)) {
     return T(0);
@@ -32,20 +41,31 @@ T computeMinMaxError(
   T error = T(0);
   if (params(data.parameterIndex) < data.limits[0]) {
     const T val = data.limits[0] - params(data.parameterIndex);
-    error = val * val * limitWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      error = limitWeight * sqrError;
+    } else {
+      error = limitWeight * loss.value(sqrError);
+    }
   }
   if (params(data.parameterIndex) > data.limits[1]) {
     const T val = data.limits[1] - params(data.parameterIndex);
-    error = val * val * limitWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      error = limitWeight * sqrError;
+    } else {
+      error = limitWeight * loss.value(sqrError);
+    }
   }
   return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeMinMaxJointError(
     const LimitMinMaxJoint& data,
     const SkeletonStateT<T>& state,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams) {
   const size_t parameterIndex = data.jointIndex * kParametersPerJoint + data.jointParameter;
   MT_CHECK(parameterIndex < static_cast<size_t>(state.jointParameters.size()));
@@ -55,20 +75,31 @@ T computeMinMaxJointError(
   T error = T(0);
   if (state.jointParameters(parameterIndex) < data.limits[0]) {
     const T val = data.limits[0] - state.jointParameters[parameterIndex];
-    error = val * val * limitWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      error = limitWeight * sqrError;
+    } else {
+      error = limitWeight * loss.value(sqrError);
+    }
   }
   if (state.jointParameters(parameterIndex) > data.limits[1]) {
     const T val = data.limits[1] - state.jointParameters[parameterIndex];
-    error = val * val * limitWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      error = limitWeight * sqrError;
+    } else {
+      error = limitWeight * loss.value(sqrError);
+    }
   }
   return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeLinearError(
     const LimitLinear& data,
     const ModelParametersT<T>& params,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters) {
   MT_CHECK(data.referenceIndex < static_cast<size_t>(params.size()));
   MT_CHECK(data.targetIndex < static_cast<size_t>(params.size()));
@@ -78,14 +109,20 @@ T computeLinearError(
   }
   const T residual =
       params(data.targetIndex) * data.scale - data.offset - params(data.referenceIndex);
-  return residual * residual * limitWeight;
+  const T sqrError = residual * residual;
+  if constexpr (IsL2) {
+    return limitWeight * sqrError;
+  } else {
+    return limitWeight * loss.value(sqrError);
+  }
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeLinearJointError(
     const LimitLinearJoint& data,
     const SkeletonStateT<T>& state,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams) {
   const size_t referenceParameterIndex =
       data.referenceJointIndex * kParametersPerJoint + data.referenceJointParameter;
@@ -99,14 +136,20 @@ T computeLinearJointError(
   }
   const T residual = state.jointParameters(targetParameterIndex) * data.scale - data.offset -
       state.jointParameters(referenceParameterIndex);
-  return residual * residual * limitWeight;
+  const T sqrError = residual * residual;
+  if constexpr (IsL2) {
+    return limitWeight * sqrError;
+  } else {
+    return limitWeight * loss.value(sqrError);
+  }
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeHalfPlaneError(
     const LimitHalfPlane& data,
     const ModelParametersT<T>& params,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters) {
   MT_CHECK(data.param1 < static_cast<size_t>(params.size()));
   MT_CHECK(data.param2 < static_cast<size_t>(params.size()));
@@ -116,13 +159,22 @@ T computeHalfPlaneError(
   const Eigen::Vector2<T> p(params(data.param1), params(data.param2));
   const T residual = p.dot(data.normal.template cast<T>()) - data.offset;
   if (residual < 0) {
-    return residual * residual * limitWeight;
+    const T sqrError = residual * residual;
+    if constexpr (IsL2) {
+      return limitWeight * sqrError;
+    } else {
+      return limitWeight * loss.value(sqrError);
+    }
   }
   return T(0);
 }
 
-template <typename T>
-T computeEllipsoidError(const LimitEllipsoid& ct, const SkeletonStateT<T>& state, T limitWeight) {
+template <typename T, bool IsL2>
+T computeEllipsoidError(
+    const LimitEllipsoid& ct,
+    const SkeletonStateT<T>& state,
+    T limitWeight,
+    const GeneralizedLossT<T>& loss) {
   const Eigen::Vector3<T> position =
       state.jointState[ct.parent].transform * ct.offset.template cast<T>();
   const Eigen::Vector3<T> localPosition =
@@ -132,15 +184,21 @@ T computeEllipsoidError(const LimitEllipsoid& ct, const SkeletonStateT<T>& state
   const Eigen::Vector3<T> projectedPosition = ct.ellipsoid.template cast<T>() * normalizedPosition;
   const Eigen::Vector3<T> diff =
       position - state.jointState[ct.ellipsoidParent].transform * projectedPosition;
-  return diff.squaredNorm() * T(kPositionWeight) * limitWeight;
+  const T sqrError = diff.squaredNorm();
+  if constexpr (IsL2) {
+    return T(kPositionWeight) * limitWeight * sqrError;
+  } else {
+    return T(kPositionWeight) * limitWeight * loss.value(sqrError);
+  }
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeMinMaxGradient(
     const LimitMinMax& data,
     const ModelParametersT<T>& params,
     T tWeight,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters,
     Ref<Eigen::VectorX<T>> gradient) {
   if (!enabledParameters.test(data.parameterIndex)) {
@@ -149,23 +207,36 @@ T computeMinMaxGradient(
   T error = T(0);
   if (params(data.parameterIndex) < data.limits[0]) {
     const T val = params(data.parameterIndex) - data.limits[0];
-    error = val * val * tWeight * limitWeight;
-    gradient[data.parameterIndex] += T(2) * val * tWeight * limitWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      error = tWeight * limitWeight * sqrError;
+      gradient[data.parameterIndex] += T(2) * val * tWeight * limitWeight;
+    } else {
+      error = tWeight * limitWeight * loss.value(sqrError);
+      gradient[data.parameterIndex] += T(2) * val * tWeight * limitWeight * loss.deriv(sqrError);
+    }
   }
   if (params(data.parameterIndex) > data.limits[1]) {
     const T val = params(data.parameterIndex) - data.limits[1];
-    error = val * val * tWeight * limitWeight;
-    gradient[data.parameterIndex] += T(2) * val * tWeight * limitWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      error = tWeight * limitWeight * sqrError;
+      gradient[data.parameterIndex] += T(2) * val * tWeight * limitWeight;
+    } else {
+      error = tWeight * limitWeight * loss.value(sqrError);
+      gradient[data.parameterIndex] += T(2) * val * tWeight * limitWeight * loss.deriv(sqrError);
+    }
   }
   return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeMinMaxJointGradient(
     const LimitMinMaxJoint& data,
     const SkeletonStateT<T>& state,
     T tWeight,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams,
     const ParameterTransform& parameterTransform,
     Ref<Eigen::VectorX<T>> gradient) {
@@ -178,25 +249,40 @@ T computeMinMaxJointGradient(
   T error = T(0);
   if (state.jointParameters(parameterIndex) < data.limits[0]) {
     const T val = state.jointParameters[parameterIndex] - data.limits[0];
-    error = val * val * tWeight * limitWeight;
-    const T jGrad = T(2) * val * tWeight * limitWeight;
+    const T sqrError = val * val;
+    T jGrad;
+    if constexpr (IsL2) {
+      error = tWeight * limitWeight * sqrError;
+      jGrad = T(2) * val * tWeight * limitWeight;
+    } else {
+      error = tWeight * limitWeight * loss.value(sqrError);
+      jGrad = T(2) * val * tWeight * limitWeight * loss.deriv(sqrError);
+    }
     gradient_jointParams_to_modelParams(jGrad, parameterIndex, parameterTransform, gradient);
   }
   if (state.jointParameters(parameterIndex) > data.limits[1]) {
     const T val = state.jointParameters[parameterIndex] - data.limits[1];
-    error = val * val * tWeight * limitWeight;
-    const T jGrad = T(2) * val * tWeight * limitWeight;
+    const T sqrError = val * val;
+    T jGrad;
+    if constexpr (IsL2) {
+      error = tWeight * limitWeight * sqrError;
+      jGrad = T(2) * val * tWeight * limitWeight;
+    } else {
+      error = tWeight * limitWeight * loss.value(sqrError);
+      jGrad = T(2) * val * tWeight * limitWeight * loss.deriv(sqrError);
+    }
     gradient_jointParams_to_modelParams(jGrad, parameterIndex, parameterTransform, gradient);
   }
   return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeLinearGradient(
     const LimitLinear& data,
     const ModelParametersT<T>& params,
     T tWeight,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters,
     Ref<Eigen::VectorX<T>> gradient) {
   MT_CHECK(data.referenceIndex < static_cast<size_t>(params.size()));
@@ -206,22 +292,32 @@ T computeLinearGradient(
   }
   const T residual =
       params(data.targetIndex) * data.scale - data.offset - params(data.referenceIndex);
-  const T error = residual * residual * limitWeight * tWeight;
+  const T sqrError = residual * residual;
+  T error;
+  T gradScale;
+  if constexpr (IsL2) {
+    error = limitWeight * tWeight * sqrError;
+    gradScale = T(2) * residual * limitWeight * tWeight;
+  } else {
+    error = limitWeight * tWeight * loss.value(sqrError);
+    gradScale = T(2) * residual * limitWeight * tWeight * loss.deriv(sqrError);
+  }
   if (enabledParameters.test(data.targetIndex)) {
-    gradient[data.targetIndex] += T(2) * residual * T(data.scale) * limitWeight * tWeight;
+    gradient[data.targetIndex] += gradScale * T(data.scale);
   }
   if (enabledParameters.test(data.referenceIndex)) {
-    gradient[data.referenceIndex] -= T(2) * residual * limitWeight * tWeight;
+    gradient[data.referenceIndex] -= gradScale;
   }
   return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeLinearJointGradient(
     const LimitLinearJoint& data,
     const SkeletonStateT<T>& state,
     T tWeight,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams,
     const ParameterTransform& parameterTransform,
     Ref<Eigen::VectorX<T>> gradient) {
@@ -239,25 +335,35 @@ T computeLinearJointGradient(
 
   const T residual = state.jointParameters(targetParameterIndex) * data.scale - data.offset -
       state.jointParameters(referenceParameterIndex);
-  const T error = residual * residual * limitWeight * tWeight;
+  const T sqrError = residual * residual;
+  T error;
+  T gradScale;
+  if constexpr (IsL2) {
+    error = limitWeight * tWeight * sqrError;
+    gradScale = T(2) * residual * limitWeight * tWeight;
+  } else {
+    error = limitWeight * tWeight * loss.value(sqrError);
+    gradScale = T(2) * residual * limitWeight * tWeight * loss.deriv(sqrError);
+  }
 
-  const T targetGrad = T(2) * residual * T(data.scale) * limitWeight * tWeight;
+  const T targetGrad = gradScale * T(data.scale);
   gradient_jointParams_to_modelParams(
       targetGrad, targetParameterIndex, parameterTransform, gradient);
 
-  const T referenceGrad = T(-2) * residual * limitWeight * tWeight;
+  const T referenceGrad = -gradScale;
   gradient_jointParams_to_modelParams(
       referenceGrad, referenceParameterIndex, parameterTransform, gradient);
 
   return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeHalfPlaneGradient(
     const LimitHalfPlane& data,
     const ModelParametersT<T>& params,
     T tWeight,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters,
     Ref<Eigen::VectorX<T>> gradient) {
   if (!enabledParameters.test(data.param1) && !enabledParameters.test(data.param2)) {
@@ -268,22 +374,32 @@ T computeHalfPlaneGradient(
   if (residual >= T(0)) {
     return T(0);
   }
-  const T error = residual * residual * limitWeight * tWeight;
+  const T sqrError = residual * residual;
+  T error;
+  T gradScale;
+  if constexpr (IsL2) {
+    error = limitWeight * tWeight * sqrError;
+    gradScale = T(2) * residual * limitWeight * tWeight;
+  } else {
+    error = limitWeight * tWeight * loss.value(sqrError);
+    gradScale = T(2) * residual * limitWeight * tWeight * loss.deriv(sqrError);
+  }
   if (enabledParameters.test(data.param1)) {
-    gradient[data.param1] += T(2) * residual * T(data.normal[0]) * limitWeight * tWeight;
+    gradient[data.param1] += gradScale * T(data.normal[0]);
   }
   if (enabledParameters.test(data.param2)) {
-    gradient[data.param2] += T(2) * residual * T(data.normal[1]) * limitWeight * tWeight;
+    gradient[data.param2] += gradScale * T(data.normal[1]);
   }
   return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeEllipsoidGradient(
     const LimitEllipsoid& ct,
     const SkeletonStateT<T>& state,
     T tWeight,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams,
     const Skeleton& skeleton,
     const ParameterTransform& parameterTransform,
@@ -297,7 +413,17 @@ T computeEllipsoidGradient(
   const Eigen::Vector3<T> projectedPosition = ct.ellipsoid.template cast<T>() * normalizedPosition;
   const Eigen::Vector3<T> diff =
       position - state.jointState[ct.ellipsoidParent].transform * projectedPosition;
-  const T wgt = T(2) * T(kPositionWeight) * limitWeight * tWeight;
+  const T sqrError = diff.squaredNorm();
+
+  // wgt is the gradient scale: d(w * loss(s))/dq has the factor 2 * w * loss'(s), with
+  // w = kPositionWeight * limitWeight * tWeight. For L2, loss'(s) is folded into tWeight by the
+  // caller.
+  T wgt;
+  if constexpr (IsL2) {
+    wgt = T(2) * T(kPositionWeight) * limitWeight * tWeight;
+  } else {
+    wgt = T(2) * T(kPositionWeight) * limitWeight * tWeight * loss.deriv(sqrError);
+  }
 
   size_t jointIndex = ct.parent;
   while (jointIndex != ct.ellipsoidParent && jointIndex != kInvalidIndex) {
@@ -323,16 +449,21 @@ T computeEllipsoidGradient(
     jointIndex = skeleton.joints[jointIndex].parent;
   }
 
-  return diff.squaredNorm() * T(kPositionWeight) * tWeight * limitWeight;
+  if constexpr (IsL2) {
+    return T(kPositionWeight) * limitWeight * tWeight * sqrError;
+  } else {
+    return T(kPositionWeight) * limitWeight * tWeight * loss.value(sqrError);
+  }
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeMinMaxJacobian(
     const LimitMinMax& data,
     const ModelParametersT<T>& params,
     T tWeight,
     T limitWeight,
     T wgt,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters,
     Ref<Eigen::MatrixX<T>> jacobian,
     Ref<Eigen::VectorX<T>> residual,
@@ -342,26 +473,43 @@ T computeMinMaxJacobian(
   }
   if (params(data.parameterIndex) < data.limits[0]) {
     const T val = params(data.parameterIndex) - data.limits[0];
-    jacobian(row, data.parameterIndex) = wgt;
-    residual(row) = val * wgt;
-    return val * val * limitWeight * tWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      jacobian(row, data.parameterIndex) = wgt;
+      residual(row) = val * wgt;
+      return tWeight * limitWeight * sqrError;
+    } else {
+      const T wgtLoss = std::sqrt(tWeight * limitWeight * loss.deriv(sqrError));
+      jacobian(row, data.parameterIndex) = wgtLoss;
+      residual(row) = val * wgtLoss;
+      return tWeight * limitWeight * loss.value(sqrError);
+    }
   }
   if (params(data.parameterIndex) > data.limits[1]) {
     const T val = params(data.parameterIndex) - data.limits[1];
-    jacobian(row, data.parameterIndex) = wgt;
-    residual(row) = val * wgt;
-    return val * val * limitWeight * tWeight;
+    const T sqrError = val * val;
+    if constexpr (IsL2) {
+      jacobian(row, data.parameterIndex) = wgt;
+      residual(row) = val * wgt;
+      return tWeight * limitWeight * sqrError;
+    } else {
+      const T wgtLoss = std::sqrt(tWeight * limitWeight * loss.deriv(sqrError));
+      jacobian(row, data.parameterIndex) = wgtLoss;
+      residual(row) = val * wgtLoss;
+      return tWeight * limitWeight * loss.value(sqrError);
+    }
   }
   return T(0);
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeMinMaxJointJacobian(
     const LimitMinMaxJoint& data,
     const SkeletonStateT<T>& state,
     T tWeight,
     T limitWeight,
     T wgt,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams,
     const ParameterTransform& parameterTransform,
     Ref<Eigen::MatrixX<T>> jacobian,
@@ -374,28 +522,49 @@ T computeMinMaxJointJacobian(
   }
   if (state.jointParameters(jointIndex) < data.limits[0]) {
     const T val = state.jointParameters[jointIndex] - data.limits[0];
+    const T sqrError = val * val;
+    T wgtLoss;
+    T error;
+    if constexpr (IsL2) {
+      wgtLoss = wgt;
+      error = tWeight * limitWeight * sqrError;
+    } else {
+      wgtLoss = std::sqrt(tWeight * limitWeight * loss.deriv(sqrError));
+      error = tWeight * limitWeight * loss.value(sqrError);
+    }
     jacobian_jointParams_to_modelParams(
-        wgt, Eigen::Index(jointIndex), Eigen::Index(row), parameterTransform, jacobian);
-    residual(row) = val * wgt;
-    return val * val * limitWeight * tWeight;
+        wgtLoss, Eigen::Index(jointIndex), Eigen::Index(row), parameterTransform, jacobian);
+    residual(row) = val * wgtLoss;
+    return error;
   }
   if (state.jointParameters(jointIndex) > data.limits[1]) {
     const T val = state.jointParameters[jointIndex] - data.limits[1];
+    const T sqrError = val * val;
+    T wgtLoss;
+    T error;
+    if constexpr (IsL2) {
+      wgtLoss = wgt;
+      error = tWeight * limitWeight * sqrError;
+    } else {
+      wgtLoss = std::sqrt(tWeight * limitWeight * loss.deriv(sqrError));
+      error = tWeight * limitWeight * loss.value(sqrError);
+    }
     jacobian_jointParams_to_modelParams(
-        wgt, Eigen::Index(jointIndex), Eigen::Index(row), parameterTransform, jacobian);
-    residual(row) = val * wgt;
-    return val * val * limitWeight * tWeight;
+        wgtLoss, Eigen::Index(jointIndex), Eigen::Index(row), parameterTransform, jacobian);
+    residual(row) = val * wgtLoss;
+    return error;
   }
   return T(0);
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeLinearJacobian(
     const LimitLinear& data,
     const ModelParametersT<T>& params,
     T tWeight,
     T limitWeight,
     T wgt,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters,
     Ref<Eigen::MatrixX<T>> jacobian,
     Ref<Eigen::VectorX<T>> residual,
@@ -408,23 +577,34 @@ T computeLinearJacobian(
     return T(0);
   }
   const T res = params(data.targetIndex) * data.scale - data.offset - params(data.referenceIndex);
-  residual(row) = res * wgt;
+  const T sqrError = res * res;
+  T wgtLoss;
+  T error;
+  if constexpr (IsL2) {
+    wgtLoss = wgt;
+    error = tWeight * limitWeight * sqrError;
+  } else {
+    wgtLoss = std::sqrt(tWeight * limitWeight * loss.deriv(sqrError));
+    error = tWeight * limitWeight * loss.value(sqrError);
+  }
+  residual(row) = res * wgtLoss;
   if (enabledParameters.test(data.targetIndex)) {
-    jacobian(row, data.targetIndex) = T(data.scale) * wgt;
+    jacobian(row, data.targetIndex) = T(data.scale) * wgtLoss;
   }
   if (enabledParameters.test(data.referenceIndex)) {
-    jacobian(row, data.referenceIndex) = -wgt;
+    jacobian(row, data.referenceIndex) = -wgtLoss;
   }
-  return res * res * limitWeight * tWeight;
+  return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeLinearJointJacobian(
     const LimitLinearJoint& data,
     const SkeletonStateT<T>& state,
     T tWeight,
     T limitWeight,
     T wgt,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams,
     const ParameterTransform& parameterTransform,
     Ref<Eigen::MatrixX<T>> jacobian,
@@ -444,11 +624,21 @@ T computeLinearJointJacobian(
 
   const T res = state.jointParameters(targetParameterIndex) * data.scale - data.offset -
       state.jointParameters(referenceParameterIndex);
-  residual(row) = res * wgt;
+  const T sqrError = res * res;
+  T wgtLoss;
+  T error;
+  if constexpr (IsL2) {
+    wgtLoss = wgt;
+    error = tWeight * limitWeight * sqrError;
+  } else {
+    wgtLoss = std::sqrt(tWeight * limitWeight * loss.deriv(sqrError));
+    error = tWeight * limitWeight * loss.value(sqrError);
+  }
+  residual(row) = res * wgtLoss;
 
   if (activeJointParams[targetParameterIndex]) {
     jacobian_jointParams_to_modelParams(
-        T(data.scale) * wgt,
+        T(data.scale) * wgtLoss,
         Eigen::Index(targetParameterIndex),
         Eigen::Index(row),
         parameterTransform,
@@ -456,22 +646,23 @@ T computeLinearJointJacobian(
   }
   if (activeJointParams[referenceParameterIndex]) {
     jacobian_jointParams_to_modelParams(
-        -wgt,
+        -wgtLoss,
         Eigen::Index(referenceParameterIndex),
         Eigen::Index(row),
         parameterTransform,
         jacobian);
   }
-  return res * res * limitWeight * tWeight;
+  return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeHalfPlaneJacobian(
     const LimitHalfPlane& data,
     const ModelParametersT<T>& params,
     T tWeight,
     T limitWeight,
     T wgt,
+    const GeneralizedLossT<T>& loss,
     const ParameterSet& enabledParameters,
     Ref<Eigen::MatrixX<T>> jacobian,
     Ref<Eigen::VectorX<T>> residual,
@@ -487,23 +678,34 @@ T computeHalfPlaneJacobian(
   if (res >= T(0)) {
     return T(0);
   }
-  residual(row) = res * wgt;
+  const T sqrError = res * res;
+  T wgtLoss;
+  T error;
+  if constexpr (IsL2) {
+    wgtLoss = wgt;
+    error = tWeight * limitWeight * sqrError;
+  } else {
+    wgtLoss = std::sqrt(tWeight * limitWeight * loss.deriv(sqrError));
+    error = tWeight * limitWeight * loss.value(sqrError);
+  }
+  residual(row) = res * wgtLoss;
   if (enabledParameters.test(data.param1)) {
-    jacobian(row, data.param1) = T(data.normal[0]) * wgt;
+    jacobian(row, data.param1) = T(data.normal[0]) * wgtLoss;
   }
   if (enabledParameters.test(data.param2)) {
-    jacobian(row, data.param2) = T(data.normal[1]) * wgt;
+    jacobian(row, data.param2) = T(data.normal[1]) * wgtLoss;
   }
-  return res * res * limitWeight * tWeight;
+  return error;
 }
 
-template <typename T>
+template <typename T, bool IsL2>
 T computeEllipsoidJacobian(
     const LimitEllipsoid& ct,
     const ModelParametersT<T>& params,
     const SkeletonStateT<T>& state,
     T totalWeight,
     T limitWeight,
+    const GeneralizedLossT<T>& loss,
     const Eigen::VectorX<bool>& activeJointParams,
     const Skeleton& skeleton,
     const ParameterTransform& parameterTransform,
@@ -519,13 +721,21 @@ T computeEllipsoidJacobian(
   const Eigen::Vector3<T> projectedPosition = ct.ellipsoid.template cast<T>() * normalizedPosition;
   const Eigen::Vector3<T> diff =
       position - state.jointState[ct.ellipsoidParent].transform * projectedPosition;
+  const T sqrError = diff.squaredNorm();
 
   Eigen::Ref<Eigen::MatrixX<T>> jac = jacobian.block(row, 0, 3, params.size());
   Eigen::Ref<Eigen::VectorX<T>> res = residual.middleRows(row, 3);
   MT_CHECK(jac.cols() == static_cast<Eigen::Index>(parameterTransform.transform.cols()));
   MT_CHECK(jac.rows() == 3);
 
-  const T jwgt = std::sqrt(totalWeight * T(kPositionWeight) * limitWeight);
+  // jwgt is the residual/Jacobian scale sqrt(w * loss'(s)), with w = totalWeight * kPositionWeight
+  // * limitWeight. For L2, loss'(s) is folded into totalWeight by the caller.
+  T jwgt;
+  if constexpr (IsL2) {
+    jwgt = std::sqrt(totalWeight * T(kPositionWeight) * limitWeight);
+  } else {
+    jwgt = std::sqrt(totalWeight * T(kPositionWeight) * limitWeight * loss.deriv(sqrError));
+  }
 
   size_t jointIndex = ct.parent;
   while (jointIndex != ct.ellipsoidParent && jointIndex != kInvalidIndex) {
@@ -567,7 +777,11 @@ T computeEllipsoidJacobian(
   }
 
   res = diff * jwgt;
-  return jwgt * jwgt * diff.squaredNorm();
+  if constexpr (IsL2) {
+    return totalWeight * T(kPositionWeight) * limitWeight * sqrError;
+  } else {
+    return totalWeight * T(kPositionWeight) * limitWeight * loss.value(sqrError);
+  }
 }
 
 } // namespace
@@ -576,19 +790,81 @@ template <typename T>
 LimitErrorFunctionT<T>::LimitErrorFunctionT(
     const Skeleton& skel,
     const ParameterTransform& pt,
-    const ParameterLimits& pl)
-    : SkeletonErrorFunctionT<T>(skel, pt), limits_(pl) {}
+    const ParameterLimits& pl,
+    const T& lossAlpha,
+    const T& lossC)
+    : SkeletonErrorFunctionT<T>(skel, pt), limits_(pl), loss_(lossAlpha, lossC) {}
 
 template <typename T>
-LimitErrorFunctionT<T>::LimitErrorFunctionT(const Character& character)
+LimitErrorFunctionT<T>::LimitErrorFunctionT(
+    const Character& character,
+    const T& lossAlpha,
+    const T& lossC)
     : LimitErrorFunctionT(
           character.skeleton,
           character.parameterTransform,
-          character.parameterLimits) {}
+          character.parameterLimits,
+          lossAlpha,
+          lossC) {}
 
 template <typename T>
-LimitErrorFunctionT<T>::LimitErrorFunctionT(const Character& character, const ParameterLimits& pl)
-    : LimitErrorFunctionT(character.skeleton, character.parameterTransform, pl) {}
+LimitErrorFunctionT<T>::LimitErrorFunctionT(
+    const Character& character,
+    const ParameterLimits& pl,
+    const T& lossAlpha,
+    const T& lossC)
+    : LimitErrorFunctionT(character.skeleton, character.parameterTransform, pl, lossAlpha, lossC) {}
+
+template <typename T>
+template <bool IsL2>
+[[nodiscard]] double LimitErrorFunctionT<T>::getErrorImpl(
+    const ModelParametersT<T>& params,
+    const SkeletonStateT<T>& state) const {
+  double error = 0.0;
+
+  for (const auto& limit : limits_) {
+    const T limitWeight = T(limit.weight);
+    switch (limit.type) {
+      case MinMax:
+        error += computeMinMaxError<T, IsL2>(
+            limit.data.minMax, params, limitWeight, loss_, this->enabledParameters_);
+        break;
+      case MinMaxJoint:
+        error += computeMinMaxJointError<T, IsL2>(
+            limit.data.minMaxJoint, state, limitWeight, loss_, this->activeJointParams_);
+        break;
+      case MinMaxJointPassive:
+        break;
+      case Linear:
+        error += computeLinearError<T, IsL2>(
+            limit.data.linear, params, limitWeight, loss_, this->enabledParameters_);
+        break;
+      case LinearJoint:
+        error += computeLinearJointError<T, IsL2>(
+            limit.data.linearJoint, state, limitWeight, loss_, this->activeJointParams_);
+        break;
+      case HalfPlane:
+        error += computeHalfPlaneError<T, IsL2>(
+            limit.data.halfPlane, params, limitWeight, loss_, this->enabledParameters_);
+        break;
+      case Ellipsoid:
+        error += computeEllipsoidError<T, IsL2>(limit.data.ellipsoid, state, limitWeight, loss_);
+        break;
+      case LimitTypeCount:
+      default:
+        MT_THROW("Unknown parameter type for joint limit");
+        break;
+    }
+  }
+
+  // For an L2 loss the per-limit terms above are raw squared residuals; the loss scale 1/c^2 is
+  // applied once here. For a non-L2 loss it is already baked into loss_.value().
+  if constexpr (IsL2) {
+    return error * kLimitWeight * this->weight_ * loss_.invC2();
+  } else {
+    return error * kLimitWeight * this->weight_;
+  }
+}
 
 template <typename T>
 double LimitErrorFunctionT<T>::getError(
@@ -601,43 +877,102 @@ double LimitErrorFunctionT<T>::getError(
       state.jointParameters.size() ==
       gsl::narrow<Eigen::Index>(this->skeleton_.joints.size() * kParametersPerJoint));
 
+  return loss_.isL2() ? getErrorImpl<true>(params, state) : getErrorImpl<false>(params, state);
+}
+
+template <typename T>
+template <bool IsL2>
+[[nodiscard]] double LimitErrorFunctionT<T>::getGradientImpl(
+    const ModelParametersT<T>& params,
+    const SkeletonStateT<T>& state,
+    Ref<Eigen::VectorX<T>> gradient) const {
+  const auto& parameterTransform = this->parameterTransform_;
   double error = 0.0;
+
+  // tWeight folds in the loss scale 1/c^2 for the L2 path so the per-constraint code below needs no
+  // loss-function calls.
+  T tWeight = kLimitWeight * this->weight_;
+  if constexpr (IsL2) {
+    tWeight *= loss_.invC2();
+  }
 
   for (const auto& limit : limits_) {
     const T limitWeight = T(limit.weight);
     switch (limit.type) {
       case MinMax:
-        error +=
-            computeMinMaxError(limit.data.minMax, params, limitWeight, this->enabledParameters_);
+        error += computeMinMaxGradient<T, IsL2>(
+            limit.data.minMax,
+            params,
+            tWeight,
+            limitWeight,
+            loss_,
+            this->enabledParameters_,
+            gradient);
         break;
       case MinMaxJoint:
-        error += computeMinMaxJointError(
-            limit.data.minMaxJoint, state, limitWeight, this->activeJointParams_);
+        error += computeMinMaxJointGradient<T, IsL2>(
+            limit.data.minMaxJoint,
+            state,
+            tWeight,
+            limitWeight,
+            loss_,
+            this->activeJointParams_,
+            parameterTransform,
+            gradient);
         break;
       case MinMaxJointPassive:
         break;
       case Linear:
-        error +=
-            computeLinearError(limit.data.linear, params, limitWeight, this->enabledParameters_);
+        error += computeLinearGradient<T, IsL2>(
+            limit.data.linear,
+            params,
+            tWeight,
+            limitWeight,
+            loss_,
+            this->enabledParameters_,
+            gradient);
         break;
       case LinearJoint:
-        error += computeLinearJointError(
-            limit.data.linearJoint, state, limitWeight, this->activeJointParams_);
+        error += computeLinearJointGradient<T, IsL2>(
+            limit.data.linearJoint,
+            state,
+            tWeight,
+            limitWeight,
+            loss_,
+            this->activeJointParams_,
+            parameterTransform,
+            gradient);
         break;
       case HalfPlane:
-        error += computeHalfPlaneError(
-            limit.data.halfPlane, params, limitWeight, this->enabledParameters_);
+        error += computeHalfPlaneGradient<T, IsL2>(
+            limit.data.halfPlane,
+            params,
+            tWeight,
+            limitWeight,
+            loss_,
+            this->enabledParameters_,
+            gradient);
         break;
       case Ellipsoid:
-        error += computeEllipsoidError(limit.data.ellipsoid, state, limitWeight);
+        error += computeEllipsoidGradient<T, IsL2>(
+            limit.data.ellipsoid,
+            state,
+            tWeight,
+            limitWeight,
+            loss_,
+            this->activeJointParams_,
+            this->skeleton_,
+            parameterTransform,
+            gradient);
         break;
+      case LimitTypeCount:
       default:
         MT_THROW("Unknown parameter type for joint limit");
         break;
     }
   }
 
-  return error * kLimitWeight * this->weight_;
+  return error;
 }
 
 template <typename T>
@@ -648,64 +983,140 @@ double LimitErrorFunctionT<T>::getGradient(
     Ref<Eigen::VectorX<T>> gradient) {
   MT_PROFILE_FUNCTION();
 
+  return loss_.isL2() ? getGradientImpl<true>(params, state, gradient)
+                      : getGradientImpl<false>(params, state, gradient);
+}
+
+template <typename T>
+template <bool IsL2>
+double LimitErrorFunctionT<T>::getJacobianImpl(
+    const ModelParametersT<T>& params,
+    const SkeletonStateT<T>& state,
+    Ref<Eigen::MatrixX<T>> jacobian,
+    Ref<Eigen::VectorX<T>> residual,
+    int& usedRows) const {
   const auto& parameterTransform = this->parameterTransform_;
   double error = 0.0;
-  const T tWeight = kLimitWeight * this->weight_;
 
+  // tWeight folds in the loss scale 1/c^2 for the L2 path. The Jacobian weight sqrt(tWeight *
+  // limitWeight) is then a constant per limit (it does not depend on the residual), so it is
+  // computed once here rather than inside the per-constraint helpers. This matches the original
+  // L2-only implementation; the non-L2 path cannot do this because its weight depends on the
+  // per-constraint residual via loss'(s).
+  T tWeight = kLimitWeight * this->weight_;
+  if constexpr (IsL2) {
+    tWeight *= loss_.invC2();
+  }
+
+  jacobian.setZero();
+  residual.setZero();
+
+  int count = 0;
   for (const auto& limit : limits_) {
     const T limitWeight = T(limit.weight);
+    T wgt = T(0);
+    if constexpr (IsL2) {
+      wgt = std::sqrt(tWeight * limitWeight);
+    }
     switch (limit.type) {
       case MinMax:
-        error += computeMinMaxGradient(
-            limit.data.minMax, params, tWeight, limitWeight, this->enabledParameters_, gradient);
+        error += computeMinMaxJacobian<T, IsL2>(
+            limit.data.minMax,
+            params,
+            tWeight,
+            limitWeight,
+            wgt,
+            loss_,
+            this->enabledParameters_,
+            jacobian,
+            residual,
+            count);
+        count++;
         break;
       case MinMaxJoint:
-        error += computeMinMaxJointGradient(
+        error += computeMinMaxJointJacobian<T, IsL2>(
             limit.data.minMaxJoint,
             state,
             tWeight,
             limitWeight,
+            wgt,
+            loss_,
             this->activeJointParams_,
             parameterTransform,
-            gradient);
+            jacobian,
+            residual,
+            count);
+        count++;
         break;
       case MinMaxJointPassive:
         break;
       case Linear:
-        error += computeLinearGradient(
-            limit.data.linear, params, tWeight, limitWeight, this->enabledParameters_, gradient);
+        error += computeLinearJacobian<T, IsL2>(
+            limit.data.linear,
+            params,
+            tWeight,
+            limitWeight,
+            wgt,
+            loss_,
+            this->enabledParameters_,
+            jacobian,
+            residual,
+            count);
+        count++;
         break;
       case LinearJoint:
-        error += computeLinearJointGradient(
+        error += computeLinearJointJacobian<T, IsL2>(
             limit.data.linearJoint,
             state,
             tWeight,
             limitWeight,
+            wgt,
+            loss_,
             this->activeJointParams_,
             parameterTransform,
-            gradient);
+            jacobian,
+            residual,
+            count);
+        count++;
         break;
       case HalfPlane:
-        error += computeHalfPlaneGradient(
-            limit.data.halfPlane, params, tWeight, limitWeight, this->enabledParameters_, gradient);
+        error += computeHalfPlaneJacobian<T, IsL2>(
+            limit.data.halfPlane,
+            params,
+            tWeight,
+            limitWeight,
+            wgt,
+            loss_,
+            this->enabledParameters_,
+            jacobian,
+            residual,
+            count);
+        count++;
         break;
       case Ellipsoid:
-        error += computeEllipsoidGradient(
+        error += computeEllipsoidJacobian<T, IsL2>(
             limit.data.ellipsoid,
+            params,
             state,
             tWeight,
             limitWeight,
+            loss_,
             this->activeJointParams_,
             this->skeleton_,
             parameterTransform,
-            gradient);
+            jacobian,
+            residual,
+            count);
+        count += 3;
         break;
+      case LimitTypeCount:
       default:
         MT_THROW("Unknown parameter type for joint limit");
         break;
     }
   }
 
+  usedRows = count;
   return error;
 }
 
@@ -719,110 +1130,8 @@ double LimitErrorFunctionT<T>::getJacobian(
     int& usedRows) {
   MT_PROFILE_FUNCTION();
 
-  const auto& parameterTransform = this->parameterTransform_;
-  double error = 0.0;
-  const T tWeight = kLimitWeight * this->weight_;
-
-  jacobian.setZero();
-  residual.setZero();
-
-  int count = 0;
-  for (const auto& limit : limits_) {
-    const T limitWeight = T(limit.weight);
-    const T wgt = std::sqrt(T(kLimitWeight) * this->weight_ * limitWeight);
-    switch (limit.type) {
-      case MinMax:
-        error += computeMinMaxJacobian(
-            limit.data.minMax,
-            params,
-            tWeight,
-            limitWeight,
-            wgt,
-            this->enabledParameters_,
-            jacobian,
-            residual,
-            count);
-        count++;
-        break;
-      case MinMaxJoint:
-        error += computeMinMaxJointJacobian(
-            limit.data.minMaxJoint,
-            state,
-            tWeight,
-            limitWeight,
-            wgt,
-            this->activeJointParams_,
-            parameterTransform,
-            jacobian,
-            residual,
-            count);
-        count++;
-        break;
-      case MinMaxJointPassive:
-        break;
-      case Linear:
-        error += computeLinearJacobian(
-            limit.data.linear,
-            params,
-            tWeight,
-            limitWeight,
-            wgt,
-            this->enabledParameters_,
-            jacobian,
-            residual,
-            count);
-        count++;
-        break;
-      case LinearJoint:
-        error += computeLinearJointJacobian(
-            limit.data.linearJoint,
-            state,
-            tWeight,
-            limitWeight,
-            wgt,
-            this->activeJointParams_,
-            parameterTransform,
-            jacobian,
-            residual,
-            count);
-        count++;
-        break;
-      case HalfPlane:
-        error += computeHalfPlaneJacobian(
-            limit.data.halfPlane,
-            params,
-            tWeight,
-            limitWeight,
-            wgt,
-            this->enabledParameters_,
-            jacobian,
-            residual,
-            count);
-        count++;
-        break;
-      case Ellipsoid:
-        error += computeEllipsoidJacobian(
-            limit.data.ellipsoid,
-            params,
-            state,
-            tWeight,
-            limitWeight,
-            this->activeJointParams_,
-            this->skeleton_,
-            parameterTransform,
-            jacobian,
-            residual,
-            count);
-        count += 3;
-        break;
-      default:
-        MT_THROW("Unknown parameter type for joint limit");
-        break;
-    }
-  }
-
-  usedRows = count;
-  return error;
+  return loss_.isL2() ? getJacobianImpl<true>(params, state, jacobian, residual, usedRows)
+                      : getJacobianImpl<false>(params, state, jacobian, residual, usedRows);
 }
 
 template <typename T>
@@ -842,6 +1151,7 @@ size_t LimitErrorFunctionT<T>::getJacobianSize() const {
       case Ellipsoid:
         count += 3;
         break;
+      case LimitTypeCount:
       default:
         MT_THROW("Unknown parameter type for joint limit");
         break;

--- a/momentum/character_solver/limit_error_function.h
+++ b/momentum/character_solver/limit_error_function.h
@@ -11,18 +11,56 @@
 #include <momentum/character_solver/fwd.h>
 #include <momentum/character_solver/limit_error_function.h>
 #include <momentum/character_solver/skeleton_error_function.h>
+#include <momentum/math/generalized_loss.h>
 
 namespace momentum {
 
+/// Penalizes model/joint parameters that violate their configured limits.
+///
+/// Each limit contributes a squared residual (e.g., how far a parameter is past a min/max bound)
+/// that is transformed by the generalized loss function (see math/generalized_loss.h) before being
+/// weighted and accumulated. The default loss is L2 (alpha = 2, c = 1), which reproduces the
+/// classic quadratic penalty; other alpha values make the penalty robust to outliers.
 template <typename T>
 class LimitErrorFunctionT : public SkeletonErrorFunctionT<T> {
  public:
+  /// Constructor
+  ///
+  /// @param[in] skel: character skeleton
+  /// @param[in] pt: character parameter transform
+  /// @param[in] pl: parameter limits to enforce
+  /// @param[in] lossAlpha: alpha (shape) parameter for the generalized loss function
+  /// @param[in] lossC: c (scale) parameter for the generalized loss function
   LimitErrorFunctionT(
       const Skeleton& skel,
       const ParameterTransform& pt,
-      const ParameterLimits& pl = ParameterLimits());
-  explicit LimitErrorFunctionT(const Character& character);
-  LimitErrorFunctionT(const Character& character, const ParameterLimits& pl);
+      const ParameterLimits& pl = ParameterLimits(),
+      const T& lossAlpha = GeneralizedLossT<T>::kL2,
+      const T& lossC = T(1));
+
+  /// A convenience constructor where character contains info of the skeleton, parameter transform,
+  /// and parameter limits.
+  ///
+  /// @param[in] character: character definition
+  /// @param[in] lossAlpha: alpha (shape) parameter for the generalized loss function
+  /// @param[in] lossC: c (scale) parameter for the generalized loss function
+  explicit LimitErrorFunctionT(
+      const Character& character,
+      const T& lossAlpha = GeneralizedLossT<T>::kL2,
+      const T& lossC = T(1));
+
+  /// A convenience constructor where character supplies the skeleton and parameter transform, with
+  /// an explicit set of parameter limits.
+  ///
+  /// @param[in] character: character definition
+  /// @param[in] pl: parameter limits to enforce
+  /// @param[in] lossAlpha: alpha (shape) parameter for the generalized loss function
+  /// @param[in] lossC: c (scale) parameter for the generalized loss function
+  LimitErrorFunctionT(
+      const Character& character,
+      const ParameterLimits& pl,
+      const T& lossAlpha = GeneralizedLossT<T>::kL2,
+      const T& lossC = T(1));
 
   [[nodiscard]] double getError(
       const ModelParametersT<T>& params,
@@ -52,6 +90,32 @@ class LimitErrorFunctionT : public SkeletonErrorFunctionT<T> {
   // weights for the error functions
   static constexpr float kLimitWeight = 1e+1;
   ParameterLimits limits_;
+  /// The generalized loss function applied to each squared limit residual.
+  const GeneralizedLossT<T> loss_;
+
+  // Implementations of the three public entry points, templated on whether the loss is a plain L2
+  // loss. The L2 path (the default) is compiled with no per-constraint loss-function calls so it
+  // matches the original hand-optimized quadratic penalty with no performance regression; the
+  // non-L2 path applies the generalized loss. getError/getGradient/getJacobian dispatch to these
+  // based on loss_.isL2().
+  template <bool IsL2>
+  [[nodiscard]] double getErrorImpl(
+      const ModelParametersT<T>& params,
+      const SkeletonStateT<T>& state) const;
+
+  template <bool IsL2>
+  [[nodiscard]] double getGradientImpl(
+      const ModelParametersT<T>& params,
+      const SkeletonStateT<T>& state,
+      Ref<Eigen::VectorX<T>> gradient) const;
+
+  template <bool IsL2>
+  double getJacobianImpl(
+      const ModelParametersT<T>& params,
+      const SkeletonStateT<T>& state,
+      Ref<Eigen::MatrixX<T>> jacobian,
+      Ref<Eigen::VectorX<T>> residual,
+      int& usedRows) const;
 };
 
 } // namespace momentum

--- a/momentum/test/character_solver/limit_error_function_loss_test.cpp
+++ b/momentum/test/character_solver/limit_error_function_loss_test.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "momentum/character/character.h"
+#include "momentum/character/mesh_state.h"
+#include "momentum/character/skeleton_state.h"
+#include "momentum/character_solver/limit_error_function.h"
+#include "momentum/math/generalized_loss.h"
+#include "momentum/test/character/character_helpers.h"
+
+#include <cfloat>
+#include <cmath>
+
+using namespace momentum;
+
+namespace {
+
+SkeletonStated makeState(const Character& character, const ModelParametersd& params) {
+  const ParameterTransformT<double> transform = character.parameterTransform.cast<double>();
+  return {transform.apply(params), character.skeleton};
+}
+
+void expectCauchyScalesSingleLimit(
+    const char* name,
+    const Character& character,
+    const ParameterLimit& limit,
+    const ModelParametersd& params,
+    const SkeletonStated& state) {
+  SCOPED_TRACE(name);
+
+  LimitErrorFunctiond l2Fn(character.skeleton, character.parameterTransform, {limit});
+  LimitErrorFunctiond cauchyFn(
+      character.skeleton,
+      character.parameterTransform,
+      {limit},
+      GeneralizedLossT<double>::kCauchy,
+      1.0);
+
+  const MeshStated meshState{};
+  const double l2Error = l2Fn.getError(params, state, meshState);
+  const double cauchyError = cauchyFn.getError(params, state, meshState);
+  ASSERT_GT(l2Error, 1e-12);
+  ASSERT_GT(cauchyError, 0.0);
+  EXPECT_LT(cauchyError, l2Error);
+
+  VectorXd l2Gradient = VectorXd::Zero(params.size());
+  VectorXd cauchyGradient = VectorXd::Zero(params.size());
+  EXPECT_NEAR(l2Fn.getGradient(params, state, meshState, l2Gradient), l2Error, 1e-9);
+  EXPECT_NEAR(cauchyFn.getGradient(params, state, meshState, cauchyGradient), cauchyError, 1e-9);
+
+  const auto rows = static_cast<Eigen::Index>(l2Fn.getJacobianSize());
+  ASSERT_EQ(cauchyFn.getJacobianSize(), static_cast<size_t>(rows));
+  MatrixXd l2Jacobian = MatrixXd::Zero(rows, params.size());
+  MatrixXd cauchyJacobian = MatrixXd::Zero(rows, params.size());
+  VectorXd l2Residual = VectorXd::Zero(rows);
+  VectorXd cauchyResidual = VectorXd::Zero(rows);
+  int l2Rows = 0;
+  int cauchyRows = 0;
+  EXPECT_NEAR(
+      l2Fn.getJacobian(params, state, meshState, l2Jacobian, l2Residual, l2Rows), l2Error, 1e-9);
+  EXPECT_NEAR(
+      cauchyFn.getJacobian(params, state, meshState, cauchyJacobian, cauchyResidual, cauchyRows),
+      cauchyError,
+      1e-9);
+  ASSERT_EQ(l2Rows, rows);
+  ASSERT_EQ(cauchyRows, rows);
+
+  Eigen::Index maxGradientIndex = 0;
+  const double maxGradient = l2Gradient.cwiseAbs().maxCoeff(&maxGradientIndex);
+  ASSERT_GT(maxGradient, 1e-12);
+
+  const double gradientScale = cauchyGradient[maxGradientIndex] / l2Gradient[maxGradientIndex];
+  ASSERT_GT(gradientScale, 0.0);
+  ASSERT_LT(gradientScale, 1.0);
+  EXPECT_TRUE(cauchyGradient.isApprox(l2Gradient * gradientScale, 1e-8))
+      << name << " gradient is not uniformly scaled by the loss derivative";
+
+  const double jacobianScale = std::sqrt(gradientScale);
+  EXPECT_TRUE(cauchyJacobian.isApprox(l2Jacobian * jacobianScale, 1e-8))
+      << name << " Jacobian is not uniformly scaled by sqrt(loss derivative)";
+  EXPECT_TRUE(cauchyResidual.isApprox(l2Residual * jacobianScale, 1e-8))
+      << name << " residual is not uniformly scaled by sqrt(loss derivative)";
+
+  // For Cauchy with c = 1, loss'(s) = 1 / (s + 2). Invert the observed gradient
+  // scale to recover the raw squared residual and independently check the loss value.
+  const double sqrError = 1.0 / gradientScale - 2.0;
+  ASSERT_GT(sqrError, 0.0);
+  const double expectedErrorRatio = std::log(1.0 + 0.5 * sqrError) / sqrError;
+  EXPECT_NEAR(cauchyError / l2Error, expectedErrorRatio, 1e-8);
+}
+
+void expectL2ScaleC(
+    const Character& character,
+    const ParameterLimit& limit,
+    const ModelParametersd& params,
+    const SkeletonStated& state) {
+  SCOPED_TRACE("L2 scale c");
+
+  LimitErrorFunctiond l2Fn(character.skeleton, character.parameterTransform, {limit});
+  LimitErrorFunctiond l2ScaledFn(
+      character.skeleton,
+      character.parameterTransform,
+      {limit},
+      GeneralizedLossT<double>::kL2,
+      2.0);
+
+  const MeshStated meshState{};
+  const double l2Error = l2Fn.getError(params, state, meshState);
+  const double l2ScaledError = l2ScaledFn.getError(params, state, meshState);
+  ASSERT_GT(l2Error, 1e-12);
+  EXPECT_NEAR(l2ScaledError, l2Error / 4.0, 1e-9);
+
+  VectorXd l2Gradient = VectorXd::Zero(params.size());
+  VectorXd l2ScaledGradient = VectorXd::Zero(params.size());
+  l2Fn.getGradient(params, state, meshState, l2Gradient);
+  l2ScaledFn.getGradient(params, state, meshState, l2ScaledGradient);
+  EXPECT_TRUE(l2ScaledGradient.isApprox(l2Gradient / 4.0, 1e-9));
+
+  const auto rows = static_cast<Eigen::Index>(l2Fn.getJacobianSize());
+  MatrixXd l2Jacobian = MatrixXd::Zero(rows, params.size());
+  MatrixXd l2ScaledJacobian = MatrixXd::Zero(rows, params.size());
+  VectorXd l2Residual = VectorXd::Zero(rows);
+  VectorXd l2ScaledResidual = VectorXd::Zero(rows);
+  int l2Rows = 0;
+  int l2ScaledRows = 0;
+  l2Fn.getJacobian(params, state, meshState, l2Jacobian, l2Residual, l2Rows);
+  l2ScaledFn.getJacobian(
+      params, state, meshState, l2ScaledJacobian, l2ScaledResidual, l2ScaledRows);
+  ASSERT_EQ(l2Rows, rows);
+  ASSERT_EQ(l2ScaledRows, rows);
+  EXPECT_TRUE(l2ScaledJacobian.isApprox(l2Jacobian / 2.0, 1e-9));
+  EXPECT_TRUE(l2ScaledResidual.isApprox(l2Residual / 2.0, 1e-9));
+}
+
+} // namespace
+
+TEST(LimitErrorFunctionLossTest, GeneralizedLossScalesEachLimitType) {
+  const Character character = createTestCharacter();
+  const ParameterTransformT<double> transform = character.parameterTransform.cast<double>();
+  const auto makeParams = [&]() {
+    return ModelParametersd::Zero(transform.numAllModelParameters());
+  };
+
+  {
+    ParameterLimit minMax{};
+    minMax.type = MinMax;
+    minMax.weight = 1.0f;
+    minMax.data.minMax.limits = Vector2f(-0.1f, 0.1f);
+    minMax.data.minMax.parameterIndex = 0;
+
+    ModelParametersd params = makeParams();
+    params[minMax.data.minMax.parameterIndex] = 1.0; // 0.9 past the upper bound
+    const SkeletonStated state = makeState(character, params);
+
+    expectCauchyScalesSingleLimit("MinMax", character, minMax, params, state);
+    expectL2ScaleC(character, minMax, params, state);
+  }
+
+  {
+    ParameterLimit minMaxJoint{};
+    minMaxJoint.type = MinMaxJoint;
+    minMaxJoint.weight = 1.0f;
+    minMaxJoint.data.minMaxJoint.limits = Vector2f(-0.1f, 0.1f);
+    minMaxJoint.data.minMaxJoint.jointIndex = 2;
+    minMaxJoint.data.minMaxJoint.jointParameter = 5;
+
+    ModelParametersd params = makeParams();
+    SkeletonStated state = makeState(character, params);
+    const size_t jointParameterIndex =
+        minMaxJoint.data.minMaxJoint.jointIndex * kParametersPerJoint +
+        minMaxJoint.data.minMaxJoint.jointParameter;
+    state.jointParameters[jointParameterIndex] = 1.0;
+
+    expectCauchyScalesSingleLimit("MinMaxJoint", character, minMaxJoint, params, state);
+  }
+
+  {
+    ParameterLimit linear{};
+    linear.type = Linear;
+    linear.weight = 1.5f;
+    linear.data.linear.referenceIndex = 0;
+    linear.data.linear.targetIndex = 5;
+    linear.data.linear.scale = 0.25f;
+    linear.data.linear.offset = 0.25f;
+    linear.data.linear.rangeMin = -FLT_MAX;
+    linear.data.linear.rangeMax = FLT_MAX;
+
+    ModelParametersd params = makeParams();
+    params[linear.data.linear.referenceIndex] = -1.0;
+    params[linear.data.linear.targetIndex] = 2.0;
+    const SkeletonStated state = makeState(character, params);
+
+    expectCauchyScalesSingleLimit("Linear", character, linear, params, state);
+  }
+
+  {
+    ParameterLimit linearJoint{};
+    linearJoint.type = LinearJoint;
+    linearJoint.weight = 0.75f;
+    linearJoint.data.linearJoint.referenceJointIndex = 0;
+    linearJoint.data.linearJoint.referenceJointParameter = 2;
+    linearJoint.data.linearJoint.targetJointIndex = 1;
+    linearJoint.data.linearJoint.targetJointParameter = 5;
+    linearJoint.data.linearJoint.scale = 1.0f;
+    linearJoint.data.linearJoint.offset = 0.0f;
+    linearJoint.data.linearJoint.rangeMin = -FLT_MAX;
+    linearJoint.data.linearJoint.rangeMax = FLT_MAX;
+
+    ModelParametersd params = makeParams();
+    SkeletonStated state = makeState(character, params);
+    const size_t referenceParameterIndex =
+        linearJoint.data.linearJoint.referenceJointIndex * kParametersPerJoint +
+        linearJoint.data.linearJoint.referenceJointParameter;
+    const size_t targetParameterIndex =
+        linearJoint.data.linearJoint.targetJointIndex * kParametersPerJoint +
+        linearJoint.data.linearJoint.targetJointParameter;
+    state.jointParameters[referenceParameterIndex] = 0.0;
+    state.jointParameters[targetParameterIndex] = 1.0;
+
+    expectCauchyScalesSingleLimit("LinearJoint", character, linearJoint, params, state);
+  }
+
+  {
+    ParameterLimit halfPlane{};
+    halfPlane.type = HalfPlane;
+    halfPlane.weight = 1.0f;
+    halfPlane.data.halfPlane.param1 = 0;
+    halfPlane.data.halfPlane.param2 = 2;
+    halfPlane.data.halfPlane.normal = Eigen::Vector2f(1.0f, -1.0f).normalized();
+    halfPlane.data.halfPlane.offset = 0.5f;
+
+    ModelParametersd params = makeParams();
+    params[halfPlane.data.halfPlane.param1] = 0.0;
+    params[halfPlane.data.halfPlane.param2] = 1.0;
+    const SkeletonStated state = makeState(character, params);
+
+    expectCauchyScalesSingleLimit("HalfPlane", character, halfPlane, params, state);
+  }
+
+  {
+    ParameterLimit ellipsoid{};
+    ellipsoid.type = Ellipsoid;
+    ellipsoid.weight = 1.0f;
+    ellipsoid.data.ellipsoid.parent = 2;
+    ellipsoid.data.ellipsoid.ellipsoidParent = 0;
+    ellipsoid.data.ellipsoid.offset = Eigen::Vector3f(0.5f, 0.0f, 0.0f);
+    Eigen::Affine3f ellipsoidTransform = Eigen::Affine3f::Identity();
+    ellipsoidTransform.linear()(0, 0) = 0.2f;
+    ellipsoidTransform.linear()(1, 1) = 0.1f;
+    ellipsoidTransform.linear()(2, 2) = 0.15f;
+    ellipsoid.data.ellipsoid.ellipsoid = ellipsoidTransform;
+    ellipsoid.data.ellipsoid.ellipsoidInv = ellipsoidTransform.inverse();
+
+    const ModelParametersd params = makeParams();
+    const SkeletonStated state = makeState(character, params);
+
+    expectCauchyScalesSingleLimit("Ellipsoid", character, ellipsoid, params, state);
+  }
+}

--- a/momentum/test/character_solver/limit_error_function_test.cpp
+++ b/momentum/test/character_solver/limit_error_function_test.cpp
@@ -16,6 +16,8 @@
 #include "momentum/test/character/character_helpers.h"
 #include "momentum/test/character_solver/error_function_helpers.h"
 
+#include <cfloat>
+
 using namespace momentum;
 
 using Types = testing::Types<float, double>;

--- a/pymomentum/solver2/solver2_error_functions.cpp
+++ b/pymomentum/solver2/solver2_error_functions.cpp
@@ -141,15 +141,23 @@ void addErrorFunctions(py::module_& m) {
             return fmt::format("LimitErrorFunction(weight={})", self.getWeight());
           })
       .def(
-          py::init<>([](const mm::Character& character, float weight) {
+          py::init<>([](const mm::Character& character, float alpha, float c, float weight) {
             validateWeight(weight, "weight");
-            auto result = std::make_shared<mm::LimitErrorFunction>(character);
+            auto result = std::make_shared<mm::LimitErrorFunction>(character, alpha, c);
             result->setWeight(weight);
             return result;
           }),
           py::keep_alive<1, 2>(),
+          R"(Construct a :class:`LimitErrorFunction` for the given character.
+
+              :param character: The character to use.
+              :param alpha: Shape parameter for the generalized loss; 2 is squared L2/quadratic, 1 is pseudo-Huber, and 0 is Cauchy/Lorentzian.
+              :param c: Positive scale parameter controlling where residuals transition from near-quadratic to robust behavior.
+              :param weight: The weight applied to the error function.)",
           py::arg("character"),
           py::kw_only(),
+          py::arg("alpha") = 2.0f,
+          py::arg("c") = 1.0f,
           py::arg("weight") = 1.0f);
 
   py::class_<

--- a/pymomentum/test/test_solver2.py
+++ b/pymomentum/test/test_solver2.py
@@ -119,6 +119,29 @@ class TestSolver(unittest.TestCase):
             pym_solver2.LimitErrorFunction(character2),
         )
 
+    def test_limit_error_generalized_loss(self) -> None:
+        """LimitErrorFunction's generalized-loss alpha/c parameters change the penalty."""
+
+        character = pym_test_utils.create_test_character(num_joints=4)
+        n_params = character.parameter_transform.size
+
+        # The test character has a MinMax limit on parameter 0; drive it well past the bound so the
+        # limit is violated and the loss shape actually matters.
+        model_params = np.zeros(n_params, dtype=np.float32)
+        model_params[0] = 1.0
+
+        # The default constructor uses an L2 loss; alpha/c select a different generalized loss
+        # (here Cauchy), which downweights the large violation relative to L2.
+        l2_limit = pym_solver2.LimitErrorFunction(character)
+        cauchy_limit = pym_solver2.LimitErrorFunction(character, alpha=0.0, c=2.0)
+
+        l2_error = l2_limit.get_error(model_params)
+        cauchy_error = cauchy_limit.get_error(model_params)
+
+        self.assertGreater(l2_error, 0.0)
+        self.assertGreater(cauchy_error, 0.0)
+        self.assertLess(cauchy_error, l2_error)
+
     def test_get_gradient_and_jacobian(self) -> None:
         """Test that get_gradient and get_jacobian do something reasonable for error functions."""
 


### PR DESCRIPTION
Summary:

`LimitErrorFunctionT` hard-coded an L2 (squared) penalty for each parameter-limit violation. This routes each limit constraint through the generalized loss in `math/generalized_loss.h` (the same loss Position/Orientation/etc. already use), letting callers pick a robust shape (Cauchy, Welsch, ...) instead of plain L2.

New optional `lossAlpha`/`lossC` constructor arguments default to `alpha = 2`, `c = 1` (plain L2), so existing call sites and behavior are unchanged. The Python binding `pymomentum.solver2.LimitErrorFunction` gains matching `alpha`/`c` keyword arguments.

Zero-overhead L2 path: `getError`/`getGradient`/`getJacobian` dispatch on `isL2()` to templated `getXImpl<bool IsL2>`, and the per-constraint helpers specialize via `if constexpr`. On the L2 path the `1/c^2` scale is folded into the weight once and the constant Jacobian weight is hoisted out of the per-constraint loop, so the default path makes no per-constraint loss calls and is equivalent to the original quadratic penalty (no measurable regression).

Working on top of this:
- Each of the 6 limit types has both an `IsL2` and a non-L2 branch in its `compute*` helper; a new type or change must update both branches.
- An isolated `LimitErrorJacobian`/`LimitErrorError`/`LimitErrorGradient` microbenchmark exercises only this error function; prefer it over the whole-solve benchmark for limit-EF perf work, and measure same-binary run-to-run variance before trusting a delta.
- The Ellipsoid limit uses an intentional fixed-projection approximate gradient, so the numerical gradient/Jacobian consistency check does not apply to it; validate it instead via L2-vs-loss error/gradient scaling (see the test).

Differential Revision: D108234910


