### PR TITLE
Update vulnerable website dependencies

### DIFF
--- a/momentum/website/package.json
+++ b/momentum/website/package.json
@@ -52,7 +52,7 @@
     "**/lodash-es": ">=4.18.0",
     "**/svgo": "^3.3.3",
     "**/picomatch": "^2.3.2",
-    "**/brace-expansion": "^5.0.8",
+    "**/brace-expansion": "^5.0.9",
     "**/webpack-dev-server/ws": ">=8.20.1",
     "**/webpack-bundle-analyzer/ws": "^7.5.11",
     "**/yaml": ">=2.8.3",

--- a/momentum/website/yarn.lock
+++ b/momentum/website/yarn.lock
@@ -3941,10 +3941,10 @@ boxen@^7.0.0:
     widest-line "^4.0.1"
     wrap-ansi "^8.1.0"
 
-brace-expansion@^1.1.7, brace-expansion@^5.0.8:
-  version "5.0.8"
-  resolved "https://registry.facebook.net/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+brace-expansion@^1.1.7, brace-expansion@^5.0.9:
+  version "5.0.9"
+  resolved "https://registry.facebook.net/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -5713,9 +5713,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fastq@^1.6.0:
   version "1.19.1"


### PR DESCRIPTION
Summary: Update fast-uri from 3.1.4 to 3.1.5 and brace-expansion from 5.0.8 to 5.0.9. These patched versions address Dependabot alerts GHSA-7p8r-x3mc-p8w7 and GHSA-rgw5-rvv9-x895.

Differential Revision: D114665720


