### PR TITLE
Import URDF sphere and box collision geometry (#1493)

### DIFF
--- a/momentum/io/urdf/urdf_io.cpp
+++ b/momentum/io/urdf/urdf_io.cpp
@@ -297,28 +297,10 @@ std::optional<Mesh> loadVisualMesh(
   }
 }
 
-std::optional<TaperedCapsule> loadCollisionCapsule(
-    const urdf::Collision& collision,
-    std::string_view linkName,
+[[nodiscard]] TaperedCapsule loadCollisionCapsule(
+    const urdf::Cylinder& cylinder,
+    const TransformT<float>& collisionOrigin,
     size_t jointIndex) {
-  if (!collision.geometry) {
-    MT_LOGW("Ignoring URDF collision on link '{}' because it has no geometry.", linkName);
-    return std::nullopt;
-  }
-
-  const auto& geometry = *collision.geometry;
-  if (geometry.type != urdf::Geometry::CYLINDER) {
-    MT_LOGW(
-        "Ignoring unsupported URDF collision geometry '{}' on link '{}'. "
-        "Only cylinder collision geometry can be imported as Momentum tapered capsules.",
-        toString(geometry),
-        linkName);
-    return std::nullopt;
-  }
-
-  const auto& cylinder = dynamic_cast<const urdf::Cylinder&>(geometry);
-  const auto collisionOrigin = toMomentumTransform<float>(collision.origin);
-
   // Convention conversion: URDF cylinders are centered at the origin with their axis along
   // +Z, while Momentum TaperedCapsules start at the origin with their axis along +X.
   //   - Rotation: compose the URDF collision origin rotation with a UnitX→UnitZ rotation so the
@@ -333,8 +315,80 @@ std::optional<TaperedCapsule> loadCollisionCapsule(
       Eigen::Quaternionf::FromTwoVectors(Eigen::Vector3f::UnitX(), Eigen::Vector3f::UnitZ());
   capsule.transformation.translation = collisionOrigin.translation * toCm<float>() +
       collisionOrigin.rotation * Eigen::Vector3f(0.0f, 0.0f, -0.5f * capsule.length);
-
   return capsule;
+}
+
+[[nodiscard]] CollisionEllipsoid loadCollisionSphere(
+    const urdf::Sphere& sphere,
+    const TransformT<float>& collisionOrigin,
+    size_t jointIndex) {
+  // A URDF sphere has a single radius and is centered at the collision origin. It maps directly to
+  // a Momentum ellipsoid with equal radii along all three local axes (a sphere is the special case
+  // of an ellipsoid). The collision origin becomes the ellipsoid center and orientation.
+  CollisionEllipsoid ellipsoid;
+  ellipsoid.parent = jointIndex;
+  ellipsoid.radii = Eigen::Vector3f::Constant(static_cast<float>(sphere.radius) * toCm<float>());
+  ellipsoid.transformation.rotation = collisionOrigin.rotation;
+  ellipsoid.transformation.translation = collisionOrigin.translation * toCm<float>();
+  return ellipsoid;
+}
+
+[[nodiscard]] CollisionBox loadCollisionBox(
+    const urdf::Box& box,
+    const TransformT<float>& collisionOrigin,
+    size_t jointIndex) {
+  // A URDF box is centered at the collision origin with full extents box.dim along its local axes,
+  // whereas a Momentum box stores half extents. The collision origin becomes the box center and
+  // orientation.
+  CollisionBox collisionBox;
+  collisionBox.parent = jointIndex;
+  collisionBox.halfExtents = Eigen::Vector3f(
+                                 static_cast<float>(box.dim.x),
+                                 static_cast<float>(box.dim.y),
+                                 static_cast<float>(box.dim.z)) *
+      (0.5f * toCm<float>());
+  collisionBox.transformation.rotation = collisionOrigin.rotation;
+  collisionBox.transformation.translation = collisionOrigin.translation * toCm<float>();
+  return collisionBox;
+}
+
+/// Imports a single URDF collision geometry as a Momentum collision primitive.
+///
+/// URDF cylinders become tapered capsules, spheres become ellipsoids with equal radii, and boxes
+/// become boxes. Mesh collision geometry is not supported and is skipped with a warning.
+[[nodiscard]] std::optional<CollisionPrimitive> loadCollisionPrimitive(
+    const urdf::Collision& collision,
+    std::string_view linkName,
+    size_t jointIndex) {
+  if (!collision.geometry) {
+    MT_LOGW("Ignoring URDF collision on link '{}' because it has no geometry.", linkName);
+    return std::nullopt;
+  }
+
+  const auto& geometry = *collision.geometry;
+  const auto collisionOrigin = toMomentumTransform<float>(collision.origin);
+
+  switch (geometry.type) {
+    case urdf::Geometry::CYLINDER:
+      return CollisionPrimitive(loadCollisionCapsule(
+          dynamic_cast<const urdf::Cylinder&>(geometry), collisionOrigin, jointIndex));
+    case urdf::Geometry::SPHERE:
+      return CollisionPrimitive(loadCollisionSphere(
+          dynamic_cast<const urdf::Sphere&>(geometry), collisionOrigin, jointIndex));
+    case urdf::Geometry::BOX:
+      return CollisionPrimitive(
+          loadCollisionBox(dynamic_cast<const urdf::Box&>(geometry), collisionOrigin, jointIndex));
+    case urdf::Geometry::MESH:
+      MT_LOGW(
+          "Ignoring unsupported URDF mesh collision geometry on link '{}'. Only cylinder, sphere, "
+          "and box collision geometry can be imported.",
+          linkName);
+      return std::nullopt;
+  }
+
+  MT_LOGW(
+      "Ignoring unknown URDF collision geometry '{}' on link '{}'.", toString(geometry), linkName);
+  return std::nullopt;
 }
 
 constexpr std::array<const char*, 3> kTranslationNames = {"tx", "ty", "tz"};
@@ -643,9 +697,9 @@ void collectCollisionGeometry(ParsingData& data, const urdf::Link& urdfLink, siz
       MT_LOGW("Ignoring null URDF collision on link '{}'.", urdfLink.name);
       continue;
     }
-    auto capsule = loadCollisionCapsule(*collision, urdfLink.name, linkJointId);
-    if (capsule) {
-      data.collision.push_back(*capsule);
+    auto primitive = loadCollisionPrimitive(*collision, urdfLink.name, linkJointId);
+    if (primitive) {
+      data.collision.push_back(*primitive);
     }
   }
 }

--- a/momentum/test/io/io_urdf_test.cpp
+++ b/momentum/test/io/io_urdf_test.cpp
@@ -493,12 +493,6 @@ TEST(IoUrdfTest, LoadUrdfWithCollisionCapsules) {
             <cylinder radius="0.01" length="0.1"/>
           </geometry>
         </collision>
-        <collision name="unsupported_box">
-          <origin xyz="0 0 0" rpy="0 0 0"/>
-          <geometry>
-            <box size="0.1 0.1 0.1"/>
-          </geometry>
-        </collision>
       </link>
       <joint name="fixed_joint" type="fixed">
         <parent link="base_link"/>
@@ -535,18 +529,18 @@ TEST(IoUrdfTest, LoadUrdfWithCollisionCapsules) {
       Eigen::Vector3f(0.0f, 0.0f, 10.0f));
 }
 
-TEST(IoUrdfTest, LoadUrdfSkipsUnsupportedCollisionGeometries) {
+TEST(IoUrdfTest, LoadUrdfImportsPrimitiveCollisionAndSkipsMesh) {
   const std::string urdfContent = R"(
     <?xml version="1.0"?>
-    <robot name="unsupported_collision_robot">
+    <robot name="primitive_collision_robot">
       <link name="base_link">
-        <collision name="unsupported_box">
+        <collision name="box_collision">
           <origin xyz="0 0 0" rpy="0 0 0"/>
           <geometry>
             <box size="0.1 0.1 0.1"/>
           </geometry>
         </collision>
-        <collision name="unsupported_sphere">
+        <collision name="sphere_collision">
           <origin xyz="0 0 0" rpy="0 0 0"/>
           <geometry>
             <sphere radius="0.05"/>
@@ -558,7 +552,7 @@ TEST(IoUrdfTest, LoadUrdfSkipsUnsupportedCollisionGeometries) {
             <mesh filename="missing.stl"/>
           </geometry>
         </collision>
-        <collision name="supported_cylinder">
+        <collision name="cylinder_collision">
           <origin xyz="0 0 0" rpy="0 0 0"/>
           <geometry>
             <cylinder radius="0.02" length="0.1"/>
@@ -571,11 +565,70 @@ TEST(IoUrdfTest, LoadUrdfSkipsUnsupportedCollisionGeometries) {
   const auto bytes = std::as_bytes(std::span(urdfContent));
   const auto character = loadUrdfCharacter(bytes);
 
-  // Only the cylinder is imported; box, sphere, and mesh collisions are skipped with warnings.
+  // Box, sphere, and cylinder collisions are imported in declaration order; only the mesh
+  // collision is skipped with a warning.
   ASSERT_NE(character.collision, nullptr);
-  ASSERT_EQ(character.collision->size(), 1);
-  EXPECT_FLOAT_EQ(character.collision->at(0).length, 10.0f);
-  EXPECT_TRUE(character.collision->at(0).radius.isApprox(Eigen::Vector2f::Constant(2.0f)));
+  ASSERT_EQ(character.collision->size(), 3);
+  EXPECT_TRUE(character.collision->at(0).isBox());
+  EXPECT_TRUE(character.collision->at(1).isEllipsoid());
+  EXPECT_TRUE(character.collision->at(2).isTaperedCapsule());
+}
+
+TEST(IoUrdfTest, LoadUrdfWithCollisionSphereAndBox) {
+  const std::string urdfContent = R"(
+    <?xml version="1.0"?>
+    <robot name="sphere_box_collision_robot">
+      <link name="base_link">
+        <collision name="base_sphere">
+          <origin xyz="0.01 0.02 0.03" rpy="0 0 0"/>
+          <geometry>
+            <sphere radius="0.05"/>
+          </geometry>
+        </collision>
+      </link>
+      <link name="child_link">
+        <collision name="child_box">
+          <origin xyz="0.04 0.05 0.06" rpy="0 0 1.57079632679"/>
+          <geometry>
+            <box size="0.1 0.2 0.3"/>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="fixed_joint" type="fixed">
+        <parent link="base_link"/>
+        <child link="child_link"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </joint>
+    </robot>
+  )";
+
+  const auto bytes = std::as_bytes(std::span(urdfContent));
+  const auto character = loadUrdfCharacter(bytes);
+
+  ASSERT_NE(character.collision, nullptr);
+  ASSERT_EQ(character.collision->size(), 2);
+
+  // A URDF sphere is imported as an ellipsoid with equal radii (meters -> centimeters), centered
+  // at the collision origin.
+  const auto& sphere = character.collision->at(0);
+  ASSERT_TRUE(sphere.isEllipsoid());
+  EXPECT_EQ(sphere.parent, 0);
+  const CollisionEllipsoid ellipsoid = sphere.toEllipsoid();
+  expectVectorNear(ellipsoid.radii, Eigen::Vector3f::Constant(5.0f));
+  expectVectorNear(ellipsoid.transformation.translation, Eigen::Vector3f(1.0f, 2.0f, 3.0f));
+  expectQuaternionNear(ellipsoid.transformation.rotation, Eigen::Quaternionf::Identity());
+
+  // A URDF box is imported with half extents (full extents / 2, meters -> centimeters) and keeps
+  // the collision origin's rotation.
+  const auto& box = character.collision->at(1);
+  ASSERT_TRUE(box.isBox());
+  EXPECT_EQ(box.parent, 1);
+  const CollisionBox collisionBox = box.toBox();
+  expectVectorNear(collisionBox.halfExtents, Eigen::Vector3f(5.0f, 10.0f, 15.0f));
+  expectVectorNear(collisionBox.transformation.translation, Eigen::Vector3f(4.0f, 5.0f, 6.0f));
+  const Eigen::Quaternionf expectedBoxRotation(
+      Eigen::AngleAxisf(pi<float>() / 2.0f, Eigen::Vector3f::UnitZ()));
+  expectQuaternionNear(collisionBox.transformation.rotation, expectedBoxRotation);
 }
 
 TEST(IoUrdfTest, LoadUrdfWithSphereVisual) {


### PR DESCRIPTION
Summary:

Adds support for importing URDF `<sphere>` and `<box>` collision geometry into Momentum collision primitives. Previously the URDF loader only imported `<cylinder>` collision geometry (as a `TaperedCapsule`) and skipped boxes and spheres with a warning, even though the `Ellipsoid` and `Box` primitive types already exist in `CollisionPrimitiveT` and are fully supported by the glTF, FBX, and USD readers/writers. URDF was the only IO path missing this support.

The collision loader in `io/urdf/urdf_io.cpp` is refactored from the cylinder-only `loadCollisionCapsule` into a `loadCollisionPrimitive` dispatcher that maps each URDF collision shape to the matching primitive:
- `<cylinder>` -> `TaperedCapsule` (unchanged math: +X->+Z axis convention and -length/2 start-point shift).
- `<sphere>` -> `CollisionEllipsoid` with equal radii (a sphere is the special case of an ellipsoid), centered at the collision origin.
- `<box>` -> `CollisionBox` with half extents (URDF stores full extents), keeping the collision origin rotation.
- `<mesh>` -> still skipped with a warning.

All radii/extents/translations are converted from meters to centimeters consistent with the rest of the URDF loader.

Differential Revision: D108370945


