### PR TITLE
resolve_backend: torch fallback under trace + force_backend override

### DIFF
--- a/pymomentum/backend/selection.py
+++ b/pymomentum/backend/selection.py
@@ -7,6 +7,10 @@
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
+from collections.abc import Iterator
+
 import torch
 
 try:
@@ -16,14 +20,55 @@ except ImportError:
 
 _HAS_TRITON: bool = triton is not None
 
+# Backend override. `is_tracing()` only catches code that runs *inside*
+# torch.jit.trace; exporters also run the model eagerly before tracing (a warm-up
+# forward to settle device placement), and that eager run would pick Triton on
+# CUDA -- which then can't be traced. `force_backend("torch")` lets the exporter
+# pin the backend across the whole export (warm-up + trace). A ContextVar (not a
+# plain global) keeps the override thread- and async-local, so it can't leak into
+# a concurrent thread's resolve_backend (e.g. dataloader/inference) mid-export.
+_FORCED_BACKEND: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "pymomentum_forced_backend", default=None
+)
+
+
+@contextlib.contextmanager
+def force_backend(backend: str | None) -> Iterator[None]:
+    """Force `resolve_backend` to return `backend` within this context.
+
+    Used by model export to keep the entire export (the eager warm-up forward and
+    the subsequent jit.trace) on the traceable torch backend, since Triton kernels
+    are not traceable. Pass None to clear the override. The override is scoped to
+    the current thread / async context.
+    """
+    token = _FORCED_BACKEND.set(backend)
+    try:
+        yield
+    finally:
+        _FORCED_BACKEND.reset(token)
+
 
 def resolve_backend(
     backend: str,
     tensor: torch.Tensor,
     use_double_precision: bool = False,
 ) -> str:
+    # Triton kernels are not traceable/scriptable, so fall back to pure torch
+    # under TorchScript/trace so the graph captures cleanly. Keep is_scripting()
+    # as a standalone early-return: the scripting compiler treats it as
+    # compile-time True and prunes everything after the return, so the
+    # is_tracing() check below is never compiled under torch.jit.script (where it
+    # may not be scriptable). is_tracing() then handles torch.jit.trace (export).
     if torch.jit.is_scripting():
         return "torch"
+    if torch.jit.is_tracing():
+        return "torch"
+    # Eager-mode export override (set via force_backend). After the jit gates so
+    # the scripting compiler still prunes it (the ContextVar access is not
+    # scriptable, but is_scripting() returns above under torch.jit.script).
+    forced = _FORCED_BACKEND.get()
+    if forced is not None:
+        return forced
     if backend != "auto":
         return backend
     if (

--- a/pymomentum/test/test_triton_fk_backend.py
+++ b/pymomentum/test/test_triton_fk_backend.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 import unittest
+from unittest import mock
 
 import pymomentum.geometry_test_utils as pym_test_utils  # @manual=:geometry_test_utils
 import pymomentum.torch.character as pym_character
@@ -44,8 +45,42 @@ class TritonFKBackendTest(unittest.TestCase):
         )
 
         device = _cuda_device()
+        cuda_tensor = cpu_tensor.to(device)
         self.assertEqual(
-            backend_selection.resolve_backend("auto", cpu_tensor.to(device)), "triton"
+            backend_selection.resolve_backend("auto", cuda_tensor), "triton"
+        )
+
+        # Under torch.jit.trace (e.g. model export) Triton is not traceable, so
+        # even a CUDA float32 tensor (and an explicit "triton" request) must fall
+        # back to the pure-torch path.
+        with mock.patch("torch.jit.is_tracing", return_value=True):
+            self.assertEqual(
+                backend_selection.resolve_backend("auto", cuda_tensor), "torch"
+            )
+            self.assertEqual(
+                backend_selection.resolve_backend("triton", cuda_tensor), "torch"
+            )
+
+    def test_force_backend_override(self) -> None:
+        # Exporters run an eager warm-up forward before tracing; is_tracing() is
+        # False there, so a CUDA float32 tensor would otherwise pick Triton (which
+        # then can't be traced). force_backend pins the backend across the whole
+        # export regardless of device/dtype/explicit request.
+        device = _cuda_device()
+        cuda_tensor = torch.empty((1,), dtype=torch.float32, device=device)
+        self.assertEqual(
+            backend_selection.resolve_backend("auto", cuda_tensor), "triton"
+        )
+        with backend_selection.force_backend("torch"):
+            self.assertEqual(
+                backend_selection.resolve_backend("auto", cuda_tensor), "torch"
+            )
+            self.assertEqual(
+                backend_selection.resolve_backend("triton", cuda_tensor), "torch"
+            )
+        # Override is cleared on exit -> back to Triton for CUDA float32.
+        self.assertEqual(
+            backend_selection.resolve_backend("auto", cuda_tensor), "triton"
         )
 
     def test_fk_matches_torch(self) -> None:


### PR DESCRIPTION
Summary:
`resolve_backend` returns "torch" instead of the experimental Triton backend in the cases needed for safe model export:
- Under `torch.jit.script` / `torch.jit.trace` (Triton kernels are not traceable/scriptable) via the `is_scripting()` / `is_tracing()` early-returns. `is_scripting()` stays the standalone first return so the scripting compiler treats it as compile-time True and prunes everything after it.
- Within a `force_backend("torch")` context. `is_tracing()` only catches code inside `torch.jit.trace`, but exporters also run the model eagerly once before tracing (a warm-up forward to settle device placement) where `is_tracing()` is False, so a CUDA float32 tensor would otherwise pick Triton. `force_backend` is a `contextvars.ContextVar`-backed context manager (thread- and async-local, so it can't leak into a concurrent thread's `resolve_backend`) that the exporter wraps the whole export in.

Reviewed By: cstollmeta

Differential Revision: D108091267


