### PR TITLE
Seed character test random inputs

### DIFF
--- a/momentum/test/character/blend_shape_test.cpp
+++ b/momentum/test/character/blend_shape_test.cpp
@@ -18,32 +18,32 @@ using Types = testing::Types<float, double>;
 template <typename T>
 struct BlendShapeTest : testing::Test {
   using Type = T;
+  Random<> rng{12345};
 };
 
 TYPED_TEST_SUITE(BlendShapeTest, Types);
 
 // Helper function to create random vertices
 template <typename T>
-std::vector<Eigen::Vector3<T>> createRandomVertices(size_t count) {
+std::vector<Eigen::Vector3<T>> createRandomVertices(Random<>& rng, size_t count) {
   std::vector<Eigen::Vector3<T>> vertices;
   vertices.reserve(count);
   for (size_t i = 0; i < count; ++i) {
-    vertices.push_back(uniform<Eigen::Vector3<T>>(T(-1), T(1)));
+    vertices.push_back(rng.template uniform<Eigen::Vector3<T>>(T(-1), T(1)));
   }
   return vertices;
 }
 
 // Helper function to create random blend weights
 template <typename T>
-BlendWeightsT<T> createRandomBlendWeights(size_t count) {
+BlendWeightsT<T> createRandomBlendWeights(Random<>& rng, size_t count) {
   BlendWeightsT<T> weights;
-  weights.v = uniform<VectorX<T>>(count, T(-1), T(1));
+  weights.v = rng.template uniform<VectorX<T>>(count, T(-1), T(1));
   return weights;
 }
 
 // Tests for BlendShapeBase
 TEST(BlendShapeTest, BlendShapeBaseConstruction) {
-  Random<>::GetSingleton().setSeed(12345);
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
@@ -56,14 +56,14 @@ TEST(BlendShapeTest, BlendShapeBaseConstruction) {
 }
 
 TEST(BlendShapeTest, BlendShapeBaseSetShapeVector) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   BlendShapeBase blendShapeBase(modelSize, numShapes);
 
   // Create a random shape vector
-  std::vector<Vector3f> shapeVector = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> shapeVector = createRandomVertices<float>(rng, modelSize);
 
   // Set the shape vector at index 2
   blendShapeBase.setShapeVector(2, shapeVector);
@@ -78,7 +78,6 @@ TEST(BlendShapeTest, BlendShapeBaseSetShapeVector) {
 }
 
 TYPED_TEST(BlendShapeTest, BlendShapeBaseComputeDeltas) {
-  Random<>::GetSingleton().setSeed(12345);
   using T = typename TestFixture::Type;
 
   const size_t modelSize = 10;
@@ -89,13 +88,13 @@ TYPED_TEST(BlendShapeTest, BlendShapeBaseComputeDeltas) {
   // Create and set random shape vectors
   std::vector<std::vector<Vector3f>> shapeVectors;
   for (size_t i = 0; i < numShapes; ++i) {
-    std::vector<Vector3f> shapeVector = createRandomVertices<float>(modelSize);
+    std::vector<Vector3f> shapeVector = createRandomVertices<float>(this->rng, modelSize);
     shapeVectors.push_back(shapeVector);
     blendShapeBase.setShapeVector(i, shapeVector);
   }
 
   // Create random blend weights
-  BlendWeightsT<T> blendWeights = createRandomBlendWeights<T>(numShapes);
+  BlendWeightsT<T> blendWeights = createRandomBlendWeights<T>(this->rng, numShapes);
 
   // Compute deltas
   VectorX<T> deltas = blendShapeBase.computeDeltas(blendWeights);
@@ -120,7 +119,6 @@ TYPED_TEST(BlendShapeTest, BlendShapeBaseComputeDeltas) {
 }
 
 TYPED_TEST(BlendShapeTest, BlendShapeBaseApplyDeltas) {
-  Random<>::GetSingleton().setSeed(12345);
   using T = typename TestFixture::Type;
 
   const size_t modelSize = 10;
@@ -131,16 +129,16 @@ TYPED_TEST(BlendShapeTest, BlendShapeBaseApplyDeltas) {
   // Create and set random shape vectors
   std::vector<std::vector<Vector3f>> shapeVectors;
   for (size_t i = 0; i < numShapes; ++i) {
-    std::vector<Vector3f> shapeVector = createRandomVertices<float>(modelSize);
+    std::vector<Vector3f> shapeVector = createRandomVertices<float>(this->rng, modelSize);
     shapeVectors.push_back(shapeVector);
     blendShapeBase.setShapeVector(i, shapeVector);
   }
 
   // Create random blend weights
-  BlendWeightsT<T> blendWeights = createRandomBlendWeights<T>(numShapes);
+  BlendWeightsT<T> blendWeights = createRandomBlendWeights<T>(this->rng, numShapes);
 
   // Create base shape
-  std::vector<Eigen::Vector3<T>> baseShape = createRandomVertices<T>(modelSize);
+  std::vector<Eigen::Vector3<T>> baseShape = createRandomVertices<T>(this->rng, modelSize);
   std::vector<Eigen::Vector3<T>> result = baseShape;
 
   // Apply deltas
@@ -165,12 +163,12 @@ TYPED_TEST(BlendShapeTest, BlendShapeBaseApplyDeltas) {
 
 // Tests for BlendShape
 TEST(BlendShapeTest, BlendShapeConstruction) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   // Create a random base shape
-  std::vector<Vector3f> baseShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape = createRandomVertices<float>(rng, modelSize);
 
   BlendShape blendShape(baseShape, numShapes);
 
@@ -190,17 +188,17 @@ TEST(BlendShapeTest, BlendShapeConstruction) {
 }
 
 TEST(BlendShapeTest, BlendShapeSetBaseShape) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   // Create a random base shape
-  std::vector<Vector3f> baseShape1 = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape1 = createRandomVertices<float>(rng, modelSize);
 
   BlendShape blendShape(baseShape1, numShapes);
 
   // Create a new random base shape
-  std::vector<Vector3f> baseShape2 = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape2 = createRandomVertices<float>(rng, modelSize);
 
   // Set the new base shape
   blendShape.setBaseShape(baseShape2);
@@ -214,27 +212,26 @@ TEST(BlendShapeTest, BlendShapeSetBaseShape) {
 }
 
 TYPED_TEST(BlendShapeTest, BlendShapeComputeShape) {
-  Random<>::GetSingleton().setSeed(12345);
   using T = typename TestFixture::Type;
 
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   // Create a random base shape
-  std::vector<Vector3f> baseShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape = createRandomVertices<float>(this->rng, modelSize);
 
   BlendShape blendShape(baseShape, numShapes);
 
   // Create and set random shape vectors
   std::vector<std::vector<Vector3f>> shapeVectors;
   for (size_t i = 0; i < numShapes; ++i) {
-    std::vector<Vector3f> shapeVector = createRandomVertices<float>(modelSize);
+    std::vector<Vector3f> shapeVector = createRandomVertices<float>(this->rng, modelSize);
     shapeVectors.push_back(shapeVector);
     blendShape.setShapeVector(i, shapeVector);
   }
 
   // Create random blend weights
-  BlendWeightsT<T> blendWeights = createRandomBlendWeights<T>(numShapes);
+  BlendWeightsT<T> blendWeights = createRandomBlendWeights<T>(this->rng, numShapes);
 
   // Compute shape
   std::vector<Eigen::Vector3<T>> shape = blendShape.computeShape(blendWeights);
@@ -274,25 +271,25 @@ TYPED_TEST(BlendShapeTest, BlendShapeComputeShape) {
 }
 
 TEST(BlendShapeTest, BlendShapeEstimateCoefficients) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   // Create a random base shape
-  std::vector<Vector3f> baseShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape = createRandomVertices<float>(rng, modelSize);
 
   BlendShape blendShape(baseShape, numShapes);
 
   // Create and set random shape vectors
   std::vector<std::vector<Vector3f>> shapeVectors;
   for (size_t i = 0; i < numShapes; ++i) {
-    std::vector<Vector3f> shapeVector = createRandomVertices<float>(modelSize);
+    std::vector<Vector3f> shapeVector = createRandomVertices<float>(rng, modelSize);
     shapeVectors.push_back(shapeVector);
     blendShape.setShapeVector(i, shapeVector);
   }
 
   // Create known blend weights
-  auto knownCoefficients = uniform<VectorXf>(numShapes, -1.f, 1.f);
+  auto knownCoefficients = rng.uniform<VectorXf>(numShapes, -1.f, 1.f);
   BlendWeightsT<float> blendWeights;
   blendWeights.v = knownCoefficients;
 
@@ -325,17 +322,17 @@ TEST(BlendShapeTest, BlendShapeEstimateCoefficients) {
 }
 
 TEST(BlendShapeTest, BlendShapeSetShapeVector) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   // Create a random base shape
-  std::vector<Vector3f> baseShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape = createRandomVertices<float>(rng, modelSize);
 
   BlendShape blendShape(baseShape, numShapes);
 
   // Create a random shape vector
-  std::vector<Vector3f> shapeVector = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> shapeVector = createRandomVertices<float>(rng, modelSize);
 
   // Set the shape vector at index 2
   blendShape.setShapeVector(2, shapeVector);
@@ -352,7 +349,7 @@ TEST(BlendShapeTest, BlendShapeSetShapeVector) {
   EXPECT_FALSE(blendShape.getFactorizationValid());
 
   // Force factorization to be computed
-  std::vector<Vector3f> targetShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> targetShape = createRandomVertices<float>(rng, modelSize);
   (void)blendShape.estimateCoefficients(targetShape);
 
   // Check that factorization is now valid
@@ -366,19 +363,19 @@ TEST(BlendShapeTest, BlendShapeSetShapeVector) {
 }
 
 TEST(BlendShapeTest, BlendShapeIsApprox) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   // Create a random base shape
-  std::vector<Vector3f> baseShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape = createRandomVertices<float>(rng, modelSize);
 
   BlendShape blendShape1(baseShape, numShapes);
 
   // Create and set random shape vectors
   std::vector<std::vector<Vector3f>> shapeVectors;
   for (size_t i = 0; i < numShapes; ++i) {
-    std::vector<Vector3f> shapeVector = createRandomVertices<float>(modelSize);
+    std::vector<Vector3f> shapeVector = createRandomVertices<float>(rng, modelSize);
     shapeVectors.push_back(shapeVector);
     blendShape1.setShapeVector(i, shapeVector);
   }
@@ -393,7 +390,7 @@ TEST(BlendShapeTest, BlendShapeIsApprox) {
   EXPECT_TRUE(blendShape1.isApprox(blendShape2));
 
   // Modify the second blend shape
-  std::vector<Vector3f> differentBaseShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> differentBaseShape = createRandomVertices<float>(rng, modelSize);
   blendShape2.setBaseShape(differentBaseShape);
 
   // Check that the blend shapes are no longer approximately equal
@@ -401,7 +398,7 @@ TEST(BlendShapeTest, BlendShapeIsApprox) {
 
   // Reset the base shape but modify a shape vector
   blendShape2.setBaseShape(baseShape);
-  std::vector<Vector3f> differentShapeVector = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> differentShapeVector = createRandomVertices<float>(rng, modelSize);
   blendShape2.setShapeVector(0, differentShapeVector);
 
   // Check that the blend shapes are no longer approximately equal
@@ -410,7 +407,6 @@ TEST(BlendShapeTest, BlendShapeIsApprox) {
 
 // Test edge cases
 TEST(BlendShapeTest, EdgeCases) {
-  Random<>::GetSingleton().setSeed(12345);
   // Test with empty base shape and no shape vectors
   BlendShape emptyBlendShape;
   EXPECT_EQ(emptyBlendShape.modelSize(), 0);
@@ -444,30 +440,30 @@ TEST(BlendShapeTest, EdgeCases) {
 
 // Test error cases
 TEST(BlendShapeTest, ErrorCases) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 
   // Create a random base shape
-  std::vector<Vector3f> baseShape = createRandomVertices<float>(modelSize);
+  std::vector<Vector3f> baseShape = createRandomVertices<float>(rng, modelSize);
 
   BlendShape blendShape(baseShape, numShapes);
 
   // Test setting a shape vector with wrong size
-  std::vector<Vector3f> wrongSizeShapeVector = createRandomVertices<float>(modelSize + 1);
+  std::vector<Vector3f> wrongSizeShapeVector = createRandomVertices<float>(rng, modelSize + 1);
 
   // This should trigger an assertion failure, but we can't test that directly in gtest
   // Just documenting that this would be an error case
 
   // Test estimating coefficients with wrong size vertices
-  std::vector<Vector3f> wrongSizeVertices = createRandomVertices<float>(modelSize + 1);
+  std::vector<Vector3f> wrongSizeVertices = createRandomVertices<float>(rng, modelSize + 1);
 
   // This should trigger an assertion failure, but we can't test that directly in gtest
   // Just documenting that this would be an error case
 
   // Test with blend weights that have more coefficients than shape vectors
   BlendWeightsT<float> tooManyWeights;
-  tooManyWeights.v = uniform<VectorXf>(numShapes + 1, -1.f, 1.f);
+  tooManyWeights.v = rng.uniform<VectorXf>(numShapes + 1, -1.f, 1.f);
 
   // This should trigger an assertion failure, but we can't test that directly in gtest
   // Just documenting that this would be an error case
@@ -475,12 +471,12 @@ TEST(BlendShapeTest, ErrorCases) {
 
 // Test with different sizes
 TEST(BlendShapeTest, DifferentSizes) {
-  Random<>::GetSingleton().setSeed(12345);
+  Random<> rng{12345};
   // Test with a larger model
   const size_t largeModelSize = 1000;
   const size_t numShapes = 10;
 
-  std::vector<Vector3f> baseShape = createRandomVertices<float>(largeModelSize);
+  std::vector<Vector3f> baseShape = createRandomVertices<float>(rng, largeModelSize);
   BlendShape largeBlendShape(baseShape, numShapes);
 
   EXPECT_EQ(largeBlendShape.modelSize(), largeModelSize);
@@ -490,7 +486,7 @@ TEST(BlendShapeTest, DifferentSizes) {
   const size_t modelSize = 10;
   const size_t manyShapes = 100;
 
-  baseShape = createRandomVertices<float>(modelSize);
+  baseShape = createRandomVertices<float>(rng, modelSize);
   BlendShape manyShapesBlendShape(baseShape, manyShapes);
 
   EXPECT_EQ(manyShapesBlendShape.modelSize(), modelSize);
@@ -498,7 +494,6 @@ TEST(BlendShapeTest, DifferentSizes) {
 }
 
 TEST(BlendShapeTest, BlendShapeNames) {
-  Random<>::GetSingleton().setSeed(12345);
   const size_t modelSize = 10;
   const size_t numShapes = 5;
 

--- a/momentum/test/character/character_helpers.cpp
+++ b/momentum/test/character/character_helpers.cpp
@@ -31,8 +31,8 @@ namespace momentum {
 namespace {
 
 template <typename T>
-Eigen::MatrixX<T> randomMatrix(Eigen::Index nRows, Eigen::Index nCols) {
-  return normal<MatrixX<T>>(nRows, nCols, 0, 1);
+Eigen::MatrixX<T> randomMatrix(Random<>& rng, Eigen::Index nRows, Eigen::Index nCols) {
+  return rng.template normal<MatrixX<T>>(nRows, nCols, 0, 1);
 }
 
 [[nodiscard]] Skeleton createDefaultSkeleton(size_t numJoints) {
@@ -247,8 +247,10 @@ Character withTestBlendShapes(const Character& character) {
   MT_CHECK(character.mesh);
 
   const int nShapes = 5;
+  Random<> rng{12345};
   auto blendShapes = std::make_shared<BlendShape>(character.mesh->vertices, nShapes);
-  blendShapes->setShapeVectors(randomMatrix<float>(3 * character.mesh->vertices.size(), nShapes));
+  blendShapes->setShapeVectors(
+      randomMatrix<float>(rng, 3 * character.mesh->vertices.size(), nShapes));
   return character.withBlendShape(blendShapes, nShapes);
 }
 
@@ -256,8 +258,10 @@ Character withTestFaceExpressionBlendShapes(const Character& character) {
   MT_CHECK(character.mesh);
 
   const int nShapes = 5;
+  Random<> rng{67890};
   auto blendShapes = std::make_shared<BlendShapeBase>();
-  blendShapes->setShapeVectors(randomMatrix<float>(3 * character.mesh->vertices.size(), nShapes));
+  blendShapes->setShapeVectors(
+      randomMatrix<float>(rng, 3 * character.mesh->vertices.size(), nShapes));
 
   return character.withFaceExpressionBlendShape(blendShapes, nShapes);
 }
@@ -299,15 +303,16 @@ std::shared_ptr<const MppcaT<T>> createDefaultPosePrior() {
   // Number of mixtures:
   const int p = 2;
 
-  Eigen::VectorX<T> pi = randomMatrix<T>(p, 1).array().abs();
+  Random<> rng{12345};
+  Eigen::VectorX<T> pi = randomMatrix<T>(rng, p, 1).array().abs();
   pi /= pi.sum();
-  Eigen::MatrixX<T> mu = randomMatrix<T>(p, d);
-  Eigen::VectorX<T> sigma2 = randomMatrix<T>(p, 1).array().square();
+  Eigen::MatrixX<T> mu = randomMatrix<T>(rng, p, d);
+  Eigen::VectorX<T> sigma2 = randomMatrix<T>(rng, p, 1).array().square();
 
   std::vector<Eigen::MatrixX<T>> W(p);
   const int q = 2;
   for (int i = 0; i < p; ++i) {
-    W[i] = randomMatrix<T>(d, q);
+    W[i] = randomMatrix<T>(rng, d, q);
   }
 
   auto result = std::make_shared<MppcaT<T>>();

--- a/momentum/test/character/skeleton_bake_test.cpp
+++ b/momentum/test/character/skeleton_bake_test.cpp
@@ -48,8 +48,8 @@ void activateSomeBakeableParams(const Character& c, ModelParametersT<T>& mp) {
 }
 
 TYPED_TEST(BakeTest, Geometry) {
-  Random<>::GetSingleton().setSeed(12345);
   using T = typename TestFixture::Type;
+  Random<> rng{12345};
 
   // Build a character with both scale & blend-shape capabilities
   const Character characterBlend = withTestBlendShapes(createTestCharacter());
@@ -60,21 +60,30 @@ TYPED_TEST(BakeTest, Geometry) {
   const ParameterTransformT<T> paramX = characterBlend.parameterTransform.cast<T>();
 
   // Random (but reproducible) model parameters
-  ModelParametersT<T> modelParams = uniform<VectorX<T>>(paramX.numAllModelParameters(), 0, 1);
+  ModelParametersT<T> modelParams = rng.uniform<VectorX<T>>(paramX.numAllModelParameters(), 0, 1);
 
   activateSomeBakeableParams(characterBlend, modelParams);
 
   // Runtime path: skinning with blend shapes
   SkeletonStateT<T> skelState(paramX.apply(modelParams), characterBlend.skeleton);
 
-  MeshT<T> posedMesh = characterBlend.mesh->cast<T>();
+  const auto* characterMesh = characterBlend.mesh.get();
+  if (characterMesh == nullptr) {
+    ADD_FAILURE() << "Expected test character mesh.";
+    return;
+  }
+  MeshT<T> posedMesh = characterMesh->cast<T>();
   skinWithBlendShapes(characterBlend, skelState, modelParams, posedMesh);
 
   // Bake-time path
   Character baked = characterBlend.bake(modelParams.template cast<float>());
-  ASSERT_TRUE(baked.mesh); // sanity
+  const auto* bakedMeshPtr = baked.mesh.get();
+  if (bakedMeshPtr == nullptr) {
+    ADD_FAILURE() << "Expected baked character mesh.";
+    return;
+  }
 
-  MeshT<T> bakedMesh = baked.mesh->cast<T>(); // convert verts to current precision
+  MeshT<T> bakedMesh = bakedMeshPtr->cast<T>(); // convert verts to current precision
 
   // Compare vertex positions
   ASSERT_EQ(posedMesh.vertices.size(), bakedMesh.vertices.size());


### PR DESCRIPTION
Summary: Make character tests draw random inputs from fixed, test-owned `Random<>` engines instead of the shared singleton helpers. Thread `Random<>` through blend-shape test helpers and character test helpers so random data generation is deterministic and local to each test/helper call.

Differential Revision: D110375520


