### PR TITLE
Silence numpy/torch warnings in camera and diff_geometry tests

### DIFF
--- a/pymomentum/test/test_camera.py
+++ b/pymomentum/test/test_camera.py
@@ -456,7 +456,7 @@ class TestCamera(unittest.TestCase):
         theta_d = theta * (
             1.0 + k1 * theta2 + k2 * theta2**2 + k3 * theta2**3 + k4 * theta2**4
         )
-        scale = np.where(r > 1e-8, theta_d / r, 1.0)
+        scale = np.where(r > 1e-8, theta_d / np.where(r > 1e-8, r, 1.0), 1.0)
         u_ref = fx_val * scale * a + cx_val
         v_ref = fy_val * scale * b + cy_val
 

--- a/pymomentum/test/test_diff_geometry.py
+++ b/pymomentum/test/test_diff_geometry.py
@@ -95,7 +95,10 @@ class TestDiffGeometry(unittest.TestCase):
         nBatch = 2
         # Some nonzero vector as 0 always maps to 0 in momentum:
         modelParams = 0.3 * torch.ones(
-            nBatch, character.parameter_transform.size, requires_grad=AUTOGRAD_ENABLED
+            nBatch,
+            character.parameter_transform.size,
+            requires_grad=AUTOGRAD_ENABLED,
+            dtype=torch.float64,
         )
         jointParams = pym_diff_geometry.apply_parameter_transform(
             character, modelParams


### PR DESCRIPTION
Summary:
Two pymomentum unit tests emitted warnings on CI (surfaced by the OSS Windows pytest run):

1. `test_camera.py::test_fisheye_matches_numpy_reference` -- `RuntimeWarning: invalid value encountered in divide`. The numpy reference computed `np.where(r > 1e-8, theta_d / r, 1.0)`, but `np.where` evaluates both branches eagerly, so `theta_d / r` divided by zero for the on-axis point (`r == 0`). The bad values were discarded by the `where`, but the warning still fired. Guard the divisor with an inner `np.where` so the division never sees zero.

2. `test_diff_geometry.py::test_diffInverseParamTransform` -- `UserWarning` from `torch.autograd.gradcheck` about a non-double-precision input. The test built `modelParams` as float32 (missing `dtype=torch.float64`), so the derived `jointParams` passed to `gradcheck` was single precision, making the finite-difference check unreliable. Every other gradcheck test in the file already uses float64; add the missing dtype to match.

Both are test-only changes; no library behavior changes.

Differential Revision: D113866040


