### PR TITLE
Honor CI generator for Windows PyPI wheels

### DIFF
--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -35,7 +35,8 @@
 {#- Windows non-GPU args for core and CPU wheels -#}
 {%- macro cmake_windows_cpu_args() %}
     "-DBUILD_SHARED_LIBS=OFF",
-    "-G Visual Studio 18 2026",
+    # The generator is selected by the build environment. Windows CI sets
+    # CMAKE_GENERATOR=Ninja so sccache can intercept compiler invocations.
     "-DMOMENTUM_BUILD_PYMOMENTUM=ON",
     "-DMOMENTUM_BUILD_TORCH_EXTENSIONS={{ 'ON' if build_torch_extensions else 'OFF' }}",
     "-DMOMENTUM_BUILD_EXAMPLES=OFF",
@@ -51,7 +52,9 @@
 {#- Windows GPU-specific args (same as CPU; GPU only changes the PyTorch variant linked) -#}
 {%- macro cmake_windows_gpu_args() %}
     "-DBUILD_SHARED_LIBS=OFF",
-    "-G Visual Studio 18 2026",
+    # The generator is selected by the build environment. Windows CI sets
+    # CMAKE_GENERATOR=Ninja so CUDA builds do not require Visual Studio's CUDA
+    # MSBuild integration.
     "-DMOMENTUM_BUILD_PYMOMENTUM=ON",
     "-DMOMENTUM_BUILD_TORCH_EXTENSIONS={{ 'ON' if build_torch_extensions else 'OFF' }}",
     "-DMOMENTUM_BUILD_EXAMPLES=OFF",


### PR DESCRIPTION
Summary: Windows PyPI wheel jobs set `CMAKE_GENERATOR=Ninja` so compiler caching can wrap CMake's compiler invocations. The generated PyPI build config still forced the Visual Studio generator, which bypassed that environment setting and sent CUDA builds through Visual Studio's CUDA toolset detection. Remove the hardcoded generator from the Windows PyPI template so the selected build environment controls the generator.

Differential Revision: D108655125


