### PR TITLE
Use embedded MSVC debug information with sccache

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -443,13 +443,16 @@ mkdir -p build && git ls-files "axel/*.h" "axel/*.cpp" "momentum/*.h" "momentum/
 lint-check = { cmd = """
 mkdir -p build && git ls-files "axel/*.h" "axel/*.cpp" "momentum/*.h" "momentum/*.cpp" "pymomentum/*.h" "pymomentum/*.cpp" > build/cf-sources-list.txt && clang-format --dry-run --Werror --files=build/cf-sources-list.txt
 """}
-# In Windows CI, sccache wraps compiler invocations.
+# In Windows CI, sccache wraps compiler invocations. Embed debug information
+# in object files because MSVC compiler PDBs cannot be cached reliably.
 config = { cmd = """
     cmake \
         -S . \
         -B build/$PIXI_ENVIRONMENT_NAME/cpp \
         -G "Ninja Multi-Config" \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POLICY_DEFAULT_CMP0141=NEW \
+        -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>" \
         -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
         -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \
         -DMOMENTUM_BUILD_EXAMPLES=ON \


### PR DESCRIPTION
Summary:
Windows Debug CI began failing when sccache-action moved from sccache 0.16.0 to 0.17.0. The same source revision, runner image, and MSVC toolchain passed with 0.16.0 and failed with 0.17.0, so the fatal build failure is a behavior regression in 0.17.0 rather than a Windows or compiler update.

The underlying issue is longstanding: MSVC's /Zi option writes compiler PDBs that sccache cannot cache reliably. CMake's compiler probe passes a directory-form /Fd argument; after cl.exe succeeds, sccache 0.17.0 looks for a non-existent Debug.pdb and aborts while collecting compiler outputs. Version 0.16.0 reported a cache error for the same probe but allowed the build to continue.

Instead of pinning an older sccache release, configure CMake policy CMP0141 and select the Embedded MSVC debug information format for Debug and RelWithDebInfo builds. This produces /Z7, which stores debug information in each object file and avoids compiler PDB handling. Debugging remains supported and the linker can still produce final PDBs. Release builds are unchanged, and CI can continue tracking the latest sccache release.

Differential Revision: D114643055


