### PR TITLE
Fix Linux wheel C++ runtime loading (#1566)

### DIFF
--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -19,10 +19,10 @@
     # The pixi environment's pybind11 uses pybind11NewTools which requires python3_add_library
     # from CMake's FindPython, but manylinux Python only has Interpreter component
     "-DMOMENTUM_USE_SYSTEM_PYBIND11=OFF",
-    # Use manylinux container's compiler (gcc-toolset-12) instead of pixi's GCC 14.3
-    # to ensure manylinux_2_28 compatibility (requires GLIBCXX <= 3.4.24, CXXABI <= 1.3.11)
-    "-DCMAKE_CXX_FLAGS=-static-libstdc++ -static-libgcc",
-    "-DCMAKE_C_FLAGS=-static-libgcc",
+    # Do not static-link libstdc++ into extension modules: duplicated static C++
+    # runtime symbols can put later extension imports, notably torch._C, into an
+    # incompatible state under Python's default RTLD_LOCAL mode. The Linux wheel
+    # repair step below gives libstdc++ a private SONAME instead.
 {%- endmacro %}
 
 {#- macOS-specific args -#}
@@ -364,8 +364,10 @@ repair-wheel-command = """
 # - manylinux_2_28 policy rejects our libs (too-recent GLIBCXX symbols)
 # - linux_x86_64 policy is not available inside the manylinux container
 #
-# We manually bundle dependencies and rename libstdc++ to avoid the dynamic
-# linker collision where Python/torch load the system libstdc++.so.6 first.
+# We manually bundle dependencies, including libstdc++, because conda-forge
+# dependencies require newer GLIBCXX symbols than manylinux_2_28's system
+# libstdc++ provides. libstdc++ is renamed to a private SONAME so torch-first
+# imports cannot pin the older system libstdc++.so.6 for PyMomentum's DSOs.
 
 set -e
 
@@ -376,6 +378,80 @@ rm -rf $WORK /tmp/final_wheel && mkdir -p $WORK /tmp/final_wheel
 echo '=== Unpacking wheel ==='
 cd $WORK
 unzip -q {wheel}
+
+echo '=== Adding Linux native loader shim ==='
+cat > pymomentum/__init__.py <<'PYMOMENTUM_INIT'
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.machinery
+import sys
+
+
+_NATIVE_MODULES = {
+    f"{__name__}.{module}"
+    for module in (
+        "axel",
+        "camera",
+        "diff_geometry",
+        "geometry",
+        "marker_tracking",
+        "renderer",
+        "solver",
+        "solver2",
+    )
+}
+
+
+class _TorchFirstExtensionLoader(importlib.abc.Loader):
+    def __init__(self, loader: importlib.abc.Loader) -> None:
+        self._loader = loader
+
+    def __getattr__(self, name: str):
+        return getattr(self._loader, name)
+
+    def create_module(self, spec):
+        _import_torch_if_available()
+        if not hasattr(self._loader, "create_module"):
+            return None
+        return self._loader.create_module(spec)
+
+    def exec_module(self, module) -> None:
+        _import_torch_if_available()
+        self._loader.exec_module(module)
+
+
+class _TorchFirstExtensionFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname: str, path=None, target=None):
+        if fullname not in _NATIVE_MODULES:
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if spec is None or not isinstance(
+            spec.loader, importlib.machinery.ExtensionFileLoader
+        ):
+            return spec
+        if not isinstance(spec.loader, _TorchFirstExtensionLoader):
+            spec.loader = _TorchFirstExtensionLoader(spec.loader)
+        return spec
+
+
+def _import_torch_if_available() -> None:
+    try:
+        import torch  # noqa: F401
+    except ImportError:
+        pass
+
+
+if sys.platform.startswith("linux") and not any(
+    isinstance(finder, _TorchFirstExtensionFinder) for finder in sys.meta_path
+):
+    sys.meta_path.insert(0, _TorchFirstExtensionFinder())
+PYMOMENTUM_INIT
 
 # Find or create the .libs directory for this distribution.
 LIBS_DIR="{{ wheel_libs_dir }}"
@@ -392,7 +468,6 @@ is_skip_lib() {
         libresolv*|libnss*|ld-linux*) return 0 ;;
         libgcc_s*) return 0 ;;
         libpython*) return 0 ;;
-        libstdc++.so*) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -462,35 +537,30 @@ done
 echo "Bundled libraries:"
 ls -la "$LIBS_DIR/"
 
-# Special handling: rename libstdc++ to avoid dynamic linker collision
+# Keep PyMomentum's C++ runtime dependency private. Python package init imports
+# torch, when available, before loading PyMomentum extension modules so torch
+# owns its process-global C++ runtime state without exposing PyMomentum's private
+# libstdc++ symbols to later native extensions such as Triton.
 echo '=== Renaming libstdc++ ==='
 RENAMED_LIBSTDCXX="libstdc++-pymomentum.so.6"
-
-# Find pixi's libstdc++ (the one with GLIBCXX_3.4.29)
-PIXI_LIBSTDCXX=$(find "$PIXI_ENV/lib" -name 'libstdc++.so.6.*' -not -type l | sort -V | tail -1)
-if [ -z "$PIXI_LIBSTDCXX" ]; then
-    PIXI_LIBSTDCXX="$PIXI_ENV/lib/libstdc++.so.6"
+if [ -f "$LIBS_DIR/libstdc++.so.6" ]; then
+    mv "$LIBS_DIR/libstdc++.so.6" "$LIBS_DIR/$RENAMED_LIBSTDCXX"
+else
+    PIXI_LIBSTDCXX=$(find "$PIXI_ENV/lib" -name 'libstdc++.so.6*' -not -type l | sort -V | tail -1)
+    if [ -z "$PIXI_LIBSTDCXX" ]; then
+        PIXI_LIBSTDCXX="$PIXI_ENV/lib/libstdc++.so.6"
+    fi
+    cp "$(readlink -f "$PIXI_LIBSTDCXX")" "$LIBS_DIR/$RENAMED_LIBSTDCXX"
 fi
-PIXI_LIBSTDCXX=$(readlink -f "$PIXI_LIBSTDCXX")
-echo "Pixi libstdc++: $PIXI_LIBSTDCXX"
-
-# Copy with renamed name
-cp "$PIXI_LIBSTDCXX" "$LIBS_DIR/$RENAMED_LIBSTDCXX"
 chmod 755 "$LIBS_DIR/$RENAMED_LIBSTDCXX"
-# Remove the original-named copy if bundled above
-rm -f "$LIBS_DIR/libstdc++.so.6"
-
-# Set the SONAME of the renamed library
 patchelf --set-soname "$RENAMED_LIBSTDCXX" "$LIBS_DIR/$RENAMED_LIBSTDCXX"
 
-# Patch DT_NEEDED in all .so files
 echo '=== Patching DT_NEEDED and RPATH ==='
 find . -name '*.so*' -type f | while read so_file; do
     case "$so_file" in
-        *libstdc++-pymomentum*) continue ;;
+        *"$RENAMED_LIBSTDCXX") continue ;;
     esac
 
-    # Replace libstdc++.so.6 reference with renamed version
     if patchelf --print-needed "$so_file" 2>/dev/null | grep -q '^libstdc++[.]so[.]6$'; then
         echo "  Patching DT_NEEDED: $so_file"
         patchelf --replace-needed libstdc++.so.6 "$RENAMED_LIBSTDCXX" "$so_file"

--- a/scripts/test_wheel.py
+++ b/scripts/test_wheel.py
@@ -131,8 +131,6 @@ def get_import_test_script(
     if torch_runtime:
         lines.extend(
             [
-                "    # Import torch before PyMomentum's torch-backed Python modules",
-                "    # or any PyMomentum extension so PyTorch sets up native paths first.",
                 "    import torch",
                 '    print(f"  PyTorch {torch.__version__}, CUDA={torch.version.cuda}")',
             ]
@@ -287,6 +285,23 @@ def get_import_test_script(
     return "\n".join(lines) + "\n"
 
 
+def get_torch_after_pymomentum_script() -> str:
+    """Return a regression test for PyMomentum's native loader state."""
+    return "\n".join(
+        [
+            "import faulthandler",
+            "faulthandler.enable()",
+            'print("Testing pymomentum.geometry before torch...")',
+            "import pymomentum.geometry",
+            'print("  pymomentum.geometry imported")',
+            "import torch",
+            'print(f"  PyTorch {torch.__version__} imported")',
+            'print("[PASS] pymomentum.geometry before torch")',
+            "",
+        ]
+    )
+
+
 def run_import_tests(
     python_exe: str,
     wheel_type: str,
@@ -305,6 +320,21 @@ def run_import_tests(
         env.pop(name, None)
     # Keep the checkout's namespace-package directories out of wheel import checks.
     with tempfile.TemporaryDirectory() as tmpdir:
+        if has_torch_runtime(wheel_type):
+            result = subprocess.run(
+                [
+                    python_exe,
+                    "-I",
+                    "-c",
+                    get_torch_after_pymomentum_script(),
+                ],
+                capture_output=False,
+                cwd=tmpdir,
+                env=env,
+            )
+            if result.returncode != 0:
+                return result.returncode
+
         result = subprocess.run(
             [
                 python_exe,
@@ -374,7 +404,7 @@ def test_in_container(
         "$PYTHON -m uv venv --python $PYTHON /tmp/test_venv",
         "",
     ]
-    if has_torch_extensions(wheel_type):
+    if has_torch_runtime(wheel_type):
         torch_index = get_torch_index(wheel_type)
         container_lines.extend(
             [
@@ -385,6 +415,7 @@ def test_in_container(
             ]
         )
 
+    torch_after_pymomentum_script = get_torch_after_pymomentum_script()
     import_test_script = get_import_test_script(
         wheel_type,
         require_cuda,
@@ -395,6 +426,21 @@ def test_in_container(
             'echo "Installing wheel..."',
             f"$PYTHON -m uv pip install --python /tmp/test_venv/bin/python /wheel/{wheel_file.name}",
             "",
+        ]
+    )
+    if has_torch_runtime(wheel_type):
+        container_lines.extend(
+            [
+                'echo "Testing pymomentum.geometry before torch..."',
+                "cat >/tmp/test_torch_after_pymomentum.py <<'PYTEST'",
+                *torch_after_pymomentum_script.rstrip().splitlines(),
+                "PYTEST",
+                "/tmp/test_venv/bin/python -I /tmp/test_torch_after_pymomentum.py",
+                "",
+            ]
+        )
+    container_lines.extend(
+        [
             'echo "Testing imports..."',
             "cat >/tmp/test_wheel_imports.py <<'PYTEST'",
             *import_test_script.rstrip().splitlines(),
@@ -465,7 +511,7 @@ def test_locally_with_uv(
             print(f"[FAIL] Failed to create venv: {result.stderr}", file=sys.stderr)
             return result.returncode
 
-        if has_torch_extensions(wheel_type):
+        if has_torch_runtime(wheel_type):
             torch_index = get_torch_index(wheel_type)
             print(f"Installing torch from {torch_index}...")
             result = subprocess.run(


### PR DESCRIPTION
Summary:

Linux PyPI wheels bundle a renamed private libstdc++ because conda-forge
runtime dependencies require newer GLIBCXX symbols than manylinux_2_28's
system libstdc++ provides.

The original import failure was caused by loading that private C++ runtime before
PyTorch under Python's default RTLD_LOCAL mode:

  import pymomentum.geometry
  import torch

That lets a second libstdc++ instance exist in the process before torch._C is
loaded, and torch can segfault during import.

A scoped RTLD_GLOBAL loader makes that order pass, but it is not a correct fix:
it exposes PyMomentum's private libstdc++ symbols to the whole process. In the
opposite order, that can poison later native library loads. In particular,
Triton's compiler fails in ConvertTritonGPUToLLVM after this order:

  import torch
  import pymomentum.geometry
  import pymomentum.quaternion  # backend=\"triton\"

Fix this by changing the Linux wheel repair shim to import torch, when torch is
available, immediately before loading any PyMomentum native extension. The
extension still loads with Python's normal RTLD_LOCAL behavior, so PyMomentum's
private libstdc++ remains hidden from later native extensions such as Triton,
while torch owns the process-global C++ runtime state before PyMomentum's private
runtime is loaded.

The generated pymomentum/__init__.py is added only during Linux wheel repair.
This keeps macOS and Windows behavior unchanged for now because the known bug is
in Linux ELF/dlopen/libstdc++ interaction. If we later want one package shape on
all platforms, we can move a no-op-on-non-Linux __init__.py into the source tree,
but that should be a separate deliberate package-shape change.

Also expand wheel smoke tests so every wheel variant installs torch and checks
the pymomentum.geometry-before-torch order. The strict GPU wheel test continues
to require CUDA and Triton.

Reviewed By: cstollmeta

Differential Revision: D110929696


