### PR TITLE
Use type-agnostic literals for templated weight constants

### DIFF
--- a/momentum/character_sequence_solver/state_sequence_error_function.h
+++ b/momentum/character_sequence_solver/state_sequence_error_function.h
@@ -110,8 +110,8 @@ class StateSequenceErrorFunctionT : public SequenceErrorFunctionT<T> {
 
  public:
   // weights for the error functions
-  static constexpr T kPositionWeight = 1e-3f;
-  static constexpr T kOrientationWeight = 1e+0f;
+  static constexpr T kPositionWeight = 1e-3;
+  static constexpr T kOrientationWeight = 1e+0;
 };
 
 } // namespace momentum

--- a/momentum/character_sequence_solver/vertex_sequence_error_function.h
+++ b/momentum/character_sequence_solver/vertex_sequence_error_function.h
@@ -97,7 +97,7 @@ class VertexSequenceErrorFunctionT : public SequenceErrorFunctionT<T> {
     return character_;
   }
 
-  static constexpr T kVelocityWeight = 1e-3f;
+  static constexpr T kVelocityWeight = 1e-3;
 
  private:
   /// Calculate gradient for a single vertex velocity constraint.

--- a/momentum/character_solver/aim_error_function.h
+++ b/momentum/character_solver/aim_error_function.h
@@ -62,7 +62,7 @@ class AimDistErrorFunctionT : public JointErrorFunctionT<T, AimDataT<T>, 3, 2, 1
 
   /// Default constant weight in MarkerErrorFunction (same as fixed axis). This can be used for
   /// backwards compatibility in setWeight().
-  static constexpr T kLegacyWeight = 1e-1f;
+  static constexpr T kLegacyWeight = 1e-1;
 
  protected:
   void evalFunction(
@@ -101,7 +101,7 @@ class AimDirErrorFunctionT : public JointErrorFunctionT<T, AimDataT<T>, 3, 2, 1>
 
   /// Default constant weight in MarkerErrorFunction (same as fixed axis). This can be used for
   /// backwards compatibility in setWeight().
-  static constexpr T kLegacyWeight = 1e-1f;
+  static constexpr T kLegacyWeight = 1e-1;
 
  protected:
   void evalFunction(

--- a/momentum/character_solver/collision_error_function.h
+++ b/momentum/character_solver/collision_error_function.h
@@ -136,7 +136,7 @@ class CollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
   CollisionGeometryStateT<T> collisionState_;
 
   // weights for the error functions
-  static constexpr T kCollisionWeight = 5e-3f;
+  static constexpr T kCollisionWeight = 5e-3;
 };
 
 } // namespace momentum

--- a/momentum/character_solver/collision_error_function_stateless.h
+++ b/momentum/character_solver/collision_error_function_stateless.h
@@ -116,7 +116,7 @@ class CollisionErrorFunctionStatelessT : public SkeletonErrorFunctionT<T> {
   CollisionGeometryStateT<T> collisionState;
 
   // weights for the error functions
-  static constexpr T kCollisionWeight = 5e-3f;
+  static constexpr T kCollisionWeight = 5e-3;
 };
 
 } // namespace momentum

--- a/momentum/character_solver/fixed_axis_error_function.h
+++ b/momentum/character_solver/fixed_axis_error_function.h
@@ -56,7 +56,7 @@ class FixedAxisDiffErrorFunctionT : public JointErrorFunctionT<T, FixedAxisDataT
 
   /// Default constant weight in MarkerErrorFunction. This can be used for backwards compatibility
   /// in setWeight().
-  static constexpr T kLegacyWeight = 1e-1f;
+  static constexpr T kLegacyWeight = 1e-1;
 
  protected:
   void evalFunction(
@@ -90,7 +90,7 @@ class FixedAxisCosErrorFunctionT : public JointErrorFunctionT<T, FixedAxisDataT<
 
   /// Default constant weight in MarkerErrorFunction. This can be used for backwards compatibility
   /// in setWeight().
-  static constexpr T kLegacyWeight = 1e-1f;
+  static constexpr T kLegacyWeight = 1e-1;
 
  protected:
   void evalFunction(
@@ -126,7 +126,7 @@ class FixedAxisAngleErrorFunctionT : public JointErrorFunctionT<T, FixedAxisData
 
   /// Default constant weight in MarkerErrorFunction. This can be used for backwards compatibility
   /// in setWeight().
-  static constexpr T kLegacyWeight = 1e-1f;
+  static constexpr T kLegacyWeight = 1e-1;
 
  protected:
   void evalFunction(

--- a/momentum/character_solver/joint_to_joint_distance_error_function.h
+++ b/momentum/character_solver/joint_to_joint_distance_error_function.h
@@ -114,7 +114,7 @@ class JointToJointDistanceErrorFunctionT : public SkeletonErrorFunctionT<T> {
   }
 
   /// Default weight for distance constraints.
-  static constexpr T kDistanceWeight = 1e-2f;
+  static constexpr T kDistanceWeight = 1e-2;
 
  private:
   std::vector<JointToJointDistanceConstraintT<T>> constraints_;

--- a/momentum/character_solver/normal_error_function.h
+++ b/momentum/character_solver/normal_error_function.h
@@ -60,7 +60,7 @@ class NormalErrorFunctionT : public JointErrorFunctionT<T, NormalDataT<T>, 1, 2,
 
   /// Default constant weight in MarkerErrorFunction. This can be used for backwards compatibility
   /// in setWeight().
-  static constexpr T kLegacyWeight = 1e-4f;
+  static constexpr T kLegacyWeight = 1e-4;
 
  protected:
   void evalFunction(

--- a/momentum/character_solver/orientation_error_function.h
+++ b/momentum/character_solver/orientation_error_function.h
@@ -60,7 +60,7 @@ class OrientationErrorFunctionT : public JointErrorFunctionT<T, OrientationDataT
 
   /// Default constant weight in MarkerErrorFunction. This can be used for backwards compatibility
   /// in setWeight().
-  static constexpr T kLegacyWeight = 1e-1f;
+  static constexpr T kLegacyWeight = 1e-1;
 
  protected:
   void evalFunction(

--- a/momentum/character_solver/plane_error_function.h
+++ b/momentum/character_solver/plane_error_function.h
@@ -83,7 +83,7 @@ class PlaneErrorFunctionT : public JointErrorFunctionT<T, PlaneDataT<T>, 1> {
 
   /// Default constant weight in MarkerErrorFunction. This can be used for backwards compatibility
   /// in setWeight().
-  static constexpr T kLegacyWeight = 1e-4f;
+  static constexpr T kLegacyWeight = 1e-4;
 
  protected:
   void evalFunction(

--- a/momentum/character_solver/position_error_function.h
+++ b/momentum/character_solver/position_error_function.h
@@ -61,7 +61,7 @@ class PositionErrorFunctionT : public JointErrorFunctionT<T, PositionDataT<T>> {
 
   /// Default constant weight in MarkerErrorFunction. This can be used for backwards compatibility
   /// in setWeight().
-  static constexpr T kLegacyWeight = 1e-4f;
+  static constexpr T kLegacyWeight = 1e-4;
 
  protected:
   void evalFunction(

--- a/momentum/character_solver/projection_error_function.h
+++ b/momentum/character_solver/projection_error_function.h
@@ -109,7 +109,7 @@ class ProjectionErrorFunctionT : public momentum::SkeletonErrorFunctionT<T> {
   std::vector<ProjectionConstraintDataT<T>> constraints_;
 
   // Projection error is roughly in radians, so a value near 1 is reasonable here:
-  static constexpr T kProjectionWeight = 1.0f;
+  static constexpr T kProjectionWeight = 1.0;
 
   // Ignore projection constraints involving joints closer than this distance.
   // Prevents divide-by-zero in the projection matrix and bad behavior close to

--- a/momentum/character_solver/state_error_function.h
+++ b/momentum/character_solver/state_error_function.h
@@ -112,8 +112,8 @@ class StateErrorFunctionT : public SkeletonErrorFunctionT<T> {
 
  public:
   // weights for the error functions
-  static constexpr T kPositionWeight = 1e-3f;
-  static constexpr T kOrientationWeight = 1e+0f;
+  static constexpr T kPositionWeight = 1e-3;
+  static constexpr T kOrientationWeight = 1e+0;
 };
 
 } // namespace momentum


### PR DESCRIPTION
Summary:
Templated `static constexpr T` weight constants in `character_solver/` and `character_sequence_solver/` were declared with a float-suffixed literal (e.g. `1e-4f`). For the `double` instantiation that rounds the value through 32-bit `float` before widening to `double`, and it was inconsistent with the `ModelParameters*` family that already used bare literals. 

Dropping the `f` lets each instantiation get its most accurate value and makes the convention uniform. The `float` instantiation is unchanged (the bare literal copy-initializes to the same `float`); only the rarely-used `double` instantiation shifts, by ~5e-12 relative. 

Affects `kLegacyWeight`, `kPositionWeight`, `kOrientationWeight`, `kCollisionWeight`, `kDistanceWeight`, `kVelocityWeight`, and `kProjectionWeight` across the aim/fixed_axis/orientation/normal/position/plane/projection/collision/joint_to_joint error functions and the state/vertex sequence error functions.

Differential Revision: D108539312


