### PR TITLE
Fix Windows debug build failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,17 @@ find_package(fmt CONFIG REQUIRED)
 find_package(fx-gltf CONFIG REQUIRED)
 find_package(indicators 2.3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(openfbx CONFIG REQUIRED)
+if(MSVC)
+  include(FetchContent)
+  FetchContent_Declare(
+    openfbx
+    GIT_REPOSITORY https://github.com/nem0/OpenFBX.git
+    GIT_TAG v0.9
+  )
+  FetchContent_MakeAvailable(openfbx)
+else()
+  find_package(openfbx CONFIG REQUIRED)
+endif()
 if(MOMENTUM_BUILD_IO_USD)
   find_package(pxr CONFIG REQUIRED HINTS ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/cmake)
   find_package(TBB CONFIG REQUIRED)
@@ -246,6 +256,7 @@ mt_library(
   PUBLIC_LINK_LIBRARIES
     Eigen3::Eigen
     drjit
+    drjit-core
 )
 
 mt_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,12 +131,27 @@ find_package(indicators 2.3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 if(MSVC)
   include(FetchContent)
-  FetchContent_Declare(
+  # OpenFBX uses CMAKE_SOURCE_DIR when installing headers, which doesn't work in a tree build
+  FetchContent_Populate(
     openfbx
     GIT_REPOSITORY https://github.com/nem0/OpenFBX.git
     GIT_TAG v0.9
   )
-  FetchContent_MakeAvailable(openfbx)
+  file(READ "${openfbx_SOURCE_DIR}/CMakeLists.txt" contents)
+  string(REPLACE
+      "\${CMAKE_SOURCE_DIR}/src/ofbx.h"
+      "\${CMAKE_CURRENT_SOURCE_DIR}/src/ofbx.h"
+      contents
+      "${contents}")
+  file(WRITE "${openfbx_SOURCE_DIR}/CMakeLists.txt" "${contents}")
+  add_subdirectory("${openfbx_SOURCE_DIR}" "${openfbx_BINARY_DIR}")
+  # TODO: Replace the above with this below once the OpenFBX CMakeLists.txt has been updated
+  # FetchContent_Declare(
+  #   openfbx
+  #   GIT_REPOSITORY https://github.com/nem0/OpenFBX.git
+  #   GIT_TAG v<version>
+  # )
+  # FetchContent_MakeAvailable(openfbx)
 else()
   find_package(openfbx CONFIG REQUIRED)
 endif()

--- a/axel/CMakeLists.txt
+++ b/axel/CMakeLists.txt
@@ -88,6 +88,7 @@ target_link_libraries(${target_name}
     Microsoft.GSL::GSL
     Dispenso::dispenso
     drjit
+    drjit-core
     nlohmann_json::nlohmann_json
 )
 


### PR DESCRIPTION
## Summary

This PR addresses two build issues when building in debug mode on windows.
See also issue #1561 

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

- Builds with `pixi run build_dev` on Windows and Linux (Debian). Not tested on macOS, unlikely this PR breaks anything but should be confirmed.
- OpenFBX version tag matches requirements in `pixi.toml`, so built artifacts should be equivalent.
- All tests pass on Windows for release builds.
- Some tests fail in debug for Windows (and Linux), but this is a preexisting issue, was not introduced by this PR.
