### PR TITLE
Add Character.with_name

### DIFF
--- a/pymomentum/geometry/character_pybind.cpp
+++ b/pymomentum/geometry/character_pybind.cpp
@@ -370,6 +370,33 @@ void registerCharacterBindings(py::class_<mm::Character>& characterClass) {
           :param metadata: The metadata string to attach to the character.
           )",
           py::arg("metadata"))
+      .def(
+          "with_name",
+          [](const mm::Character& character, const std::string& name) {
+            return momentum::Character(
+                character.skeleton,
+                character.parameterTransform,
+                character.parameterLimits,
+                character.locators,
+                character.mesh.get(),
+                character.skinWeights.get(),
+                character.collision.get(),
+                character.poseShapes.get(),
+                character.blendShape,
+                character.faceExpressionBlendShape,
+                name,
+                character.inverseBindPose,
+                character.skinnedLocators,
+                character.metadata,
+                character.physicalProperties);
+          },
+          R"(Returns a new character with the passed-in name.
+
+          The name is written out as the character's root node name when the character is exported to glTF, and is read back into :attr:`name` when the file is loaded. Setting a meaningful name is therefore how a character keeps its identity across a glTF round trip.
+
+          :param name: The name to give the character.
+          )",
+          py::arg("name"))
       .def_readonly("name", &mm::Character::name, "The character's name.")
       .def_readonly("metadata", &mm::Character::metadata, "The character's metadata.")
       .def_readonly(


### PR DESCRIPTION
Summary:
`Character.name` was exposed to Python as a read-only attribute, so there was no
way to set a name from Python. This matters most for glTF: the character name is
written out as the character's root node name and read back when the file is
loaded, so it is the channel a character uses to carry its identity across a file
round trip. Code that loads a character, modifies it and re-exports it had no way
to attach a name, leaving downstream consumers to guess one from the file path.

Add a `with_name()` builder that returns a new character with the given name and
every other field preserved, following the existing `with_metadata()` pattern.

Tests cover the builder semantics -- the name is set, the original character is
unchanged, and the adjacent `metadata` field is not clobbered (`name` and
`metadata` are neighbouring string arguments of the underlying constructor, so
transposing them is an easy mistake) -- plus a glTF round trip showing that a name
is recovered on load and that a character saved without one comes back nameless.

Differential Revision: D114930014


