### PR TITLE
Bump Node.js from 20 to 22 in publish_website workflow

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -49,7 +49,7 @@ jobs:
     # 2) Build Docusaurus site with C++ docs (using Doxygen)
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-          node-version: 20
+          node-version: 22
 
     - name: Install Doxygen
       run: sudo apt-get install doxygen


### PR DESCRIPTION
Summary:
Update the Node.js version used by the Publish Website GitHub Actions
workflow from 20 to 22, which is required to build the Docusaurus site.

Differential Revision: D113610419


