### PR TITLE
Avoid importing Torch when locating CMake files

### DIFF
--- a/scripts/build_pypi_wheel.py
+++ b/scripts/build_pypi_wheel.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import sys
+from importlib.util import find_spec
 from pathlib import Path
 
 
@@ -38,14 +39,16 @@ def run(args: list[str], env: dict[str, str] | None = None) -> None:
 
 
 def torch_cmake_prefix_path() -> str:
-    return subprocess.check_output(
-        [
-            sys.executable,
-            "-c",
-            "import torch; print(torch.utils.cmake_prefix_path)",
-        ],
-        text=True,
-    ).strip()
+    """Find Torch's CMake package without loading its native extension."""
+    torch_spec = find_spec("torch")
+    if torch_spec is None or not torch_spec.submodule_search_locations:
+        raise RuntimeError("Unable to locate the installed torch package")
+
+    package_dir = Path(next(iter(torch_spec.submodule_search_locations)))
+    cmake_prefix = package_dir / "share" / "cmake"
+    if not cmake_prefix.is_dir():
+        raise RuntimeError(f"Torch CMake package directory not found: {cmake_prefix}")
+    return str(cmake_prefix)
 
 
 def main() -> None:

--- a/scripts/test_build_pypi_wheel.py
+++ b/scripts/test_build_pypi_wheel.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the PyPI wheel build helper."""
+
+import unittest
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from scripts.build_pypi_wheel import torch_cmake_prefix_path
+
+
+class TorchCmakePrefixPathTest(unittest.TestCase):
+    def test_finds_cmake_directory_without_importing_torch(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            package_dir = Path(temp_dir) / "torch"
+            cmake_dir = package_dir / "share" / "cmake"
+            cmake_dir.mkdir(parents=True)
+
+            torch_spec = ModuleSpec("torch", loader=None, is_package=True)
+            torch_spec.submodule_search_locations = [str(package_dir)]
+            with patch("scripts.build_pypi_wheel.find_spec", return_value=torch_spec):
+                self.assertEqual(torch_cmake_prefix_path(), str(cmake_dir))
+
+    def test_rejects_installation_without_cmake_files(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            package_dir = Path(temp_dir) / "torch"
+            package_dir.mkdir()
+
+            torch_spec = ModuleSpec("torch", loader=None, is_package=True)
+            torch_spec.submodule_search_locations = [str(package_dir)]
+            with patch("scripts.build_pypi_wheel.find_spec", return_value=torch_spec):
+                with self.assertRaisesRegex(
+                    RuntimeError, "Torch CMake package directory not found"
+                ):
+                    torch_cmake_prefix_path()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**Why:** The macOS CPU PyPI wheel build aborts while `scripts/build_pypi_wheel.py` imports `torch` only to discover its CMake prefix. In the Pixi build environment, that import loads conflicting `libomp.dylib` copies after the PyPI Torch reinstall. The failure is visible in [the original main-branch run](https://github.com/facebookresearch/momentum/actions/runs/31446579235/job/93642084816) and reproduced in [the latest lockfile-update run](https://github.com/facebookresearch/momentum/actions/runs/31834009646).

**What:** Locate the installed `torch/share/cmake` directory without importing the Torch native extension.

**How:**

- **Wheel helper** -- use the Python package spec to locate Torch, then verify that its CMake directory exists before building.
- **Regression coverage** -- test successful discovery and the missing-CMake-files error path.

**API changes:** None.

**Hosted evidence:** The exact formerly failing [`pypi-cpu-py3.12-mac-arm64` job](https://github.com/jeongseok-meta/momentum/actions/runs/32089618705/job/95569099325) **passed** wheel build, macOS repair, and artifact upload with this branch.

## Checklist

- [x] Adheres to the project style guidelines
- [x] Python changes formatted with `black` (no C++ files changed)

## Test Plan

```bash
pixi run -e py312 python -c 'import sys; from pathlib import Path; from scripts.build_pypi_wheel import torch_cmake_prefix_path; assert "torch" not in sys.modules; prefix = Path(torch_cmake_prefix_path()); assert "torch" not in sys.modules; assert (prefix / "Torch" / "TorchConfig.cmake").is_file(); print(prefix)'
```
Run URL: local only (no run URL emitted)

```bash
pixi run -e py312 python -m unittest scripts.test_build_pypi_wheel -v
```
Run URL: local only (no run URL emitted)

```bash
black --check scripts/build_pypi_wheel.py scripts/test_build_pypi_wheel.py
```
Run URL: local only (no run URL emitted)
