### PR TITLE
Move pinned macOS CI runners from macos-14 to macos-15

### DIFF
--- a/.github/workflows/ci_runners_probe.yml
+++ b/.github/workflows/ci_runners_probe.yml
@@ -37,7 +37,7 @@ jobs:
           - runner: macos-latest
             pixi_env: py312
             conda_override_cuda: ""
-          - runner: macos-14
+          - runner: macos-15
             pixi_env: py312
             conda_override_cuda: ""
           - runner: windows-latest

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-14, windows-latest]
+        os: [macos-15, windows-latest]
         python-version: ['3.12', '3.13']
         package-variant: [core, cpu]
         include:
@@ -130,7 +130,7 @@ jobs:
             pixi-environment: py312
           - python-version: '3.13'
             pixi-environment: py313
-          - os: macos-14
+          - os: macos-15
             os-short: mac-arm64
           - os: windows-latest
             os-short: win64
@@ -444,20 +444,20 @@ jobs:
             artifact-pattern: wheels-core-linux
             wheel-type: core
           # macOS core - always test py3.12
-          - os: macos-14
+          - os: macos-15
             os-short: mac-arm64
             variant: core
             python-version: '3.12'
             pixi-environment: py312
-            artifact-pattern: wheels-core-macos-14-py3.12
+            artifact-pattern: wheels-core-macos-15-py3.12
             wheel-type: core
           # macOS core - py3.13 only on tags/releases
-          - os: macos-14
+          - os: macos-15
             os-short: mac-arm64
             variant: core
             python-version: '3.13'
             pixi-environment: py313
-            artifact-pattern: wheels-core-macos-14-py3.13
+            artifact-pattern: wheels-core-macos-15-py3.13
             wheel-type: core
           # Windows core - always test py3.12
           - os: windows-latest
@@ -492,20 +492,20 @@ jobs:
             artifact-pattern: wheels-cpu-linux
             wheel-type: cpu
           # macOS CPU - always test py3.12
-          - os: macos-14
+          - os: macos-15
             os-short: mac-arm64
             variant: cpu
             python-version: '3.12'
             pixi-environment: py312
-            artifact-pattern: wheels-cpu-macos-14-py3.12
+            artifact-pattern: wheels-cpu-macos-15-py3.12
             wheel-type: cpu
           # macOS CPU - py3.13 only on tags/releases
-          - os: macos-14
+          - os: macos-15
             os-short: mac-arm64
             variant: cpu
             python-version: '3.13'
             pixi-environment: py313
-            artifact-pattern: wheels-cpu-macos-14-py3.13
+            artifact-pattern: wheels-cpu-macos-15-py3.13
             wheel-type: cpu
           # Windows CPU - always test py3.12
           - os: windows-latest


### PR DESCRIPTION
Summary:
GitHub started deprecating the `macos-14` hosted runner image in July 2026 and
retires it completely in November 2026 (https://github.com/actions/runner-images/issues/13518). 

Moving pinned `macos-14` jobs to `macos-15`. Both labels are Apple Silicon runners, so the wheel platform tag is unchanged; only the host image moves. 

Wheel test jobs download build artifacts by name and those names embed the runner label, so the `artifact-pattern` values move together with the matrix entries that produce them.

Jobs that run on `macos-latest` are unaffected and will be automatically updated.

Differential Revision: D116510860


