### PR TITLE
Add quaternion_np.angular_distance (geodesic angle between orientations)

### DIFF
--- a/pymomentum/quaternion_np.py
+++ b/pymomentum/quaternion_np.py
@@ -130,6 +130,30 @@ def inverse(q: NDArray) -> NDArray:
     return conjugate(q) / np.maximum((q * q).sum(axis=-1, keepdims=True), 1e-7)
 
 
+def angular_distance(q0: NDArray, q1: NDArray) -> NDArray:
+    """
+    Compute the geodesic angle, in radians, between two orientations.
+
+    Returns the rotation angle of the relative rotation ``q0^{-1} * q1`` along
+    the shorter arc, so the result lies in ``[0, pi]``. Uses the numerically
+    robust ``2 * atan2(|vec|, |w|)`` form rather than ``arccos``, which loses
+    precision for small angles. Inputs are assumed normalized. Convert to
+    degrees with :func:`numpy.degrees` if needed.
+
+    Vectorized over leading dimensions: for inputs of shape ``[..., 4]`` the
+    result has shape ``[...]``.
+
+    :param q0: A normalized quaternion ((x, y, z), w)).
+    :param q1: A normalized quaternion ((x, y, z), w)).
+    :return: The angle between ``q0`` and ``q1`` in radians.
+    """
+    check(q0)
+    check(q1)
+    rel = multiply_assume_normalized(conjugate(q0), q1)
+    vec_norm = np.linalg.norm(rel[..., 0:3], axis=-1)
+    return 2.0 * np.arctan2(vec_norm, np.abs(rel[..., 3]))
+
+
 def align_z_with(direction: NDArray) -> NDArray:
     """
     Return an xyzw quaternion that rotates the +Z axis onto *direction*.

--- a/pymomentum/test/test_quaternion_np.py
+++ b/pymomentum/test/test_quaternion_np.py
@@ -112,6 +112,63 @@ class TestQuaternionNumpy(unittest.TestCase):
             "Matrix rotation should match quaternion rotation",
         )
 
+    def test_angular_distance(self) -> None:
+        # Identical orientations -> zero angle.
+        q = generateRandomQuats(5)
+        self.assertTrue(
+            np.allclose(quaternion.angular_distance(q, q), 0.0, atol=1e-6),
+            "Angle between identical orientations should be zero.",
+        )
+
+        ident = np.array([[0.0, 0.0, 0.0, 1.0]])
+        # Identity vs a 90-degree rotation about X -> pi/2.
+        q90 = quaternion.euler_xyz_to_quaternion(np.array([[0.5 * math.pi, 0.0, 0.0]]))
+        self.assertTrue(
+            np.allclose(
+                quaternion.angular_distance(ident, q90), 0.5 * math.pi, atol=1e-5
+            ),
+            "Identity vs 90deg-about-X should be pi/2 radians.",
+        )
+        # Antipodal quaternions (q and -q) represent the same orientation, so the
+        # angle is zero -- this exercises the abs() on the scalar part (without it
+        # the result would be 2*pi).
+        q_anti = generateRandomQuats(5)
+        self.assertTrue(
+            np.allclose(quaternion.angular_distance(q_anti, -q_anti), 0.0, atol=1e-6),
+            "Antipodal quaternions (q and -q) should have zero angular distance.",
+        )
+
+        # A 180-degree rotation is exactly pi.
+        q180 = quaternion.euler_xyz_to_quaternion(np.array([[math.pi, 0.0, 0.0]]))
+        self.assertTrue(
+            np.allclose(quaternion.angular_distance(ident, q180), math.pi, atol=1e-5),
+            "180deg-about-X should be pi radians.",
+        )
+
+        # Shorter arc: a 270-degree rotation is reported as pi/2 (stays in [0, pi]).
+        q270 = quaternion.euler_xyz_to_quaternion(np.array([[1.5 * math.pi, 0.0, 0.0]]))
+        self.assertTrue(
+            np.allclose(
+                quaternion.angular_distance(ident, q270), 0.5 * math.pi, atol=1e-5
+            ),
+            "Angle should take the shorter arc and stay within [0, pi].",
+        )
+
+        # Symmetry, output shape, and agreement with an independent arccos reference.
+        rng = np.random.default_rng(1)
+        q0 = quaternion.normalize(rng.normal(size=(7, 4)))
+        q1 = quaternion.normalize(rng.normal(size=(7, 4)))
+        d01 = quaternion.angular_distance(q0, q1)
+        d10 = quaternion.angular_distance(q1, q0)
+        self.assertEqual(d01.shape, (7,))
+        self.assertTrue(np.allclose(d01, d10, atol=1e-6), "Distance is symmetric.")
+        dot = np.abs(np.sum(q0 * q1, axis=-1))
+        ref = 2.0 * np.arccos(np.clip(dot, -1.0, 1.0))
+        self.assertTrue(
+            np.allclose(d01, ref, atol=1e-5),
+            "Should match the 2*arccos(|dot|) reference.",
+        )
+
     def test_blend_same(self) -> None:
         nMat = 5
         q = generateRandomQuats(nMat)


### PR DESCRIPTION
Summary: Add `angular_distance(q0, q1)` to `pymomentum.quaternion_np`. It returns the geodesic angle, in radians, between two orientations — the rotation angle of the relative rotation `q0^{-1} * q1` along the shorter arc, so the result lies in `[0, pi]`. It uses the numerically robust `2 * atan2(|vec|, |w|)` form rather than `arccos`, which loses precision for small angles, and is vectorized over leading dimensions. It returns radians (callers convert with `numpy.degrees`), matching the rest of the module such as `quaternion_to_xyz_euler`.

Differential Revision: D108337953


