### PR TITLE
Clean up Eigen 5 compiler warnings

### DIFF
--- a/momentum/character/blend_shape.cpp
+++ b/momentum/character/blend_shape.cpp
@@ -60,7 +60,7 @@ VectorXf BlendShape::estimateCoefficients(
   // damped least squares) or document it on the header.
   if (weights.size() != static_cast<Eigen::Index>(vertices.size())) {
     if (!factorizationValid_) {
-      factorization_.compute(shapeVectors_, Eigen::ComputeThinU | Eigen::ComputeThinV);
+      factorization_.compute(shapeVectors_);
       factorizationValid_ = true;
     }
 

--- a/momentum/character/blend_shape.h
+++ b/momentum/character/blend_shape.h
@@ -102,7 +102,7 @@ struct BlendShape : public BlendShapeBase {
 
  private:
   std::vector<Vector3f> baseShape_;
-  mutable Eigen::JacobiSVD<MatrixXf> factorization_;
+  mutable Eigen::JacobiSVD<MatrixXf, Eigen::ComputeThinU | Eigen::ComputeThinV> factorization_;
   mutable bool factorizationValid_;
 };
 

--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -898,14 +898,18 @@ RigidTransformNodeResult addRigidTransformNode(
 
   // Rebuild the sparse transform matrix: keep existing triplets and add 6 new ones
   std::vector<Eigen::Triplet<float>> triplets = toTriplets(newParamTransform.transform);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + TX, parameterStartIndex + 0, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + TY, parameterStartIndex + 1, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + TZ, parameterStartIndex + 2, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + RX, parameterStartIndex + 3, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + RY, parameterStartIndex + 4, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + RZ, parameterStartIndex + 5, 1.0f);
+  const auto jointParameterStart = static_cast<Eigen::Index>(boneIndex * kParametersPerJoint);
+  const auto parameterStart = static_cast<Eigen::Index>(parameterStartIndex);
+  triplets.emplace_back(jointParameterStart + TX, parameterStart + 0, 1.0f);
+  triplets.emplace_back(jointParameterStart + TY, parameterStart + 1, 1.0f);
+  triplets.emplace_back(jointParameterStart + TZ, parameterStart + 2, 1.0f);
+  triplets.emplace_back(jointParameterStart + RX, parameterStart + 3, 1.0f);
+  triplets.emplace_back(jointParameterStart + RY, parameterStart + 4, 1.0f);
+  triplets.emplace_back(jointParameterStart + RZ, parameterStart + 5, 1.0f);
 
-  newParamTransform.transform.resize(newNumJointParams, newParamTransform.name.size());
+  newParamTransform.transform.resize(
+      static_cast<Eigen::Index>(newNumJointParams),
+      static_cast<Eigen::Index>(newParamTransform.name.size()));
   newParamTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
 
   // Recompute activeJointParams

--- a/momentum/character_solver/sdf_collision_error_function.h
+++ b/momentum/character_solver/sdf_collision_error_function.h
@@ -140,8 +140,6 @@ class SDFCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
       const std::vector<int>& participatingVertices,
       const std::vector<T>& weights);
 
-  void organizeVerticesByBone(const std::vector<std::pair<int, T>>& vertexWeightPairs);
-
   void initializeBoneCollisionPairs(bool filterRestPoseIntersections);
 
   [[nodiscard]] bool testRestPoseIntersection(

--- a/momentum/character_solver/vertex_vertex_distance_error_function.h
+++ b/momentum/character_solver/vertex_vertex_distance_error_function.h
@@ -114,31 +114,6 @@ class VertexVertexDistanceErrorFunctionT : public SkeletonErrorFunctionT<T> {
       const VertexVertexDistanceConstraintT<T>& constraint,
       Eigen::Ref<Eigen::VectorX<T>> gradient) const;
 
-  /// Calculate gradient contribution from a single vertex
-  void calculateVertexGradient(
-      const ModelParametersT<T>& modelParameters,
-      const SkeletonStateT<T>& state,
-      const MeshStateT<T>& meshState,
-      int vertexIndex,
-      const Eigen::Vector3<T>& gradientDirection,
-      Eigen::Ref<Eigen::VectorX<T>> gradient) const;
-
-  /// Calculate jacobian contribution from a single vertex
-  void calculateVertexJacobian(
-      const ModelParametersT<T>& modelParameters,
-      const SkeletonStateT<T>& state,
-      const MeshStateT<T>& meshState,
-      int vertexIndex,
-      const Eigen::Vector3<T>& jacobianDirection,
-      Eigen::Ref<Eigen::MatrixX<T>> jacobian) const;
-
-  /// Calculate world space position derivative for blend shape parameters
-  void calculateDWorldPos(
-      const SkeletonStateT<T>& state,
-      int vertexIndex,
-      const Eigen::Vector3<T>& d_restPos,
-      Eigen::Vector3<T>& d_worldPos) const;
-
   const Character& character_;
 
   std::vector<VertexVertexDistanceConstraintT<T>> constraints_;

--- a/momentum/io/bvh/bvh_io.cpp
+++ b/momentum/io/bvh/bvh_io.cpp
@@ -86,6 +86,7 @@ const char* channelTypeName(BvhChannel ch) {
     case BvhChannel::Zrotation:
       return "Zrotation";
   }
+  MT_THROW("Invalid BVH channel enum value: {}", static_cast<int>(ch));
 }
 
 // Returns the Eigen axis index for a rotation channel (0=X, 1=Y, 2=Z)
@@ -102,6 +103,7 @@ int rotationAxisIndex(BvhChannel ch) {
     case BvhChannel::Zposition:
       MT_THROW("Not a rotation channel");
   }
+  MT_THROW("Invalid BVH channel enum value: {}", static_cast<int>(ch));
 }
 
 // Returns the joint parameter index for a position channel (TX=0, TY=1, TZ=2)
@@ -118,6 +120,7 @@ int positionParameterIndex(BvhChannel ch) {
     case BvhChannel::Zrotation:
       MT_THROW("Not a position channel");
   }
+  MT_THROW("Invalid BVH channel enum value: {}", static_cast<int>(ch));
 }
 
 bool isRotationChannel(BvhChannel ch) {

--- a/momentum/math/utility.cpp
+++ b/momentum/math/utility.cpp
@@ -192,7 +192,7 @@ Vector3<T> rotationMatrixToEuler(
     return rotationMatrixToEuler(m, axis2, axis1, axis0, EulerConvention::Intrinsic).reverse();
   }
 
-  return m.eulerAngles(axis0, axis1, axis2);
+  return m.canonicalEulerAngles(axis0, axis1, axis2);
 }
 
 template <typename T>
@@ -422,7 +422,7 @@ Quaternionf quaternionAverage(momentum::span<const Quaternionf> q, momentum::spa
 template <typename T>
 MatrixX<T> pseudoInverse(const MatrixX<T>& mat) {
   constexpr T pinvtoler = Eps<T>(T(1e-6), T(1e-60)); // choose your tolerance wisely!
-  const auto svd = mat.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV);
+  const auto svd = mat.template jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeThinV>();
   VectorX<T> singularValues_inv = svd.singularValues();
   for (int j = 0; j < singularValues_inv.size(); ++j) {
     if (singularValues_inv(j) > pinvtoler) {


### PR DESCRIPTION
Summary: Update Momentum code for Eigen 5 APIs and clean up compiler warning sites. This moves SVD option selection to the Eigen 5 compile-time form, uses the canonical Euler conversion API, adds explicit error paths for invalid BVH channel enum values, removes stale private declarations that MSVC warns about during explicit template instantiation, and casts Eigen sparse matrix indices before constructing triplets.

Differential Revision: D108691805


