### PR TITLE
Fix ModelParametersSequenceErrorFunction::getJacobianSize over-count

### DIFF
--- a/momentum/character_sequence_solver/model_parameters_sequence_error_function.cpp
+++ b/momentum/character_sequence_solver/model_parameters_sequence_error_function.cpp
@@ -94,7 +94,20 @@ double ModelParametersSequenceErrorFunctionT<T>::getGradient(
 
 template <typename T>
 size_t ModelParametersSequenceErrorFunctionT<T>::getJacobianSize() const {
-  return (targetWeights_.array() > 0).count();
+  // Count only parameters that are both enabled and positively weighted, matching the row-emission
+  // condition in getGradient()/getJacobian() so getJacobianSize() stays consistent with usedRows
+  // when a caller disables parameters via setEnabledParameters().
+  const auto np = gsl::narrow_cast<Eigen::Index>(this->parameterTransform_.numAllModelParameters());
+  if (targetWeights_.size() != np) {
+    return 0;
+  }
+  size_t count = 0;
+  for (Eigen::Index i = 0; i < np; ++i) {
+    if (this->enabledParameters_.test(i) && targetWeights_(i) > 0) {
+      ++count;
+    }
+  }
+  return count;
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:
`ModelParametersSequenceErrorFunctionT::getJacobianSize()` counted every positively-weighted parameter, but `getGradient()`/`getJacobian()` emit a row only for parameters that are both enabled and positively weighted. When a caller disables parameters via `setEnabledParameters()`, the reported size over-counted relative to `usedRows`. 

It now counts enabled-and-weighted parameters so the size matches the rows actually written, returning 0 on a mismatched `targetWeights_` size like the other methods.

Behavior is unchanged on the common all-parameters-enabled path.

Differential Revision: D108539311


