### PR TITLE
Reduce Windows MSVC compiler warnings

### DIFF
--- a/momentum/character/character_utility.cpp
+++ b/momentum/character/character_utility.cpp
@@ -898,12 +898,30 @@ RigidTransformNodeResult addRigidTransformNode(
 
   // Rebuild the sparse transform matrix: keep existing triplets and add 6 new ones
   std::vector<Eigen::Triplet<float>> triplets = toTriplets(newParamTransform.transform);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + TX, parameterStartIndex + 0, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + TY, parameterStartIndex + 1, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + TZ, parameterStartIndex + 2, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + RX, parameterStartIndex + 3, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + RY, parameterStartIndex + 4, 1.0f);
-  triplets.emplace_back(boneIndex * kParametersPerJoint + RZ, parameterStartIndex + 5, 1.0f);
+  triplets.emplace_back(
+      static_cast<int>(boneIndex * kParametersPerJoint + TX),
+      static_cast<int>(parameterStartIndex + 0),
+      1.0f);
+  triplets.emplace_back(
+      static_cast<int>(boneIndex * kParametersPerJoint + TY),
+      static_cast<int>(parameterStartIndex + 1),
+      1.0f);
+  triplets.emplace_back(
+      static_cast<int>(boneIndex * kParametersPerJoint + TZ),
+      static_cast<int>(parameterStartIndex + 2),
+      1.0f);
+  triplets.emplace_back(
+      static_cast<int>(boneIndex * kParametersPerJoint + RX),
+      static_cast<int>(parameterStartIndex + 3),
+      1.0f);
+  triplets.emplace_back(
+      static_cast<int>(boneIndex * kParametersPerJoint + RY),
+      static_cast<int>(parameterStartIndex + 4),
+      1.0f);
+  triplets.emplace_back(
+      static_cast<int>(boneIndex * kParametersPerJoint + RZ),
+      static_cast<int>(parameterStartIndex + 5),
+      1.0f);
 
   newParamTransform.transform.resize(newNumJointParams, newParamTransform.name.size());
   newParamTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
@@ -1077,7 +1095,10 @@ std::vector<Eigen::Vector3i> remapFaces(
         mapping[face[0]] != kInvalidIndex && mapping[face[1]] != kInvalidIndex &&
         mapping[face[2]] != kInvalidIndex);
 
-    remappedFaces.emplace_back(mapping[face[0]], mapping[face[1]], mapping[face[2]]);
+    remappedFaces.emplace_back(
+        static_cast<int>(mapping[face[0]]),
+        static_cast<int>(mapping[face[1]]),
+        static_cast<int>(mapping[face[2]]));
   }
 
   return remappedFaces;

--- a/momentum/character_solver/sdf_collision_error_function.h
+++ b/momentum/character_solver/sdf_collision_error_function.h
@@ -140,8 +140,6 @@ class SDFCollisionErrorFunctionT : public SkeletonErrorFunctionT<T> {
       const std::vector<int>& participatingVertices,
       const std::vector<T>& weights);
 
-  void organizeVerticesByBone(const std::vector<std::pair<int, T>>& vertexWeightPairs);
-
   void initializeBoneCollisionPairs(bool filterRestPoseIntersections);
 
   [[nodiscard]] bool testRestPoseIntersection(

--- a/momentum/character_solver/vertex_vertex_distance_error_function.h
+++ b/momentum/character_solver/vertex_vertex_distance_error_function.h
@@ -114,31 +114,6 @@ class VertexVertexDistanceErrorFunctionT : public SkeletonErrorFunctionT<T> {
       const VertexVertexDistanceConstraintT<T>& constraint,
       Eigen::Ref<Eigen::VectorX<T>> gradient) const;
 
-  /// Calculate gradient contribution from a single vertex
-  void calculateVertexGradient(
-      const ModelParametersT<T>& modelParameters,
-      const SkeletonStateT<T>& state,
-      const MeshStateT<T>& meshState,
-      int vertexIndex,
-      const Eigen::Vector3<T>& gradientDirection,
-      Eigen::Ref<Eigen::VectorX<T>> gradient) const;
-
-  /// Calculate jacobian contribution from a single vertex
-  void calculateVertexJacobian(
-      const ModelParametersT<T>& modelParameters,
-      const SkeletonStateT<T>& state,
-      const MeshStateT<T>& meshState,
-      int vertexIndex,
-      const Eigen::Vector3<T>& jacobianDirection,
-      Eigen::Ref<Eigen::MatrixX<T>> jacobian) const;
-
-  /// Calculate world space position derivative for blend shape parameters
-  void calculateDWorldPos(
-      const SkeletonStateT<T>& state,
-      int vertexIndex,
-      const Eigen::Vector3<T>& d_restPos,
-      Eigen::Vector3<T>& d_worldPos) const;
-
   const Character& character_;
 
   std::vector<VertexVertexDistanceConstraintT<T>> constraints_;

--- a/momentum/io/bvh/bvh_io.cpp
+++ b/momentum/io/bvh/bvh_io.cpp
@@ -86,6 +86,7 @@ const char* channelTypeName(BvhChannel ch) {
     case BvhChannel::Zrotation:
       return "Zrotation";
   }
+  MT_THROW("Invalid BVH channel: {}", static_cast<int>(ch));
 }
 
 // Returns the Eigen axis index for a rotation channel (0=X, 1=Y, 2=Z)
@@ -102,6 +103,7 @@ int rotationAxisIndex(BvhChannel ch) {
     case BvhChannel::Zposition:
       MT_THROW("Not a rotation channel");
   }
+  MT_THROW("Invalid BVH channel: {}", static_cast<int>(ch));
 }
 
 // Returns the joint parameter index for a position channel (TX=0, TY=1, TZ=2)
@@ -118,6 +120,7 @@ int positionParameterIndex(BvhChannel ch) {
     case BvhChannel::Zrotation:
       MT_THROW("Not a position channel");
   }
+  MT_THROW("Invalid BVH channel: {}", static_cast<int>(ch));
 }
 
 bool isRotationChannel(BvhChannel ch) {

--- a/momentum/io/common/json_utils.cpp
+++ b/momentum/io/common/json_utils.cpp
@@ -265,7 +265,7 @@ ParameterTransform parameterTransformFromJson(const Character& character, const 
 
           // add triplet
           triplets.emplace_back(
-              static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
+              static_cast<int>(jointIndex * kParametersPerJoint + attributeIndex),
               static_cast<int>(parameterIndex),
               weight);
         }

--- a/momentum/io/skeleton/parameter_transform_io.cpp
+++ b/momentum/io/skeleton/parameter_transform_io.cpp
@@ -220,7 +220,7 @@ void parseParameter(
 
       // add triplet
       triplets.emplace_back(
-          static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
+          static_cast<int>(jointIndex * kParametersPerJoint + attributeIndex),
           static_cast<int>(parameterIndex),
           weight);
     } else if (
@@ -233,7 +233,7 @@ void parseParameter(
         const auto& t = triplets[tr];
         if (static_cast<size_t>(t.row()) == refJointId) {
           triplets.emplace_back(
-              static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
+              static_cast<int>(jointIndex * kParametersPerJoint + attributeIndex),
               static_cast<int>(t.col()),
               t.value() * weight);
         }
@@ -241,7 +241,7 @@ void parseParameter(
     } else if (parameterIndex != kInvalidIndex) {
       // add triplet
       triplets.emplace_back(
-          static_cast<int>(jointIndex) * kParametersPerJoint + static_cast<int>(attributeIndex),
+          static_cast<int>(jointIndex * kParametersPerJoint + attributeIndex),
           static_cast<int>(parameterIndex),
           weight);
     } else {

--- a/momentum/marker_tracking/glove_utils.cpp
+++ b/momentum/marker_tracking/glove_utils.cpp
@@ -82,7 +82,7 @@ Character addGloveBones(
     }
 
     // Resize the transform matrix rows for the new joint (no new columns)
-    const int newRows = static_cast<int>(newSkel.joints.size()) * kParametersPerJoint;
+    const int newRows = static_cast<int>(newSkel.joints.size() * kParametersPerJoint);
     const int curCols = static_cast<int>(newTransform.name.size());
     newTransform.transform.conservativeResize(newRows, curCols);
   }
@@ -121,8 +121,7 @@ Character addGloveCalibrationParameters(
     // Add 6 DOF parameters (TX, TY, TZ, RX, RY, RZ) for this glove bone
     for (size_t d = 0; d < 6; ++d) {
       const std::string paramName = gloveBoneName + dofNames[d];
-      const auto row =
-          static_cast<int>(jointIdx) * kParametersPerJoint + static_cast<int>(dofIndices[d]);
+      const int row = static_cast<int>(jointIdx * kParametersPerJoint + dofIndices[d]);
       const auto col = static_cast<int>(newTransform.name.size());
 
       triplets.emplace_back(row, col, 1.0f);
@@ -139,7 +138,7 @@ Character addGloveCalibrationParameters(
   newTransform.parameterSets["gloves"] = gloveSet;
 
   // Update the parameter transform matrix
-  const int newRows = static_cast<int>(newSkel.joints.size()) * kParametersPerJoint;
+  const int newRows = static_cast<int>(newSkel.joints.size() * kParametersPerJoint);
   const int newCols = static_cast<int>(newTransform.name.size());
   newTransform.transform.conservativeResize(newRows, newCols);
   SparseRowMatrixf additionalTransforms(newRows, newCols);

--- a/momentum/marker_tracking/tracker_utils.cpp
+++ b/momentum/marker_tracking/tracker_utils.cpp
@@ -672,7 +672,7 @@ Character createLocatorCharacter(const Character& sourceCharacter, const std::st
       }
       const std::string jname = joint.name + tNames[j];
       triplets.emplace_back(
-          static_cast<int>(id) * kParametersPerJoint + static_cast<int>(j),
+          static_cast<int>(id * kParametersPerJoint + j),
           static_cast<int>(newTransform.name.size()),
           1.0f);
       MT_CHECK(

--- a/momentum/math/online_householder_qr.cpp
+++ b/momentum/math/online_householder_qr.cpp
@@ -106,7 +106,7 @@ std::pair<T, T> computeHouseholderVec(
 {
   const T sigma = vec.squaredNorm();
   if (sigma == 0) {
-    return {0, x1};
+    return {T(0), x1};
   }
 
   const T mu = std::sqrt(sqr(x1) + sigma);

--- a/momentum/rasterizer/geometry.cpp
+++ b/momentum/rasterizer/geometry.cpp
@@ -70,7 +70,9 @@ Mesh mergeMeshes(const std::initializer_list<Mesh>& meshes) {
     // Add faces with offset
     for (const auto& face : m.faces) {
       result.faces.emplace_back(
-          face.x() + vertOffset, face.y() + vertOffset, face.z() + vertOffset);
+          static_cast<int>(face.x() + vertOffset),
+          static_cast<int>(face.y() + vertOffset),
+          static_cast<int>(face.z() + vertOffset));
     }
   }
 
@@ -181,7 +183,7 @@ Mesh makeCylinderCap(int numCircleSubdivisions, bool top, float radius = 1.0) {
   const Eigen::Vector3f normal = (top ? 1.0f : -1.0f) * Eigen::Vector3f::UnitX();
 
   // Add center vertex
-  result.vertices.emplace_back(xValue, 0, 0);
+  result.vertices.emplace_back(xValue, 0.0f, 0.0f);
   result.normals.push_back(normal);
 
   // Add circle vertices
@@ -305,8 +307,9 @@ Mesh makeCapsule(
 
   // Build the main cylinder body vertices
   size_t vertexOffset = 0;
-  auto vertexIndex = [&](int iLength, int jRadius) {
-    return vertexOffset + iLength * numCircleSubdivisions + (jRadius % numCircleSubdivisions);
+  auto vertexIndex = [&](int iLength, int jRadius) -> int {
+    return static_cast<int>(
+        vertexOffset + iLength * numCircleSubdivisions + (jRadius % numCircleSubdivisions));
   };
 
   // Build the vertices along the length:
@@ -461,8 +464,9 @@ Mesh makeArrowhead(
   //     \ |/______________|__ x axis
   const float normalX = -(endRadius - startRadius) / length;
 
-  auto vertexIndex = [&](int iLength, int jRadius) {
-    return vertexOffset + iLength * numCircleSubdivisions + (jRadius % numCircleSubdivisions);
+  auto vertexIndex = [&](int iLength, int jRadius) -> int {
+    return static_cast<int>(
+        vertexOffset + iLength * numCircleSubdivisions + (jRadius % numCircleSubdivisions));
   };
 
   // Build the vertices along the length:
@@ -506,13 +510,13 @@ Mesh makeArrowhead(
     const int iCircleNext = (iCircle + 1) % numCircleSubdivisions;
 
     result.faces.emplace_back(
-        vertexOffset + 2 * iCircle + 0,
-        vertexOffset + 2 * iCircleNext + 0,
-        vertexOffset + 2 * iCircle + 1);
+        static_cast<int>(vertexOffset + 2 * iCircle + 0),
+        static_cast<int>(vertexOffset + 2 * iCircleNext + 0),
+        static_cast<int>(vertexOffset + 2 * iCircle + 1));
     result.faces.emplace_back(
-        vertexOffset + 2 * iCircle + 1,
-        vertexOffset + 2 * iCircleNext + 0,
-        vertexOffset + 2 * iCircleNext + 1);
+        static_cast<int>(vertexOffset + 2 * iCircle + 1),
+        static_cast<int>(vertexOffset + 2 * iCircleNext + 0),
+        static_cast<int>(vertexOffset + 2 * iCircleNext + 1));
   }
 
   return result;
@@ -583,7 +587,7 @@ std::array<Mesh, 2> makeCheckerboard(float width, int numChecks, int subdivision
             const float xPos = xPositions.at(iCheck * subdivisions + iSubd);
             const float zPos = xPositions.at(jCheck * subdivisions + jSubd);
 
-            positions.emplace_back(xPos, 0, zPos);
+            positions.emplace_back(xPos, 0.0f, zPos);
 
             if (iSubd >= 1 && jSubd >= 1) {
               triangles.emplace_back(
@@ -679,10 +683,10 @@ std::tuple<Mesh, std::vector<Eigen::Vector3f>> makeOctahedron(float radius, floa
     const Eigen::Vector3f p_cur = midPoints[iSide];
     const Eigen::Vector3f p_next = midPoints[(iSide + 1) % 4];
 
-    lines.emplace_back(0, 0, 0);
+    lines.emplace_back(0.0f, 0.0f, 0.0f);
     lines.push_back(midPoints[iSide]);
     lines.push_back(midPoints[iSide]);
-    lines.emplace_back(1, 0, 0);
+    lines.emplace_back(1.0f, 0.0f, 0.0f);
 
     {
       // left triangle:
@@ -837,7 +841,8 @@ struct ExtendableTriangleMesh {
     }
 
     bool inserted = false;
-    std::tie(edgeItr, inserted) = edgeVerts.insert(std::make_pair(edge, vertices.size()));
+    std::tie(edgeItr, inserted) =
+        edgeVerts.insert(std::make_pair(edge, static_cast<int>(vertices.size())));
     vertices.push_back(blend(vertices.at(edge.first), vertices.at(edge.second)));
     return edgeItr->second;
   }

--- a/momentum/test/character/character_utility_test.cpp
+++ b/momentum/test/character/character_utility_test.cpp
@@ -1197,9 +1197,12 @@ Character createTestCharacterWithConstrainedJoints() {
   // Set up identity transform matrix (for simplicity, each joint param maps to itself)
   std::vector<Eigen::Triplet<float>> triplets;
   for (size_t i = 0; i < numJoints; ++i) {
-    triplets.emplace_back(i * kParametersPerJoint + 4, i * 3 + 0, 1.0f); // Y rotation
-    triplets.emplace_back(i * kParametersPerJoint + 3, i * 3 + 1, 1.0f); // X rotation
-    triplets.emplace_back(i * kParametersPerJoint + 5, i * 3 + 2, 1.0f); // Z rotation
+    triplets.emplace_back(
+        static_cast<int>(i * kParametersPerJoint + 4), static_cast<int>(i * 3 + 0), 1.0f); // Y rot
+    triplets.emplace_back(
+        static_cast<int>(i * kParametersPerJoint + 3), static_cast<int>(i * 3 + 1), 1.0f); // X rot
+    triplets.emplace_back(
+        static_cast<int>(i * kParametersPerJoint + 5), static_cast<int>(i * 3 + 2), 1.0f); // Z rot
   }
   parameterTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
 

--- a/momentum/test/character_solver/collision_error_function_test.cpp
+++ b/momentum/test/character_solver/collision_error_function_test.cpp
@@ -131,15 +131,15 @@ std::pair<Skeleton, ParameterTransform> makeScalableDoubleBranchSkeletonAndTrans
   pt.offsets = Eigen::VectorXf::Zero(numJointParams);
   pt.transform.resize(numJointParams, static_cast<int>(pt.name.size()));
   std::vector<Eigen::Triplet<float>> triplets;
-  triplets.emplace_back(0 * kParametersPerJoint + 0, 0, 1.0f); // root_tx
-  triplets.emplace_back(0 * kParametersPerJoint + 1, 1, 1.0f); // root_ty
-  triplets.emplace_back(0 * kParametersPerJoint + 2, 2, 1.0f); // root_tz
-  triplets.emplace_back(0 * kParametersPerJoint + 3, 3, 1.0f); // root_rx
-  triplets.emplace_back(0 * kParametersPerJoint + 4, 4, 1.0f); // root_ry
-  triplets.emplace_back(0 * kParametersPerJoint + 5, 5, 1.0f); // root_rz
-  triplets.emplace_back(0 * kParametersPerJoint + 6, 6, 1.0f); // scale_global
-  triplets.emplace_back(1 * kParametersPerJoint + 5, 7, 1.0f); // joint1_rz
-  triplets.emplace_back(3 * kParametersPerJoint + 5, 8, 1.0f); // joint3_rz
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 0), 0, 1.0f); // root_tx
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 1), 1, 1.0f); // root_ty
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 2), 2, 1.0f); // root_tz
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 3), 3, 1.0f); // root_rx
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 4), 4, 1.0f); // root_ry
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 5), 5, 1.0f); // root_rz
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 6), 6, 1.0f); // scale_global
+  triplets.emplace_back(static_cast<int>(1 * kParametersPerJoint + 5), 7, 1.0f); // joint1_rz
+  triplets.emplace_back(static_cast<int>(3 * kParametersPerJoint + 5), 8, 1.0f); // joint3_rz
   pt.transform.setFromTriplets(triplets.begin(), triplets.end());
   pt.activeJointParams = pt.computeActiveJointParams();
 
@@ -468,7 +468,7 @@ TYPED_TEST(Momentum_ErrorFunctionsTest, BoxCollisionError_ProducesError) {
   rootYTransform.offsets = Eigen::VectorXf::Zero(numJointParams);
   rootYTransform.transform.resize(numJointParams, 1);
   std::vector<Eigen::Triplet<float>> triplets;
-  triplets.emplace_back(0 * kParametersPerJoint + 1, 0, 1.0f);
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 1), 0, 1.0f);
   rootYTransform.transform.setFromTriplets(triplets.begin(), triplets.end());
   rootYTransform.activeJointParams = rootYTransform.computeActiveJointParams();
 

--- a/momentum/test/character_solver/plane_collision_error_function_test.cpp
+++ b/momentum/test/character_solver/plane_collision_error_function_test.cpp
@@ -29,7 +29,7 @@ ParameterTransform makeRootYTransform(size_t numJoints) {
   transform.offsets = Eigen::VectorXf::Zero(numJointParams);
   transform.transform.resize(numJointParams, 1);
   std::vector<Eigen::Triplet<float>> triplets;
-  triplets.emplace_back(0 * kParametersPerJoint + 1, 0, 1.0f);
+  triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + 1), 0, 1.0f);
   transform.transform.setFromTriplets(triplets.begin(), triplets.end());
   transform.activeJointParams = transform.computeActiveJointParams();
   return transform;
@@ -61,7 +61,7 @@ ParameterTransform makeRootSevenDofTransform(size_t numJoints) {
   transform.transform.resize(numJointParams, kParametersPerJoint);
   std::vector<Eigen::Triplet<float>> triplets;
   for (size_t i = 0; i < kParametersPerJoint; ++i) {
-    triplets.emplace_back(0 * kParametersPerJoint + i, i, 1.0f);
+    triplets.emplace_back(static_cast<int>(0 * kParametersPerJoint + i), static_cast<int>(i), 1.0f);
   }
   transform.transform.setFromTriplets(triplets.begin(), triplets.end());
   transform.activeJointParams = transform.computeActiveJointParams();

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -4,6 +4,20 @@
 # LICENSE file in the root directory of this source tree.
 
 #===============================================================================
+# MSVC warning suppression
+#===============================================================================
+
+# PyMomentum links against LibTorch, whose headers trigger a large volume of
+# MSVC C4267/C4244 "possible loss of data" (size_t -> int) warnings from
+# template instantiations we do not control. Silence them for the pymomentum
+# targets defined in this directory so they do not drown out actionable
+# warnings. Momentum core (which does not depend on torch) fixes these at the
+# source instead.
+if(MSVC)
+  add_compile_options(/wd4267 /wd4244)
+endif()
+
+#===============================================================================
 # Find dependencies
 #===============================================================================
 


### PR DESCRIPTION
Summary:
The Windows (MSVC) build emits a large volume of compiler warnings. This diff reduces them across several categories:

1. C4267/C4244 "possible loss of data" from LibTorch headers (the bulk of the noise). These come from template instantiations inside third-party torch headers that we do not control and cannot fix at the source. Suppress C4267/C4244 for the pymomentum targets via `add_compile_options(/wd4267 /wd4244)` (MSVC-only). The suppression is scoped to the pymomentum directory, so momentum core -- which does not depend on torch -- still surfaces and fixes its own warnings.

2. C4267/C4244 narrowing in momentum core and tests. These are genuine `size_t`/`Eigen::Index` -> `int` conversions at Eigen `Triplet` and fixed-size integer-vector (`Vector3i`/`Vector3f`) construction sites, now made explicit by casting the full expression to `int` (or using float literals). Several pre-existing `static_cast<int>(x)` casts were ineffective because `int * kParametersPerJoint` (a `size_t`) re-widens the whole expression back to `size_t`; casting the entire expression is what removes the warning. All of these conversions are numerically no-ops.

3. C4661 "no suitable definition provided for explicit template instantiation" in `sdf_collision_error_function` and `vertex_vertex_distance_error_function`. Caused by declaration-only private methods that were never defined or called (an `organizeVerticesByBone` overload in the former; `calculateVertexGradient`, `calculateVertexJacobian`, and `calculateDWorldPos` in the latter). Removed the dead declarations.

4. C4715 "not all control paths return a value" in `bvh_io`. The enum `switch` statements cover every enumerator, but MSVC does not treat a `switch` without a `default` as exhaustive, so the "no case matched" path fell off the end. Added a trailing `MT_THROW` (which is `[[noreturn]]`) after each switch.

Differential Revision: D113863072


