### PR TITLE
resolve_backend: fall back to torch under torch.compile/torch.export (#1540)

### DIFF
--- a/pymomentum/backend/selection.py
+++ b/pymomentum/backend/selection.py
@@ -63,6 +63,12 @@ def resolve_backend(
         return "torch"
     if torch.jit.is_tracing():
         return "torch"
+    # torch.compile / torch.export (Dynamo) capture: the _FORCED_BACKEND
+    # ContextVar read below is not traceable by Dynamo, and the torch.jit gates
+    # above do not catch Dynamo export. Fall back to the traceable torch backend
+    # before touching the ContextVar so the graph captures cleanly.
+    if torch.compiler.is_compiling():
+        return "torch"
     # Eager-mode export override (set via force_backend). After the jit gates so
     # the scripting compiler still prunes it (the ContextVar access is not
     # scriptable, but is_scripting() returns above under torch.jit.script).

--- a/pymomentum/test/test_triton_fk_backend.py
+++ b/pymomentum/test/test_triton_fk_backend.py
@@ -61,6 +61,18 @@ class TritonFKBackendTest(unittest.TestCase):
                 backend_selection.resolve_backend("triton", cuda_tensor), "torch"
             )
 
+        # Under torch.compile/Dynamo `tensor.numel()` is a SymInt that Triton
+        # receives as a pointer arg, so the kernel fails to compile; fall back to
+        # the torch path here too. is_tracing() is False during compilation, so
+        # this is a distinct gate.
+        with mock.patch("torch.compiler.is_compiling", return_value=True):
+            self.assertEqual(
+                backend_selection.resolve_backend("auto", cuda_tensor), "torch"
+            )
+            self.assertEqual(
+                backend_selection.resolve_backend("triton", cuda_tensor), "torch"
+            )
+
     def test_force_backend_override(self) -> None:
         # Exporters run an eager warm-up forward before tracing; is_tracing() is
         # False there, so a CUDA float32 tensor would otherwise pick Triton (which


### PR DESCRIPTION
Summary:

`resolve_backend` reads the `_FORCED_BACKEND` `ContextVar` on its eager path, but reading a `contextvars.ContextVar` is not traceable by Dynamo. Under `torch.export` / `torch.compile`, the existing `torch.jit.is_scripting()` and `torch.jit.is_tracing()` gates are both `False` (they only catch the legacy TorchScript paths), so execution falls through to `_FORCED_BACKEND.get()` and Dynamo aborts capture with:

```
torch._dynamo.exc.Unsupported: Unsupported method call
  Explanation: Dynamo does not know how to trace method `get` of class `ContextVar`
```

This is a regression introduced by the recently added `force_backend` / `_FORCED_BACKEND` ContextVar mechanism. It broke the CARMM ExecuTorch export test, which traces `to_rotation_matrix` -> `resolve_backend` via `torch.export`.

This adds a `torch.compiler.is_compiling()` gate (true under both `torch.compile` and `torch.export`) before the ContextVar read, completing the existing `is_scripting` / `is_tracing` guard pattern and returning the traceable `torch` backend during capture. This is the correct fallback anyway: Triton kernels are not traceable, and `force_backend` was added precisely to pin `torch` for export.

Reviewed By: juliencbmeta

Differential Revision: D109216845


