### PR TITLE
Bump brace-expansion to 5.0.8 for website security

### DIFF
--- a/momentum/website/package.json
+++ b/momentum/website/package.json
@@ -52,7 +52,7 @@
     "**/lodash-es": ">=4.18.0",
     "**/svgo": "^3.3.3",
     "**/picomatch": "^2.3.2",
-    "**/brace-expansion": "^5.0.7",
+    "**/brace-expansion": "^5.0.8",
     "**/webpack-dev-server/ws": ">=8.20.1",
     "**/webpack-bundle-analyzer/ws": "^7.5.11",
     "**/yaml": ">=2.8.3",

--- a/momentum/website/yarn.lock
+++ b/momentum/website/yarn.lock
@@ -3941,10 +3941,10 @@ boxen@^7.0.0:
     widest-line "^4.0.1"
     wrap-ansi "^8.1.0"
 
-brace-expansion@^1.1.7, brace-expansion@^5.0.7:
-  version "5.0.7"
-  resolved "https://registry.facebook.net/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+brace-expansion@^1.1.7, brace-expansion@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.facebook.net/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
Summary:
Bump the pinned **/brace-expansion resolution from 5.0.7 to 5.0.8 to
resolve GHSA-mh99-v99m-4gvg (out-of-memory denial of service via
unbounded brace expansion length).

This advisory requires brace-expansion >=5.0.8. When the previous bump
landed, 5.0.8 was not yet published, so it pinned 5.0.7 (which resolved
the other brace-expansion advisory, GHSA-3jxr-9vmj-r5cp, but not this
one). Now that 5.0.8 is available, this updates the lockfile to pick it
up. The caret range does not upgrade a committed lockfile on its own, so
an explicit bump is needed.

Differential Revision: D113846784


