### PR TITLE
Add SDF operations: offset, floodFillExterior, public applySignsToDistanceField

### DIFF
--- a/axel/axel/MeshToSdf.cpp
+++ b/axel/axel/MeshToSdf.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <numbers>
 #include <random>
+#include <tuple>
 #include <unordered_map>
 
 #ifndef AXEL_NO_DISPENSO
@@ -22,6 +23,7 @@
 #endif
 
 #include "axel/BoundingBox.h"
+#include "axel/Checks.h"
 #include "axel/Ray.h"
 #include "axel/TriBvh.h"
 #include "axel/common/Constants.h"
@@ -135,7 +137,7 @@ void meshToSdfImpl(
   if (config.verbose) {
     std::cout << "Step 3: Applying signs..." << std::endl;
   }
-  applySignsToDistanceField(sdf, vertices, triangles, config.signMethod);
+  detail::applySignsToDistanceField(sdf, vertices, triangles, config.signMethod);
   if (config.verbose) {
     std::cout << "Signs applied" << std::endl;
   }
@@ -824,6 +826,235 @@ BoundingBox<ScalarType> computeMeshBounds(std::span<const Eigen::Vector3<ScalarT
 } // namespace detail
 
 // ================================================================================================
+// PUBLIC API: applySignsToDistanceField
+// ================================================================================================
+
+template <typename ScalarType>
+void applySignsToDistanceField(
+    SignedDistanceField<ScalarType>& sdf,
+    std::span<const Eigen::Vector3<ScalarType>> vertices,
+    std::span<const Eigen::Vector3i> triangles,
+    SignMethod signMethod) {
+  detail::applySignsToDistanceField(sdf, vertices, triangles, signMethod);
+}
+
+namespace {
+
+// Offsets of the 6 face-adjacent neighbors in a voxel grid, shared by the
+// flood-fill and morphological passes below.
+constexpr std::array<std::array<Index, 3>, 6> kFaceNeighborOffsets = {
+    {{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}}};
+
+} // namespace
+
+// ================================================================================================
+// PUBLIC API: floodFillExterior
+// ================================================================================================
+
+template <typename ScalarType>
+void floodFillExterior(SignedDistanceField<ScalarType>& sdf) {
+  const auto& resolution = sdf.resolution();
+  const Index nx = resolution.x();
+  const Index ny = resolution.y();
+  const Index nz = resolution.z();
+  const size_t totalVoxels = sdf.totalVoxels();
+
+  auto& data = sdf.data();
+  std::vector<bool> visited(totalVoxels, false);
+  std::queue<std::tuple<Index, Index, Index>> queue;
+
+  auto linearIdx = [&](Index i, Index j, Index k) -> size_t {
+    return static_cast<size_t>(k) * nx * ny + static_cast<size_t>(j) * nx + static_cast<size_t>(i);
+  };
+
+  // Seed from all 6 boundary faces
+  auto trySeed = [&](Index i, Index j, Index k) {
+    const size_t idx = linearIdx(i, j, k);
+    if (!visited[idx] && data[idx] >= ScalarType{0}) {
+      visited[idx] = true;
+      queue.push({i, j, k});
+    }
+  };
+
+  // Z faces (k=0 and k=nz-1)
+  for (Index i = 0; i < nx; ++i) {
+    for (Index j = 0; j < ny; ++j) {
+      trySeed(i, j, 0);
+      if (nz > 1) {
+        trySeed(i, j, nz - 1);
+      }
+    }
+  }
+  // Y faces (j=0 and j=ny-1)
+  for (Index i = 0; i < nx; ++i) {
+    for (Index k = 0; k < nz; ++k) {
+      trySeed(i, 0, k);
+      if (ny > 1) {
+        trySeed(i, ny - 1, k);
+      }
+    }
+  }
+  // X faces (i=0 and i=nx-1)
+  for (Index j = 0; j < ny; ++j) {
+    for (Index k = 0; k < nz; ++k) {
+      trySeed(0, j, k);
+      if (nx > 1) {
+        trySeed(nx - 1, j, k);
+      }
+    }
+  }
+
+  // BFS through 6-connected neighbors with value >= 0
+  while (!queue.empty()) {
+    const auto [ci, cj, ck] = queue.front();
+    queue.pop();
+
+    for (const auto& offset : kFaceNeighborOffsets) {
+      const Index ni = ci + offset[0];
+      const Index nj = cj + offset[1];
+      const Index nk = ck + offset[2];
+
+      if (sdf.isValidIndex(ni, nj, nk)) {
+        const size_t nIdx = linearIdx(ni, nj, nk);
+        if (!visited[nIdx] && data[nIdx] >= ScalarType{0}) {
+          visited[nIdx] = true;
+          queue.push({ni, nj, nk});
+        }
+      }
+    }
+  }
+
+  // Negate unreached positive voxels (interior voids)
+  for (size_t idx = 0; idx < totalVoxels; ++idx) {
+    if (!visited[idx] && data[idx] >= ScalarType{0}) {
+      data[idx] = -data[idx];
+    }
+  }
+}
+
+// ================================================================================================
+// PUBLIC API: closeInterior
+// ================================================================================================
+
+namespace {
+
+/**
+ * One pass of 6-connected binary dilation/erosion over a flat (k-major) mask.
+ *
+ * For dilation a voxel is set when itself or any face neighbor is set; for erosion
+ * a voxel stays set only when itself and all face neighbors are set. Out-of-grid
+ * neighbors are treated as unset (grid faces act as exterior), so erosion may
+ * nibble the boundary — harmless here since the object interior is padded away
+ * from the grid faces.
+ */
+void morphologicalPass(
+    std::span<const char> in,
+    std::span<char> out,
+    Index nx,
+    Index ny,
+    Index nz,
+    bool dilate) {
+  const size_t totalVoxels =
+      static_cast<size_t>(nx) * static_cast<size_t>(ny) * static_cast<size_t>(nz);
+  XR_CHECK(
+      in.size() == totalVoxels && out.size() == totalVoxels,
+      "morphologicalPass requires in/out spans sized to the voxel grid");
+  auto idxOf = [&](Index i, Index j, Index k) -> size_t {
+    return static_cast<size_t>(k) * nx * ny + static_cast<size_t>(j) * nx + static_cast<size_t>(i);
+  };
+
+  for (Index k = 0; k < nz; ++k) {
+    for (Index j = 0; j < ny; ++j) {
+      for (Index i = 0; i < nx; ++i) {
+        const size_t idx = idxOf(i, j, k);
+        // Dilation keeps any set voxel set; erosion keeps any unset voxel unset.
+        if (in[idx] == (dilate ? 1 : 0)) {
+          out[idx] = in[idx];
+          continue;
+        }
+        bool result = !dilate; // erosion assumes set until a neighbor disproves
+        for (const auto& off : kFaceNeighborOffsets) {
+          const Index ni = i + off[0];
+          const Index nj = j + off[1];
+          const Index nk = k + off[2];
+          const bool inBounds = ni >= 0 && ni < nx && nj >= 0 && nj < ny && nk >= 0 && nk < nz;
+          const bool neighborSet = inBounds && in[idxOf(ni, nj, nk)] != 0;
+          if (dilate && neighborSet) {
+            result = true;
+            break;
+          }
+          if (!dilate && !neighborSet) {
+            result = false;
+            break;
+          }
+        }
+        out[idx] = result ? 1 : 0;
+      }
+    }
+  }
+}
+
+/**
+ * Shared body for closeInterior / openInterior.
+ *
+ * Builds an interior mask from the SDF sign, runs `iterations` passes of one
+ * morphological op followed by `iterations` passes of its inverse, then flips
+ * the sign of every voxel whose new interior classification disagrees with its
+ * current sign. `firstDilate == true` performs a closing (dilate then erode);
+ * `false` performs an opening (erode then dilate).
+ */
+template <typename ScalarType>
+void morphInterior(SignedDistanceField<ScalarType>& sdf, int iterations, bool firstDilate) {
+  if (iterations <= 0) {
+    return;
+  }
+
+  const auto& resolution = sdf.resolution();
+  const Index nx = resolution.x();
+  const Index ny = resolution.y();
+  const Index nz = resolution.z();
+  const size_t totalVoxels = sdf.totalVoxels();
+
+  auto& data = sdf.data();
+  std::vector<char> mask(totalVoxels);
+  for (size_t idx = 0; idx < totalVoxels; ++idx) {
+    mask[idx] = data[idx] < ScalarType{0} ? 1 : 0;
+  }
+
+  std::vector<char> scratch(totalVoxels);
+  for (int pass = 0; pass < iterations; ++pass) {
+    morphologicalPass(mask, scratch, nx, ny, nz, /*dilate=*/firstDilate);
+    mask.swap(scratch);
+  }
+  for (int pass = 0; pass < iterations; ++pass) {
+    morphologicalPass(mask, scratch, nx, ny, nz, /*dilate=*/!firstDilate);
+    mask.swap(scratch);
+  }
+
+  // Flip the sign wherever the new interior mask disagrees with the current
+  // sign. Closing is extensive (only sets mask where data >= 0) and opening is
+  // anti-extensive (only clears mask where data < 0), so both reduce to this
+  // single disagreement predicate.
+  for (size_t idx = 0; idx < totalVoxels; ++idx) {
+    if ((mask[idx] != 0) != (data[idx] < ScalarType{0})) {
+      data[idx] = -data[idx];
+    }
+  }
+}
+
+} // namespace
+
+template <typename ScalarType>
+void closeInterior(SignedDistanceField<ScalarType>& sdf, int iterations) {
+  morphInterior(sdf, iterations, /*firstDilate=*/true);
+}
+
+template <typename ScalarType>
+void openInterior(SignedDistanceField<ScalarType>& sdf, int iterations) {
+  morphInterior(sdf, iterations, /*firstDilate=*/false);
+}
+
+// ================================================================================================
 // EXPLICIT INSTANTIATIONS
 // ================================================================================================
 
@@ -916,5 +1147,30 @@ template BoundingBox<float> computeMeshBounds<float>(std::span<const Eigen::Vect
 template BoundingBox<double> computeMeshBounds<double>(std::span<const Eigen::Vector3<double>>);
 
 } // namespace detail
+
+// Public API explicit instantiations
+template void applySignsToDistanceField<float>(
+    SignedDistanceField<float>&,
+    std::span<const Eigen::Vector3<float>>,
+    std::span<const Eigen::Vector3i>,
+    SignMethod);
+
+template void applySignsToDistanceField<double>(
+    SignedDistanceField<double>&,
+    std::span<const Eigen::Vector3<double>>,
+    std::span<const Eigen::Vector3i>,
+    SignMethod);
+
+template void floodFillExterior<float>(SignedDistanceField<float>&);
+
+template void floodFillExterior<double>(SignedDistanceField<double>&);
+
+template void closeInterior<float>(SignedDistanceField<float>&, int);
+
+template void closeInterior<double>(SignedDistanceField<double>&, int);
+
+template void openInterior<float>(SignedDistanceField<float>&, int);
+
+template void openInterior<double>(SignedDistanceField<double>&, int);
 
 } // namespace axel

--- a/axel/axel/MeshToSdf.h
+++ b/axel/axel/MeshToSdf.h
@@ -133,6 +133,75 @@ void meshToSdf(
     SignedDistanceField<ScalarType>& sdf,
     const MeshToSdfConfig<ScalarType>& config = {});
 
+/**
+ * Apply signs to an existing (unsigned) distance field based on inside/outside classification.
+ * This is the sign determination step from the meshToSdf pipeline, exposed for cases where
+ * you need to re-sign an SDF with a different method without recomputing distances.
+ *
+ * @param sdf Distance field to apply signs to (modified in place)
+ * @param vertices Mesh vertex positions
+ * @param triangles Mesh triangle indices
+ * @param signMethod Method for inside/outside classification
+ */
+template <typename ScalarType>
+void applySignsToDistanceField(
+    SignedDistanceField<ScalarType>& sdf,
+    std::span<const Eigen::Vector3<ScalarType>> vertices,
+    std::span<const Eigen::Vector3i> triangles,
+    SignMethod signMethod = SignMethod::RayCasting);
+
+/**
+ * Fill interior voids in an SDF using boundary-seeded flood fill.
+ *
+ * Identifies connected exterior regions by flood-filling from boundary voxels (faces of the grid)
+ * through 6-connected neighbors with value >= 0. Any voxel with value >= 0 not reached by the
+ * flood fill is considered an interior void and has its value negated.
+ *
+ * @param sdf Signed distance field to modify in place
+ */
+template <typename ScalarType>
+void floodFillExterior(SignedDistanceField<ScalarType>& sdf);
+
+/**
+ * Morphologically close the interior region of an SDF.
+ *
+ * Treats voxels with value < 0 as "interior" and performs a binary morphological
+ * closing (`iterations` dilations followed by `iterations` erosions) of that
+ * region using a 6-connected (face-adjacent) structuring element. Grid faces are
+ * treated as exterior for both passes. Any voxel newly classified as interior by
+ * the closing has its (positive) value negated, preserving distance magnitude.
+ *
+ * Unlike floodFillExterior, which only fixes fully enclosed voids, closing also
+ * bridges thin interior regions that the sign step misclassified as exterior even
+ * when they remain connected to the outside (e.g. an open grip cavity on a
+ * controller). Closing is extensive, so it only ever adds interior voxels.
+ *
+ * @param sdf Signed distance field to modify in place
+ * @param iterations Number of dilation/erosion passes (closing radius in voxels)
+ */
+template <typename ScalarType>
+void closeInterior(SignedDistanceField<ScalarType>& sdf, int iterations = 1);
+
+/**
+ * Morphologically open the interior region of an SDF.
+ *
+ * Treats voxels with value < 0 as "interior" and performs a binary morphological
+ * opening (`iterations` erosions followed by `iterations` dilations) using a
+ * 6-connected structuring element. This removes isolated interior specks and
+ * protrusions thinner than `iterations` voxels (e.g. spurious single voxels the
+ * winding-number sign step marks as interior in free space). Grid faces are
+ * treated as exterior. Any voxel removed from the interior has its (negative)
+ * value flipped positive, preserving distance magnitude.
+ *
+ * Opening is anti-extensive, so it only ever removes interior voxels — apply it
+ * after closeInterior / floodFillExterior to despeckle the result.
+ *
+ * @param sdf Signed distance field to modify in place
+ * @param iterations Number of erosion/dilation passes (opening radius in voxels)
+ */
+template <typename ScalarType>
+void openInterior(SignedDistanceField<ScalarType>& sdf, int iterations = 1);
+
 namespace detail {
 
 // ================================================================================================

--- a/axel/axel/SignedDistanceField.cpp
+++ b/axel/axel/SignedDistanceField.cpp
@@ -269,6 +269,13 @@ void SignedDistanceField<ScalarType>::fill(Scalar value) {
 }
 
 template <typename ScalarType>
+void SignedDistanceField<ScalarType>::offset(Scalar delta) {
+  for (auto& value : data_) {
+    value -= delta;
+  }
+}
+
+template <typename ScalarType>
 void SignedDistanceField<ScalarType>::clear() {
   fill(Scalar{0});
 }

--- a/axel/axel/SignedDistanceField.h
+++ b/axel/axel/SignedDistanceField.h
@@ -224,6 +224,14 @@ class SignedDistanceField {
   void fill(Scalar value);
 
   /**
+   * Offset the SDF by subtracting delta from all voxel values.
+   * Positive delta grows the inside region (shifts zero-crossing outward).
+   *
+   * @param delta Amount to subtract from all values
+   */
+  void offset(Scalar delta);
+
+  /**
    * Clear the SDF and reset it to zero values.
    */
   void clear();

--- a/axel/axel/test/MeshToSdfTest.cpp
+++ b/axel/axel/test/MeshToSdfTest.cpp
@@ -807,4 +807,186 @@ TEST_F(MeshToSdfTest, InPlaceOverload_MatchesReturnOverload) {
   }
 }
 
+TEST_F(MeshToSdfTest, FloodFillExteriorNegatesInteriorVoids) {
+  // Create a simple SDF with an artificial interior void:
+  // A 6x6x6 grid where the boundary is positive (outside) and the center has
+  // a pocket of positive values surrounded by negative values (interior void).
+  const BoundingBox<float> bounds(
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f), Eigen::Vector3f(5.0f, 5.0f, 5.0f));
+  const Eigen::Vector3<Index> resolution(6, 6, 6);
+  SignedDistanceField<float> sdf(bounds, resolution, 1.0f); // All positive (outside)
+
+  // Create a negative shell (inside) from grid indices 1-4 in each axis
+  for (Index i = 1; i <= 4; ++i) {
+    for (Index j = 1; j <= 4; ++j) {
+      for (Index k = 1; k <= 4; ++k) {
+        sdf.set(i, j, k, -1.0f);
+      }
+    }
+  }
+
+  // Create an interior void: positive pocket at center (grid 2-3)
+  for (Index i = 2; i <= 3; ++i) {
+    for (Index j = 2; j <= 3; ++j) {
+      for (Index k = 2; k <= 3; ++k) {
+        sdf.set(i, j, k, 0.5f);
+      }
+    }
+  }
+
+  // Before flood fill: center voxels are positive
+  EXPECT_GT(sdf.at(2, 2, 2), 0.0f);
+  EXPECT_GT(sdf.at(3, 3, 3), 0.0f);
+
+  // Boundary voxels should remain positive (they're connected to exterior)
+  EXPECT_GT(sdf.at(0, 0, 0), 0.0f);
+
+  floodFillExterior(sdf);
+
+  // After flood fill: interior void voxels should be negated
+  EXPECT_LT(sdf.at(2, 2, 2), 0.0f);
+  EXPECT_LT(sdf.at(3, 3, 3), 0.0f);
+
+  // Boundary positive voxels remain positive (connected to true exterior)
+  EXPECT_GT(sdf.at(0, 0, 0), 0.0f);
+  EXPECT_GT(sdf.at(5, 5, 5), 0.0f);
+
+  // Negative voxels remain negative (unaffected)
+  EXPECT_LT(sdf.at(1, 1, 1), 0.0f);
+}
+
+TEST_F(MeshToSdfTest, FloodFillExteriorNoVoidsIsNoOp) {
+  // A simple SDF with no interior voids should be unchanged
+  const BoundingBox<float> bounds(
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f), Eigen::Vector3f(3.0f, 3.0f, 3.0f));
+  const Eigen::Vector3<Index> resolution(4, 4, 4);
+  SignedDistanceField<float> sdf(bounds, resolution, 1.0f); // All positive
+
+  // Make center negative (no voids, just a proper inside region)
+  sdf.set(1, 1, 1, -1.0f);
+  sdf.set(2, 2, 2, -1.0f);
+
+  // Copy original data
+  auto originalData = sdf.data();
+
+  floodFillExterior(sdf);
+
+  // Data should be unchanged since all positive voxels are boundary-connected
+  EXPECT_EQ(sdf.data(), originalData);
+}
+
+TEST_F(MeshToSdfTest, CloseInteriorFillsOpenPocketFloodFillCannot) {
+  // A 5x5x5 negative block with a 1-voxel-wide slot carved from one face into
+  // its center. The slot stays positive and is connected to the exterior, so a
+  // flood fill cannot reach-and-fill it, but a morphological close bridges it.
+  const BoundingBox<float> bounds(
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f), Eigen::Vector3f(6.0f, 6.0f, 6.0f));
+  const Eigen::Vector3<Index> resolution(7, 7, 7);
+  SignedDistanceField<float> sdf(bounds, resolution, 1.0f); // outside
+
+  for (Index i = 1; i <= 5; ++i) {
+    for (Index j = 1; j <= 5; ++j) {
+      for (Index k = 1; k <= 5; ++k) {
+        sdf.set(i, j, k, -1.0f);
+      }
+    }
+  }
+  // Carve an open slot along -j at column (i=3, k=3): positive, opening at j=0.
+  for (Index j = 1; j <= 3; ++j) {
+    sdf.set(3, j, 3, 0.5f);
+  }
+
+  // Flood fill cannot close the slot: it is reachable from the j=0 face.
+  SignedDistanceField<float> sdfFlood = sdf;
+  floodFillExterior(sdfFlood);
+  EXPECT_GT(sdfFlood.at(3, 3, 3), 0.0f) << "open slot must remain exterior under flood fill";
+
+  // Closing bridges the 1-voxel slot at depth.
+  closeInterior(sdf, 1);
+  EXPECT_LT(sdf.at(3, 3, 3), 0.0f) << "closing must fill the deep slot voxel";
+  // Original interior stays interior; true exterior stays exterior.
+  EXPECT_LT(sdf.at(2, 2, 2), 0.0f);
+  EXPECT_GT(sdf.at(0, 0, 0), 0.0f);
+}
+
+TEST_F(MeshToSdfTest, CloseInteriorIsNoOpOnSolidBlock) {
+  // Closing a solid convex interior region adds nothing (it is extensive and the
+  // dilate/erode round-trip restores a pocket-free block).
+  const BoundingBox<float> bounds(
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f), Eigen::Vector3f(5.0f, 5.0f, 5.0f));
+  const Eigen::Vector3<Index> resolution(6, 6, 6);
+  SignedDistanceField<float> sdf(bounds, resolution, 1.0f);
+  for (Index i = 1; i <= 4; ++i) {
+    for (Index j = 1; j <= 4; ++j) {
+      for (Index k = 1; k <= 4; ++k) {
+        sdf.set(i, j, k, -1.0f);
+      }
+    }
+  }
+
+  const auto originalData = sdf.data();
+  closeInterior(sdf, 1);
+  EXPECT_EQ(sdf.data(), originalData);
+}
+
+TEST_F(MeshToSdfTest, OpenInteriorRemovesIsolatedSpeckButKeepsSolid) {
+  // A solid interior block plus one isolated interior speck floating in free
+  // space. Opening should remove the speck while preserving the block.
+  const BoundingBox<float> bounds(
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f), Eigen::Vector3f(7.0f, 7.0f, 7.0f));
+  const Eigen::Vector3<Index> resolution(8, 8, 8);
+  SignedDistanceField<float> sdf(bounds, resolution, 1.0f);
+  for (Index i = 1; i <= 4; ++i) {
+    for (Index j = 1; j <= 4; ++j) {
+      for (Index k = 1; k <= 4; ++k) {
+        sdf.set(i, j, k, -1.0f);
+      }
+    }
+  }
+  sdf.set(6, 6, 6, -1.0f); // isolated interior speck
+
+  openInterior(sdf, 1);
+
+  EXPECT_GT(sdf.at(6, 6, 6), 0.0f) << "isolated speck must be removed";
+  EXPECT_LT(sdf.at(2, 2, 2), 0.0f) << "solid block interior must survive";
+}
+
+TEST_F(MeshToSdfTest, PublicApplySignsToDistanceField) {
+  // Create an unsigned SDF from the cube mesh
+  const BoundingBox<float> bounds(
+      Eigen::Vector3f(-1.0f, -1.0f, -1.0f), Eigen::Vector3f(1.0f, 1.0f, 1.0f));
+  const Eigen::Vector3<Index> resolution(8, 8, 8);
+
+  MeshToSdfConfig<float> config;
+  config.signMethod = SignMethod::RayCasting;
+  auto sdf = meshToSdf<float>(
+      std::span<const Eigen::Vector3f>(cubeVertices),
+      std::span<const Eigen::Vector3i>(cubeFaces),
+      bounds,
+      resolution,
+      config);
+
+  // Center should be negative (inside the cube)
+  EXPECT_LT(sdf.sample(Eigen::Vector3f(0.0f, 0.0f, 0.0f)), 0.0f);
+
+  // Now make all values positive (unsigned) and re-apply signs using public API
+  auto& data = sdf.data();
+  for (auto& v : data) {
+    v = std::abs(v);
+  }
+
+  // Center should now be positive (unsigned)
+  EXPECT_GT(sdf.sample(Eigen::Vector3f(0.0f, 0.0f, 0.0f)), 0.0f);
+
+  // Re-apply signs using public API
+  applySignsToDistanceField<float>(
+      sdf,
+      std::span<const Eigen::Vector3f>(cubeVertices),
+      std::span<const Eigen::Vector3i>(cubeFaces),
+      SignMethod::RayCasting);
+
+  // Center should be negative again
+  EXPECT_LT(sdf.sample(Eigen::Vector3f(0.0f, 0.0f, 0.0f)), 0.0f);
+}
+
 } // namespace axel

--- a/axel/axel/test/SignedDistanceFieldTest.cpp
+++ b/axel/axel/test/SignedDistanceFieldTest.cpp
@@ -590,4 +590,38 @@ TEST_F(SignedDistanceFieldTest, SampleWithGradientConsistency) {
   }
 }
 
+TEST_F(SignedDistanceFieldTest, OffsetShiftsZeroCrossing) {
+  // Create a sphere SDF with radius 1.0
+  auto sdf = SignedDistanceFieldf::createSphere(1.0f, Eigen::Vector3<Index>(16, 16, 16));
+
+  // Sample at a point on the original surface
+  const Eigen::Vector3f surfacePoint(1.0f, 0.0f, 0.0f);
+  EXPECT_NEAR(sdf.sample(surfacePoint), 0.0f, 0.15f);
+
+  // Offset by 0.2 (grow inside): zero-crossing should move outward
+  sdf.offset(0.2f);
+
+  // Point that was on surface is now inside (negative)
+  EXPECT_LT(sdf.sample(surfacePoint), 0.0f);
+
+  // Point at radius 1.2 should now be near zero-crossing
+  const Eigen::Vector3f newSurfacePoint(1.2f, 0.0f, 0.0f);
+  EXPECT_NEAR(sdf.sample(newSurfacePoint), 0.0f, 0.15f);
+}
+
+TEST_F(SignedDistanceFieldTest, OffsetNegativeShrinks) {
+  auto sdf = SignedDistanceFieldf::createSphere(1.0f, Eigen::Vector3<Index>(16, 16, 16));
+
+  // Offset by -0.2 (shrink inside): zero-crossing should move inward
+  sdf.offset(-0.2f);
+
+  // Point at radius 1.0 is now outside (positive)
+  const Eigen::Vector3f originalSurface(1.0f, 0.0f, 0.0f);
+  EXPECT_GT(sdf.sample(originalSurface), 0.0f);
+
+  // Point at radius 0.8 should now be near zero-crossing
+  const Eigen::Vector3f newSurface(0.8f, 0.0f, 0.0f);
+  EXPECT_NEAR(sdf.sample(newSurface), 0.0f, 0.15f);
+}
+
 } // namespace axel

--- a/pymomentum/axel/axel_pybind.cpp
+++ b/pymomentum/axel/axel_pybind.cpp
@@ -418,6 +418,16 @@ More efficient than calling sample() and gradient() separately.
 
 :param value: The value to fill with.)",
           py::arg("value"))
+      .def(
+          "offset",
+          &axel::SignedDistanceField<float>::offset,
+          R"(Offset the SDF by subtracting delta from all voxel values.
+
+Positive delta grows the inside region (shifts zero-crossing outward).
+Negative delta shrinks the inside region (shifts zero-crossing inward).
+
+:param delta: Amount to subtract from all values.)",
+          py::arg("delta"))
       .def_buffer([](axel::SignedDistanceField<float>& self) -> py::buffer_info {
         const auto& res = self.resolution();
         auto& data = self.data();
@@ -1135,6 +1145,105 @@ Example usage::
       py::arg("vertex_mask") = py::array_t<bool>(),
       py::arg("iterations") = 1,
       py::arg("step") = 0.5f);
+
+  // Bind apply_signs_to_distance_field function
+  m.def(
+      "apply_signs",
+      [](axel::SignedDistanceField<float>& sdf,
+         const py::array_t<float>& vertices,
+         const py::array_t<int>& triangles,
+         axel::SignMethod signMethod) {
+        // Validate input arrays
+        validatePositionArray(vertices, "vertices");
+        validateTriangleIndexArray(triangles, "triangles", vertices.shape(0));
+
+        const auto vertexVector = arrayToEigenVectors<float, 3>(vertices, "vertices");
+        const auto triangleVector = arrayToEigenVectors<int, 3>(triangles, "triangles");
+
+        {
+          py::gil_scoped_release release;
+          axel::applySignsToDistanceField<float>(
+              sdf,
+              std::span<const Eigen::Vector3f>(vertexVector),
+              std::span<const Eigen::Vector3i>(triangleVector),
+              signMethod);
+        }
+      },
+      R"(Apply signs to an existing (unsigned) distance field based on inside/outside classification.
+
+This is the sign determination step from the mesh_to_sdf pipeline, exposed for cases
+where you need to re-sign an SDF with a different method without recomputing distances.
+
+:param sdf: Distance field to apply signs to (modified in place).
+:param vertices: Mesh vertex positions as 2D array of shape (N, 3).
+:param triangles: Mesh triangle indices as 2D array of shape (M, 3).
+:param sign_method: Method for inside/outside classification (default: RayCasting).)",
+      py::arg("sdf"),
+      py::arg("vertices"),
+      py::arg("triangles"),
+      py::arg("sign_method") = axel::SignMethod::RayCasting);
+
+  // Bind flood_fill_exterior function
+  m.def(
+      "flood_fill_exterior",
+      [](axel::SignedDistanceField<float>& sdf) {
+        py::gil_scoped_release release;
+        axel::floodFillExterior<float>(sdf);
+      },
+      R"(Fill interior voids in an SDF using boundary-seeded flood fill.
+
+Identifies connected exterior regions by flood-filling from boundary voxels (faces
+of the grid) through 6-connected neighbors with value >= 0. Any voxel with value >= 0
+not reached by the flood fill is considered an interior void and has its value negated.
+
+:param sdf: Signed distance field to modify in place.)",
+      py::arg("sdf"));
+
+  // Bind close_interior function
+  m.def(
+      "close_interior",
+      [](axel::SignedDistanceField<float>& sdf, int iterations) {
+        py::gil_scoped_release release;
+        axel::closeInterior<float>(sdf, iterations);
+      },
+      R"(Morphologically close the interior region of an SDF.
+
+Treats voxels with value < 0 as interior and performs a binary morphological closing
+(``iterations`` dilations followed by ``iterations`` erosions) of that region using a
+6-connected structuring element. Newly-interior voxels have their value negated.
+
+Unlike :func:`flood_fill_exterior`, which only fixes fully enclosed voids, closing also
+bridges thin interior regions misclassified as exterior even when they stay connected to
+the outside (e.g. an open grip cavity). Closing is extensive, so it only adds interior
+voxels.
+
+:param sdf: Signed distance field to modify in place.
+:param iterations: Number of dilation/erosion passes (closing radius in voxels).)",
+      py::arg("sdf"),
+      py::arg("iterations") = 1);
+
+  // Bind open_interior function
+  m.def(
+      "open_interior",
+      [](axel::SignedDistanceField<float>& sdf, int iterations) {
+        py::gil_scoped_release release;
+        axel::openInterior<float>(sdf, iterations);
+      },
+      R"(Morphologically open the interior region of an SDF.
+
+Treats voxels with value < 0 as interior and performs a binary morphological opening
+(``iterations`` erosions followed by ``iterations`` dilations) using a 6-connected
+structuring element. This removes isolated interior specks and protrusions thinner than
+``iterations`` voxels (e.g. spurious single voxels the sign step marks interior in free
+space). Removed voxels have their value flipped positive.
+
+Opening is anti-extensive, so it only removes interior voxels. Apply it after
+:func:`close_interior` / :func:`flood_fill_exterior` to despeckle the result.
+
+:param sdf: Signed distance field to modify in place.
+:param iterations: Number of erosion/dilation passes (opening radius in voxels).)",
+      py::arg("sdf"),
+      py::arg("iterations") = 1);
 
   // SDF serialization
   m.def(

--- a/pymomentum/test/test_axel.py
+++ b/pymomentum/test/test_axel.py
@@ -769,23 +769,24 @@ class TestAxel(unittest.TestCase):
 
         vertices, normals, quads = axel.dual_contouring(sdf, isovalue=0.0)
 
-        if len(vertices) > 0:
-            # Check vertex bounds - should be within SDF bounds
-            vertex_min = np.min(vertices, axis=0)
-            vertex_max = np.max(vertices, axis=0)
-            bounds_min = sdf.bounds.min
-            bounds_max = sdf.bounds.max
+        self.assertGreater(len(vertices), 0, "Expected vertices from dual contouring")
 
-            # Vertices should be within SDF bounds (with small tolerance)
-            tolerance = 0.1
-            self.assertTrue(
-                np.all(vertex_min >= bounds_min - tolerance),
-                f"Some vertices are below bounds: {vertex_min} vs {bounds_min}",
-            )
-            self.assertTrue(
-                np.all(vertex_max <= bounds_max + tolerance),
-                f"Some vertices are above bounds: {vertex_max} vs {bounds_max}",
-            )
+        # Check vertex bounds - should be within SDF bounds
+        vertex_min = np.min(vertices, axis=0)
+        vertex_max = np.max(vertices, axis=0)
+        bounds_min = sdf.bounds.min
+        bounds_max = sdf.bounds.max
+
+        # Vertices should be within SDF bounds (with small tolerance)
+        tolerance = 0.1
+        self.assertTrue(
+            np.all(vertex_min >= bounds_min - tolerance),
+            f"Some vertices are below bounds: {vertex_min} vs {bounds_min}",
+        )
+        self.assertTrue(
+            np.all(vertex_max <= bounds_max + tolerance),
+            f"Some vertices are above bounds: {vertex_max} vs {bounds_max}",
+        )
 
     def test_dual_contouring_quad_indices(self):
         """Test that quad indices are valid."""
@@ -793,19 +794,20 @@ class TestAxel(unittest.TestCase):
 
         vertices, normals, quads = axel.dual_contouring(sdf, isovalue=0.0)
 
-        if len(quads) > 0:
-            # Check quad index bounds
-            max_vertex_index = np.max(quads)
-            min_vertex_index = np.min(quads)
+        self.assertGreater(len(quads), 0, "Expected quads from dual contouring")
 
-            self.assertGreaterEqual(
-                min_vertex_index, 0, "Quad indices should be non-negative"
-            )
-            self.assertLess(
-                max_vertex_index,
-                len(vertices),
-                "Quad indices should be within vertex array bounds",
-            )
+        # Check quad index bounds
+        max_vertex_index = np.max(quads)
+        min_vertex_index = np.min(quads)
+
+        self.assertGreaterEqual(
+            min_vertex_index, 0, "Quad indices should be non-negative"
+        )
+        self.assertLess(
+            max_vertex_index,
+            len(vertices),
+            "Quad indices should be within vertex array bounds",
+        )
 
     def test_dual_contouring_different_resolutions(self):
         """Test dual contouring with different grid resolutions."""
@@ -939,24 +941,25 @@ class TestAxel(unittest.TestCase):
 
         vertices, normals, quads = axel.dual_contouring(sdf, isovalue=0.0)
 
-        if len(vertices) > 0:
-            # Check distances from origin - should be roughly around the sphere radius
-            distances = np.linalg.norm(vertices, axis=1)
-            mean_distance = np.mean(distances)
+        self.assertGreater(len(vertices), 0, "Expected vertices from dual contouring")
 
-            # Since we're using surface positioning now, vertices should be much closer to the sphere
-            tolerance = 0.2  # Tighter tolerance since we push vertices to surface
+        # Check distances from origin - should be roughly around the sphere radius
+        distances = np.linalg.norm(vertices, axis=1)
+        mean_distance = np.mean(distances)
 
-            self.assertGreater(
-                mean_distance,
-                radius - tolerance,
-                f"Mean distance {mean_distance:.3f} too far inside sphere",
-            )
-            self.assertLess(
-                mean_distance,
-                radius + tolerance,
-                f"Mean distance {mean_distance:.3f} too far outside sphere",
-            )
+        # Since we're using surface positioning now, vertices should be much closer to the sphere
+        tolerance = 0.2  # Tighter tolerance since we push vertices to surface
+
+        self.assertGreater(
+            mean_distance,
+            radius - tolerance,
+            f"Mean distance {mean_distance:.3f} too far inside sphere",
+        )
+        self.assertLess(
+            mean_distance,
+            radius + tolerance,
+            f"Mean distance {mean_distance:.3f} too far outside sphere",
+        )
 
     def test_smooth_mesh_laplacian(self):
         """Test basic mesh smoothing functionality."""
@@ -1435,6 +1438,167 @@ class TestAxel(unittest.TestCase):
         """Test that loading from a nonexistent file raises RuntimeError."""
         with self.assertRaises(RuntimeError):
             axel.load_sdf_from_msgpack("/nonexistent/path/sdf.msgpack")
+
+    def test_offset_shifts_values(self):
+        """Test that offset() subtracts delta from all voxel values."""
+        min_corner = np.array([-1.0, -1.0, -1.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+        resolution = np.array([4, 4, 4], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution, 2.0)
+
+        sdf.offset(0.5)
+
+        data = np.array(sdf)
+        np.testing.assert_array_almost_equal(data, np.full((4, 4, 4), 1.5))
+
+    def test_offset_negative(self):
+        """Test that negative offset adds to values."""
+        min_corner = np.array([-1.0, -1.0, -1.0])
+        max_corner = np.array([1.0, 1.0, 1.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+        resolution = np.array([4, 4, 4], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution, 1.0)
+
+        sdf.offset(-0.5)
+
+        data = np.array(sdf)
+        np.testing.assert_array_almost_equal(data, np.full((4, 4, 4), 1.5))
+
+    def test_flood_fill_exterior_negates_voids(self):
+        """Test that flood_fill_exterior negates interior void voxels."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([5.0, 5.0, 5.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+        resolution = np.array([6, 6, 6], dtype=np.int32)
+
+        # Start with all positive (outside)
+        sdf = axel.SignedDistanceField(bbox, resolution, 1.0)
+
+        # Create negative shell (inside) around center
+        data = np.array(sdf, copy=False)
+        data[1:5, 1:5, 1:5] = -1.0
+        # Interior void (positive pocket surrounded by negative)
+        data[2:4, 2:4, 2:4] = 0.5
+
+        # Before: interior void is positive
+        self.assertGreater(data[2, 2, 2], 0.0)
+
+        axel.flood_fill_exterior(sdf)
+
+        result = np.array(sdf)
+        # Interior void voxels should now be negative
+        self.assertLess(result[2, 2, 2], 0.0)
+        self.assertLess(result[3, 3, 3], 0.0)
+        # Boundary positive voxels remain positive
+        self.assertGreater(result[0, 0, 0], 0.0)
+        self.assertGreater(result[5, 5, 5], 0.0)
+
+    def test_flood_fill_exterior_no_voids_is_noop(self):
+        """Test that flood_fill_exterior is a no-op when there are no voids."""
+        min_corner = np.array([0.0, 0.0, 0.0])
+        max_corner = np.array([3.0, 3.0, 3.0])
+        bbox = axel.BoundingBox(min_corner, max_corner)
+        resolution = np.array([4, 4, 4], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution, 1.0)
+
+        original_data = np.array(sdf).copy()
+        axel.flood_fill_exterior(sdf)
+        np.testing.assert_array_equal(np.array(sdf), original_data)
+
+    def test_close_interior_fills_open_pocket(self):
+        """close_interior bridges an open slot that flood_fill_exterior cannot."""
+        bbox = axel.BoundingBox(np.array([0.0, 0.0, 0.0]), np.array([6.0, 6.0, 6.0]))
+        resolution = np.array([7, 7, 7], dtype=np.int32)
+
+        def make_sdf() -> axel.SignedDistanceField:
+            sdf = axel.SignedDistanceField(bbox, resolution, 1.0)
+            data = np.array(sdf, copy=False)
+            data[1:6, 1:6, 1:6] = -1.0  # solid interior block
+            data[3, 1:4, 3] = 0.5  # open slot carved from the j=0 face to center
+            return sdf
+
+        # Flood fill leaves the slot positive (it is reachable from the face).
+        sdf_flood = make_sdf()
+        axel.flood_fill_exterior(sdf_flood)
+        self.assertGreater(np.array(sdf_flood)[3, 3, 3], 0.0)
+
+        # Closing fills the deep slot voxel while preserving exterior/interior.
+        sdf_close = make_sdf()
+        axel.close_interior(sdf_close, iterations=1)
+        result = np.array(sdf_close)
+        self.assertLess(result[3, 3, 3], 0.0)
+        self.assertLess(result[2, 2, 2], 0.0)
+        self.assertGreater(result[0, 0, 0], 0.0)
+
+    def test_open_interior_removes_isolated_speck(self):
+        """open_interior drops an isolated interior speck but keeps the solid."""
+        bbox = axel.BoundingBox(np.array([0.0, 0.0, 0.0]), np.array([7.0, 7.0, 7.0]))
+        resolution = np.array([8, 8, 8], dtype=np.int32)
+        sdf = axel.SignedDistanceField(bbox, resolution, 1.0)
+        data = np.array(sdf, copy=False)
+        data[1:5, 1:5, 1:5] = -1.0  # solid block
+        data[6, 6, 6] = -1.0  # isolated speck
+
+        axel.open_interior(sdf, iterations=1)
+
+        result = np.array(sdf)
+        self.assertGreater(result[6, 6, 6], 0.0)
+        self.assertLess(result[2, 2, 2], 0.0)
+
+    def test_apply_signs(self):
+        """Test that apply_signs correctly signs an unsigned SDF."""
+        # Create a cube mesh
+        vertices = np.array(
+            [
+                [-0.5, -0.5, -0.5],
+                [0.5, -0.5, -0.5],
+                [0.5, 0.5, -0.5],
+                [-0.5, 0.5, -0.5],
+                [-0.5, -0.5, 0.5],
+                [0.5, -0.5, 0.5],
+                [0.5, 0.5, 0.5],
+                [-0.5, 0.5, 0.5],
+            ],
+            dtype=np.float32,
+        )
+        triangles = np.array(
+            [
+                [0, 1, 2],
+                [0, 2, 3],
+                [4, 7, 6],
+                [4, 6, 5],
+                [0, 4, 5],
+                [0, 5, 1],
+                [2, 6, 7],
+                [2, 7, 3],
+                [0, 3, 7],
+                [0, 7, 4],
+                [1, 5, 6],
+                [1, 6, 2],
+            ],
+            dtype=np.int32,
+        )
+
+        # Create signed SDF first
+        sdf = axel.mesh_to_sdf(vertices, triangles, voxel_size=0.2)
+
+        # Center should be negative (inside)
+        center_val = sdf.sample(np.array([0.0, 0.0, 0.0]))
+        self.assertLess(center_val, 0.0)
+
+        # Make all values positive (unsigned)
+        data = np.array(sdf, copy=False)
+        np.abs(data, out=data)
+
+        # Center should now be positive
+        self.assertGreater(sdf.sample(np.array([0.0, 0.0, 0.0])), 0.0)
+
+        # Re-apply signs
+        axel.apply_signs(sdf, vertices, triangles)
+
+        # Center should be negative again
+        self.assertLess(sdf.sample(np.array([0.0, 0.0, 0.0])), 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Exposes three SDF operations as reusable primitives in the axel library:

1. **applySignsToDistanceField** (public free function): Previously only in
   detail namespace, now exposed for cases where you need to re-sign an SDF
   with a different method without recomputing distances.

2. **SignedDistanceField::offset(delta)**: Subtracts delta from all voxel
   values, shifting the zero-crossing. Positive delta grows the inside region.

3. **floodFillExterior(sdf)**: BFS from boundary voxels through 6-connected
   neighbors with value >= 0. Unreached positive voxels are considered interior
   voids and negated. Replaces the Python scipy-based implementation.

Python bindings added for all three operations with GIL release.

Reviewed By: FallenShard

Differential Revision: D107935723


