### PR TITLE
Consolidate collision joint-chain derivative accumulation

### DIFF
--- a/momentum/character_solver/collision_error_function.cpp
+++ b/momentum/character_solver/collision_error_function.cpp
@@ -110,31 +110,20 @@ void CollisionErrorFunctionT<T>::accumulateGradientAlongChain(
     size_t stopJoint,
     Ref<VectorX<T>> gradient,
     T scaleCorrection) const {
-  size_t jointIndex = startJoint;
-  while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
-    const auto& jointState = state.jointState[jointIndex];
-    const size_t paramIndex = jointIndex * kParametersPerJoint;
-    const Vector3<T> posd = position - jointState.translation();
-
-    for (size_t d = 0; d < 3; d++) {
-      if (this->activeJointParams_[paramIndex + d]) {
-        const T val = direction.dot(jointState.getTranslationDerivative(d)) * weight;
+  accumulateChainDerivatives<T>(
+      state,
+      this->skeleton_,
+      this->activeJointParams_,
+      position,
+      direction,
+      weight,
+      startJoint,
+      stopJoint,
+      scaleCorrection,
+      [&](T value, size_t jointParamIndex) {
         gradient_jointParams_to_modelParams(
-            val, paramIndex + d, this->parameterTransform_, gradient);
-      }
-      if (this->activeJointParams_[paramIndex + 3 + d]) {
-        const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * weight;
-        gradient_jointParams_to_modelParams(
-            val, paramIndex + 3 + d, this->parameterTransform_, gradient);
-      }
-    }
-    if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * weight;
-      gradient_jointParams_to_modelParams(val, paramIndex + 6, this->parameterTransform_, gradient);
-    }
-
-    jointIndex = this->skeleton_.joints[jointIndex].parent;
-  }
+            value, jointParamIndex, this->parameterTransform_, gradient);
+      });
 }
 
 template <typename T>
@@ -148,32 +137,20 @@ void CollisionErrorFunctionT<T>::accumulateJacobianAlongChain(
     Ref<MatrixX<T>> jacobian,
     int row,
     T scaleCorrection) const {
-  size_t jointIndex = startJoint;
-  while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
-    const auto& jointState = state.jointState[jointIndex];
-    const size_t paramIndex = jointIndex * kParametersPerJoint;
-    const Vector3<T> posd = position - jointState.translation();
-
-    for (size_t d = 0; d < 3; d++) {
-      if (this->activeJointParams_[paramIndex + d]) {
-        const T val = direction.dot(jointState.getTranslationDerivative(d)) * factor;
+  accumulateChainDerivatives<T>(
+      state,
+      this->skeleton_,
+      this->activeJointParams_,
+      position,
+      direction,
+      factor,
+      startJoint,
+      stopJoint,
+      scaleCorrection,
+      [&](T value, size_t jointParamIndex) {
         jacobian_jointParams_to_modelParams(
-            val, paramIndex + d, row, this->parameterTransform_, jacobian);
-      }
-      if (this->activeJointParams_[paramIndex + 3 + d]) {
-        const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * factor;
-        jacobian_jointParams_to_modelParams(
-            val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
-      }
-    }
-    if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * factor;
-      jacobian_jointParams_to_modelParams(
-          val, paramIndex + 6, row, this->parameterTransform_, jacobian);
-    }
-
-    jointIndex = this->skeleton_.joints[jointIndex].parent;
-  }
+            value, jointParamIndex, row, this->parameterTransform_, jacobian);
+      });
 }
 
 template <typename T>

--- a/momentum/character_solver/collision_error_function_stateless.cpp
+++ b/momentum/character_solver/collision_error_function_stateless.cpp
@@ -104,31 +104,20 @@ void CollisionErrorFunctionStatelessT<T>::accumulateGradientAlongChain(
     size_t stopJoint,
     Ref<VectorX<T>> gradient,
     T scaleCorrection) const {
-  size_t jointIndex = startJoint;
-  while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
-    const auto& jointState = state.jointState[jointIndex];
-    const size_t paramIndex = jointIndex * kParametersPerJoint;
-    const Vector3<T> posd = position - jointState.translation();
-
-    for (size_t d = 0; d < 3; d++) {
-      if (this->activeJointParams_[paramIndex + d]) {
-        const T val = direction.dot(jointState.getTranslationDerivative(d)) * weight;
+  accumulateChainDerivatives<T>(
+      state,
+      this->skeleton_,
+      this->activeJointParams_,
+      position,
+      direction,
+      weight,
+      startJoint,
+      stopJoint,
+      scaleCorrection,
+      [&](T value, size_t jointParamIndex) {
         gradient_jointParams_to_modelParams(
-            val, paramIndex + d, this->parameterTransform_, gradient);
-      }
-      if (this->activeJointParams_[paramIndex + 3 + d]) {
-        const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * weight;
-        gradient_jointParams_to_modelParams(
-            val, paramIndex + 3 + d, this->parameterTransform_, gradient);
-      }
-    }
-    if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * weight;
-      gradient_jointParams_to_modelParams(val, paramIndex + 6, this->parameterTransform_, gradient);
-    }
-
-    jointIndex = this->skeleton_.joints[jointIndex].parent;
-  }
+            value, jointParamIndex, this->parameterTransform_, gradient);
+      });
 }
 
 template <typename T>
@@ -142,32 +131,20 @@ void CollisionErrorFunctionStatelessT<T>::accumulateJacobianAlongChain(
     Ref<MatrixX<T>> jacobian,
     int row,
     T scaleCorrection) const {
-  size_t jointIndex = startJoint;
-  while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
-    const auto& jointState = state.jointState[jointIndex];
-    const size_t paramIndex = jointIndex * kParametersPerJoint;
-    const Vector3<T> posd = position - jointState.translation();
-
-    for (size_t d = 0; d < 3; d++) {
-      if (this->activeJointParams_[paramIndex + d]) {
-        const T val = direction.dot(jointState.getTranslationDerivative(d)) * factor;
+  accumulateChainDerivatives<T>(
+      state,
+      this->skeleton_,
+      this->activeJointParams_,
+      position,
+      direction,
+      factor,
+      startJoint,
+      stopJoint,
+      scaleCorrection,
+      [&](T value, size_t jointParamIndex) {
         jacobian_jointParams_to_modelParams(
-            val, paramIndex + d, row, this->parameterTransform_, jacobian);
-      }
-      if (this->activeJointParams_[paramIndex + 3 + d]) {
-        const T val = direction.dot(jointState.getRotationDerivative(d, posd)) * factor;
-        jacobian_jointParams_to_modelParams(
-            val, paramIndex + 3 + d, row, this->parameterTransform_, jacobian);
-      }
-    }
-    if (this->activeJointParams_[paramIndex + 6]) {
-      const T val = (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * factor;
-      jacobian_jointParams_to_modelParams(
-          val, paramIndex + 6, row, this->parameterTransform_, jacobian);
-    }
-
-    jointIndex = this->skeleton_.joints[jointIndex].parent;
-  }
+            value, jointParamIndex, row, this->parameterTransform_, jacobian);
+      });
 }
 
 template <typename T>

--- a/momentum/character_solver/error_function_utils.h
+++ b/momentum/character_solver/error_function_utils.h
@@ -9,6 +9,8 @@
 
 #include <momentum/character/fwd.h>
 #include <momentum/character/parameter_transform.h>
+#include <momentum/character/skeleton.h>
+#include <momentum/character/skeleton_state.h>
 
 namespace momentum {
 
@@ -85,6 +87,50 @@ void jacobian_jointParams_to_modelParams(
        ++index) {
     jacobian(iRow, parameterTransform.transform.innerIndexPtr()[index]) +=
         jacobian_jointParams * parameterTransform.transform.valuePtr()[index];
+  }
+}
+
+/// Accumulate the derivatives of `direction . position` with respect to the model parameters along
+/// the joint parent chain, walking from `startJoint` up to (but not including) `stopJoint`.
+///
+/// For each active joint parameter, `sink(value, jointParamIndex)` routes the joint-parameter
+/// derivative into the destination buffer (a gradient vector or a single Jacobian row). Pass
+/// `stopJoint = kInvalidIndex` to walk all the way to the skeleton root. `scaleCorrection` is added
+/// to the scale-parameter derivative to account for a collision primitive's support radius scaling
+/// with the joint's uniform scale.
+template <typename T, typename SinkFn>
+void accumulateChainDerivatives(
+    const SkeletonStateT<T>& state,
+    const Skeleton& skeleton,
+    const VectorX<bool>& activeJointParams,
+    const Vector3<T>& position,
+    const Vector3<T>& direction,
+    T weight,
+    size_t startJoint,
+    size_t stopJoint,
+    T scaleCorrection,
+    const SinkFn& sink) {
+  size_t jointIndex = startJoint;
+  while (jointIndex != kInvalidIndex && jointIndex != stopJoint) {
+    const auto& jointState = state.jointState[jointIndex];
+    const size_t paramIndex = jointIndex * kParametersPerJoint;
+    const Vector3<T> posd = position - jointState.translation();
+
+    for (size_t d = 0; d < 3; ++d) {
+      if (activeJointParams[paramIndex + d]) {
+        sink(direction.dot(jointState.getTranslationDerivative(d)) * weight, paramIndex + d);
+      }
+      if (activeJointParams[paramIndex + 3 + d]) {
+        sink(direction.dot(jointState.getRotationDerivative(d, posd)) * weight, paramIndex + 3 + d);
+      }
+    }
+    if (activeJointParams[paramIndex + 6]) {
+      sink(
+          (direction.dot(jointState.getScaleDerivative(posd)) + scaleCorrection) * weight,
+          paramIndex + 6);
+    }
+
+    jointIndex = skeleton.joints[jointIndex].parent;
   }
 }
 


### PR DESCRIPTION
Summary:
`CollisionErrorFunctionT` and `CollisionErrorFunctionStatelessT` each carried byte-for-byte identical `accumulateGradientAlongChain` and `accumulateJacobianAlongChain` implementations (~35 lines each) that walk a joint parent chain and route per-joint translation/rotation/scale derivatives through `gradient_jointParams_to_modelParams` / `jacobian_jointParams_to_modelParams`. The gradient and Jacobian variants differed only in their destination (a gradient vector vs a single Jacobian row).

This extracts that walk into a single `accumulateChainDerivatives` template helper in `error_function_utils.h`. The helper takes a `sink(value, jointParamIndex)` callback so the same loop serves both the gradient and Jacobian cases; the four methods across the two classes now delegate to it via a small lambda. Because the sink is a template parameter, the lambda inlines and the generated code is unchanged — this is a behavior-preserving refactor.

The helper also takes a `stopJoint` parameter (pass `kInvalidIndex` to walk to the root), which lets the plane collision error function stacked on top reuse it directly instead of introducing a third copy of the same loop.

Differential Revision: D108691880


