### PR TITLE
Preserve physical properties in USD IO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,18 @@ mt_library(
 )
 
 mt_library(
+  NAME io_json_utils
+  HEADERS_VARS io_json_utils_public_headers
+  SOURCES_VARS io_json_utils_sources
+  PUBLIC_LINK_LIBRARIES
+    character
+    nlohmann_json::nlohmann_json
+  PRIVATE_LINK_LIBRARIES
+    common
+    math
+)
+
+mt_library(
   NAME io_fbx
   HEADERS_VARS
     io_fbx_public_headers
@@ -488,6 +500,7 @@ mt_library(
     io_skeleton
   PRIVATE_LINK_LIBRARIES
     io_common
+    io_json_utils
     ${io_fbx_private_link_libraries}
     OpenFBX
 )
@@ -495,18 +508,6 @@ mt_library(
 if(MOMENTUM_ENABLE_FBX_SAVING)
   target_compile_definitions(io_fbx PRIVATE MOMENTUM_WITH_FBX_SDK)
 endif()
-
-mt_library(
-  NAME io_json_utils
-  HEADERS_VARS io_json_utils_public_headers
-  SOURCES_VARS io_json_utils_sources
-  PUBLIC_LINK_LIBRARIES
-    character
-    nlohmann_json::nlohmann_json
-  PRIVATE_LINK_LIBRARIES
-    common
-    math
-)
 
 mt_library(
   NAME io_gltf

--- a/momentum/io/fbx/fbx_builder.cpp
+++ b/momentum/io/fbx/fbx_builder.cpp
@@ -78,6 +78,7 @@ void FbxBuilder::addCharacter(const Character& character, const FileSaveOptions&
   // Create skeleton hierarchy
   auto skeletonResult = createSkeletonNodes(character, impl_->scene);
   addMetaData(skeletonResult.rootNode, character);
+  addPhysicalProperties(character, skeletonResult.jointToNodeMap);
 
   if (options.locators) {
     createLocatorNodes(character, impl_->scene, skeletonResult.nodes);
@@ -119,6 +120,7 @@ void FbxBuilder::addRigidBody(
   // Create skeleton hierarchy
   auto skeletonResult = createSkeletonNodes(character, impl_->scene);
   addMetaData(skeletonResult.rootNode, character);
+  addPhysicalProperties(character, skeletonResult.jointToNodeMap);
 
   // Prefix skeleton joint names with charName to avoid collisions when
   // multiple rigid bodies share the scene (e.g. "root" -> "controller_l:root").

--- a/momentum/io/fbx/fbx_io.cpp
+++ b/momentum/io/fbx/fbx_io.cpp
@@ -20,6 +20,8 @@
 #include "momentum/io/skeleton/parameter_transform_io.h"
 #include "momentum/io/skeleton/parameters_io.h"
 
+#include <gsl/gsl>
+
 #include <variant>
 #endif // MOMENTUM_WITH_FBX_SDK
 
@@ -47,6 +49,11 @@ void saveFbxCommon(
   // initialize FBX SDK and prepare for export
   // ---------------------------------------------
   auto* manager = ::fbxsdk::FbxManager::Create();
+  // FBX SDK uses manual memory management. Use a scope guard so the manager — and the exporter,
+  // scene, and nodes it owns — are always destroyed, including when an exception is thrown mid-
+  // export (e.g. by addPhysicalProperties). Without it, a throw leaks the manager (flagged by
+  // ASAN).
+  const auto managerGuard = gsl::finally([manager]() { manager->Destroy(); });
   auto* ios = ::fbxsdk::FbxIOSettings::Create(manager, IOSROOT);
   manager->SetIOSettings(ios);
 
@@ -89,6 +96,7 @@ void saveFbxCommon(
   // Create skeleton hierarchy
   auto skeletonResult = createSkeletonNodes(character, scene);
   addMetaData(skeletonResult.rootNode, character);
+  addPhysicalProperties(character, skeletonResult.jointToNodeMap);
   createLocatorNodes(character, scene, skeletonResult.nodes);
   createCollisionGeometryNodes(character, scene, skeletonResult.nodes);
 
@@ -158,15 +166,9 @@ void saveFbxCommon(
   // close the fbx exporter
   // ---------------------------------------------
 
-  // finally export the scene
+  // finally export the scene; managerGuard destroys the exporter, scene, and manager (and
+  // everything they own) when this function returns or throws.
   lExporter->Export(scene);
-  lExporter->Destroy();
-
-  // destroy the scene and the manager
-  if (scene != nullptr) {
-    scene->Destroy();
-  }
-  manager->Destroy();
 }
 
 } // namespace

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -12,11 +12,13 @@
 
 #include "momentum/character/blend_shape.h"
 #include "momentum/character/character.h"
+#include "momentum/character/character_utility.h"
 #include "momentum/character/collision_geometry_state.h"
 #include "momentum/character/marker.h"
 #include "momentum/character/skin_weights.h"
 #include "momentum/common/exception.h"
 #include "momentum/common/log.h"
+#include "momentum/io/common/json_utils.h"
 #include "momentum/io/file_save_options.h"
 #include "momentum/math/constants.h"
 #include "momentum/math/mesh.h"
@@ -28,13 +30,16 @@
 // They do the most awful things to isnan in here
 #include <fbxsdk.h>
 #include <fbxsdk/fileio/fbxiosettings.h>
+#include <nlohmann/json.hpp>
 
 #ifdef isnan
 #undef isnan
 #endif
 
 #include <span>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace momentum::fbx_internal {
 
@@ -175,6 +180,37 @@ inline SkeletonNodeResult createSkeletonNodes(
   }
 
   return result;
+}
+
+inline void addPhysicalProperties(
+    const Character& character,
+    const std::unordered_map<size_t, fbxsdk::FbxNode*>& jointToNodeMap) {
+  std::unordered_set<size_t> seenJoints;
+  for (const auto& jointProperties : character.physicalProperties) {
+    const size_t jointIndex =
+        resolvePhysicalPropertiesJointIndex(jointProperties, character.skeleton);
+
+    MT_THROW_IF(
+        jointIndex == kInvalidIndex || jointIndex >= character.skeleton.joints.size(),
+        "Physical properties entry references unknown joint '{}'",
+        jointProperties.jointName);
+    MT_THROW_IF(
+        !seenJoints.insert(jointIndex).second,
+        "Multiple physical properties entries resolve to joint '{}' (index {})",
+        character.skeleton.joints.at(jointIndex).name,
+        jointIndex);
+
+    const auto nodeIt = jointToNodeMap.find(jointIndex);
+    MT_THROW_IF(
+        nodeIt == jointToNodeMap.end() || nodeIt->second == nullptr,
+        "Unable to find FBX node for physical properties joint '{}'",
+        character.skeleton.joints.at(jointIndex).name);
+
+    nlohmann::json physicalPropertiesJson;
+    jointPhysicalPropertiesToJson(jointProperties, physicalPropertiesJson);
+    ::fbxsdk::FbxProperty::Create(nodeIt->second, ::fbxsdk::FbxStringDT, "physicalProperties")
+        .Set(FbxString(physicalPropertiesJson.dump().c_str()));
+  }
 }
 
 // ============================================================================

--- a/momentum/io/fbx/openfbx_loader.cpp
+++ b/momentum/io/fbx/openfbx_loader.cpp
@@ -16,6 +16,7 @@
 #include "momentum/common/filesystem.h"
 #include "momentum/common/log.h"
 #include "momentum/io/common/gsl_utils.h"
+#include "momentum/io/common/json_utils.h"
 #include "momentum/io/fbx/polygon_data.h"
 #include "momentum/io/skeleton/locator_io.h"
 #include "momentum/io/skeleton/parameter_limits_io.h"
@@ -30,6 +31,7 @@
 #include <gsl/span_ext>
 
 #include <cmath>
+#include <exception>
 #include <fstream>
 #include <functional>
 #include <numeric>
@@ -111,6 +113,44 @@ const char* propertyTypeStr(ofbx::IElementProperty::Type type) {
     default:
       return "Unknown";
   }
+}
+
+ofbx::IElement* resolveProperty(const ofbx::Object& object, const char* name);
+std::string resolveStringProperty(const ofbx::Object& object, const char* name);
+
+PhysicalProperties loadPhysicalPropertiesFromNodes(
+    const Skeleton& skeleton,
+    const std::vector<const ofbx::Object*>& jointFbxNodes) {
+  PhysicalProperties result;
+
+  for (size_t jointIndex = 0; jointIndex < jointFbxNodes.size(); ++jointIndex) {
+    const ofbx::Object* jointNode = jointFbxNodes.at(jointIndex);
+    if (jointNode == nullptr) {
+      continue;
+    }
+
+    // Reading the FBX property itself can throw: resolveProperty/resolveStringProperty use MT_THROW
+    // (std::runtime_error) when a node carries a malformed "physicalProperties" property, and the
+    // embedded JSON may be corrupt. Catch broadly so a single bad joint is skipped rather than
+    // aborting the whole character load.
+    try {
+      if (resolveProperty(*jointNode, "physicalProperties") == nullptr) {
+        continue;
+      }
+
+      const nlohmann::json physicalPropertiesJson =
+          nlohmann::json::parse(resolveStringProperty(*jointNode, "physicalProperties"));
+      result.push_back(jointPhysicalPropertiesFromJson(
+          physicalPropertiesJson, skeleton.joints.at(jointIndex).name, jointIndex));
+    } catch (const std::exception& e) {
+      MT_LOGW(
+          "Skipping physical properties for FBX joint '{}': {}",
+          skeleton.joints.at(jointIndex).name,
+          e.what());
+    }
+  }
+
+  return result;
 }
 
 template <typename T>
@@ -1471,6 +1511,7 @@ std::tuple<Character, std::vector<MatrixXf>, float> loadOpenFbx(
       metadata);
   result.resetJointMap();
   result.inverseBindPose = inverseBindPoseTransforms;
+  result.physicalProperties = loadPhysicalPropertiesFromNodes(result.skeleton, jointFbxNodes);
 
   return {result, jointParamMotions, scene->getSceneFrameRate()};
 }

--- a/momentum/io/usd/usd_io.cpp
+++ b/momentum/io/usd/usd_io.cpp
@@ -9,6 +9,7 @@
 
 #include "momentum/character/blend_shape.h"
 #include "momentum/character/character.h"
+#include "momentum/character/character_utility.h"
 #include "momentum/character/collision_geometry.h"
 #include "momentum/character/inverse_parameter_transform.h"
 #include "momentum/character/parameter_transform.h"
@@ -22,6 +23,7 @@
 #include "momentum/io/usd/usd_animation_io.h"
 #include "momentum/io/usd/usd_mesh_io.h"
 #include "momentum/io/usd/usd_skeleton_io.h"
+#include "momentum/io/usd/usd_utils.h"
 #include "momentum/math/mesh.h"
 
 #include <nlohmann/json.hpp>
@@ -34,6 +36,7 @@
 #include <pxr/usd/sdf/valueTypeName.h>
 #include <pxr/usd/usd/primRange.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdGeom/scope.h>
 #include <pxr/usd/usdSkel/root.h>
 
 #include <tbb/global_control.h>
@@ -70,6 +73,7 @@
 #include <mutex>
 #include <span>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 // Import USD namespace
@@ -81,7 +85,9 @@ TF_DEFINE_PRIVATE_TOKENS(
       "momentum:characterName"))((momentumParameterTransform, "momentum:parameterTransform"))(
         (momentumParameterLimits,
          "momentum:parameterLimits"))((momentumParameterSets, "momentum:parameterSets"))(
-        (momentumPoseConstraints, "momentum:poseConstraints")));
+        (momentumPoseConstraints,
+         "momentum:poseConstraints"))(PhysicalProperties)((momentumJoint, "momentum:joint"))(
+        (momentumPhysicalProperties, "momentum:physicalProperties")));
 
 namespace momentum {
 
@@ -232,6 +238,53 @@ void saveMomentumMetadata(const Character& character, const UsdPrim& skelRootPri
   }
 }
 
+void savePhysicalPropertiesToUsd(
+    const Character& character,
+    const UsdStageRefPtr& stage,
+    const SdfPath& skelRootPath) {
+  if (character.physicalProperties.empty()) {
+    return;
+  }
+
+  auto physicalPropertiesScope =
+      UsdGeomScope::Define(stage, skelRootPath.AppendChild(_tokens->PhysicalProperties));
+  MT_THROW_IF(
+      !physicalPropertiesScope.GetPrim().IsValid(),
+      "Failed to define physical properties scope on USD stage");
+
+  std::unordered_set<size_t> seenJoints;
+  for (const auto& jointProperties : character.physicalProperties) {
+    const size_t jointIndex =
+        resolvePhysicalPropertiesJointIndex(jointProperties, character.skeleton);
+
+    MT_THROW_IF(
+        jointIndex == kInvalidIndex || jointIndex >= character.skeleton.joints.size(),
+        "Physical properties entry references unknown joint '{}'",
+        jointProperties.jointName);
+    MT_THROW_IF(
+        !seenJoints.insert(jointIndex).second,
+        "Multiple physical properties entries resolve to joint '{}' (index {})",
+        character.skeleton.joints.at(jointIndex).name,
+        jointIndex);
+
+    const std::string& jointName = character.skeleton.joints.at(jointIndex).name;
+    const std::string primName =
+        sanitizePrimName(jointName + "_physical_properties_" + std::to_string(jointIndex));
+    auto prim = stage->DefinePrim(physicalPropertiesScope.GetPath().AppendChild(TfToken(primName)));
+    MT_THROW_IF(
+        !prim.IsValid(),
+        "Failed to define physical properties prim '{}' for joint '{}'",
+        primName,
+        jointName);
+
+    nlohmann::json physicalJson;
+    jointPhysicalPropertiesToJson(jointProperties, physicalJson);
+    prim.CreateAttribute(_tokens->momentumJoint, SdfValueTypeNames->String).Set(jointName);
+    prim.CreateAttribute(_tokens->momentumPhysicalProperties, SdfValueTypeNames->String)
+        .Set(physicalJson.dump());
+  }
+}
+
 void loadMomentumMetadata(Character& character, const UsdPrim& skelRootPrim) {
   // Load character name
   auto nameAttr = skelRootPrim.GetAttribute(_tokens->momentumCharacterName);
@@ -299,6 +352,56 @@ void loadMomentumMetadata(Character& character, const UsdPrim& skelRootPrim) {
   }
 }
 
+PhysicalProperties loadPhysicalPropertiesFromUsd(
+    const UsdStageRefPtr& stage,
+    const Skeleton& skeleton) {
+  PhysicalProperties result;
+
+  // Physical properties are authored under <SkelRoot>/PhysicalProperties (see
+  // savePhysicalPropertiesToUsd); resolve that scope and iterate only its children instead of
+  // scanning every prim on the stage.
+  UsdPrim physicalPropertiesScope;
+  for (const auto& prim : stage->Traverse()) {
+    if (prim.IsA<UsdSkelRoot>()) {
+      physicalPropertiesScope =
+          stage->GetPrimAtPath(prim.GetPath().AppendChild(_tokens->PhysicalProperties));
+      break;
+    }
+  }
+  if (!physicalPropertiesScope) {
+    return result;
+  }
+
+  for (const auto& prim : physicalPropertiesScope.GetChildren()) {
+    auto jointAttr = prim.GetAttribute(_tokens->momentumJoint);
+    auto physicalAttr = prim.GetAttribute(_tokens->momentumPhysicalProperties);
+    if (!jointAttr || !physicalAttr) {
+      continue;
+    }
+
+    std::string jointName;
+    std::string physicalStr;
+    if (!jointAttr.Get(&jointName) || !physicalAttr.Get(&physicalStr)) {
+      continue;
+    }
+
+    const size_t jointIndex = skeleton.getJointIdByName(jointName);
+    if (jointIndex == kInvalidIndex) {
+      MT_LOGW("Skipping USD physical properties for unknown joint '{}'", jointName);
+      continue;
+    }
+
+    try {
+      auto physicalJson = nlohmann::json::parse(physicalStr);
+      result.push_back(jointPhysicalPropertiesFromJson(physicalJson, jointName, jointIndex));
+    } catch (const nlohmann::json::exception& e) {
+      MT_LOGW("Failed to parse USD physical properties for joint '{}': {}", jointName, e.what());
+    }
+  }
+
+  return result;
+}
+
 Character loadUsdCharacterFromStage(const UsdStageRefPtr& stage) {
   Character character;
 
@@ -352,6 +455,7 @@ Character loadUsdCharacterFromStage(const UsdStageRefPtr& stage) {
   }
 
   character.locators = loadLocatorsFromUsd(stage, character.skeleton);
+  character.physicalProperties = loadPhysicalPropertiesFromUsd(stage, character.skeleton);
 
   // Load momentum-specific metadata from SkelRoot prim
   for (const auto& prim : stage->Traverse()) {
@@ -486,6 +590,7 @@ UsdSaveContext createUsdSaveContext(
 
 void finalizeUsdSave(const UsdSaveContext& ctx, const Character& character) {
   saveMomentumMetadata(character, ctx.skelRoot.GetPrim());
+  savePhysicalPropertiesToUsd(character, ctx.stage, ctx.skelRoot.GetPath());
   ctx.stage->GetRootLayer()->Save();
 }
 

--- a/momentum/test/character/character_helpers.cpp
+++ b/momentum/test/character/character_helpers.cpp
@@ -22,6 +22,8 @@
 #include "momentum/math/mppca.h"
 #include "momentum/math/random.h"
 
+#include <Eigen/Geometry>
+
 #include <limits>
 
 namespace momentum {
@@ -258,6 +260,33 @@ Character withTestFaceExpressionBlendShapes(const Character& character) {
   blendShapes->setShapeVectors(randomMatrix<float>(3 * character.mesh->vertices.size(), nShapes));
 
   return character.withFaceExpressionBlendShape(blendShapes, nShapes);
+}
+
+Character withTestPhysicalProperties(const Character& character) {
+  MT_CHECK(character.skeleton.joints.size() >= 2);
+
+  Character result = character;
+
+  JointPhysicalProperties rootProperties;
+  rootProperties.jointName = result.skeleton.joints.at(0).name;
+  rootProperties.jointIndex = 0;
+  rootProperties.mass = 10.0f;
+  rootProperties.centerOfMassOffset = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
+  rootProperties.inertia << 100.0f, 1.0f, 2.0f, 1.0f, 110.0f, 3.0f, 2.0f, 3.0f, 120.0f;
+  rootProperties.inertiaRotation =
+      Eigen::Quaternionf(Eigen::AngleAxisf(0.25f, Eigen::Vector3f::UnitZ()));
+  result.physicalProperties.push_back(rootProperties);
+
+  JointPhysicalProperties childProperties;
+  childProperties.jointName = result.skeleton.joints.at(1).name;
+  childProperties.jointIndex = 1;
+  childProperties.mass = 4.0f;
+  childProperties.centerOfMassOffset = Eigen::Vector3f(-2.0f, 0.5f, 1.0f);
+  childProperties.inertia << 25.0f, 0.5f, 0.0f, 0.5f, 30.0f, 0.25f, 0.0f, 0.25f, 35.0f;
+  childProperties.inertiaRotation = Eigen::Quaternionf::Identity();
+  result.physicalProperties.push_back(childProperties);
+
+  return result;
 }
 
 template <typename T>

--- a/momentum/test/character/character_helpers.h
+++ b/momentum/test/character/character_helpers.h
@@ -27,4 +27,10 @@ template <typename T>
 
 [[nodiscard]] Character withTestFaceExpressionBlendShapes(const Character& character);
 
+/// Returns a copy of `character` with deterministic physical mass properties attached to its first
+/// two joints, for exercising physical-properties I/O round trips.
+///
+/// @pre `character.skeleton.joints.size() >= 2`.
+[[nodiscard]] Character withTestPhysicalProperties(const Character& character);
+
 } // namespace momentum

--- a/momentum/test/character/character_helpers_gtest.cpp
+++ b/momentum/test/character/character_helpers_gtest.cpp
@@ -22,6 +22,8 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <string>
+#include <unordered_map>
 
 namespace momentum {
 
@@ -229,6 +231,44 @@ void compareCollisionGeometry(
   }
 }
 
+void comparePhysicalProperties(
+    const PhysicalProperties& refProperties,
+    const PhysicalProperties& properties) {
+  ASSERT_EQ(refProperties.size(), properties.size());
+
+  // Match entries by joint name rather than by position: the save/load order is not guaranteed to
+  // be preserved across formats (e.g. USD traversal order can differ from insertion order).
+  std::unordered_map<std::string, const JointPhysicalProperties*> propertiesByJoint;
+  for (const auto& entry : properties) {
+    propertiesByJoint[entry.jointName] = &entry;
+  }
+
+  for (const auto& refEntry : refProperties) {
+    const auto entryIt = propertiesByJoint.find(refEntry.jointName);
+    ASSERT_NE(entryIt, propertiesByJoint.end())
+        << "Missing physical properties for joint '" << refEntry.jointName << "'";
+    const auto& entry = *entryIt->second;
+    EXPECT_EQ(refEntry.jointIndex, entry.jointIndex);
+    EXPECT_FLOAT_EQ(refEntry.mass, entry.mass);
+    EXPECT_TRUE(refEntry.centerOfMassOffset.isApprox(
+        entry.centerOfMassOffset, kPhysicalPropertiesTolerance))
+        << "Physical center-of-mass offset for joint '" << refEntry.jointName << "' is not equal:\n"
+        << "- Expected: " << refEntry.centerOfMassOffset.transpose() << "\n"
+        << "- Actual  : " << entry.centerOfMassOffset.transpose() << "\n";
+    EXPECT_TRUE(refEntry.inertia.isApprox(entry.inertia, kPhysicalPropertiesTolerance))
+        << "Physical inertia for joint '" << refEntry.jointName << "' is not equal:\n"
+        << "- Expected:\n"
+        << refEntry.inertia << "\n"
+        << "- Actual:\n"
+        << entry.inertia << "\n";
+    EXPECT_TRUE(
+        refEntry.inertiaRotation.isApprox(entry.inertiaRotation, kPhysicalPropertiesTolerance))
+        << "Physical inertia rotation for joint '" << refEntry.jointName << "' is not equal:\n"
+        << "- Expected: " << refEntry.inertiaRotation.coeffs().transpose() << "\n"
+        << "- Actual  : " << entry.inertiaRotation.coeffs().transpose() << "\n";
+  }
+}
+
 void compareChars(
     const Character& refChar,
     const Character& character,
@@ -271,30 +311,7 @@ void compareChars(
   }
   EXPECT_EQ(refChar.jointMap, character.jointMap);
   if (withPhysicalProperties) {
-    ASSERT_EQ(refChar.physicalProperties.size(), character.physicalProperties.size());
-    for (size_t i = 0; i < refChar.physicalProperties.size(); ++i) {
-      const auto& refProperties = refChar.physicalProperties.at(i);
-      const auto& properties = character.physicalProperties.at(i);
-      EXPECT_EQ(refProperties.jointName, properties.jointName);
-      EXPECT_EQ(refProperties.jointIndex, properties.jointIndex);
-      EXPECT_FLOAT_EQ(refProperties.mass, properties.mass);
-      EXPECT_TRUE(refProperties.centerOfMassOffset.isApprox(
-          properties.centerOfMassOffset, kPhysicalPropertiesTolerance))
-          << "Physical center-of-mass offset " << i << " is not equal:\n"
-          << "- Expected: " << refProperties.centerOfMassOffset.transpose() << "\n"
-          << "- Actual  : " << properties.centerOfMassOffset.transpose() << "\n";
-      EXPECT_TRUE(refProperties.inertia.isApprox(properties.inertia, kPhysicalPropertiesTolerance))
-          << "Physical inertia " << i << " is not equal:\n"
-          << "- Expected:\n"
-          << refProperties.inertia << "\n"
-          << "- Actual:\n"
-          << properties.inertia << "\n";
-      EXPECT_TRUE(refProperties.inertiaRotation.isApprox(
-          properties.inertiaRotation, kPhysicalPropertiesTolerance))
-          << "Physical inertia rotation " << i << " is not equal:\n"
-          << "- Expected: " << refProperties.inertiaRotation.coeffs().transpose() << "\n"
-          << "- Actual  : " << properties.inertiaRotation.coeffs().transpose() << "\n";
-    }
+    comparePhysicalProperties(refChar.physicalProperties, character.physicalProperties);
   }
 
   if (withMesh) {

--- a/momentum/test/character/character_helpers_gtest.h
+++ b/momentum/test/character/character_helpers_gtest.h
@@ -17,6 +17,11 @@ void compareMeshes(const Mesh_u& refMesh, const Mesh_u& mesh);
 void compareCollisionGeometry(
     const CollisionGeometry_u& refCollision,
     const CollisionGeometry_u& collision);
+/// Asserts that two sets of joint physical properties are equal, matching entries by joint name so
+/// the comparison is independent of save/load ordering.
+void comparePhysicalProperties(
+    const PhysicalProperties& refProperties,
+    const PhysicalProperties& properties);
 void compareChars(
     const Character& refChar,
     const Character& character,

--- a/momentum/test/io/io_usd_test.cpp
+++ b/momentum/test/io/io_usd_test.cpp
@@ -17,13 +17,16 @@
 #include "momentum/character/skin_weights.h"
 #include "momentum/math/mesh.h"
 #include "momentum/test/character/character_helpers.h"
+#include "momentum/test/character/character_helpers_gtest.h"
 #include "momentum/test/io/io_helpers.h"
 
 #include <pxr/base/gf/half.h>
 #include <pxr/base/gf/quatf.h>
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/gf/vec3h.h>
+#include <pxr/base/tf/token.h>
 #include <pxr/base/vt/array.h>
+#include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/primRange.h>
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usdGeom/mesh.h>
@@ -33,11 +36,14 @@
 #include <pxr/usd/usdSkel/skeleton.h>
 
 #include <gtest/gtest.h>
+#include <Eigen/Geometry>
 
 #include <filesystem>
 #include <fstream>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -52,6 +58,25 @@ std::optional<filesystem::path> getTestResourcePath(const std::string& filename)
     return std::nullopt;
   }
   return filesystem::path(envVar.value()) / "usd" / filename;
+}
+
+std::unordered_set<std::string> loadPhysicalPropertiesJointNames(const UsdStageRefPtr& stage) {
+  std::unordered_set<std::string> result;
+  for (const auto& prim : stage->Traverse()) {
+    auto jointAttr = prim.GetAttribute(TfToken("momentum:joint"));
+    auto physicalAttr = prim.GetAttribute(TfToken("momentum:physicalProperties"));
+    if (!jointAttr || !physicalAttr) {
+      continue;
+    }
+
+    std::string jointName;
+    std::string physicalProperties;
+    if (jointAttr.Get(&jointName) && physicalAttr.Get(&physicalProperties) &&
+        !physicalProperties.empty()) {
+      result.insert(jointName);
+    }
+  }
+  return result;
 }
 
 } // namespace
@@ -437,6 +462,41 @@ TEST_F(UsdIoTest, SaveAndLoadRoundTrip_MomentumMetadata) {
         loadedCharacter.parameterLimits[i].weight, testCharacter.parameterLimits[i].weight)
         << "Parameter limit weight mismatch at index " << i;
   }
+}
+
+TEST_F(UsdIoTest, SaveAndLoadRoundTrip_PhysicalProperties) {
+  testCharacter = withTestPhysicalProperties(testCharacter);
+
+  auto tempFile = temporaryFile("momentum_usd_physical_properties", ".usda");
+  saveUsd(tempFile.path(), testCharacter);
+
+  const auto stage = UsdStage::Open(tempFile.path().string());
+  ASSERT_TRUE(stage);
+  const auto skelRootPrim = stage->GetPrimAtPath(SdfPath("/SkelRoot"));
+  ASSERT_TRUE(skelRootPrim.IsValid());
+  EXPECT_FALSE(skelRootPrim.GetAttribute(TfToken("momentum:physicalProperties")));
+
+  const std::unordered_set<std::string> physicalPropertiesJointNames =
+      loadPhysicalPropertiesJointNames(stage);
+  EXPECT_EQ(physicalPropertiesJointNames.size(), testCharacter.physicalProperties.size());
+  for (const auto& jointProperties : testCharacter.physicalProperties) {
+    EXPECT_TRUE(
+        physicalPropertiesJointNames.find(jointProperties.jointName) !=
+        physicalPropertiesJointNames.end());
+  }
+
+  const auto loadedCharacter = loadUsdCharacter(tempFile.path());
+
+  comparePhysicalProperties(testCharacter.physicalProperties, loadedCharacter.physicalProperties);
+}
+
+TEST_F(UsdIoTest, SaveRejectsDuplicatePhysicalProperties) {
+  testCharacter = withTestPhysicalProperties(testCharacter);
+  // A second entry that resolves to the same joint must be rejected rather than silently dropped.
+  testCharacter.physicalProperties.push_back(testCharacter.physicalProperties.at(0));
+
+  auto tempFile = temporaryFile("momentum_usd_duplicate_physical_properties", ".usda");
+  EXPECT_THROW(saveUsd(tempFile.path(), testCharacter), std::runtime_error);
 }
 
 TEST_F(UsdIoTest, SaveAndLoadRoundTrip_SkeletonStates) {


### PR DESCRIPTION
Summary:
Round-trips per-joint physical mass properties through USD, mirroring the FBX support. 

On save, each entry is serialized to JSON and stored as a per-joint child prim under `/SkelRoot/PhysicalProperties`, carrying a `momentum:joint` name attribute and a `momentum:physicalProperties` string attribute, instead of a character-level attribute on `/SkelRoot`. On load, the stage is traversed and each stored body is mapped back to its joint by name. Joint resolution on save reuses `resolvePhysicalPropertiesJointIndex`, and an entry referencing an unknown joint is rejected on save.

Adds round-trip coverage built on the shared `withTestPhysicalProperties` and `comparePhysicalProperties` helpers, plus structural assertions that the SkelRoot does not carry `momentum:physicalProperties` and that each stored physical body maps back to its joint.

Reviewed By: cstollmeta

Differential Revision: D104556530


