### PR TITLE
Update PyPI core wheel extras

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -565,8 +565,9 @@ librerun-sdk = ">=0.23.3,<0.24"
 # pixi-based dev loop (and OSS CI) can always exercise the viser_vis tests.
 # Kept as its own feature for symmetry with rerun-latest/rerun-legacy and to
 # make future version pinning easier.
-# End users installing from PyPI keep viser optional via the
-# `pymomentum-core[viser]` extra in pyproject-pypi.toml.j2.
+# End users installing from PyPI keep visualization helpers optional via
+# the `pymomentum-core[viser]` and `pymomentum-core[rerun]` extras in
+# pyproject-pypi.toml.j2.
 #==============
 
 [feature.viser]

--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -123,7 +123,7 @@ keywords = [
     "motion-capture",
     "character-animation",
     "robotics",
-{% if build_torch_extensions %}
+{% if build_torch_extensions or tag == "core" %}
     "torch",
 {% endif %}
 ]
@@ -148,6 +148,10 @@ classifiers = [
 dependencies = [
     "numpy>=1.20.0",
     "scipy>=1.7.0",
+{% if not build_torch_extensions %}
+    # Pure-Python torch helpers in the core package do not require the Torch C++ ABI.
+    "torch>=1.13",
+{% endif %}
 {% if build_torch_extensions and tag != "gpu" %}
     # PyTorch version constraints - platform and Python version specific
     # Torch extension packages link against libtorch and must use a matching PyTorch version.
@@ -171,12 +175,7 @@ dependencies = [
 # Opt-in extras. Visualization stacks are large and have transitive deps
 # users may not want; keep them out of the default install.
 [project.optional-dependencies]
-{% if not build_torch_extensions %}
-# Pure-Python torch helpers do not require the Torch C++ ABI. Install this extra
-# when using pymomentum.quaternion, pymomentum.skel_state, pymomentum.trs, or
-# pymomentum.torch.* from the core package.
-torch = ["torch>=1.13"]
-{% endif %}
+rerun = ["rerun-sdk>=0.23.3,<0.34"]
 viser = ["viser>=1.0.24,<2"]
 
 [project.urls]

--- a/scripts/test_wheel.py
+++ b/scripts/test_wheel.py
@@ -90,6 +90,10 @@ def has_torch_extensions(wheel_type: str) -> bool:
     return wheel_type in {"cpu", "gpu"}
 
 
+def has_torch_runtime(wheel_type: str) -> bool:
+    return wheel_type in {"core", "cpu", "gpu"}
+
+
 def get_torch_index(wheel_type: str) -> str:
     """Get the appropriate PyTorch index URL for the wheel type."""
     if wheel_type == "gpu":
@@ -108,6 +112,7 @@ def get_import_test_script(
 ) -> str:
     """Return the Python smoke test script for a wheel type."""
     torch_extensions = has_torch_extensions(wheel_type)
+    torch_runtime = has_torch_runtime(wheel_type)
     lines = [
         "import importlib.util",
         "import os",
@@ -123,20 +128,21 @@ def get_import_test_script(
         'print("Testing imports...")',
         "try:",
     ]
-    if torch_extensions:
+    if torch_runtime:
         lines.extend(
             [
-                "    # Import torch before any PyMomentum extension so PyTorch sets up",
-                "    # native library paths first.",
+                "    # Import torch before PyMomentum's torch-backed Python modules",
+                "    # or any PyMomentum extension so PyTorch sets up native paths first.",
                 "    import torch",
                 '    print(f"  PyTorch {torch.__version__}, CUDA={torch.version.cuda}")',
-                (
-                    '    assert torch.version.cuda is not None, "pymomentum-gpu requires CUDA PyTorch"'
-                    if wheel_type == "gpu"
-                    else '    assert torch.version.cuda is None, "pymomentum-cpu should be tested with CPU PyTorch"'
-                ),
             ]
         )
+        if torch_extensions:
+            lines.append(
+                '    assert torch.version.cuda is not None, "pymomentum-gpu requires CUDA PyTorch"'
+                if wheel_type == "gpu"
+                else '    assert torch.version.cuda is None, "pymomentum-cpu should be tested with CPU PyTorch"'
+            )
     lines.extend(
         [
             "    import pymomentum.geometry as geom",
@@ -162,6 +168,15 @@ def get_import_test_script(
                 ]
             )
     else:
+        if wheel_type == "core":
+            lines.extend(
+                [
+                    "    import pymomentum.quaternion as quaternion",
+                    "    import pymomentum.skel_state as skel_state",
+                    "    import pymomentum.trs as trs",
+                    "    import pymomentum.torch.character as torch_character",
+                ]
+            )
         lines.extend(
             [
                 '    assert importlib.util.find_spec("pymomentum.diff_geometry") is None, "pymomentum-core must not expose pymomentum.diff_geometry"',


### PR DESCRIPTION
Summary: Make `torch` a default runtime dependency for `pymomentum-core` so the torch-backed Python helper modules work after a normal install. Replace the old `torch` extra with a `rerun` extra for visualization dependencies, and extend the wheel smoke test to cover the core package's torch-backed modules.

Differential Revision: D108832980


