### PR TITLE
Validate glove marker tracking inputs

### DIFF
--- a/momentum/marker_tracking/glove_utils.cpp
+++ b/momentum/marker_tracking/glove_utils.cpp
@@ -33,12 +33,15 @@ Character addGloveBones(
     const GloveConfig& cfg,
     const std::array<GloveOffset, 2>& offsets,
     const std::string& prefix) {
+  MT_THROW_IF(prefix.empty(), "addGloveBones: prefix must not be empty.");
   auto& newSkel = character.skeleton;
   auto& newTransform = character.parameterTransform;
   auto& newInvBindPose = character.inverseBindPose;
 
   for (size_t hand = 0; hand < 2; ++hand) {
     const auto& wristName = cfg.wristJointNames[hand];
+    MT_THROW_IF(
+        wristName.empty(), "addGloveBones: wrist joint name for hand {} must not be empty.", hand);
 
     const size_t wristIdx = newSkel.getJointIdByName(wristName);
     if (wristIdx == kInvalidIndex) {
@@ -91,6 +94,7 @@ Character addGloveCalibrationParameters(
     Character character,
     const GloveConfig& cfg,
     const std::string& prefix) {
+  MT_THROW_IF(prefix.empty(), "addGloveCalibrationParameters: prefix must not be empty.");
   auto& newSkel = character.skeleton;
   auto& newTransform = character.parameterTransform;
 
@@ -103,6 +107,10 @@ Character addGloveCalibrationParameters(
   static const std::array<size_t, 6> dofIndices{TX, TY, TZ, RX, RY, RZ};
 
   for (size_t hand = 0; hand < 2; ++hand) {
+    MT_THROW_IF(
+        cfg.wristJointNames[hand].empty(),
+        "addGloveCalibrationParameters: wrist joint name for hand {} must not be empty.",
+        hand);
     const std::string gloveBoneName = prefix + cfg.wristJointNames[hand];
     const size_t jointIdx = newSkel.getJointIdByName(gloveBoneName);
     if (jointIdx == kInvalidIndex) {

--- a/momentum/marker_tracking/process_markers.cpp
+++ b/momentum/marker_tracking/process_markers.cpp
@@ -22,10 +22,17 @@ namespace momentum {
 
 namespace {
 
-/// Validate that glove data frame count matches marker data and return the
-/// subspan corresponding to [firstFrame, lastFrame).
+/// Validate glove data and return the subspan corresponding to
+/// [firstFrame, lastFrame).
+///
+/// Checks that the glove frame count matches the marker data, then validates
+/// each observation in the [firstFrame, lastFrame) window: rejects empty or
+/// unknown joint names, non-finite positions/orientations, and zero-norm
+/// (degenerate) orientations. Observations outside the window are not validated
+/// since they are sliced away and never used downstream.
 std::span<const GloveFrameData> validateAndSliceGloveData(
     std::span<const GloveFrameData> gloveData,
+    const Character& character,
     size_t markerFrames,
     size_t firstFrame,
     size_t lastFrame,
@@ -39,7 +46,59 @@ std::span<const GloveFrameData> validateAndSliceGloveData(
       label,
       gloveData.size(),
       markerFrames);
+  // Validate only the [firstFrame, lastFrame) window that is actually consumed
+  // downstream; frames outside the range are sliced away and never used, so a
+  // bad observation in an excluded frame should not abort the solve.
+  for (size_t frameIndex = firstFrame; frameIndex < lastFrame; ++frameIndex) {
+    const auto& frame = gloveData[frameIndex];
+    for (size_t obsIndex = 0; obsIndex < frame.size(); ++obsIndex) {
+      const auto& obs = frame[obsIndex];
+      if (!obs.valid) {
+        continue;
+      }
+      MT_THROW_IF(
+          obs.jointName.empty(),
+          "{} glove observation has empty joint name at frame {}, observation {}",
+          label,
+          frameIndex,
+          obsIndex);
+      MT_THROW_IF(
+          character.skeleton.getJointIdByName(obs.jointName) == kInvalidIndex,
+          "{} glove observation uses unknown joint '{}' at frame {}, observation {}",
+          label,
+          obs.jointName,
+          frameIndex,
+          obsIndex);
+      MT_THROW_IF(
+          !obs.position.allFinite(),
+          "{} glove observation '{}' has non-finite position at frame {}, observation {}",
+          label,
+          obs.jointName,
+          frameIndex,
+          obsIndex);
+      MT_THROW_IF(
+          !obs.orientation.coeffs().allFinite(),
+          "{} glove observation '{}' has non-finite orientation at frame {}, observation {}",
+          label,
+          obs.jointName,
+          frameIndex,
+          obsIndex);
+      MT_THROW_IF(
+          obs.orientation.norm() <= 1e-6f,
+          "{} glove observation '{}' has zero orientation at frame {}, observation {}",
+          label,
+          obs.jointName,
+          frameIndex,
+          obsIndex);
+    }
+  }
   return gloveData.subspan(firstFrame, lastFrame - firstFrame);
+}
+
+bool hasAnyGloveData(
+    std::span<const GloveFrameData> leftGloveData,
+    std::span<const GloveFrameData> rightGloveData) {
+  return !leftGloveData.empty() || !rightGloveData.empty();
 }
 
 /// Slice camera keypoint data to match the [firstFrame, lastFrame) range.
@@ -100,10 +159,17 @@ void calibrateMarkers(
       firstFrame,
       maxFrames);
 
-  const auto leftGloveSlice =
-      validateAndSliceGloveData(leftGloveData, markerData.size(), firstFrame, lastFrame, "Left");
-  const auto rightGloveSlice =
-      validateAndSliceGloveData(rightGloveData, markerData.size(), firstFrame, lastFrame, "Right");
+  // Check the glove_config precondition before validating observations, so the
+  // specific "glove_config must be provided" error fires instead of a vaguer
+  // "unknown joint" error when the missing config would have added the joints.
+  MT_THROW_IF(
+      hasAnyGloveData(leftGloveData, rightGloveData) && !gloveConfig,
+      "glove_config must be provided when left_glove_data or right_glove_data is non-empty.");
+
+  const auto leftGloveSlice = validateAndSliceGloveData(
+      leftGloveData, character, markerData.size(), firstFrame, lastFrame, "Left");
+  const auto rightGloveSlice = validateAndSliceGloveData(
+      rightGloveData, character, markerData.size(), firstFrame, lastFrame, "Right");
 
   MT_CHECK(
       !(calibrationConfig.globalScaleOnly & calibrationConfig.locatorsOnly),
@@ -161,10 +227,17 @@ Eigen::MatrixXf processMarkers(
       firstFrame,
       maxFrames);
 
-  const auto leftGloveSlice =
-      validateAndSliceGloveData(leftGloveData, markerData.size(), firstFrame, lastFrame, "Left");
-  const auto rightGloveSlice =
-      validateAndSliceGloveData(rightGloveData, markerData.size(), firstFrame, lastFrame, "Right");
+  // Check the glove_config precondition before validating observations, so the
+  // specific "glove_config must be provided" error fires instead of a vaguer
+  // "unknown joint" error when the missing config would have added the joints.
+  MT_THROW_IF(
+      hasAnyGloveData(leftGloveData, rightGloveData) && !gloveConfig,
+      "glove_config must be provided when left_glove_data or right_glove_data is non-empty.");
+
+  const auto leftGloveSlice = validateAndSliceGloveData(
+      leftGloveData, character, markerData.size(), firstFrame, lastFrame, "Left");
+  const auto rightGloveSlice = validateAndSliceGloveData(
+      rightGloveData, character, markerData.size(), firstFrame, lastFrame, "Right");
 
   const auto slicedKeypointData =
       sliceCameraKeypointData(cameraKeypointData, firstFrame, lastFrame);

--- a/momentum/test/process_markers/process_markers_test.cpp
+++ b/momentum/test/process_markers/process_markers_test.cpp
@@ -15,6 +15,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 using namespace momentum;
 
 namespace {
@@ -104,6 +106,22 @@ std::vector<std::vector<Marker>> createLinearlyMovingMarkerData(
   return markerData;
 }
 
+std::vector<GloveFrameData> createGloveData(
+    const Character& character,
+    size_t numFrames,
+    const Eigen::Vector3f& position = Eigen::Vector3f::Ones()) {
+  std::vector<GloveFrameData> gloveData(numFrames);
+  for (size_t f = 0; f < numFrames; ++f) {
+    GloveSensorObservation obs;
+    obs.jointName = character.skeleton.joints.at(1).name;
+    obs.position = position;
+    obs.orientation = Eigen::Quaternionf::Identity();
+    obs.valid = true;
+    gloveData[f] = {obs};
+  }
+  return gloveData;
+}
+
 } // namespace
 
 // Tests that calibrateMarkers throws when firstFrame exceeds markerData size.
@@ -114,6 +132,90 @@ TEST(ProcessMarkersTest, CalibrateMarkers_FirstFrameExceedsSize_Throws) {
 
   EXPECT_THROW(
       calibrateMarkers(character, identity, markerData, config, /*firstFrame=*/6), std::exception);
+}
+
+TEST(ProcessMarkersTest, CalibrateMarkers_GloveDataWithoutConfig_Throws) {
+  auto [character, identity] = createTestCharacterWithIdentity();
+  const auto markerData = createMarkerData(character, 5);
+  const auto leftGloveData = createGloveData(character, 5);
+  CalibrationConfig config;
+
+  EXPECT_THROW(
+      calibrateMarkers(
+          character,
+          identity,
+          markerData,
+          config,
+          /*firstFrame=*/0,
+          /*maxFrames=*/0,
+          leftGloveData),
+      std::exception);
+}
+
+TEST(ProcessMarkersTest, CalibrateMarkers_UnknownGloveJoint_Throws) {
+  auto [character, identity] = createTestCharacterWithIdentity();
+  const auto markerData = createMarkerData(character, 5);
+  auto leftGloveData = createGloveData(character, 5);
+  leftGloveData.at(0).at(0).jointName = "missing_joint";
+  CalibrationConfig config;
+  GloveConfig gloveConfig;
+
+  EXPECT_THROW(
+      calibrateMarkers(
+          character,
+          identity,
+          markerData,
+          config,
+          /*firstFrame=*/0,
+          /*maxFrames=*/0,
+          leftGloveData,
+          {},
+          gloveConfig),
+      std::exception);
+}
+
+TEST(ProcessMarkersTest, CalibrateMarkers_NonFiniteGloveObservation_Throws) {
+  auto [character, identity] = createTestCharacterWithIdentity();
+  const auto markerData = createMarkerData(character, 5);
+  const auto leftGloveData = createGloveData(
+      character, 5, Eigen::Vector3f(std::numeric_limits<float>::quiet_NaN(), 1.0f, 2.0f));
+  CalibrationConfig config;
+  GloveConfig gloveConfig;
+
+  EXPECT_THROW(
+      calibrateMarkers(
+          character,
+          identity,
+          markerData,
+          config,
+          /*firstFrame=*/0,
+          /*maxFrames=*/0,
+          leftGloveData,
+          {},
+          gloveConfig),
+      std::exception);
+}
+
+TEST(ProcessMarkersTest, CalibrateMarkers_ZeroGloveOrientation_Throws) {
+  auto [character, identity] = createTestCharacterWithIdentity();
+  const auto markerData = createMarkerData(character, 5);
+  auto leftGloveData = createGloveData(character, 5);
+  leftGloveData.at(0).at(0).orientation.coeffs().setZero();
+  CalibrationConfig config;
+  GloveConfig gloveConfig;
+
+  EXPECT_THROW(
+      calibrateMarkers(
+          character,
+          identity,
+          markerData,
+          config,
+          /*firstFrame=*/0,
+          /*maxFrames=*/0,
+          leftGloveData,
+          {},
+          gloveConfig),
+      std::exception);
 }
 
 // Tests that processMarkers throws when firstFrame exceeds markerData size.
@@ -132,6 +234,30 @@ TEST(ProcessMarkersTest, ProcessMarkers_FirstFrameExceedsSize_Throws) {
           calibrationConfig,
           /*calibrate=*/false,
           /*firstFrame=*/6),
+      std::exception);
+}
+
+// Tests that processMarkers enforces the same glove_config-required guard as
+// calibrateMarkers (the check is duplicated, not shared, so it needs its own
+// coverage). The guard runs even when calibrate=false.
+TEST(ProcessMarkersTest, ProcessMarkers_GloveDataWithoutConfig_Throws) {
+  auto [character, identity] = createTestCharacterWithIdentity();
+  const auto markerData = createMarkerData(character, 5);
+  const auto leftGloveData = createGloveData(character, 5);
+  TrackingConfig trackingConfig;
+  CalibrationConfig calibrationConfig;
+
+  EXPECT_THROW(
+      processMarkers(
+          character,
+          identity,
+          markerData,
+          trackingConfig,
+          calibrationConfig,
+          /*calibrate=*/false,
+          /*firstFrame=*/0,
+          /*maxFrames=*/0,
+          leftGloveData),
       std::exception);
 }
 


### PR DESCRIPTION
Summary: Validate glove observations before slicing and passing them into marker tracking or calibration. Reject missing glove config when glove data is present, reject empty or unknown joint names, reject non-finite positions/orientations, and reject zero quaternions. This turns bad glove input into actionable errors before lower-level code can fail with ambiguous exceptions.

Reviewed By: yutingye

Differential Revision: D104477341


