### PR TITLE
Add Mesh-based addAnimatedMesh overload to FbxBuilder (#1521)

### DIFF
--- a/momentum/io/fbx/fbx_builder.cpp
+++ b/momentum/io/fbx/fbx_builder.cpp
@@ -281,79 +281,70 @@ void FbxBuilder::addAnimatedMesh(
     const std::string& name,
     float fps,
     const MatrixXf& jointParams) {
+  MT_THROW_IF(character.mesh == nullptr, "Character has no mesh");
+  addAnimatedMesh(
+      *character.mesh,
+      name,
+      fps,
+      jointParams,
+      character.skeleton.joints.empty() ? Vector3f::Zero()
+                                        : character.skeleton.joints[0].translationOffset);
+}
+
+void FbxBuilder::addAnimatedMesh(
+    const Mesh& mesh,
+    const std::string& name,
+    float fps,
+    const MatrixXf& jointParams,
+    const Vector3f& translationOffset) {
   MT_THROW_IF(!impl_, "FbxBuilder has been moved from or already saved");
   MT_THROW_IF(!impl_->scene, "FBX scene is null");
-  MT_THROW_IF(character.mesh == nullptr, "Character has no mesh");
-  MT_THROW_IF(character.skeleton.joints.empty(), "Character skeleton has no joints");
   MT_THROW_IF(jointParams.cols() == 0, "jointParams is empty");
 
   auto* root = impl_->scene->GetRootNode();
   MT_THROW_IF(root == nullptr, "Unable to get root node from FBX scene");
 
   // Create mesh node directly under scene root (no skeleton)
-  const auto numVertices = static_cast<int>(character.mesh->vertices.size());
+  const auto numVertices = static_cast<int>(mesh.vertices.size());
   ::fbxsdk::FbxNode* meshNode = ::fbxsdk::FbxNode::Create(impl_->scene, name.c_str());
   ::fbxsdk::FbxMesh* lMesh = ::fbxsdk::FbxMesh::Create(impl_->scene, (name + "_geo").c_str());
   lMesh->SetControlPointCount(numVertices);
   lMesh->InitNormals(numVertices);
   for (int i = 0; i < numVertices; i++) {
     lMesh->SetControlPointAt(
-        FbxVector4(
-            character.mesh->vertices[i].x(),
-            character.mesh->vertices[i].y(),
-            character.mesh->vertices[i].z()),
-        FbxVector4(
-            character.mesh->normals[i].x(),
-            character.mesh->normals[i].y(),
-            character.mesh->normals[i].z()),
+        FbxVector4(mesh.vertices[i].x(), mesh.vertices[i].y(), mesh.vertices[i].z()),
+        FbxVector4(mesh.normals[i].x(), mesh.normals[i].y(), mesh.normals[i].z()),
         i);
   }
-  writePolygonsToFbxMesh(*character.mesh, lMesh);
+  writePolygonsToFbxMesh(mesh, lMesh);
   lMesh->BuildMeshEdgeArray();
   meshNode->SetNodeAttribute(lMesh);
 
-  if (!character.mesh->texcoords.empty()) {
+  if (!mesh.texcoords.empty()) {
     const fbxsdk::FbxLayerElement::EType uvType = fbxsdk::FbxLayerElement::eTextureDiffuse;
     lMesh->InitTextureUV(0, uvType);
     lMesh->InitTextureUVIndices(::fbxsdk::FbxLayerElement::EMappingMode::eByPolygonVertex, uvType);
-    for (const auto& texcoords : character.mesh->texcoords) {
+    for (const auto& texcoords : mesh.texcoords) {
       lMesh->AddTextureUV(::fbxsdk::FbxVector2(texcoords[0], 1.0f - texcoords[1]), uvType);
     }
-    writeTextureUVIndicesToFbxMesh(*character.mesh, lMesh, uvType);
+    writeTextureUVIndicesToFbxMesh(mesh, lMesh, uvType);
   }
 
   root->AddChild(meshNode);
 
   // Animate the mesh node's transform using the root joint parameters.
-  // Joint params layout per joint: tx, ty, tz, rx, ry, rz, sx, sy, sz.
   setFrameRate(impl_->scene, fps);
   auto [animStack, animBaseLayer] =
       getOrCreateAnimStackAndLayer(impl_->scene, "Skeleton Animation Stack");
 
-  meshNode->LclTranslation.GetCurveNode(true);
-  meshNode->LclRotation.GetCurveNode(true);
-  meshNode->LclScaling.GetCurveNode(true);
-
-  // Create all 9 curves for the root joint transform
-  std::array<::fbxsdk::FbxAnimCurve*, 9> curves = {
-      meshNode->LclTranslation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_X, true),
-      meshNode->LclTranslation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Y, true),
-      meshNode->LclTranslation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Z, true),
-      meshNode->LclRotation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_X, true),
-      meshNode->LclRotation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Y, true),
-      meshNode->LclRotation.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Z, true),
-      meshNode->LclScaling.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_X, true),
-      meshNode->LclScaling.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Y, true),
-      meshNode->LclScaling.GetCurve(animBaseLayer, FBXSDK_CURVENODE_COMPONENT_Z, true),
-  };
-
   // jointParams is (nJointParams x nFrames) in C++ convention.
-  // FBX curves use 9 channels (tx,ty,tz,rx,ry,rz,sx,sy,sz); momentum uses 7
-  // (uniform scale maps to all three scale channels via jointParamToFbx).
-  const auto nFrames = jointParams.cols();
-  const auto& rootJoint = character.skeleton.joints[0];
+  // FBX uses 9 channels; momentum uses 7 (uniform scale maps to all three).
+  Joint rootJoint;
+  rootJoint.translationOffset = translationOffset;
 
-  // Set static default transform, then only animate channels that vary
+  const auto nFrames = jointParams.cols();
+
+  // Set static default transform (used for constant channels)
   FbxDouble3 staticTrans(
       jointParamToFbx(jointParams(0, 0), 0, rootJoint),
       jointParamToFbx(jointParams(1, 0), 1, rootJoint),
@@ -368,6 +359,19 @@ void FbxBuilder::addAnimatedMesh(
   const float staticScale = jointParamToFbx(jointParams(scaleRow, 0), 6, rootJoint);
   meshNode->LclScaling.Set(FbxDouble3(staticScale, staticScale, staticScale));
 
+  // Only create curve nodes and curves for non-constant channels to avoid
+  // empty curves overriding the static property values in DCC tools.
+  const std::array<::fbxsdk::FbxProperty*, 3> properties = {
+      &meshNode->LclTranslation,
+      &meshNode->LclRotation,
+      &meshNode->LclScaling,
+  };
+  const std::array<const char*, 3> components = {
+      FBXSDK_CURVENODE_COMPONENT_X,
+      FBXSDK_CURVENODE_COMPONENT_Y,
+      FBXSDK_CURVENODE_COMPONENT_Z,
+  };
+
   ::fbxsdk::FbxTime time;
   for (size_t c = 0; c < 9; c++) {
     const auto paramRow = static_cast<Eigen::Index>(std::min(c, size_t(6)));
@@ -375,7 +379,6 @@ void FbxBuilder::addAnimatedMesh(
       break;
     }
 
-    // Skip channels where the value is constant across all frames
     bool isConstant = true;
     const float firstVal = jointParams(paramRow, 0);
     for (Eigen::Index f = 1; f < nFrames; f++) {
@@ -388,14 +391,18 @@ void FbxBuilder::addAnimatedMesh(
       continue;
     }
 
-    curves[c]->KeyModifyBegin();
+    auto* prop = properties[c / 3];
+    prop->GetCurveNode(true);
+    auto* curve = prop->GetCurve(animBaseLayer, components[c % 3], true);
+
+    curve->KeyModifyBegin();
     for (Eigen::Index f = 0; f < nFrames; f++) {
       const float val = jointParamToFbx(jointParams(paramRow, f), c, rootJoint);
       time.SetSecondDouble(static_cast<double>(f) / fps);
-      const auto keyIndex = curves[c]->KeyAdd(time);
-      curves[c]->KeySet(keyIndex, time, val);
+      const auto keyIndex = curve->KeyAdd(time);
+      curve->KeySet(keyIndex, time, val);
     }
-    curves[c]->KeyModifyEnd();
+    curve->KeyModifyEnd();
   }
 }
 
@@ -468,6 +475,15 @@ void FbxBuilder::addMotionWithJointParams(const Character&, float, const MatrixX
 }
 
 void FbxBuilder::addAnimatedMesh(const Character&, const std::string&, float, const MatrixXf&) {
+  MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
+}
+
+void FbxBuilder::addAnimatedMesh(
+    const Mesh&,
+    const std::string&,
+    float,
+    const MatrixXf&,
+    const Vector3f&) {
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 

--- a/momentum/io/fbx/fbx_builder.h
+++ b/momentum/io/fbx/fbx_builder.h
@@ -11,6 +11,7 @@
 #include <momentum/character/marker.h>
 #include <momentum/common/filesystem.h>
 #include <momentum/io/file_save_options.h>
+#include <momentum/math/mesh.h>
 #include <momentum/math/types.h>
 
 #include <span>
@@ -112,6 +113,26 @@ class FbxBuilder final {
       const std::string& name,
       float fps,
       const MatrixXf& jointParams);
+
+  /// Add an animated mesh from a Mesh object (no Character needed).
+  ///
+  /// Creates a standalone mesh node and animates its transform from joint
+  /// parameters. The joint params follow momentum convention: 7 values per
+  /// joint (tx, ty, tz, rx, ry, rz, sc). Only the first joint's parameters
+  /// are used (root transform).
+  ///
+  /// @param mesh The mesh geometry.
+  /// @param name Name for the mesh node.
+  /// @param fps Animation frame rate in frames per second.
+  /// @param jointParams Joint parameters matrix with shape (nFrames x nJointParams).
+  /// @param translationOffset Rest-pose translation offset added to the
+  ///   translation channels (defaults to zero).
+  void addAnimatedMesh(
+      const Mesh& mesh,
+      const std::string& name,
+      float fps,
+      const MatrixXf& jointParams,
+      const Vector3f& translationOffset = Vector3f::Zero());
 
   /// Add a marker sequence to the scene.
   ///

--- a/pymomentum/geometry/fbx_builder_pybind.cpp
+++ b/pymomentum/geometry/fbx_builder_pybind.cpp
@@ -10,6 +10,7 @@
 #include <momentum/character/character.h>
 #include <momentum/character/marker.h>
 #include <momentum/io/fbx/fbx_builder.h>
+#include <momentum/math/mesh.h>
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
@@ -145,6 +146,41 @@ as a simple animated mesh without any skeleton hierarchy.
           py::arg("name"),
           py::arg("fps") = 120.0f,
           py::arg("joint_params") = std::nullopt)
+      .def(
+          "add_animated_mesh",
+          [](mm::FbxBuilder& builder,
+             const mm::Mesh& mesh,
+             const std::string& name,
+             float fps,
+             const std::optional<Eigen::MatrixXf>& jointParams,
+             const std::optional<Eigen::Vector3f>& translationOffset) {
+            mm::MatrixXf transposedJointParams;
+            if (jointParams.has_value() && jointParams->size() > 0) {
+              transposedJointParams = jointParams->transpose();
+            }
+            builder.addAnimatedMesh(
+                mesh,
+                name,
+                fps,
+                transposedJointParams,
+                translationOffset.value_or(Eigen::Vector3f::Zero()));
+          },
+          R"(Add an animated mesh from a Mesh object (no Character needed).
+
+Creates a standalone mesh node and animates its transform from joint
+parameters. Only the root transform (first 7 joint params) is used.
+
+:param mesh: The mesh geometry.
+:param name: Name for the mesh node.
+:param fps: Animation frame rate in frames per second.
+:param joint_params: Joint parameters matrix with shape (nFrames, nJointParams).
+:param translation_offset: Rest-pose translation offset added to the translation
+    channels (defaults to zero).)",
+          py::arg("mesh"),
+          py::arg("name"),
+          py::arg("fps") = 120.0f,
+          py::arg("joint_params") = std::nullopt,
+          py::arg("translation_offset") = std::nullopt)
       .def(
           "add_marker_sequence",
           [](mm::FbxBuilder& builder,


### PR DESCRIPTION
Summary:

Add an `addAnimatedMesh(Mesh, ...)` overload that takes a raw Mesh instead of a Character. This lets callers export animated meshes (e.g. held objects in HOI sequences) without constructing a full Character with skeleton and skin weights.

The existing `addAnimatedMesh(Character, ...)` now delegates to the new overload, extracting the mesh and root joint translation offset.

Also fixes a bug where empty FBX animation curves were created for constant channels. DCC tools like Maya interpret an empty curve as zero rather than falling back to the static property value, so static rotations and scales were silently zeroed out on import. The fix only creates curve nodes for channels that actually vary across frames.

Reviewed By: cstollmeta

Differential Revision: D104091365


