### PR TITLE
Handle duplicate character names in scene builders

### DIFF
--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -15,6 +15,7 @@ common_public_headers = [
     "common/log_channel.h",
     "common/log.h",
     "common/memory.h",
+    "common/name_utils.h",
     "common/profile.h",
     "common/string.h",
 ]

--- a/momentum/common/name_utils.h
+++ b/momentum/common/name_utils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace momentum {
+
+/// Return a name that is unique within a set of existing names.
+///
+/// If @p requestedName is not already present in @p existingNames it is returned unchanged.
+/// Otherwise a numeric suffix is appended ("name_1", "name_2", ...) until an unused name is found.
+///
+/// @param requestedName The desired name.
+/// @param existingNames Any container with a `find()` member returning an end-comparable iterator
+///   (e.g. std::unordered_map / std::set keyed by name).
+/// @return The first name not present in @p existingNames.
+template <typename T>
+std::string makeUniqueName(const std::string& requestedName, const T& existingNames) {
+  if (existingNames.find(requestedName) == existingNames.end()) {
+    return requestedName;
+  }
+
+  for (std::size_t suffix = 1;; ++suffix) {
+    std::string candidate = requestedName + "_" + std::to_string(suffix);
+    if (existingNames.find(candidate) == existingNames.end()) {
+      return candidate;
+    }
+  }
+}
+
+} // namespace momentum

--- a/momentum/io/fbx/fbx_builder.cpp
+++ b/momentum/io/fbx/fbx_builder.cpp
@@ -8,11 +8,13 @@
 #include "momentum/io/fbx/fbx_builder.h"
 
 #include "momentum/common/exception.h"
+#include "momentum/common/log.h"
 
 #ifdef MOMENTUM_WITH_FBX_SDK
 
 #include "momentum/character/character.h"
 #include "momentum/character/character_state.h"
+#include "momentum/common/name_utils.h"
 #include "momentum/io/fbx/fbx_io_internal.h"
 
 #include <unordered_map>
@@ -20,6 +22,23 @@
 namespace momentum {
 
 using namespace fbx_internal; // NOLINT(google-build-using-namespace)
+
+namespace {
+
+void prefixSkeletonNodeNames(
+    const std::string& prefix,
+    const std::vector<::fbxsdk::FbxNode*>& nodes) {
+  for (auto* node : nodes) {
+    MT_THROW_IF(node == nullptr, "Cannot rename a null FBX node");
+    const std::string prefixedName = prefix + ":" + node->GetName();
+    node->SetName(prefixedName.c_str());
+    if (auto* attribute = node->GetNodeAttribute()) {
+      attribute->SetName(prefixedName.c_str());
+    }
+  }
+}
+
+} // namespace
 
 struct FbxBuilder::Impl {
   struct CharacterData {
@@ -30,7 +49,25 @@ struct FbxBuilder::Impl {
 
   ::fbxsdk::FbxManager* manager = nullptr;
   ::fbxsdk::FbxScene* scene = nullptr;
+
+  // --- Character name model (read before changing name handling) ---
+  // Every added character/rigid body is stored in `characters` under a UNIQUE *exported* name (the
+  // map key). The exported name is derived from a requested name -- character.name for
+  // addCharacter, or the `name` argument (falling back to character.name) for addRigidBody -- and
+  // is made unique by makeUniqueName(), which appends a numeric suffix ("name_1", ...) on
+  // collision. Because of the addRigidBody `name` override AND suffixing, the exported name is
+  // frequently NOT equal to character.name: character.name is the *source* name, not the identity.
+  // addCharacter/ addRigidBody RETURN the exported name; callers pass it back as `characterName` to
+  // addMotion* to target a specific character -- required for instancing (the same Character object
+  // added more than once) or whenever the name was overridden/suffixed.
+  //
+  // `exportedNameBySourceName` maps source name (character.name) -> exported name, FIRST-WINS
+  // (never overwritten). It lets addMotion* resolve an EMPTY characterName back to a character even
+  // when the exported name differs from character.name (e.g. an addRigidBody `name` override).
+  // First-wins (not latest-wins) makes an empty characterName deterministically resolve to the
+  // *name-owner* -- the first character added under that source name -- never a later duplicate.
   std::unordered_map<std::string, CharacterData> characters;
+  std::unordered_map<std::string, std::string> exportedNameBySourceName;
 
   Impl() {
     manager = ::fbxsdk::FbxManager::Create();
@@ -54,6 +91,38 @@ struct FbxBuilder::Impl {
   Impl& operator=(const Impl&) = delete;
   Impl(Impl&&) = delete;
   Impl& operator=(Impl&&) = delete;
+
+  // Resolve which stored character an addMotion* call targets (see the "Character name model" note
+  // above) and validate that its skeleton matches `character`. Returns the stored CharacterData.
+  CharacterData& resolveCharacterForMotion(
+      const Character& character,
+      const std::string& characterName) {
+    std::string resolvedCharacterName = characterName;
+    if (resolvedCharacterName.empty()) {
+      const auto sourceIt = exportedNameBySourceName.find(character.name);
+      MT_THROW_IF(
+          sourceIt == exportedNameBySourceName.end(),
+          "Character '{}' has not been added to the builder",
+          character.name);
+      resolvedCharacterName = sourceIt->second;
+    }
+
+    const auto it = characters.find(resolvedCharacterName);
+    MT_THROW_IF(
+        it == characters.end(),
+        "Character '{}' has not been added to the builder",
+        resolvedCharacterName);
+
+    MT_THROW_IF(
+        it->second.skeletonResult.nodes.size() != character.skeleton.joints.size(),
+        "Character '{}' ({} joints) does not match exported character '{}' ({} skeleton nodes). When multiple characters share a name, pass the exact name returned by addCharacter/addRigidBody.",
+        character.name,
+        character.skeleton.joints.size(),
+        resolvedCharacterName,
+        it->second.skeletonResult.nodes.size());
+
+    return it->second;
+  }
 };
 
 FbxBuilder::FbxBuilder() : impl_(std::make_unique<Impl>()) {}
@@ -64,9 +133,15 @@ FbxBuilder::FbxBuilder(FbxBuilder&&) noexcept = default;
 
 FbxBuilder& FbxBuilder::operator=(FbxBuilder&&) noexcept = default;
 
-void FbxBuilder::addCharacter(const Character& character, const FileSaveOptions& options) {
+std::string FbxBuilder::addCharacter(const Character& character, const FileSaveOptions& options) {
   MT_THROW_IF(!impl_, "FbxBuilder has been moved from or already saved");
   MT_THROW_IF(!impl_->scene, "FBX scene is null");
+
+  std::string characterName = makeUniqueName(character.name, impl_->characters);
+  if (characterName != character.name) {
+    MT_LOGW(
+        "Character name '{}' is already in use; exporting as '{}'.", character.name, characterName);
+  }
 
   auto* root = impl_->scene->GetRootNode();
   MT_THROW_IF(root == nullptr, "Unable to get root node from FBX scene");
@@ -77,7 +152,10 @@ void FbxBuilder::addCharacter(const Character& character, const FileSaveOptions&
 
   // Create skeleton hierarchy
   auto skeletonResult = createSkeletonNodes(character, impl_->scene);
-  addMetaData(skeletonResult.rootNode, character);
+  if (characterName != character.name) {
+    prefixSkeletonNodeNames(characterName, skeletonResult.nodes);
+  }
+  addMetaData(skeletonResult.rootNode, character, characterName);
   addPhysicalProperties(character, skeletonResult.jointToNodeMap);
 
   if (options.locators) {
@@ -90,8 +168,10 @@ void FbxBuilder::addCharacter(const Character& character, const FileSaveOptions&
   // Create mesh with blend shapes (parented to scene root = skinned)
   MeshBlendShapeResult meshResult;
   if (options.mesh && character.mesh != nullptr) {
+    const std::string meshName =
+        characterName == character.name ? "body_mesh" : characterName + "_mesh";
     meshResult = createMeshNode(
-        character, impl_->scene, root, skeletonResult.jointToNodeMap, options.permissive);
+        character, impl_->scene, root, skeletonResult.jointToNodeMap, options.permissive, meshName);
   }
 
   // Add skeleton to scene root
@@ -100,11 +180,17 @@ void FbxBuilder::addCharacter(const Character& character, const FileSaveOptions&
   }
 
   // Store character data for later animation
-  const std::string& name = character.name;
-  impl_->characters[name] = {std::move(skeletonResult), std::move(meshResult), name};
+  impl_->characters[characterName] = {
+      .skeletonResult = std::move(skeletonResult),
+      .meshResult = std::move(meshResult),
+      .name = characterName};
+  // First-wins: record source name -> exported name so an empty characterName in addMotion*
+  // resolves to the first character added under this source name (see FbxBuilder::Impl).
+  impl_->exportedNameBySourceName.emplace(character.name, characterName);
+  return characterName;
 }
 
-void FbxBuilder::addRigidBody(
+std::string FbxBuilder::addRigidBody(
     const Character& character,
     const std::string& name,
     size_t parentJoint,
@@ -115,23 +201,22 @@ void FbxBuilder::addRigidBody(
   auto* root = impl_->scene->GetRootNode();
   MT_THROW_IF(root == nullptr, "Unable to get root node from FBX scene");
 
-  const std::string charName = name.empty() ? character.name : name;
+  const std::string requestedName = name.empty() ? character.name : name;
+  std::string characterName = makeUniqueName(requestedName, impl_->characters);
+  if (characterName != requestedName) {
+    MT_LOGW(
+        "Character name '{}' is already in use; exporting as '{}'.", requestedName, characterName);
+  }
 
   // Create skeleton hierarchy
   auto skeletonResult = createSkeletonNodes(character, impl_->scene);
-  addMetaData(skeletonResult.rootNode, character);
+  addMetaData(skeletonResult.rootNode, character, characterName);
   addPhysicalProperties(character, skeletonResult.jointToNodeMap);
 
-  // Prefix skeleton joint names with charName to avoid collisions when
+  // Prefix skeleton joint names with characterName to avoid collisions when
   // multiple rigid bodies share the scene (e.g. "root" -> "controller_l:root").
-  if (!name.empty()) {
-    for (auto* node : skeletonResult.nodes) {
-      std::string prefixed = charName + ":" + node->GetName();
-      node->SetName(prefixed.c_str());
-      if (auto* attr = node->GetNodeAttribute()) {
-        attr->SetName(prefixed.c_str());
-      }
-    }
+  if (!name.empty() || characterName != character.name) {
+    prefixSkeletonNodeNames(characterName, skeletonResult.nodes);
   }
 
   // Resolve which joint node to parent the mesh under
@@ -149,7 +234,7 @@ void FbxBuilder::addRigidBody(
     // Parent it under the target joint so it moves rigidly with that joint.
     const auto numVertices = static_cast<int>(character.mesh->vertices.size());
     ::fbxsdk::FbxNode* meshNode =
-        ::fbxsdk::FbxNode::Create(impl_->scene, (charName + "_mesh").c_str());
+        ::fbxsdk::FbxNode::Create(impl_->scene, (characterName + "_mesh").c_str());
     ::fbxsdk::FbxMesh* lMesh = ::fbxsdk::FbxMesh::Create(impl_->scene, "mesh");
     lMesh->SetControlPointCount(numVertices);
     lMesh->InitNormals(numVertices);
@@ -191,21 +276,25 @@ void FbxBuilder::addRigidBody(
     root->AddChild(skeletonResult.rootNode);
   }
 
-  impl_->characters[character.name] = {std::move(skeletonResult), std::move(meshResult), charName};
+  impl_->characters[characterName] = {
+      .skeletonResult = std::move(skeletonResult),
+      .meshResult = std::move(meshResult),
+      .name = characterName};
+  // First-wins: record source name -> exported name so an empty characterName in addMotion*
+  // resolves to the first character added under this source name (see FbxBuilder::Impl).
+  impl_->exportedNameBySourceName.emplace(character.name, characterName);
+  return characterName;
 }
 
 void FbxBuilder::addMotion(
     const Character& character,
     float fps,
     const MatrixXf& motion,
-    const VectorXf& offsets) {
+    const VectorXf& offsets,
+    const std::string& characterName) {
   MT_THROW_IF(!impl_, "FbxBuilder has been moved from or already saved");
 
-  auto it = impl_->characters.find(character.name);
-  MT_THROW_IF(
-      it == impl_->characters.end(),
-      "Character '{}' has not been added to the builder",
-      character.name);
+  const auto& charData = impl_->resolveCharacterForMotion(character, characterName);
 
   if (motion.cols() == 0) {
     return;
@@ -233,7 +322,6 @@ void FbxBuilder::addMotion(
     jointValues.col(f) = state.skeletonState.jointParameters.v;
   }
 
-  const auto& charData = it->second;
   if (jointValues.rows() == character.parameterTransform.numJointParameters()) {
     createAnimationCurves(
         character, impl_->scene, charData.skeletonResult.nodes, jointValues, fps, false);
@@ -255,20 +343,16 @@ void FbxBuilder::addMotion(
 void FbxBuilder::addMotionWithJointParams(
     const Character& character,
     float fps,
-    const MatrixXf& jointParams) {
+    const MatrixXf& jointParams,
+    const std::string& characterName) {
   MT_THROW_IF(!impl_, "FbxBuilder has been moved from or already saved");
 
-  auto it = impl_->characters.find(character.name);
-  MT_THROW_IF(
-      it == impl_->characters.end(),
-      "Character '{}' has not been added to the builder",
-      character.name);
+  const auto& charData = impl_->resolveCharacterForMotion(character, characterName);
 
   if (jointParams.cols() == 0) {
     return;
   }
 
-  const auto& charData = it->second;
   createAnimationCurves(
       character,
       impl_->scene,
@@ -456,23 +540,29 @@ FbxBuilder::FbxBuilder(FbxBuilder&&) noexcept = default;
 
 FbxBuilder& FbxBuilder::operator=(FbxBuilder&&) noexcept = default;
 
-void FbxBuilder::addCharacter(const Character&, const FileSaveOptions&) {
+std::string FbxBuilder::addCharacter(const Character&, const FileSaveOptions&) {
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 
-void FbxBuilder::addRigidBody(
+std::string
+FbxBuilder::addRigidBody(const Character&, const std::string&, size_t, const FileSaveOptions&) {
+  MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
+}
+
+void FbxBuilder::addMotion(
     const Character&,
-    const std::string&,
-    size_t,
-    const FileSaveOptions&) {
+    float,
+    const MatrixXf&,
+    const VectorXf&,
+    const std::string&) {
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 
-void FbxBuilder::addMotion(const Character&, float, const MatrixXf&, const VectorXf&) {
-  MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
-}
-
-void FbxBuilder::addMotionWithJointParams(const Character&, float, const MatrixXf&) {
+void FbxBuilder::addMotionWithJointParams(
+    const Character&,
+    float,
+    const MatrixXf&,
+    const std::string&) {
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 

--- a/momentum/io/fbx/fbx_builder.h
+++ b/momentum/io/fbx/fbx_builder.h
@@ -24,6 +24,17 @@ namespace momentum {
 /// skinned characters, rigid bodies, motions, and marker data. This is useful
 /// for creating scenes with multiple characters/objects in a single FBX file.
 ///
+/// @note A scene may hold multiple characters, but the momentum loaders cannot read a
+/// multi-character scene back as separate characters (all skeletons load as one merged
+/// Character). Names returned by addCharacter/addRigidBody are handles for use within this
+/// builder session, not persistent identifiers recoverable on reload.
+///
+/// @note Character identity is the *exported* name, not character.name. addCharacter/addRigidBody
+/// dedupe names (and addRigidBody accepts a `name` override), so the exported name they RETURN may
+/// differ from character.name. Pass that returned name as `characterName` to addMotion* to target a
+/// specific character or instance; an empty characterName resolves to the first character added
+/// under character.name.
+///
 /// Example usage:
 /// @code
 ///   FbxBuilder builder;
@@ -54,7 +65,12 @@ class FbxBuilder final {
   ///
   /// @param character The character to add.
   /// @param options File save options controlling mesh, locators, collisions.
-  void addCharacter(const Character& character, const FileSaveOptions& options = FileSaveOptions());
+  /// @return The name used for the exported character. Duplicate names receive a numeric suffix.
+  /// This returned name is a within-session handle: pass it as characterName to addMotion to target
+  /// this specific character. It is not a persistent identifier recoverable on reload.
+  std::string addCharacter(
+      const Character& character,
+      const FileSaveOptions& options = FileSaveOptions());
 
   /// Add a rigid body (skeleton + mesh parented to a joint, no skinning).
   ///
@@ -63,10 +79,14 @@ class FbxBuilder final {
   /// root, so it inherits the skeleton's animation without needing skin weights.
   ///
   /// @param character The character to add as a rigid body.
-  /// @param name Optional name override. Uses character.name if empty.
+  /// @param name Optional requested base name. Uses character.name if empty. A numeric suffix is
+  /// appended if the resulting name is already in use.
   /// @param parentJoint Index of the joint to parent the mesh under.
   /// @param options File save options (mesh option is respected).
-  void addRigidBody(
+  /// @return The name used for the exported rigid body. Duplicate names receive a numeric suffix.
+  /// Pass it as characterName to addMotion/addMotionWithJointParams to target this specific rigid
+  /// body.
+  std::string addRigidBody(
       const Character& character,
       const std::string& name = "",
       size_t parentJoint = 0,
@@ -82,11 +102,17 @@ class FbxBuilder final {
   /// @param fps Animation frame rate in frames per second.
   /// @param motion Model parameters matrix with shape (nFrames x nModelParams).
   /// @param offsets Identity/offset parameters for the bind pose.
+  /// @param characterName Exported name returned by addCharacter/addRigidBody, selecting which
+  /// exported character to animate. Pass it to target a specific instance when the same Character
+  /// object was added more than once, or a duplicate whose name was auto-suffixed. When empty,
+  /// resolves to the character exported under character.name (the first added under that name), and
+  /// throws if none exists.
   void addMotion(
       const Character& character,
       float fps,
       const MatrixXf& motion = {},
-      const VectorXf& offsets = {});
+      const VectorXf& offsets = {},
+      const std::string& characterName = "");
 
   /// Add joint-parameter animation for a previously added character.
   ///
@@ -96,7 +122,16 @@ class FbxBuilder final {
   /// @param character The character to animate (must match a previously added character).
   /// @param fps Animation frame rate in frames per second.
   /// @param jointParams Joint parameters matrix with shape (nFrames x nJointParams).
-  void addMotionWithJointParams(const Character& character, float fps, const MatrixXf& jointParams);
+  /// @param characterName Exported name returned by addCharacter/addRigidBody, selecting which
+  /// exported character to animate. Pass it to target a specific instance when the same Character
+  /// object was added more than once, or a duplicate whose name was auto-suffixed. When empty,
+  /// resolves to the character exported under character.name (the first added under that name), and
+  /// throws if none exists.
+  void addMotionWithJointParams(
+      const Character& character,
+      float fps,
+      const MatrixXf& jointParams,
+      const std::string& characterName = "");
 
   /// Add an animated mesh (mesh node with per-frame transform, no skeleton).
   ///

--- a/momentum/io/fbx/fbx_io_internal.h
+++ b/momentum/io/fbx/fbx_io_internal.h
@@ -214,14 +214,18 @@ inline void addPhysicalProperties(
 // Metadata, locators, collision geometry
 // ============================================================================
 
-inline void addMetaData(::fbxsdk::FbxNode* skeletonRootNode, const Character& character) {
+inline void addMetaData(
+    ::fbxsdk::FbxNode* skeletonRootNode,
+    const Character& character,
+    const std::string& characterName = "") {
   if (skeletonRootNode != nullptr) {
+    const std::string& exportedName = characterName.empty() ? character.name : characterName;
     ::fbxsdk::FbxProperty::Create(skeletonRootNode, ::fbxsdk::FbxStringDT, "metadata")
         .Set(FbxString(character.metadata.c_str()));
     ::fbxsdk::FbxProperty::Create(skeletonRootNode, ::fbxsdk::FbxStringDT, "name")
-        .Set(FbxString(character.name.c_str()));
+        .Set(FbxString(exportedName.c_str()));
     ::fbxsdk::FbxProperty::Create(skeletonRootNode, ::fbxsdk::FbxStringDT, "RigName")
-        .Set(FbxString(character.name.c_str()));
+        .Set(FbxString(exportedName.c_str()));
   }
 }
 

--- a/momentum/io/gltf/gltf_builder.cpp
+++ b/momentum/io/gltf/gltf_builder.cpp
@@ -17,6 +17,7 @@
 #include "momentum/common/exception.h"
 #include "momentum/common/filesystem.h"
 #include "momentum/common/log.h"
+#include "momentum/common/name_utils.h"
 #include "momentum/io/common/json_utils.h"
 #include "momentum/io/gltf/gltf_io.h"
 #include "momentum/io/gltf/utils/accessor_utils.h"
@@ -931,7 +932,24 @@ struct GltfBuilder::Impl {
 
   Impl();
   fx::gltf::Document document;
+
+  // --- Character name model (read before changing name handling) ---
+  // Every added character is stored in `characterData` under a UNIQUE *exported* name (the map
+  // key), derived from character.name and made unique by makeUniqueName(), which appends a numeric
+  // suffix
+  // ("name_1", ...) on collision. So the exported name is NOT equal to character.name when the same
+  // source name is added more than once: character.name is the *source* name, not the identity.
+  // addCharacter RETURNS the exported name; callers pass it back as `characterName` to addMotion/
+  // addSkeletonStates to target a specific character -- required for instancing (the same Character
+  // object added more than once) or whenever the name was suffixed.
+  //
+  // `exportedNameBySourceName` maps source name (character.name) -> exported name, FIRST-WINS
+  // (never overwritten). It lets addMotion/addSkeletonStates resolve an EMPTY characterName back to
+  // a character even when the exported name differs from character.name. First-wins (not
+  // latest-wins) makes an empty characterName deterministically resolve to the *name-owner* -- the
+  // first character added under that source name -- never a later duplicate.
   std::unordered_map<std::string, CharacterData> characterData;
+  std::unordered_map<std::string, std::string> exportedNameBySourceName;
   MarkerMesh markerMesh = MarkerMesh::None;
 };
 
@@ -950,20 +968,20 @@ GltfBuilder::GltfBuilder(GltfBuilder&&) noexcept = default;
 
 GltfBuilder& GltfBuilder::operator=(GltfBuilder&&) noexcept = default;
 
-void GltfBuilder::addCharacter(
+std::string GltfBuilder::addCharacter(
     const Character& character,
     const Vector3f& positionOffset /*= Vector3f::Zero()*/,
     const Quaternionf& rotationOffset /*= Quaternionf::Identity()*/,
     const FileSaveOptions& options) {
-  if (impl_->characterData.find(character.name) != impl_->characterData.end()) {
-    // Character already exist. Doesn't allow character with the same name to be saved.
-    // #TODO: proper warning
-    return;
+  std::string characterName = makeUniqueName(character.name, impl_->characterData);
+  if (characterName != character.name) {
+    MT_LOGW(
+        "Character name '{}' is already in use; exporting as '{}'.", character.name, characterName);
   }
   auto& scene = getDefaultScene(impl_->document);
 
   // Add character root node
-  const auto rootNodeIdx = appendNode(impl_->document, character.name);
+  const auto rootNodeIdx = appendNode(impl_->document, characterName);
   MT_CHECK(
       rootNodeIdx >= 0 && rootNodeIdx < impl_->document.nodes.size(),
       "{}: {}",
@@ -974,7 +992,11 @@ void GltfBuilder::addCharacter(
   node.translation = {translation[0], translation[1], translation[2]};
   node.rotation = fromMomentumQuaternionf(rotationOffset);
   scene.nodes.push_back(static_cast<uint32_t>(rootNodeIdx));
-  auto& characterData = impl_->characterData[character.name];
+  auto& characterData = impl_->characterData[characterName];
+  // First-wins: record source name -> exported name so an empty characterName in addMotion/
+  // addSkeletonStates resolves to the first character added under this source name (see
+  // GltfBuilder::Impl).
+  impl_->exportedNameBySourceName.emplace(character.name, characterName);
   characterData.rootIndex = rootNodeIdx;
 
   // fill with data
@@ -1010,6 +1032,8 @@ void GltfBuilder::addCharacter(
       def["metadata"] = character.metadata;
     }
   }
+
+  return characterName;
 }
 
 void GltfBuilder::addMesh(const Mesh& mesh, const std::string& name, bool addColor) {
@@ -1063,6 +1087,37 @@ void GltfBuilder::setFps(float fps) {
   }
 }
 
+std::string GltfBuilder::resolveCharacterForMotion(
+    const Character& character,
+    const std::string& characterName) {
+  // See the "Character name model" note on GltfBuilder::Impl. A non-empty characterName is used
+  // directly; an empty one resolves through exportedNameBySourceName to the first character added
+  // under character.name, auto-adding the character if none has been added yet.
+  std::string resolvedCharacterName = characterName;
+  if (resolvedCharacterName.empty()) {
+    const auto sourceIt = impl_->exportedNameBySourceName.find(character.name);
+    resolvedCharacterName = sourceIt != impl_->exportedNameBySourceName.end()
+        ? sourceIt->second
+        : addCharacter(character);
+  } else {
+    MT_THROW_IF(
+        impl_->characterData.find(resolvedCharacterName) == impl_->characterData.end(),
+        "Character '{}' has not been added to the builder",
+        resolvedCharacterName);
+  }
+
+  const auto& characterData = impl_->characterData.at(resolvedCharacterName);
+  MT_THROW_IF(
+      characterData.nodeMap.size() != character.skeleton.joints.size(),
+      "Character '{}' ({} joints) does not match exported character '{}' ({} nodes). When multiple characters share a name, pass the exact name returned by addCharacter.",
+      character.name,
+      character.skeleton.joints.size(),
+      resolvedCharacterName,
+      characterData.nodeMap.size());
+
+  return resolvedCharacterName;
+}
+
 void GltfBuilder::addMotion(
     const Character& character,
     const float fps /*= 120.0f*/,
@@ -1070,15 +1125,13 @@ void GltfBuilder::addMotion(
     const IdentityParameters& offsets /*= {}*/,
     const bool addExtensions /*= true*/,
     const std::string& customName /*= "default"*/,
-    std::span<const int64_t> timestamps /*= {}*/) {
+    std::span<const int64_t> timestamps /*= {}*/,
+    const std::string& characterName /*= ""*/) {
   setFps(fps);
-  if (impl_->characterData.find(character.name) == impl_->characterData.end()) {
-    // #TODO: Warn about this addition
-    addCharacter(character);
-  }
-
-  const auto& jointToNodeMap = impl_->characterData[character.name].nodeMap;
-  const size_t meshIndex = impl_->characterData[character.name].meshIndex;
+  const std::string resolvedCharacterName = resolveCharacterForMotion(character, characterName);
+  auto& characterData = impl_->characterData.at(resolvedCharacterName);
+  const auto& jointToNodeMap = characterData.nodeMap;
+  const size_t meshIndex = characterData.meshIndex;
   // add motion
   addMotionToModel(
       impl_->document,
@@ -1097,7 +1150,7 @@ void GltfBuilder::addMotion(
       [&customName](const fx::gltf::Animation& anim) { return anim.name == customName; });
   if (animIter != impl_->document.animations.end()) {
     const auto animIdx = static_cast<size_t>(animIter - impl_->document.animations.begin());
-    impl_->characterData[character.name].animationIndices.push_back(animIdx);
+    characterData.animationIndices.push_back(animIdx);
   }
 
   // Add timestamps to the FB_momentum extension
@@ -1180,14 +1233,12 @@ void GltfBuilder::addSkeletonStates(
     const Character& character,
     const float fps,
     std::span<const SkeletonState> skeletonStates,
-    const std::string& customName) {
+    const std::string& customName,
+    const std::string& characterName) {
   setFps(fps);
-  if (impl_->characterData.find(character.name) == impl_->characterData.end()) {
-    // #TODO: Warn about this addition
-    addCharacter(character);
-  }
-
-  const auto& jointToNodeMap = impl_->characterData[character.name].nodeMap;
+  const std::string resolvedCharacterName = resolveCharacterForMotion(character, characterName);
+  auto& characterData = impl_->characterData.at(resolvedCharacterName);
+  const auto& jointToNodeMap = characterData.nodeMap;
 
   // add motion from skeleton states
   addSkeletonStatesToModel(
@@ -1199,7 +1250,7 @@ void GltfBuilder::addSkeletonStates(
       [&customName](const fx::gltf::Animation& anim) { return anim.name == customName; });
   if (animIter != impl_->document.animations.end()) {
     const auto animIdx = static_cast<size_t>(animIter - impl_->document.animations.begin());
-    impl_->characterData[character.name].animationIndices.push_back(animIdx);
+    characterData.animationIndices.push_back(animIdx);
   }
 }
 

--- a/momentum/io/gltf/gltf_builder.h
+++ b/momentum/io/gltf/gltf_builder.h
@@ -30,6 +30,16 @@ using IdentityParameters = std::tuple<std::vector<std::string>, JointParameters>
 /// and motions for each character.
 /// By default, momentum extension is added to the glb nodes. This is required if you
 /// want to correctly load the exported character back.
+///
+/// @note A scene may hold multiple characters, but the momentum loaders can only read a
+/// single-character scene back (loading a multi-character scene throws or drops all but the
+/// first). Names returned by addCharacter are handles for use within this builder session, not
+/// persistent identifiers recoverable on reload.
+///
+/// @note Character identity is the *exported* name, not character.name. addCharacter dedupes names,
+/// so the exported name it RETURNS may differ from character.name. Pass that returned name as
+/// `characterName` to addMotion/addSkeletonStates to target a specific character or instance; an
+/// empty characterName resolves to the first character added under character.name.
 class GltfBuilder final {
  public:
   GltfBuilder();
@@ -50,7 +60,12 @@ class GltfBuilder final {
   /// Add a character to the scene. Each character will have a root node with the character's
   /// name as the parent of the skeleton root and the character mesh.
   /// positionOffset and rotationOffset can be provided as an initial offset to the character.
-  void addCharacter(
+  /// Duplicate names are made unique by appending a numeric suffix.
+  ///
+  /// @return The name used for the exported character. This is a within-session handle: pass it as
+  /// characterName to addMotion/addSkeletonStates to target this specific character. It is not a
+  /// persistent identifier recoverable on reload.
+  std::string addCharacter(
       const Character& character,
       const Vector3f& positionOffset = Vector3f::Zero(),
       const Quaternionf& rotationOffset = Quaternionf::Identity(),
@@ -71,6 +86,11 @@ class GltfBuilder final {
   /// @param[in] addExtensions Whether to add momentum extensions to the document.
   /// @param[in] customName Custom name for the animation (default is "default").
   /// @param[in] timestamps Per-frame timestamps. Size should match motion columns.
+  /// @param[in] characterName Exported name returned by addCharacter, selecting which exported
+  /// character to animate. Pass it to target a specific instance when the same Character object was
+  /// added more than once, or a duplicate whose name was auto-suffixed. When empty, resolves to the
+  /// character exported under character.name (the first added under that name); if none exists, the
+  /// character is auto-added with default settings.
   void addMotion(
       const Character& character,
       float fps = 120.0f,
@@ -78,15 +98,21 @@ class GltfBuilder final {
       const IdentityParameters& offsets = {},
       bool addExtensions = true,
       const std::string& customName = "default",
-      std::span<const int64_t> timestamps = {});
+      std::span<const int64_t> timestamps = {},
+      const std::string& characterName = "");
 
   /// Add a skeleton states to the provided character. If addCharacter is not called before adding
   /// the skeleton states, the character will be automatically added with the default settings.
+  ///
+  /// @param[in] characterName Exported name returned by addCharacter, selecting which exported
+  /// character to animate (see addMotion). When empty, resolves to the character exported under
+  /// character.name; if none exists, the character is auto-added with default settings.
   void addSkeletonStates(
       const Character& character,
       float fps,
       std::span<const SkeletonState> skeletonStates,
-      const std::string& customName = "default");
+      const std::string& customName = "default",
+      const std::string& characterName = "");
 
   /// Add marker data to the file
   ///
@@ -138,6 +164,14 @@ class GltfBuilder final {
   std::vector<size_t> getCharacterMotions(const std::string& characterName);
 
  private:
+  /// Resolve which exported character an addMotion/addSkeletonStates call targets (see the
+  /// "Character name model" note in gltf_builder.cpp) and validate its skeleton matches @p
+  /// character; returns the resolved exported name. For an empty @p characterName whose source name
+  /// was never added, the character is auto-added with default settings.
+  std::string resolveCharacterForMotion(
+      const Character& character,
+      const std::string& characterName);
+
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };

--- a/momentum/test/io/io_fbx_builder_test.cpp
+++ b/momentum/test/io/io_fbx_builder_test.cpp
@@ -15,6 +15,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 using namespace momentum;
 
 TEST(FbxBuilderTest, AddCharacter_RoundTripsNameAndMetadata) {
@@ -143,21 +145,32 @@ TEST(FbxBuilderTest, AddRigidBodyWithMotion) {
 
 TEST(FbxBuilderTest, MultipleCharacters) {
   Character body = createTestCharacter(5);
-  body.name = "body";
   Character prop = createTestCharacter(3);
-  prop.name = "prop";
+
+  const auto numPropJointParams =
+      static_cast<Eigen::Index>(prop.parameterTransform.numJointParameters());
+  const MatrixXf propJointParams = MatrixXf::Zero(numPropJointParams, 2);
 
   const auto outFile = temporaryFile("builder_multi", "fbx");
   {
     FbxBuilder builder;
-    builder.addCharacter(body);
-    builder.addRigidBody(prop, "prop");
+    const std::string bodyName = builder.addCharacter(body);
+    const std::string propName = builder.addRigidBody(prop);
+    EXPECT_EQ(bodyName, "test character");
+    EXPECT_EQ(propName, "test character_1");
+    builder.addMotionWithJointParams(prop, 30.0f, propJointParams, propName);
     builder.save(outFile.path());
   }
 
-  // The FBX should load without error; permissive because of the rigid body mesh
   const Character loaded = loadFbxCharacter(outFile.path(), KeepLocators::No, Permissive::Yes);
-  EXPECT_FALSE(loaded.skeleton.joints.empty());
+  EXPECT_EQ(
+      loaded.skeleton.joints.size(), body.skeleton.joints.size() + prop.skeleton.joints.size());
+  EXPECT_EQ(
+      std::count_if(
+          loaded.skeleton.joints.begin(),
+          loaded.skeleton.joints.end(),
+          [](const Joint& joint) { return joint.parent == kInvalidIndex; }),
+      2);
 }
 
 TEST(FbxBuilderTest, MarkerSequence) {
@@ -196,4 +209,90 @@ TEST(FbxBuilderTest, SaveConsumesBuilder) {
   // After save, the builder is consumed — further operations should throw
   EXPECT_THROW(builder.addCharacter(character), std::runtime_error);
   EXPECT_THROW(builder.save(outFile.path()), std::runtime_error);
+}
+
+TEST(FbxBuilderTest, DuplicateNamesGetSequentialSuffixes) {
+  FbxBuilder builder;
+  EXPECT_EQ(builder.addRigidBody(createTestCharacter(3)), "test character");
+  EXPECT_EQ(builder.addRigidBody(createTestCharacter(3)), "test character_1");
+  EXPECT_EQ(builder.addRigidBody(createTestCharacter(3)), "test character_2");
+}
+
+TEST(FbxBuilderTest, DuplicateSkinnedCharacterNamesArePrefixed) {
+  Character body = createTestCharacter(4);
+  Character other = createTestCharacter(6);
+
+  const auto outFile = temporaryFile("builder_dup_skinned", "fbx");
+  std::string name1;
+  std::string name2;
+  {
+    FbxBuilder builder;
+    name1 = builder.addCharacter(body);
+    name2 = builder.addCharacter(other);
+    EXPECT_EQ(name1, "test character");
+    EXPECT_EQ(name2, "test character_1");
+    builder.save(outFile.path());
+  }
+
+  // Load without stripping namespaces so the deduped second character's prefix is visible.
+  const Character loaded = loadFbxCharacter(
+      outFile.path(), KeepLocators::No, Permissive::Yes, LoadBlendShapes::No, false);
+  EXPECT_EQ(
+      loaded.skeleton.joints.size(), body.skeleton.joints.size() + other.skeleton.joints.size());
+  EXPECT_TRUE(
+      std::any_of(
+          loaded.skeleton.joints.begin(),
+          loaded.skeleton.joints.end(),
+          [&name2](const Joint& joint) { return joint.name.rfind(name2 + ":", 0) == 0; }));
+}
+
+TEST(FbxBuilderTest, AddMotionWrongExplicitNameThrows) {
+  Character body = createTestCharacter(5);
+  Character prop = createTestCharacter(3);
+
+  const auto numBodyJointParams =
+      static_cast<Eigen::Index>(body.parameterTransform.numJointParameters());
+  const auto numPropJointParams =
+      static_cast<Eigen::Index>(prop.parameterTransform.numJointParameters());
+  const MatrixXf bodyJointParams = MatrixXf::Zero(numBodyJointParams, 2);
+  const MatrixXf propJointParams = MatrixXf::Zero(numPropJointParams, 2);
+
+  FbxBuilder builder;
+  const std::string bodyName = builder.addCharacter(body);
+  const std::string propName = builder.addRigidBody(prop);
+  ASSERT_EQ(bodyName, "test character");
+  ASSERT_EQ(propName, "test character_1");
+
+  // Passing the explicit name of a different-skeleton character (the rigid body, 3 joints) while
+  // animating body (5 joints) must throw instead of indexing out of bounds.
+  EXPECT_THROW(
+      builder.addMotionWithJointParams(body, 30.0f, bodyJointParams, propName), std::exception);
+  // Empty characterName resolves to the character exported under character.name (body), which
+  // matches.
+  EXPECT_NO_THROW(builder.addMotionWithJointParams(body, 30.0f, bodyJointParams));
+  // Passing the exact returned name targets the correct character.
+  EXPECT_NO_THROW(builder.addMotionWithJointParams(prop, 30.0f, propJointParams, propName));
+}
+
+TEST(FbxBuilderTest, AddMotionUnknownCharacterThrows) {
+  Character character = createTestCharacter(3);
+  const auto numJointParams =
+      static_cast<Eigen::Index>(character.parameterTransform.numJointParameters());
+  const MatrixXf jointParams = MatrixXf::Zero(numJointParams, 2);
+
+  FbxBuilder builder;
+  EXPECT_THROW(builder.addMotionWithJointParams(character, 30.0f, jointParams), std::exception);
+  EXPECT_THROW(
+      builder.addMotionWithJointParams(character, 30.0f, jointParams, "nonexistent"),
+      std::exception);
+}
+
+TEST(FbxBuilderTest, DedupeSkipsNamesTakenByExplicitNames) {
+  FbxBuilder builder;
+  EXPECT_EQ(builder.addRigidBody(createTestCharacter(3), "dup_1"), "dup_1");
+  EXPECT_EQ(builder.addRigidBody(createTestCharacter(3), "dup"), "dup");
+  // The auto-generated "dup_1" is already taken, so the next free suffix is used.
+  EXPECT_EQ(builder.addRigidBody(createTestCharacter(3), "dup"), "dup_2");
+  // An explicit name colliding with an existing one is itself suffixed.
+  EXPECT_EQ(builder.addRigidBody(createTestCharacter(3), "dup_1"), "dup_1_1");
 }

--- a/pymomentum/geometry/fbx_builder_pybind.cpp
+++ b/pymomentum/geometry/fbx_builder_pybind.cpp
@@ -43,7 +43,8 @@ Creates the skeleton hierarchy, mesh with skin deformer, locators,
 collision geometry, and metadata.
 
 :param character: The character to add.
-:param options: File save options controlling mesh, locators, collisions.)",
+:param options: File save options controlling mesh, locators, collisions.
+:return: The exported character name. A numeric suffix is added when the requested name is already in use.)",
           py::arg("character"),
           py::arg("options") = mm::FileSaveOptions())
       .def(
@@ -56,10 +57,12 @@ The mesh is parented under the specified joint node instead of the scene
 root, so it inherits the skeleton's animation without needing skin weights.
 
 :param character: The character to add as a rigid body.
-:param name: Optional name override. Uses character.name if empty.
+:param name: Optional requested base name. Uses character.name if empty. A numeric
+    suffix is appended if the resulting name is already in use.
 :param parent_joint: Index of the joint to parent the mesh under. Defaults to 0
     (the root joint).
-:param options: File save options (mesh option is respected).)",
+:param options: File save options (mesh option is respected).
+:return: The exported rigid-body name. A numeric suffix is added when the requested name is already in use.)",
           py::arg("character"),
           py::arg("name") = "",
           py::arg("parent_joint") = 0,
@@ -70,7 +73,8 @@ root, so it inherits the skeleton's animation without needing skin weights.
              const mm::Character& character,
              float fps,
              const std::optional<Eigen::MatrixXf>& motion,
-             const std::optional<Eigen::VectorXf>& offsets) {
+             const std::optional<Eigen::VectorXf>& offsets,
+             const std::optional<std::string>& characterName) {
             // pymomentum convention: (nFrames x nParams), C++ convention: (nParams x nFrames)
             mm::MatrixXf transposedMotion;
             if (motion.has_value() && motion->size() > 0) {
@@ -80,7 +84,8 @@ root, so it inherits the skeleton's animation without needing skin weights.
             if (offsets.has_value()) {
               actualOffsets = offsets.value();
             }
-            builder.addMotion(character, fps, transposedMotion, actualOffsets);
+            builder.addMotion(
+                character, fps, transposedMotion, actualOffsets, characterName.value_or(""));
           },
           R"(Add model-parameter animation for a previously added character.
 
@@ -90,23 +95,27 @@ curves. Also extracts and animates blend shape weights when applicable.
 :param character: The character to animate (must match a previously added character).
 :param fps: Animation frame rate in frames per second.
 :param motion: Model parameters matrix with shape (nFrames, nModelParams). None for no animation.
-:param offsets: Identity/offset parameters for the bind pose. None to use default bind pose.)",
+:param offsets: Identity/offset parameters for the bind pose. None to use default bind pose.
+:param character_name: Exported name returned by :meth:`add_character` or :meth:`add_rigid_body`, selecting which exported character to animate. Pass it to target a specific instance when the same character was added more than once, or a duplicate whose name was auto-suffixed. When omitted, resolves to the character exported under the source name.)",
           py::arg("character"),
           py::arg("fps") = 120.0f,
           py::arg("motion") = std::nullopt,
-          py::arg("offsets") = std::nullopt)
+          py::arg("offsets") = std::nullopt,
+          py::arg("character_name") = std::nullopt)
       .def(
           "add_motion_with_joint_params",
           [](mm::FbxBuilder& builder,
              const mm::Character& character,
              float fps,
-             const std::optional<Eigen::MatrixXf>& jointParams) {
+             const std::optional<Eigen::MatrixXf>& jointParams,
+             const std::optional<std::string>& characterName) {
             // pymomentum convention: (nFrames x nParams), C++ convention: (nParams x nFrames)
             mm::MatrixXf transposedJointParams;
             if (jointParams.has_value() && jointParams->size() > 0) {
               transposedJointParams = jointParams->transpose();
             }
-            builder.addMotionWithJointParams(character, fps, transposedJointParams);
+            builder.addMotionWithJointParams(
+                character, fps, transposedJointParams, characterName.value_or(""));
           },
           R"(Add joint-parameter animation for a previously added character.
 
@@ -115,10 +124,12 @@ This is useful for rigid bodies or characters with simple parameterization.
 
 :param character: The character to animate (must match a previously added character).
 :param fps: Animation frame rate in frames per second.
-:param joint_params: Joint parameters matrix with shape (nFrames, nJointParams). None for no animation.)",
+:param joint_params: Joint parameters matrix with shape (nFrames, nJointParams). None for no animation.
+:param character_name: Exported name returned by :meth:`add_character` or :meth:`add_rigid_body`, selecting which exported character to animate. Pass it to target a specific instance when the same character was added more than once, or a duplicate whose name was auto-suffixed. When omitted, resolves to the character exported under the source name.)",
           py::arg("character"),
           py::arg("fps") = 120.0f,
-          py::arg("joint_params") = std::nullopt)
+          py::arg("joint_params") = std::nullopt,
+          py::arg("character_name") = std::nullopt)
       .def(
           "add_animated_mesh",
           [](mm::FbxBuilder& builder,

--- a/pymomentum/geometry/gltf_builder_pybind.cpp
+++ b/pymomentum/geometry/gltf_builder_pybind.cpp
@@ -96,7 +96,8 @@ Setting this value will affect subsequently added motions and animations.
                 actualRotationOffset[1], // y
                 actualRotationOffset[2]); // z
 
-            builder.addCharacter(character, actualPositionOffset, quaternionOffset, actualOptions);
+            return builder.addCharacter(
+                character, actualPositionOffset, quaternionOffset, actualOptions);
           },
           R"(Add a character to the GLTF scene.
 
@@ -107,10 +108,8 @@ can be provided as an initial transform for the character.
 :param character: The character to add to the scene.
 :param position_offset: Translation offset for the character's root node. Defaults to zero vector if None.
 :param rotation_offset: Rotation offset as a quaternion in (x,y,z,w) format. Defaults to identity quaternion if None.
-:param add_extensions: Whether to add momentum extensions to GLTF nodes.
-:param add_collisions: Whether to add collision geometry to the scene.
-:param add_locators: Whether to add locator data to the scene.
-:param add_mesh: Whether to add the character's mesh to the scene.)",
+:param options: File save options controlling extensions, collisions, locators, and meshes.
+:return: The exported character name. A numeric suffix is added when the requested name is already in use.)",
           py::arg("character"),
           py::arg("position_offset") = std::nullopt,
           py::arg("rotation_offset") = std::nullopt,
@@ -138,7 +137,8 @@ node in the scene with the specified name.
              const std::optional<mm::MotionParameters>& motion,
              const std::optional<std::tuple<std::vector<std::string>, Eigen::VectorXf>>& offsets,
              bool addExtensions,
-             const std::string& customName) {
+             const std::string& customName,
+             const std::optional<std::string>& characterName) {
             // Apply same validation and transposition as
             // saveGLTFCharacterToFile
             mm::MotionParameters transposedMotion;
@@ -164,7 +164,9 @@ node in the scene with the specified name.
                 pymomentum::transpose(motion.value_or(mm::MotionParameters{})),
                 identityParams,
                 addExtensions,
-                customName);
+                customName,
+                {},
+                characterName.value_or(""));
           },
           R"(Add a motion sequence to the specified character.
 
@@ -179,26 +181,30 @@ model parameters that animate the character over time.
 :param offsets: Optional identity parameters as a tuple of (joint_names, offset_data).
                 Offset data should be a vector with shape [n_joints * 7].
 :param add_extensions: Whether to add momentum extensions to GLTF nodes.
-:param custom_name: Custom name for the animation in the GLTF file.)",
+:param custom_name: Custom name for the animation in the GLTF file.
+:param character_name: Exported name returned by :meth:`add_character`, selecting which exported character to animate. Pass it to target a specific instance when the same character was added more than once, or a duplicate whose name was auto-suffixed. When omitted, resolves to the character exported under the source name (auto-adding it if absent).)",
           py::arg("character"),
           py::arg("fps") = 120.0f,
           py::arg("motion") = std::optional<mm::MotionParameters>{},
           py::arg("offsets") = std::optional<mm::IdentityParameters>{},
           py::arg("add_extensions") = true,
-          py::arg("custom_name") = "default")
+          py::arg("custom_name") = "default",
+          py::arg("character_name") = std::nullopt)
       .def(
           "add_skeleton_states",
           [](mm::GltfBuilder& builder,
              const mm::Character& character,
              float fps,
              const py::array_t<float>& skeletonStates,
-             const std::string& customName) {
+             const std::string& customName,
+             const std::optional<std::string>& characterName) {
             // Use the shared utility function for conversion
             std::vector<mm::SkeletonState> skelStates =
                 pymomentum::arrayToSkeletonStates(skeletonStates, character);
 
             // Call the addSkeletonStates method
-            builder.addSkeletonStates(character, fps, std::span(skelStates), customName);
+            builder.addSkeletonStates(
+                character, fps, std::span(skelStates), customName, characterName.value_or(""));
           },
           R"(Add skeleton states animation to the specified character.
 
@@ -212,11 +218,13 @@ per-joint transforms that define the character's pose over time.
                        Each joint state contains [tx, ty, tz, rx, ry, rz, rw, s] where
                        translation is (tx,ty,tz), rotation is quaternion (rx,ry,rz,rw)
                        in (x,y,z,w) format, and s is scale.
-:param custom_name: Custom name for the animation in the GLTF file.)",
+:param custom_name: Custom name for the animation in the GLTF file.
+:param character_name: Exported name returned by :meth:`add_character`, selecting which exported character to animate. Pass it to target a specific instance when the same character was added more than once, or a duplicate whose name was auto-suffixed. When omitted, resolves to the character exported under the source name (auto-adding it if absent).)",
           py::arg("character"),
           py::arg("fps"),
           py::arg("skeleton_states"),
-          py::arg("custom_name") = "default")
+          py::arg("custom_name") = "default",
+          py::arg("character_name") = std::nullopt)
       .def(
           "add_marker_sequence",
           [](mm::GltfBuilder& builder,

--- a/pymomentum/test/test_fbx.py
+++ b/pymomentum/test/test_fbx.py
@@ -29,6 +29,102 @@ class TestFBX(unittest.TestCase):
             self.character, self.model_params
         )
 
+    def test_fbx_builder_multiple_characters(self) -> None:
+        if not pym_geometry.is_fbxsdk_available():
+            return
+
+        body = pym_test_utils.create_test_character(num_joints=5)
+        prop = pym_test_utils.create_test_character(num_joints=3)
+        prop_model_params = np.zeros(
+            (2, prop.parameter_transform.size), dtype=np.float32
+        )
+        prop_joint_params = prop.parameter_transform.apply(prop_model_params)
+
+        builder = pym_geometry.FbxBuilder()
+        body_name = builder.add_character(body)
+        prop_name = builder.add_rigid_body(prop)
+        self.assertEqual(body_name, "test character")
+        self.assertEqual(prop_name, "test character_1")
+        builder.add_motion_with_joint_params(
+            prop,
+            fps=30.0,
+            joint_params=prop_joint_params,
+            character_name=prop_name,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".fbx") as temp_file:
+            builder.save(temp_file.name)
+            loaded = pym_geometry.Character.load_fbx(
+                temp_file.name,
+                permissive=True,
+                strip_namespaces=False,
+            )
+
+        self.assertEqual(
+            loaded.skeleton.size,
+            body.skeleton.size + prop.skeleton.size,
+        )
+        self.assertEqual(
+            sum(parent == -1 for parent in loaded.skeleton.joint_parents),
+            2,
+        )
+        self.assertIn(
+            f"{prop_name}:{prop.skeleton.joint_names[0]}",
+            loaded.skeleton.joint_names,
+        )
+
+    def test_fbx_builder_duplicate_name_mismatch_raises(self) -> None:
+        if not pym_geometry.is_fbxsdk_available():
+            return
+
+        body = pym_test_utils.create_test_character(num_joints=5)
+        prop = pym_test_utils.create_test_character(num_joints=3)
+        body_joint_params = body.parameter_transform.apply(
+            np.zeros((2, body.parameter_transform.size), dtype=np.float32)
+        )
+
+        builder = pym_geometry.FbxBuilder()
+        body_name = builder.add_character(body)
+        prop_name = builder.add_rigid_body(prop)
+        self.assertEqual(body_name, "test character")
+        self.assertEqual(prop_name, "test character_1")
+
+        # Passing the explicit name of a different-skeleton character (the rigid body, 3 joints)
+        # while animating body (5 joints) must raise.
+        with self.assertRaisesRegex(Exception, "does not match exported character"):
+            builder.add_motion_with_joint_params(
+                body,
+                fps=30.0,
+                joint_params=body_joint_params,
+                character_name=prop_name,
+            )
+
+        # Passing the explicit correct name works.
+        builder.add_motion_with_joint_params(
+            body,
+            fps=30.0,
+            joint_params=body_joint_params,
+            character_name=body_name,
+        )
+
+    def test_fbx_builder_duplicate_name_sequential_suffixes(self) -> None:
+        if not pym_geometry.is_fbxsdk_available():
+            return
+
+        builder = pym_geometry.FbxBuilder()
+        self.assertEqual(
+            builder.add_rigid_body(pym_test_utils.create_test_character(num_joints=3)),
+            "test character",
+        )
+        self.assertEqual(
+            builder.add_rigid_body(pym_test_utils.create_test_character(num_joints=3)),
+            "test character_1",
+        )
+        self.assertEqual(
+            builder.add_rigid_body(pym_test_utils.create_test_character(num_joints=3)),
+            "test character_2",
+        )
+
     def test_load_animation(self) -> None:
         """
         Loads a very simple 3-bone chain with animation from FBX and verifies that


### PR DESCRIPTION
Summary:
Both gltf io and fbx io support adding multiple "characters" (including rigid objects) to the same file. However, they will silently ignore a character with duplicated names.

This diff automatically assign a unique name (eg. "character_1") in this case with a warning, and return the new name in the API, so the caller can starting using the new name (eg. for adding associated data later). 

Also added more tests to catch corner cases.

Differential Revision: D113994586


