### PR TITLE
Honor Windows CI generator for cached builds

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -425,13 +425,12 @@ cibuildwheel = ">=2.22.0,<3"
 twine = ">=6.1.0,<7"
 
 [target.win-64.tasks]
-# Use the current Visual Studio generator for native C++ pixi builds on Windows.
-# Clear generator metadata that may be inherited from CI environment overrides.
+# Let CMake use its default generator unless CMAKE_GENERATOR is set. Windows CI
+# sets CMAKE_GENERATOR=Ninja so sccache can wrap compiler invocations.
 config = { cmd = """
     cmake \
         -S . \
         -B build/$PIXI_ENVIRONMENT_NAME/cpp \
-        -G 'Visual Studio 18 2026' \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ wheel.exclude = ["geometry_test_helper.*"]
 if.platform-system = "^win32"
 cmake.args = [
     "-DBUILD_SHARED_LIBS=OFF",
-    "-G Visual Studio 18 2026",
+    # Honor CMAKE_GENERATOR from the build environment. Windows CI sets Ninja
+    # so sccache can wrap compiler invocations.
     "-DMOMENTUM_BUILD_PYMOMENTUM=ON",
     "-DMOMENTUM_BUILD_EXAMPLES=OFF",
     "-DMOMENTUM_BUILD_TESTING=ON",


### PR DESCRIPTION
Summary: Windows CI sets `CMAKE_GENERATOR=Ninja` and compiler launcher environment variables so `sccache` can wrap CMake builds, but the Windows PyMomentum config still forced the Visual Studio generator. That caused CMake to build Visual Studio projects, so `sccache` saw no compiler invocations and the cache directory was never created. Let CMake use the generator selected by the environment while keeping the local default when no override is present.

Differential Revision: D108687056


