### PR TITLE
Relax normal distribution flaky test

### DIFF
--- a/momentum/test/math/random_test.cpp
+++ b/momentum/test/math/random_test.cpp
@@ -730,13 +730,16 @@ TEST(RandomTest, NormalDistributionStatisticalProperties) {
   const int numSamples = 10000;
   const float expectedMean = 5.0f;
   const float expectedSigma = 2.0f;
+  const float meanTolerance = 5.0f * expectedSigma / std::sqrt(static_cast<float>(numSamples));
+  const float sigmaTolerance = 0.10f;
 
   std::vector<float> samples;
   samples.reserve(numSamples);
+  Random<> rng(42);
 
   // Generate large sample
   for (int i = 0; i < numSamples; ++i) {
-    samples.push_back(normal<float>(expectedMean, expectedSigma));
+    samples.push_back(rng.normal<float>(expectedMean, expectedSigma));
   }
 
   // Calculate sample statistics
@@ -755,9 +758,9 @@ TEST(RandomTest, NormalDistributionStatisticalProperties) {
   float sampleStdDev = std::sqrt(sampleVariance);
 
   // With large sample size, statistics should be very close to expected values
-  EXPECT_NEAR(sampleMean, expectedMean, 0.05f)
+  EXPECT_NEAR(sampleMean, expectedMean, meanTolerance)
       << "Sample mean should be very close to expected mean with large sample";
-  EXPECT_NEAR(sampleStdDev, expectedSigma, 0.05f)
+  EXPECT_NEAR(sampleStdDev, expectedSigma, sigmaTolerance)
       << "Sample std dev should be very close to expected sigma with large sample";
 
   // Test empirical rule (68-95-99.7 rule)


### PR DESCRIPTION
Summary:
`RandomTest.NormalDistributionStatisticalProperties` was asserting a 0.05 mean delta over 10000 samples from sigma=2, which is only 2.5 standard errors and can fail naturally under stress. This change gives the test its own deterministic `Random` instance and uses a 5-standard-error mean tolerance plus a conservative 0.10 sigma tolerance, preserving the statistical coverage while removing expected random false failures.

Differential Revision: D115381093


