### PR TITLE
Mitigate website dependency vulnerabilities

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -54,11 +54,20 @@ jobs:
     - name: Install Doxygen
       run: sudo apt-get install doxygen
 
+    - name: Install Website Dependencies
+      working-directory: momentum/website
+      timeout-minutes: 10
+      run: yarn install --frozen-lockfile
+
+    - name: Test Image Parser Security
+      working-directory: momentum/website
+      timeout-minutes: 5
+      run: yarn test:image-size-security
+
     - name: Build the Website
       working-directory: momentum/website
-      run: |
-        yarn install --frozen-lockfile
-        yarn run build
+      timeout-minutes: 15
+      run: yarn build
 
     # 3) Build Python API docs for main-branch deploys when pymomentum changed.
     # PR validation happens in CI Ubuntu after the PyMomentum tests build the extension.

--- a/momentum/website/package.json
+++ b/momentum/website/package.json
@@ -2,6 +2,7 @@
   "name": "momentum-website",
   "version": "0.0.0",
   "private": true,
+  "//": "image-size is pinned to 2.0.2 only while patches/image-size+2.0.2.patch is needed; remove both when upstream ships a fixed release.",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
@@ -13,11 +14,12 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "test:image-size-security": "node scripts/test-image-size-security.cjs",
     "ci": "yarn lint && yarn prettier:diff",
     "lint": "eslint --cache \"**/*.js\" && stylelint \"**/*.css\"",
     "prettier": "prettier --config .prettierrc --write \"**/*.{js,jsx,ts,tsx,md,mdx}\"",
     "prettier:diff": "prettier --config .prettierrc --list-different \"**/*.{js,jsx,ts,tsx,md,mdx}\"",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package --error-on-fail"
   },
   "dependencies": {
     "@algolia/client-search": "^4.23.3",
@@ -42,7 +44,8 @@
     "**/nth-check": ">=2.0.1",
     "**/webpack-dev-server": ">=5.2.1",
     "**/on-headers": ">=1.1.0",
-    "**/js-yaml": "^4.3.0",
+    "**/image-size": "2.0.2",
+    "**/js-yaml": "^4.3.1",
     "**/gray-matter": ">=4.0.3",
     "**/node-forge": ">=1.4.0",
     "@docsearch/react": "^4.6.3",
@@ -75,6 +78,7 @@
     "yarn": "^1.5"
   },
   "devDependencies": {
+    "image-size": "2.0.2",
     "patch-package": "^8.0.0"
   }
 }

--- a/momentum/website/patches/image-size+2.0.2.patch
+++ b/momentum/website/patches/image-size+2.0.2.patch
@@ -1,0 +1,853 @@
+diff --git a/node_modules/image-size/package.json b/node_modules/image-size/package.json
+--- a/node_modules/image-size/package.json
++++ b/node_modules/image-size/package.json
+@@ -2,39 +2,29 @@
+   "name": "image-size",
+   "version": "2.0.2",
+   "description": "get dimensions of any image file",
+-  "main": "./dist/index.cjs",
+-  "module": "./dist/index.mjs",
+-  "types": "./dist/index.d.ts",
++  "main": "./dist/momentum-website-root-shim.cjs",
++  "module": "./dist/momentum-website-root-shim.mjs",
++  "types": "./dist/momentum-website-root-shim.d.ts",
+   "exports": {
+     ".": {
+       "import": {
+-        "types": "./dist/index.d.ts",
+-        "default": "./dist/index.mjs"
++        "types": "./dist/momentum-website-root-shim.d.ts",
++        "default": "./dist/momentum-website-root-shim.mjs"
+       },
+       "require": {
+-        "types": "./dist/index.d.ts",
+-        "default": "./dist/index.cjs"
++        "types": "./dist/momentum-website-root-shim.d.ts",
++        "default": "./dist/momentum-website-root-shim.cjs"
+       }
+     },
+     "./fromFile": {
+       "import": {
+-        "types": "./dist/fromFile.d.ts",
+-        "default": "./dist/fromFile.mjs"
++        "types": "./dist/momentum-website-from-file-shim.d.ts",
++        "default": "./dist/momentum-website-from-file-shim.mjs"
+       },
+       "require": {
+-        "types": "./dist/fromFile.d.ts",
+-        "default": "./dist/fromFile.cjs"
++        "types": "./dist/momentum-website-from-file-shim.d.ts",
++        "default": "./dist/momentum-website-from-file-shim.cjs"
+       }
+-    },
+-    "./types/*": {
+-      "import": {
+-        "types": "./dist/types/*.d.ts",
+-        "default": "./dist/types/*.mjs"
+-      },
+-      "require": {
+-        "types": "./dist/types/*.d.ts",
+-        "default": "./dist/types/*.cjs"
+-      }
+     }
+   },
+   "files": [
+diff --git a/node_modules/image-size/bin/image-size.js b/node_modules/image-size/bin/image-size.js
+--- a/node_modules/image-size/bin/image-size.js
++++ b/node_modules/image-size/bin/image-size.js
+@@ -3,7 +3,7 @@
+ 
+ const fs = require('node:fs')
+ const path = require('node:path')
+-const { imageSizeFromFile } = require('../dist/fromFile.cjs')
++const { imageSizeFromFile } = require('../dist/momentum-website-from-file-shim.cjs')
+ 
+ const files = process.argv.slice(2)
+ 
+diff --git a/node_modules/image-size/dist/index.cjs b/node_modules/image-size/dist/index.cjs
+--- a/node_modules/image-size/dist/index.cjs
++++ b/node_modules/image-size/dist/index.cjs
+@@ -163,6 +163,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -253,6 +256,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+       imageOffset += imageHeader[1];
+@@ -487,6 +493,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/index.mjs b/node_modules/image-size/dist/index.mjs
+--- a/node_modules/image-size/dist/index.mjs
++++ b/node_modules/image-size/dist/index.mjs
+@@ -159,6 +159,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -249,6 +252,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+       imageOffset += imageHeader[1];
+@@ -483,6 +489,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/lookup.cjs b/node_modules/image-size/dist/lookup.cjs
+--- a/node_modules/image-size/dist/lookup.cjs
++++ b/node_modules/image-size/dist/lookup.cjs
+@@ -161,6 +161,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -251,6 +254,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+       imageOffset += imageHeader[1];
+@@ -485,6 +491,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/lookup.mjs b/node_modules/image-size/dist/lookup.mjs
+--- a/node_modules/image-size/dist/lookup.mjs
++++ b/node_modules/image-size/dist/lookup.mjs
+@@ -159,6 +159,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -249,6 +252,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+       imageOffset += imageHeader[1];
+@@ -483,6 +489,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/fromFile.cjs b/node_modules/image-size/dist/fromFile.cjs
+--- a/node_modules/image-size/dist/fromFile.cjs
++++ b/node_modules/image-size/dist/fromFile.cjs
+@@ -187,6 +187,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -277,6 +280,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+       imageOffset += imageHeader[1];
+@@ -511,6 +517,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+@@ -1052,5 +1061,6 @@
+   processQueue();
+ });
+ 
+-exports.imageSizeFromFile = imageSizeFromFile;
+-exports.setConcurrency = setConcurrency;
++const shim = require("./momentum-website-from-file-shim.cjs");
++exports.imageSizeFromFile = shim.imageSizeFromFile;
++exports.setConcurrency = shim.setConcurrency;
+diff --git a/node_modules/image-size/dist/fromFile.mjs b/node_modules/image-size/dist/fromFile.mjs
+--- a/node_modules/image-size/dist/fromFile.mjs
++++ b/node_modules/image-size/dist/fromFile.mjs
+@@ -1,3 +1,7 @@
++import {
++  imageSizeFromFile as shimImageSizeFromFile,
++  setConcurrency as shimSetConcurrency,
++} from "./momentum-website-from-file-shim.mjs";
+ import * as fs from 'node:fs';
+ import * as path from 'node:path';
+ 
+@@ -164,6 +168,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -254,6 +261,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+       imageOffset += imageHeader[1];
+@@ -488,6 +498,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+@@ -1029,4 +1042,7 @@
+   processQueue();
+ });
+ 
+-export { imageSizeFromFile, setConcurrency };
++export {
++  shimImageSizeFromFile as imageSizeFromFile,
++  shimSetConcurrency as setConcurrency,
++};
+diff --git a/node_modules/image-size/dist/types/index.cjs b/node_modules/image-size/dist/types/index.cjs
+--- a/node_modules/image-size/dist/types/index.cjs
++++ b/node_modules/image-size/dist/types/index.cjs
+@@ -161,6 +161,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -251,6 +254,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize = getImageSize2(imageHeader[0]);
+       images.push(imageSize);
+       imageOffset += imageHeader[1];
+@@ -485,6 +491,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/types/index.mjs b/node_modules/image-size/dist/types/index.mjs
+--- a/node_modules/image-size/dist/types/index.mjs
++++ b/node_modules/image-size/dist/types/index.mjs
+@@ -159,6 +159,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+@@ -249,6 +252,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize = getImageSize2(imageHeader[0]);
+       images.push(imageSize);
+       imageOffset += imageHeader[1];
+@@ -483,6 +489,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/types/heif.cjs b/node_modules/image-size/dist/types/heif.cjs
+--- a/node_modules/image-size/dist/types/heif.cjs
++++ b/node_modules/image-size/dist/types/heif.cjs
+@@ -59,6 +59,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+diff --git a/node_modules/image-size/dist/types/heif.mjs b/node_modules/image-size/dist/types/heif.mjs
+--- a/node_modules/image-size/dist/types/heif.mjs
++++ b/node_modules/image-size/dist/types/heif.mjs
+@@ -57,6 +57,9 @@
+     while (currentOffset < ipcoBox.offset + ipcoBox.size) {
+       const ispeBox = findBox(input, "ispe", currentOffset);
+       if (!ispeBox) break;
++      if (ispeBox.size < 20) {
++        throw new TypeError("Invalid HEIF, invalid ispe box size");
++      }
+       const rawWidth = readUInt32BE(input, ispeBox.offset + 12);
+       const rawHeight = readUInt32BE(input, ispeBox.offset + 16);
+       const clapBox = findBox(input, "clap", currentOffset);
+diff --git a/node_modules/image-size/dist/types/icns.cjs b/node_modules/image-size/dist/types/icns.cjs
+--- a/node_modules/image-size/dist/types/icns.cjs
++++ b/node_modules/image-size/dist/types/icns.cjs
+@@ -72,6 +72,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize = getImageSize(imageHeader[0]);
+       images.push(imageSize);
+       imageOffset += imageHeader[1];
+diff --git a/node_modules/image-size/dist/types/icns.mjs b/node_modules/image-size/dist/types/icns.mjs
+--- a/node_modules/image-size/dist/types/icns.mjs
++++ b/node_modules/image-size/dist/types/icns.mjs
+@@ -70,6 +70,9 @@
+     const images = [];
+     while (imageOffset < fileLength && imageOffset < inputLength) {
+       const imageHeader = readImageHeader(input, imageOffset);
++      if (imageHeader[1] < 8) {
++        throw new TypeError("Invalid ICNS, invalid entry length");
++      }
+       const imageSize = getImageSize(imageHeader[0]);
+       images.push(imageSize);
+       imageOffset += imageHeader[1];
+diff --git a/node_modules/image-size/dist/types/jxl.cjs b/node_modules/image-size/dist/types/jxl.cjs
+--- a/node_modules/image-size/dist/types/jxl.cjs
++++ b/node_modules/image-size/dist/types/jxl.cjs
+@@ -116,6 +116,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/types/jxl.mjs b/node_modules/image-size/dist/types/jxl.mjs
+--- a/node_modules/image-size/dist/types/jxl.mjs
++++ b/node_modules/image-size/dist/types/jxl.mjs
+@@ -114,6 +114,9 @@
+   while (offset < input.length) {
+     const jxlpBox = findBox(input, "jxlp", offset);
+     if (!jxlpBox) break;
++    if (jxlpBox.size < 12) {
++      throw new TypeError("Invalid JXL, invalid jxlp box size");
++    }
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+diff --git a/node_modules/image-size/dist/momentum-website-shim.cjs b/node_modules/image-size/dist/momentum-website-shim.cjs
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-shim.cjs
+@@ -0,0 +1,290 @@
++"use strict";
++
++const { execFile } = require("node:child_process");
++const { constants } = require("node:fs");
++const { open } = require("node:fs/promises");
++const { resolve: resolvePath } = require("node:path");
++
++const FILE_READ_TIMEOUT_MILLISECONDS = 2000;
++const MAX_CONCURRENCY = 4;
++const PNG_HEADER_SIZE = 49;
++const types = ["png"];
++let disabledTypes = new Set();
++let concurrency = MAX_CONCURRENCY;
++let activeJobs = 0;
++const queue = [];
++
++function asBytes(input) {
++  if (input instanceof Uint8Array) {
++    return input;
++  }
++  throw new TypeError("Expected image input to be a Uint8Array");
++}
++
++function hasAscii(input, offset, value) {
++  if (offset + value.length > input.length) {
++    return false;
++  }
++  for (let index = 0; index < value.length; index += 1) {
++    if (input[offset + index] !== value.charCodeAt(index)) {
++      return false;
++    }
++  }
++  return true;
++}
++
++function readUInt32BE(input, offset) {
++  if (offset + 4 > input.length) {
++    throw new TypeError("Invalid PNG");
++  }
++  return (
++    input[offset] * 0x1000000 +
++    ((input[offset + 1] << 16) | (input[offset + 2] << 8) | input[offset + 3])
++  );
++}
++
++function hasPngSignature(input) {
++  return (
++    input.length >= 8 &&
++    input[0] === 0x89 &&
++    hasAscii(input, 1, "PNG\r\n\u001a\n")
++  );
++}
++
++function crc32(input, start, end) {
++  let crc = 0xffffffff;
++  for (let index = start; index < end; index += 1) {
++    crc ^= input[index];
++    for (let bit = 0; bit < 8; bit += 1) {
++      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
++    }
++  }
++  return (crc ^ 0xffffffff) >>> 0;
++}
++
++function isValidBitDepth(bitDepth, colorType) {
++  const validDepths = {
++    0: [1, 2, 4, 8, 16],
++    2: [8, 16],
++    3: [1, 2, 4, 8],
++    4: [8, 16],
++    6: [8, 16],
++  };
++  return validDepths[colorType]?.includes(bitDepth) ?? false;
++}
++
++function parsePng(input) {
++  let ihdrOffset = 12;
++  if (hasAscii(input, ihdrOffset, "CgBI")) {
++    if (
++      readUInt32BE(input, 8) !== 4 ||
++      crc32(input, 12, 20) !== readUInt32BE(input, 20)
++    ) {
++      throw new TypeError("Invalid PNG");
++    }
++    ihdrOffset = 28;
++  }
++  if (
++    input.length < ihdrOffset + 21 ||
++    readUInt32BE(input, ihdrOffset - 4) !== 13 ||
++    !hasAscii(input, ihdrOffset, "IHDR")
++  ) {
++    throw new TypeError("Invalid PNG");
++  }
++  const width = readUInt32BE(input, ihdrOffset + 4);
++  const height = readUInt32BE(input, ihdrOffset + 8);
++  const bitDepth = input[ihdrOffset + 12];
++  const colorType = input[ihdrOffset + 13];
++  const compression = input[ihdrOffset + 14];
++  const filter = input[ihdrOffset + 15];
++  const interlace = input[ihdrOffset + 16];
++  const expectedCrc = readUInt32BE(input, ihdrOffset + 17);
++  if (
++    width === 0 ||
++    height === 0 ||
++    width > 0x7fffffff ||
++    height > 0x7fffffff ||
++    !isValidBitDepth(bitDepth, colorType) ||
++    compression !== 0 ||
++    filter !== 0 ||
++    (interlace !== 0 && interlace !== 1) ||
++    crc32(input, ihdrOffset, ihdrOffset + 17) !== expectedCrc
++  ) {
++    throw new TypeError("Invalid PNG");
++  }
++  return {
++    width,
++    height,
++    type: "png",
++  };
++}
++
++function imageSize(input) {
++  const bytes = asBytes(input);
++  if (!hasPngSignature(bytes)) {
++    throw new TypeError("unsupported file type: undefined");
++  }
++  if (disabledTypes.has("png")) {
++    throw new TypeError("disabled file type: png");
++  }
++  return parsePng(bytes);
++}
++
++async function readHeader(handle, size) {
++  const input = new Uint8Array(Math.min(size, PNG_HEADER_SIZE));
++  let bytesRead = 0;
++  while (bytesRead < input.length) {
++    const result = await handle.read(
++      input,
++      bytesRead,
++      input.length - bytesRead,
++      bytesRead,
++    );
++    if (result.bytesRead === 0) {
++      break;
++    }
++    bytesRead += result.bytesRead;
++  }
++  return input.subarray(0, bytesRead);
++}
++
++async function readImageSizeFromFile(filePath) {
++  const handle = await open(
++    resolvePath(filePath),
++    constants.O_RDONLY | (constants.O_NONBLOCK ?? 0),
++  );
++  try {
++    const stats = await handle.stat();
++    if (!stats.isFile()) {
++      throw new TypeError("Expected image path to reference a regular file");
++    }
++    const { size } = stats;
++    if (size <= 0) {
++      throw new Error("Empty file");
++    }
++    return imageSize(await readHeader(handle, size));
++  } finally {
++    await handle.close();
++  }
++}
++
++function imageSizeFromFileNow(filePath) {
++  return new Promise((resolve, reject) => {
++    execFile(
++      process.execPath,
++      [
++        __filename,
++        "--read-file",
++        resolvePath(filePath),
++        "0",
++      ],
++      {
++        encoding: "utf8",
++        killSignal: "SIGKILL",
++        timeout: FILE_READ_TIMEOUT_MILLISECONDS,
++        windowsHide: true,
++      },
++      (error, stdout, stderr) => {
++        if (error) {
++          const message = error.killed
++            ? "Timed out reading image file"
++            : stderr.trim() || error.message;
++          const helperError = new Error(message);
++          for (const property of ["code", "errno", "syscall", "path"]) {
++            if (error[property] !== undefined) {
++              helperError[property] = error[property];
++            }
++          }
++          if (error.killed) {
++            helperError.code = "ETIMEDOUT";
++          }
++          reject(helperError);
++          return;
++        }
++        try {
++          const result = JSON.parse(stdout);
++          if (result.error) {
++            const ErrorType =
++              result.error.name === "TypeError" ? TypeError : Error;
++            const helperError = new ErrorType(result.error.message);
++            for (const property of ["code", "errno", "syscall", "path"]) {
++              if (result.error[property] !== undefined) {
++                helperError[property] = result.error[property];
++              }
++            }
++            reject(helperError);
++          } else {
++            resolve(result.size);
++          }
++        } catch (parseError) {
++          reject(parseError);
++        }
++      },
++    );
++  });
++}
++
++function processQueue() {
++  while (activeJobs < concurrency && queue.length > 0) {
++    activeJobs += 1;
++    const { filePath, reject, resolve } = queue.shift();
++    imageSizeFromFileNow(filePath)
++      .then(resolve, reject)
++      .finally(() => {
++        activeJobs -= 1;
++        processQueue();
++      });
++  }
++}
++
++function imageSizeFromFile(filePath) {
++  return new Promise((resolve, reject) => {
++    queue.push({ filePath, reject, resolve });
++    processQueue();
++  });
++}
++
++function disableTypes(typesToDisable = []) {
++  disabledTypes = new Set(typesToDisable);
++}
++
++function setConcurrency(value) {
++  const nextConcurrency = Math.trunc(Number(value));
++  concurrency =
++    Number.isFinite(nextConcurrency) && nextConcurrency > 0
++      ? Math.min(nextConcurrency, MAX_CONCURRENCY)
++      : 1;
++  processQueue();
++}
++
++Object.defineProperty(module.exports, "__esModule", { value: true });
++module.exports.default = imageSize;
++module.exports.disableTypes = disableTypes;
++module.exports.imageSize = imageSize;
++module.exports.imageSizeFromFile = imageSizeFromFile;
++module.exports.setConcurrency = setConcurrency;
++module.exports.types = types;
++
++if (require.main === module && process.argv[2] === "--read-file") {
++  disableTypes(process.argv[4] === "1" ? ["png"] : []);
++  readImageSizeFromFile(process.argv[3])
++    .then((size) => {
++      process.stdout.write(JSON.stringify({ size }));
++    })
++    .catch((error) => {
++      const serializedError = {
++        message: error?.message ?? String(error),
++        name: error?.name ?? "Error",
++      };
++      for (const property of ["code", "errno", "syscall", "path"]) {
++        if (error?.[property] !== undefined) {
++          serializedError[property] = error[property];
++        }
++      }
++      process.stdout.write(
++        JSON.stringify({
++          error: serializedError,
++        }),
++      );
++    });
++}
+diff --git a/node_modules/image-size/dist/momentum-website-shim.mjs b/node_modules/image-size/dist/momentum-website-shim.mjs
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-shim.mjs
+@@ -0,0 +1,19 @@
++import shim from "./momentum-website-shim.cjs";
++
++const {
++  default: defaultExport,
++  disableTypes,
++  imageSize,
++  imageSizeFromFile,
++  setConcurrency,
++  types,
++} = shim;
++
++export {
++  defaultExport as default,
++  disableTypes,
++  imageSize,
++  imageSizeFromFile,
++  setConcurrency,
++  types,
++};
+diff --git a/node_modules/image-size/dist/momentum-website-shim.d.ts b/node_modules/image-size/dist/momentum-website-shim.d.ts
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-shim.d.ts
+@@ -0,0 +1,19 @@
++import type { imageType } from "./types/index.js";
++import { ISizeCalculationResult } from "./types/interface.js";
++
++declare const types: imageType[];
++declare function imageSize(input: Uint8Array): ISizeCalculationResult;
++declare function imageSizeFromFile(
++  filePath: string,
++): Promise<ISizeCalculationResult>;
++declare function disableTypes(types: imageType[]): void;
++declare function setConcurrency(concurrency: number): void;
++
++export {
++  imageSize as default,
++  disableTypes,
++  imageSize,
++  imageSizeFromFile,
++  setConcurrency,
++  types,
++};
+diff --git a/node_modules/image-size/dist/momentum-website-root-shim.cjs b/node_modules/image-size/dist/momentum-website-root-shim.cjs
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-root-shim.cjs
+@@ -0,0 +1,14 @@
++"use strict";
++
++const {
++  default: defaultExport,
++  disableTypes,
++  imageSize,
++  types,
++} = require("./momentum-website-shim.cjs");
++
++Object.defineProperty(module.exports, "__esModule", { value: true });
++module.exports.default = defaultExport;
++module.exports.disableTypes = disableTypes;
++module.exports.imageSize = imageSize;
++module.exports.types = types;
+diff --git a/node_modules/image-size/dist/momentum-website-root-shim.mjs b/node_modules/image-size/dist/momentum-website-root-shim.mjs
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-root-shim.mjs
+@@ -0,0 +1,6 @@
++export {
++  default,
++  disableTypes,
++  imageSize,
++  types,
++} from "./momentum-website-shim.mjs";
+diff --git a/node_modules/image-size/dist/momentum-website-root-shim.d.ts b/node_modules/image-size/dist/momentum-website-root-shim.d.ts
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-root-shim.d.ts
+@@ -0,0 +1,8 @@
++import type { imageType } from "./types/index.js";
++import { ISizeCalculationResult } from "./types/interface.js";
++
++declare const types: imageType[];
++declare function imageSize(input: Uint8Array): ISizeCalculationResult;
++declare function disableTypes(types: imageType[]): void;
++
++export { imageSize as default, disableTypes, imageSize, types };
+diff --git a/node_modules/image-size/dist/momentum-website-from-file-shim.cjs b/node_modules/image-size/dist/momentum-website-from-file-shim.cjs
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-from-file-shim.cjs
+@@ -0,0 +1,9 @@
++"use strict";
++
++const {
++  imageSizeFromFile,
++  setConcurrency,
++} = require("./momentum-website-shim.cjs");
++
++module.exports.imageSizeFromFile = imageSizeFromFile;
++module.exports.setConcurrency = setConcurrency;
+diff --git a/node_modules/image-size/dist/momentum-website-from-file-shim.mjs b/node_modules/image-size/dist/momentum-website-from-file-shim.mjs
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-from-file-shim.mjs
+@@ -0,0 +1 @@
++export { imageSizeFromFile, setConcurrency } from "./momentum-website-shim.mjs";
+diff --git a/node_modules/image-size/dist/momentum-website-from-file-shim.d.ts b/node_modules/image-size/dist/momentum-website-from-file-shim.d.ts
+new file mode 100644
+--- /dev/null
++++ b/node_modules/image-size/dist/momentum-website-from-file-shim.d.ts
+@@ -0,0 +1,8 @@
++import { ISizeCalculationResult } from "./types/interface.js";
++
++declare function imageSizeFromFile(
++  filePath: string,
++): Promise<ISizeCalculationResult>;
++declare function setConcurrency(concurrency: number): void;
++
++export { imageSizeFromFile, setConcurrency };

--- a/momentum/website/scripts/test-image-size-security.cjs
+++ b/momentum/website/scripts/test-image-size-security.cjs
@@ -1,0 +1,1020 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-env node */
+
+const { spawnSync } = require("node:child_process");
+const {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} = require("node:fs");
+const { tmpdir } = require("node:os");
+const { dirname, join, resolve } = require("node:path");
+const { pathToFileURL } = require("node:url");
+const { deflateSync } = require("node:zlib");
+
+const CHILD_PROCESS_TIMEOUT_MILLISECONDS = 5000;
+const CLI_FILE_COUNT = 101;
+const DOCS_IMAGE_DIRECTORIES = ["docs_cpp", "docs_python"];
+const CLI_TIMEOUT_MILLISECONDS = 30000;
+const LARGE_PNG_TRAILING_BYTES = 2 * 1024 * 1024;
+
+const uint32Bytes = (value) => [
+  (value >>> 24) & 0xff,
+  (value >>> 16) & 0xff,
+  (value >>> 8) & 0xff,
+  value & 0xff,
+];
+const asciiBytes = (value) => [...Buffer.from(value, "ascii")];
+
+function box(type, payload, extendsToEnd = false) {
+  return [
+    ...uint32Bytes(extendsToEnd ? 0 : 8 + payload.length),
+    ...asciiBytes(type),
+    ...payload,
+  ];
+}
+
+function heifWithZeroLengthIspe() {
+  return [
+    ...box("ftyp", [...asciiBytes("mif1"), 0, 0, 0, 0]),
+    ...box("meta", [
+      0,
+      0,
+      0,
+      0,
+      ...box("iprp", [
+        ...box("ipco", [
+          ...uint32Bytes(0),
+          ...asciiBytes("ispe"),
+          0,
+          0,
+          0,
+          0,
+          ...uint32Bytes(32),
+          ...uint32Bytes(16),
+        ]),
+      ]),
+    ]),
+  ];
+}
+
+function heifWithShortIspe() {
+  return [
+    ...box("ftyp", [...asciiBytes("mif1"), 0, 0, 0, 0]),
+    ...box("meta", [
+      0,
+      0,
+      0,
+      0,
+      ...box("iprp", [
+        ...box("ipco", [
+          ...uint32Bytes(1),
+          ...asciiBytes("ispe"),
+          0,
+          0,
+          0,
+          0,
+          ...uint32Bytes(32),
+          ...uint32Bytes(16),
+        ]),
+      ]),
+    ]),
+  ];
+}
+
+function crc32(input) {
+  let crc = 0xffffffff;
+  for (const byte of input) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type, data) {
+  const typeBytes = Buffer.from(type, "ascii");
+  const payload = Buffer.from(data);
+  const crcInput = Buffer.concat([typeBytes, payload]);
+  return Buffer.concat([
+    Buffer.from(uint32Bytes(payload.length)),
+    crcInput,
+    Buffer.from(uint32Bytes(crc32(crcInput))),
+  ]);
+}
+
+function ihdrData(width, height) {
+  return Buffer.from([
+    ...uint32Bytes(width),
+    ...uint32Bytes(height),
+    8,
+    6,
+    0,
+    0,
+    0,
+  ]);
+}
+
+function pngPayload({ cgbi = false, height = 16, width = 32 } = {}) {
+  const rowSize = width * 4 + 1;
+  const imageData = Buffer.alloc(rowSize * height);
+  const chunks = [];
+  if (cgbi) {
+    chunks.push(pngChunk("CgBI", Buffer.alloc(4)));
+  }
+  chunks.push(
+    pngChunk("IHDR", ihdrData(width, height)),
+    pngChunk("IDAT", deflateSync(imageData)),
+    pngChunk("IEND", Buffer.alloc(0)),
+  );
+  return Buffer.concat([
+    Buffer.from([0x89, ...asciiBytes("PNG\r\n\u001a\n")]),
+    ...chunks,
+  ]);
+}
+
+function invalidPng(mutate, { updateCrc = true } = {}) {
+  const bytes = Buffer.from(pngPayload());
+  mutate(bytes);
+  if (updateCrc) {
+    bytes.writeUInt32BE(crc32(bytes.subarray(12, 29)), 29);
+  }
+  return bytes;
+}
+
+const payloads = {
+  cgbiPng: {
+    bytes: pngPayload({ cgbi: true, height: 24, width: 48 }),
+    expectedSize: { width: 48, height: 24, type: "png" },
+  },
+  invalidCgbiCrc: {
+    bytes: (() => {
+      const bytes = Buffer.from(pngPayload({ cgbi: true }));
+      bytes[23] ^= 1;
+      return bytes;
+    })(),
+    expectedError: /^Invalid PNG$/,
+  },
+  invalidPngCompression: {
+    bytes: invalidPng((bytes) => {
+      bytes[26] = 1;
+    }),
+    expectedError: /^Invalid PNG$/,
+  },
+  invalidPngCrc: {
+    bytes: invalidPng(
+      (bytes) => {
+        bytes[32] ^= 1;
+      },
+      { updateCrc: false },
+    ),
+    expectedError: /^Invalid PNG$/,
+  },
+  invalidPngChunkLength: {
+    bytes: invalidPng((bytes) => {
+      bytes.writeUInt32BE(12, 8);
+    }),
+    expectedError: /^Invalid PNG$/,
+  },
+  invalidPngHeight: {
+    bytes: invalidPng((bytes) => {
+      bytes.writeUInt32BE(0, 20);
+    }),
+    expectedError: /^Invalid PNG$/,
+  },
+  invalidPngTruncated: {
+    bytes: pngPayload().subarray(0, 24),
+    expectedError: /^Invalid PNG$/,
+  },
+  invalidPngWidth: {
+    bytes: invalidPng((bytes) => {
+      bytes.writeUInt32BE(0x80000000, 16);
+    }),
+    expectedError: /^Invalid PNG$/,
+  },
+  jpeg: {
+    bytes: [0xff, 0xd8, 0xff, 0xd9],
+    expectedError: /^unsupported file type: undefined$/,
+  },
+  maliciousIcns: {
+    bytes: [
+      ...asciiBytes("icns"),
+      ...uint32Bytes(16),
+      ...asciiBytes("is32"),
+      ...uint32Bytes(0),
+    ],
+    expectedError: /^unsupported file type: undefined$/,
+  },
+  maliciousIcnsShort: {
+    bytes: [
+      ...asciiBytes("icns"),
+      ...uint32Bytes(16),
+      ...asciiBytes("is32"),
+      ...uint32Bytes(1),
+    ],
+    expectedError: /^unsupported file type: undefined$/,
+  },
+  maliciousHeif: {
+    bytes: heifWithZeroLengthIspe(),
+    expectedError: /^unsupported file type: undefined$/,
+  },
+  maliciousHeifShort: {
+    bytes: heifWithShortIspe(),
+    expectedError: /^unsupported file type: undefined$/,
+  },
+  maliciousJxl: {
+    bytes: [
+      ...box("JXL ", [0x0d, 0x0a, 0x87, 0x0a]),
+      ...box("ftyp", [...asciiBytes("jxl "), 0, 0, 0, 0]),
+      ...box("jxlp", [], true),
+    ],
+    expectedError: /^unsupported file type: undefined$/,
+  },
+  maliciousJxlShort: {
+    bytes: [
+      ...box("JXL ", [0x0d, 0x0a, 0x87, 0x0a]),
+      ...box("ftyp", [...asciiBytes("jxl "), 0, 0, 0, 0]),
+      0,
+      0,
+      0,
+      1,
+      ...asciiBytes("jxlp"),
+      0,
+      0,
+      0,
+      0,
+    ],
+    expectedError: /^unsupported file type: undefined$/,
+  },
+  png: {
+    bytes: pngPayload(),
+    expectedSize: { width: 32, height: 16, type: "png" },
+  },
+};
+
+const childMode = process.argv[2];
+const childFile = process.argv[3];
+
+async function expectRejection(label, parse, expectedError) {
+  try {
+    await parse();
+  } catch (error) {
+    const message = error?.message ?? String(error);
+    if (expectedError.test(message)) {
+      return;
+    }
+    throw new Error(`${label} rejected with unexpected error: ${message}`);
+  }
+  throw new Error(`${label} accepted unsupported input`);
+}
+
+async function expectDimensions(label, parse, expectedSize) {
+  const actualSize = await parse();
+  for (const [key, value] of Object.entries(expectedSize)) {
+    if (actualSize[key] !== value) {
+      throw new Error(
+        `${label} returned ${key}=${actualSize[key]}, expected ${value}`,
+      );
+    }
+  }
+}
+
+async function runPayload(name, filePath) {
+  if (!Object.prototype.hasOwnProperty.call(payloads, name)) {
+    throw new Error(`Unknown image-size regression payload: ${name}`);
+  }
+  const payload = payloads[name];
+  const { imageSize } = require("image-size");
+  const { imageSizeFromFile } = require("image-size/fromFile");
+  const [rootImport, fromFileImport] = await Promise.all([
+    import("image-size"),
+    import("image-size/fromFile"),
+  ]);
+  const checks = [
+    [`require fromFile(${name})`, () => imageSizeFromFile(filePath)],
+    [`require root(${name})`, () => imageSize(new Uint8Array(payload.bytes))],
+    [`import fromFile(${name})`, () =>
+      fromFileImport.imageSizeFromFile(filePath)],
+    [`import root(${name})`, () =>
+      rootImport.imageSize(new Uint8Array(payload.bytes))],
+  ];
+
+  for (const [label, parse] of checks) {
+    if (payload.expectedSize) {
+      await expectDimensions(label, parse, payload.expectedSize);
+    } else {
+      await expectRejection(label, parse, payload.expectedError);
+    }
+  }
+}
+
+async function runSpecialFile(filePath) {
+  const { imageSizeFromFile } = require("image-size/fromFile");
+  const fromFileImport = await import("image-size/fromFile");
+  const packageDirectory = imageSizePackageDirectory();
+  const absoluteFromFile = require(join(packageDirectory, "dist/fromFile.cjs"));
+  const absoluteFromFileImport = await import(
+    pathToFileURL(join(packageDirectory, "dist/fromFile.mjs")).href
+  );
+  const expectedError = /^Expected image path to reference a regular file$/;
+  await expectRejection(
+    "require fromFile(fifo)",
+    () => imageSizeFromFile(filePath),
+    expectedError,
+  );
+  await expectRejection(
+    "import fromFile(fifo)",
+    () => fromFileImport.imageSizeFromFile(filePath),
+    expectedError,
+  );
+  await expectRejection(
+    "absolute CJS fromFile(fifo)",
+    () => absoluteFromFile.imageSizeFromFile(filePath),
+    expectedError,
+  );
+  await expectRejection(
+    "absolute ESM fromFile(fifo)",
+    () => absoluteFromFileImport.imageSizeFromFile(filePath),
+    expectedError,
+  );
+}
+
+function expectEqual(label, actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`${label}=${actual}, expected ${expected}`);
+  }
+}
+
+function expectNotExported(label, load) {
+  try {
+    load();
+  } catch (error) {
+    if (error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+      return;
+    }
+    throw new Error(`${label} failed with unexpected error: ${error.message}`);
+  }
+  throw new Error(`${label} unexpectedly resolved`);
+}
+
+function imageSizePackageDirectory() {
+  return dirname(dirname(require.resolve("image-size")));
+}
+
+function markdownFiles(directory) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...markdownFiles(path));
+    } else if (entry.isFile() && /\.(?:md|mdx)$/.test(entry.name)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function markdownReferenceLabel(label) {
+  return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function markdownDestination(rawDestination) {
+  const trimmed = rawDestination.trim();
+  if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function expectPngMarkdownImage(filePath, target) {
+  const normalizedTarget = markdownDestination(target).replace(/[?#].*$/, "");
+  if (/^(?:https?:|data:|pathname:\/\/)/.test(normalizedTarget)) {
+    return;
+  }
+  if (!normalizedTarget.toLowerCase().endsWith(".png")) {
+    throw new Error(`${filePath} uses a non-PNG Markdown image: ${target}`);
+  }
+}
+
+function expectMarkdownImagesArePng() {
+  const definition = /^\s{0,3}\[([^\]]+)]:\s*(<[^>]+>|[^\s]+)(?:\s|$)/gm;
+  const fullReferenceImage = /!\[([^\]]+)]\[([^\]]*)]/g;
+  const inlineImage = /!\[[^\]]*]\(\s*(<[^>]+>|[^)\s]+)(?:\s+["'][^)]*)?\)/g;
+  const shortcutReferenceImage = /!\[([^\]]+)](?![\[(])/g;
+  for (const directory of DOCS_IMAGE_DIRECTORIES) {
+    if (!statSync(directory).isDirectory()) {
+      throw new Error(`${directory} is not a docs directory`);
+    }
+    for (const filePath of markdownFiles(directory)) {
+      const contents = readFileSync(filePath, "utf8");
+      const definitions = new Map();
+      for (const match of contents.matchAll(definition)) {
+        definitions.set(markdownReferenceLabel(match[1]), match[2]);
+      }
+      for (const match of contents.matchAll(inlineImage)) {
+        expectPngMarkdownImage(filePath, match[1]);
+      }
+      for (const match of contents.matchAll(fullReferenceImage)) {
+        const label = markdownReferenceLabel(match[2] || match[1]);
+        if (!definitions.has(label)) {
+          continue;
+        }
+        expectPngMarkdownImage(filePath, definitions.get(label));
+      }
+      for (const match of contents.matchAll(shortcutReferenceImage)) {
+        const label = markdownReferenceLabel(match[1]);
+        if (!definitions.has(label)) {
+          continue;
+        }
+        expectPngMarkdownImage(filePath, definitions.get(label));
+      }
+    }
+  }
+}
+
+function expectPackageSurface() {
+  const packageJson = JSON.parse(
+    readFileSync(join(imageSizePackageDirectory(), "package.json"), "utf8"),
+  );
+  const expectedEntries = [
+    ["main", packageJson.main, "./dist/momentum-website-root-shim.cjs"],
+    ["module", packageJson.module, "./dist/momentum-website-root-shim.mjs"],
+    ["types", packageJson.types, "./dist/momentum-website-root-shim.d.ts"],
+    [
+      "root require export",
+      packageJson.exports["."].require.default,
+      "./dist/momentum-website-root-shim.cjs",
+    ],
+    [
+      "root require types",
+      packageJson.exports["."].require.types,
+      "./dist/momentum-website-root-shim.d.ts",
+    ],
+    [
+      "root import export",
+      packageJson.exports["."].import.default,
+      "./dist/momentum-website-root-shim.mjs",
+    ],
+    [
+      "root import types",
+      packageJson.exports["."].import.types,
+      "./dist/momentum-website-root-shim.d.ts",
+    ],
+    [
+      "fromFile require export",
+      packageJson.exports["./fromFile"].require.default,
+      "./dist/momentum-website-from-file-shim.cjs",
+    ],
+    [
+      "fromFile require types",
+      packageJson.exports["./fromFile"].require.types,
+      "./dist/momentum-website-from-file-shim.d.ts",
+    ],
+    [
+      "fromFile import export",
+      packageJson.exports["./fromFile"].import.default,
+      "./dist/momentum-website-from-file-shim.mjs",
+    ],
+    [
+      "fromFile import types",
+      packageJson.exports["./fromFile"].import.types,
+      "./dist/momentum-website-from-file-shim.d.ts",
+    ],
+  ];
+  for (const [label, actual, expected] of expectedEntries) {
+    expectEqual(`image-size ${label}`, actual, expected);
+  }
+  if (Object.prototype.hasOwnProperty.call(packageJson.exports, "./types/*")) {
+    throw new Error("image-size still exports parser internals");
+  }
+}
+
+function expectShimResourceGuards() {
+  const shimSource = readFileSync(
+    join(imageSizePackageDirectory(), "dist/momentum-website-shim.cjs"),
+    "utf8",
+  );
+  const expectations = [
+    ["bounded header size", "const PNG_HEADER_SIZE = 49"],
+    ["bounded file read", "Math.min(size, PNG_HEADER_SIZE)"],
+    ["helper timeout", "timeout: FILE_READ_TIMEOUT_MILLISECONDS"],
+    ["helper kill signal", 'killSignal: "SIGKILL"'],
+    ["helper concurrency cap", "const MAX_CONCURRENCY = 4"],
+    ["active helper limit", "activeJobs < concurrency"],
+    ["nonblocking open", "O_NONBLOCK"],
+    ["regular-file check", "stats.isFile()"],
+  ];
+  for (const [label, needle] of expectations) {
+    if (!shimSource.includes(needle)) {
+      throw new Error(`image-size shim missing ${label}`);
+    }
+  }
+}
+
+async function expectInternalParserGuards() {
+  const packageDirectory = imageSizePackageDirectory();
+  const internalRoot = require(join(packageDirectory, "dist/index.cjs"));
+  const internalRootImport = await import(
+    pathToFileURL(join(packageDirectory, "dist/index.mjs")).href
+  );
+  const internalLookup = require(join(packageDirectory, "dist/lookup.cjs"));
+  const internalLookupImport = await import(
+    pathToFileURL(join(packageDirectory, "dist/lookup.mjs")).href
+  );
+  const internalTypeIndex = require(
+    join(packageDirectory, "dist/types/index.cjs"),
+  );
+  const internalTypeIndexImport = await import(
+    pathToFileURL(join(packageDirectory, "dist/types/index.mjs")).href
+  );
+  const cases = [
+    {
+      cjsPath: "dist/types/heif.cjs",
+      error: /^Invalid HEIF, invalid ispe box size$/,
+      exportName: "HEIF",
+      mjsPath: "dist/types/heif.mjs",
+      name: "maliciousHeif",
+      type: "heif",
+    },
+    {
+      cjsPath: "dist/types/heif.cjs",
+      error: /^Invalid HEIF, invalid ispe box size$/,
+      exportName: "HEIF",
+      mjsPath: "dist/types/heif.mjs",
+      name: "maliciousHeifShort",
+      type: "heif",
+    },
+    {
+      cjsPath: "dist/types/icns.cjs",
+      error: /^Invalid ICNS, invalid entry length$/,
+      exportName: "ICNS",
+      mjsPath: "dist/types/icns.mjs",
+      name: "maliciousIcns",
+      type: "icns",
+    },
+    {
+      cjsPath: "dist/types/icns.cjs",
+      error: /^Invalid ICNS, invalid entry length$/,
+      exportName: "ICNS",
+      mjsPath: "dist/types/icns.mjs",
+      name: "maliciousIcnsShort",
+      type: "icns",
+    },
+    {
+      cjsPath: "dist/types/jxl.cjs",
+      error: /^Invalid JXL, invalid jxlp box size$/,
+      exportName: "JXL",
+      mjsPath: "dist/types/jxl.mjs",
+      name: "maliciousJxl",
+      type: "jxl",
+    },
+    {
+      cjsPath: "dist/types/jxl.cjs",
+      error: /^Invalid JXL, invalid jxlp box size$/,
+      exportName: "JXL",
+      mjsPath: "dist/types/jxl.mjs",
+      name: "maliciousJxlShort",
+      type: "jxl",
+    },
+  ];
+  for (const entry of cases) {
+    const payload = new Uint8Array(payloads[entry.name].bytes);
+    const cjsParser = require(join(packageDirectory, entry.cjsPath))[
+      entry.exportName
+    ];
+    const mjsParser = await import(
+      pathToFileURL(join(packageDirectory, entry.mjsPath)).href
+    );
+    await expectRejection(
+      `internal root ${entry.name}`,
+      () => internalRoot.imageSize(payload),
+      entry.error,
+    );
+    await expectRejection(
+      `internal ESM root ${entry.name}`,
+      () => internalRootImport.imageSize(payload),
+      entry.error,
+    );
+    await expectRejection(
+      `internal CJS lookup ${entry.name}`,
+      () => internalLookup.imageSize(payload),
+      entry.error,
+    );
+    await expectRejection(
+      `internal ESM lookup ${entry.name}`,
+      () => internalLookupImport.imageSize(payload),
+      entry.error,
+    );
+    await expectRejection(
+      `internal CJS type index ${entry.name}`,
+      () => internalTypeIndex.typeHandlers.get(entry.type).calculate(payload),
+      entry.error,
+    );
+    await expectRejection(
+      `internal ESM type index ${entry.name}`,
+      () =>
+        internalTypeIndexImport.typeHandlers
+          .get(entry.type)
+          .calculate(payload),
+      entry.error,
+    );
+    await expectRejection(
+      `internal CJS ${entry.name}`,
+      () => cjsParser.calculate(payload),
+      entry.error,
+    );
+    await expectRejection(
+      `internal ESM ${entry.name}`,
+      () => mjsParser[entry.exportName].calculate(payload),
+      entry.error,
+    );
+  }
+}
+
+async function expectRootApi(pngFilePath) {
+  const root = require("image-size");
+  const fromFile = require("image-size/fromFile");
+  const rootImport = await import("image-size");
+  const fromFileImport = await import("image-size/fromFile");
+
+  expectEqual("image-size __esModule", root.__esModule, true);
+  expectEqual("image-size types", root.types.join(","), "png");
+  expectEqual("image-size ESM types", rootImport.types.join(","), "png");
+  expectEqual("image-size CJS default type", typeof root.default, "function");
+  expectEqual("image-size ESM default type", typeof rootImport.default, "function");
+  expectEqual(
+    "image-size CJS imageSizeFromFile type",
+    typeof root.imageSizeFromFile,
+    "undefined",
+  );
+  expectEqual(
+    "image-size ESM imageSizeFromFile type",
+    typeof rootImport.imageSizeFromFile,
+    "undefined",
+  );
+  expectEqual(
+    "image-size CJS setConcurrency type",
+    typeof root.setConcurrency,
+    "undefined",
+  );
+  expectEqual(
+    "image-size ESM setConcurrency type",
+    typeof rootImport.setConcurrency,
+    "undefined",
+  );
+  expectEqual(
+    "image-size/fromFile CJS default type",
+    typeof fromFile.default,
+    "undefined",
+  );
+  expectEqual(
+    "image-size/fromFile CJS disableTypes type",
+    typeof fromFile.disableTypes,
+    "undefined",
+  );
+  expectEqual(
+    "image-size/fromFile ESM disableTypes type",
+    typeof fromFileImport.disableTypes,
+    "undefined",
+  );
+  await expectDimensions(
+    "image-size CJS default",
+    () => root.default(new Uint8Array(payloads.png.bytes)),
+    payloads.png.expectedSize,
+  );
+  await expectDimensions(
+    "image-size ESM default",
+    () => rootImport.default(new Uint8Array(payloads.png.bytes)),
+    payloads.png.expectedSize,
+  );
+
+  const disabled = ["png"];
+  try {
+    root.disableTypes(disabled);
+    disabled.length = 0;
+    await expectRejection(
+      "imageSize(disabled png)",
+      () => root.imageSize(new Uint8Array(payloads.png.bytes)),
+      /^disabled file type: png$/,
+    );
+    await expectDimensions(
+      "imageSizeFromFile(disabled ignored)",
+      () => fromFile.imageSizeFromFile(pngFilePath),
+      payloads.png.expectedSize,
+    );
+    await expectDimensions(
+      "import imageSizeFromFile(disabled ignored)",
+      () => fromFileImport.imageSizeFromFile(pngFilePath),
+      payloads.png.expectedSize,
+    );
+  } finally {
+    root.disableTypes([]);
+  }
+}
+
+async function expectLargePngFile(temporaryDirectory) {
+  const filePath = join(temporaryDirectory, "large.png");
+  const bytes = Buffer.concat([
+    Buffer.from(payloads.png.bytes),
+    Buffer.alloc(LARGE_PNG_TRAILING_BYTES),
+  ]);
+  writeFileSync(filePath, bytes);
+
+  const { imageSize } = require("image-size");
+  const { imageSizeFromFile, setConcurrency } = require("image-size/fromFile");
+  await expectDimensions(
+    "imageSize(large png)",
+    () =>
+      imageSize(
+        new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+      ),
+    payloads.png.expectedSize,
+  );
+
+  setConcurrency(1);
+  await Promise.all(
+    Array.from({ length: 4 }, (_, index) =>
+      expectDimensions(
+        `imageSizeFromFile(large png ${index})`,
+        () => imageSizeFromFile(filePath),
+        payloads.png.expectedSize,
+      ),
+    ),
+  );
+  setConcurrency(Number.MAX_SAFE_INTEGER);
+  await expectDimensions(
+    "imageSizeFromFile(capped concurrency)",
+    () => imageSizeFromFile(filePath),
+    payloads.png.expectedSize,
+  );
+}
+
+function expectCliUsesShim(pngFilePath, maliciousJxlPath) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      join(imageSizePackageDirectory(), "bin/image-size.js"),
+      ...Array.from({ length: CLI_FILE_COUNT - 1 }, () => pngFilePath),
+      maliciousJxlPath,
+    ],
+    { encoding: "utf8", timeout: CLI_TIMEOUT_MILLISECONDS },
+  );
+  assertChildCompleted(result, "image-size CLI");
+  const plainStdout = result.stdout.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+  const resultCount = plainStdout.split("32x16").length - 1;
+  const plainStderr = result.stderr.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+  if (
+    result.status !== 0 ||
+    resultCount !== CLI_FILE_COUNT - 1 ||
+    !plainStderr.includes("unsupported file type: undefined") ||
+    !plainStderr.includes(maliciousJxlPath)
+  ) {
+    const details =
+      result.stderr || result.stdout || `exit status ${result.status}`;
+    throw new Error(`image-size CLI did not use the shim: ${details}`);
+  }
+}
+
+async function expectFilesystemError(temporaryDirectory) {
+  const missingPath = join(temporaryDirectory, "missing.png");
+  const { imageSizeFromFile } = require("image-size/fromFile");
+  const fromFileImport = await import("image-size/fromFile");
+  for (const [label, parse] of [
+    ["require fromFile(missing)", () => imageSizeFromFile(missingPath)],
+    [
+      "import fromFile(missing)",
+      () => fromFileImport.imageSizeFromFile(missingPath),
+    ],
+  ]) {
+    try {
+      await parse();
+    } catch (error) {
+      expectEqual(`${label} code`, error.code, "ENOENT");
+      expectEqual(`${label} syscall`, error.syscall, "open");
+      expectEqual(`${label} path`, error.path, resolve(missingPath));
+      continue;
+    }
+    throw new Error(`${label} unexpectedly succeeded`);
+  }
+}
+
+async function expectAbsoluteFromFileApi(pngFilePath, temporaryDirectory) {
+  const missingPath = join(temporaryDirectory, "absolute-missing.png");
+  const packageDirectory = imageSizePackageDirectory();
+  const absoluteFromFile = require(join(packageDirectory, "dist/fromFile.cjs"));
+  const absoluteFromFileImport = await import(
+    pathToFileURL(join(packageDirectory, "dist/fromFile.mjs")).href
+  );
+  for (const [label, api] of [
+    ["absolute CJS fromFile", absoluteFromFile],
+    ["absolute ESM fromFile", absoluteFromFileImport],
+  ]) {
+    expectEqual(`${label} default type`, typeof api.default, "undefined");
+    await expectDimensions(
+      `${label}(png)`,
+      () => api.imageSizeFromFile(pngFilePath),
+      payloads.png.expectedSize,
+    );
+    try {
+      await api.imageSizeFromFile(missingPath);
+    } catch (error) {
+      expectEqual(`${label}(missing) code`, error.code, "ENOENT");
+      expectEqual(`${label}(missing) syscall`, error.syscall, "open");
+      expectEqual(`${label}(missing) path`, error.path, resolve(missingPath));
+      continue;
+    }
+    throw new Error(`${label}(missing) unexpectedly succeeded`);
+  }
+}
+
+function expectBoundedHelperRead(temporaryDirectory) {
+  const packageDirectory = imageSizePackageDirectory();
+  const preloadPath = join(temporaryDirectory, "bounded-read-preload.cjs");
+  writeFileSync(
+    preloadPath,
+    `
+const fsPromises = require("node:fs/promises");
+const header = Uint8Array.from(${JSON.stringify(
+      [...payloads.png.bytes].slice(0, 49),
+    )});
+fsPromises.open = async () => ({
+  stat: async () => ({ isFile: () => true, size: 1024 * 1024 * 1024 }),
+  read: async (buffer, offset, length, position) => {
+    if (length > 49) {
+      throw new Error(\`read length exceeded PNG header: \${length}\`);
+    }
+    const chunk = header.subarray(position, position + length);
+    buffer.set(chunk, offset);
+    return { bytesRead: chunk.length };
+  },
+  close: async () => {},
+});
+`,
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--require",
+      preloadPath,
+      join(packageDirectory, "dist/momentum-website-shim.cjs"),
+      "--read-file",
+      "instrumented.png",
+      "0",
+    ],
+    { encoding: "utf8", timeout: CHILD_PROCESS_TIMEOUT_MILLISECONDS },
+  );
+  assertChildCompleted(result, "bounded helper read");
+  const parsed = JSON.parse(result.stdout);
+  if (parsed.error) {
+    throw new Error(`bounded helper read failed: ${parsed.error.message}`);
+  }
+  expectEqual("bounded helper read width", parsed.size.width, 32);
+  expectEqual("bounded helper read height", parsed.size.height, 16);
+}
+
+async function expectConcurrencyCap() {
+  const childProcess = require("node:child_process");
+  let active = 0;
+  let peak = 0;
+  childProcess.execFile = (_file, _args, _options, callback) => {
+    active += 1;
+    peak = Math.max(peak, active);
+    setTimeout(() => {
+      active -= 1;
+      callback(null, JSON.stringify({ size: payloads.png.expectedSize }), "");
+    }, 20);
+    return {};
+  };
+
+  const { imageSizeFromFile, setConcurrency } = require("image-size/fromFile");
+  setConcurrency(Number.MAX_SAFE_INTEGER);
+  await Promise.all(
+    Array.from({ length: 8 }, () => imageSizeFromFile("instrumented.png")),
+  );
+  expectEqual("imageSizeFromFile peak capped concurrency", peak, 4);
+
+  peak = 0;
+  setConcurrency(1);
+  await Promise.all(
+    Array.from({ length: 3 }, () => imageSizeFromFile("instrumented.png")),
+  );
+  expectEqual("imageSizeFromFile peak serial concurrency", peak, 1);
+}
+
+function assertChildCompleted(result, label) {
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(`${label} hung`);
+  }
+  if (result.error) {
+    throw new Error(`${label} could not run: ${result.error.message}`);
+  }
+  if (result.signal !== null) {
+    throw new Error(`${label} was terminated by ${result.signal}`);
+  }
+  if (result.status !== 0) {
+    const details =
+      result.stderr || result.stdout || `exit status ${result.status}`;
+    throw new Error(`${label} failed: ${details}`);
+  }
+}
+
+function runChild(mode, filePath) {
+  const args = [__filename, mode];
+  if (filePath !== undefined) {
+    args.push(filePath);
+  }
+  const result = spawnSync(process.execPath, args, {
+    encoding: "utf8",
+    timeout: CHILD_PROCESS_TIMEOUT_MILLISECONDS,
+  });
+  assertChildCompleted(result, `image-size ${mode} regression`);
+}
+
+async function expectSpecialFileRejection(temporaryDirectory) {
+  if (process.platform === "win32") {
+    return;
+  }
+  const fifoPath = join(temporaryDirectory, "image.fifo");
+  const result = spawnSync("mkfifo", [fifoPath], {
+    encoding: "utf8",
+    timeout: CHILD_PROCESS_TIMEOUT_MILLISECONDS,
+  });
+  assertChildCompleted(result, "mkfifo");
+  runChild("fifo", fifoPath);
+}
+
+async function runRegressionChecks() {
+  const temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "image-size-security-"),
+  );
+  try {
+    for (const [name, payload] of Object.entries(payloads)) {
+      const filePath = join(temporaryDirectory, name);
+      writeFileSync(filePath, new Uint8Array(payload.bytes));
+      runChild(name, filePath);
+    }
+
+    expectNotExported("image-size/types/heif", () =>
+      require("image-size/types/heif"),
+    );
+    await expectRejection(
+      "import(image-size/types/heif)",
+      () => import("image-size/types/heif"),
+      /Package subpath '.\/types\/heif' is not defined by "exports"/,
+    );
+    expectMarkdownImagesArePng();
+    expectPackageSurface();
+    expectShimResourceGuards();
+    runChild("internal-guards");
+    runChild("concurrency");
+    expectBoundedHelperRead(temporaryDirectory);
+    await expectRootApi(join(temporaryDirectory, "png"));
+    await expectLargePngFile(temporaryDirectory);
+    await expectSpecialFileRejection(temporaryDirectory);
+    await expectFilesystemError(temporaryDirectory);
+    await expectAbsoluteFromFileApi(
+      join(temporaryDirectory, "png"),
+      temporaryDirectory,
+    );
+    expectCliUsesShim(
+      join(temporaryDirectory, "png"),
+      join(temporaryDirectory, "maliciousJxl"),
+    );
+  } finally {
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+}
+
+if (childMode) {
+  const run =
+    childMode === "fifo"
+      ? () => runSpecialFile(childFile)
+      : childMode === "internal-guards"
+        ? () => expectInternalParserGuards()
+        : childMode === "concurrency"
+          ? () => expectConcurrencyCap()
+      : () => runPayload(childMode, childFile);
+  run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+} else {
+  runRegressionChecks()
+    .then(() => {
+      console.log("image-size security regression checks passed");
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/momentum/website/yarn.lock
+++ b/momentum/website/yarn.lock
@@ -6500,7 +6500,7 @@ ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-image-size@^2.0.2:
+image-size@2.0.2, image-size@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-2.0.2.tgz#84a7b43704db5736f364bf0d1b029821299b4bdc"
   integrity sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==
@@ -6915,10 +6915,10 @@ joi@^17.9.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.facebook.net/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Summary:
Mitigate website exposure to vulnerable image-size parsers.

The website currently uses PNG Markdown images. Pin image-size at 2.0.2 while the dependency has no fixed release, and apply a patch-package shim that exposes only the package surfaces the site needs: root buffer sizing and fromFile sizing. The public entrypoints parse PNG headers only, validate PNG/CgBI structure and CRCs, bound file reads to the header window, isolate file reads in helper processes with timeout/concurrency limits, and reject other formats before vulnerable parsers run.

Guard the remaining legacy built bundles against malformed HEIF, ICNS, and JXL records so direct file imports cannot retain known loops. Add a focused regression script and run it in the website publishing workflow before the Docusaurus build. The script also enforces that Markdown docs keep using PNG images while this temporary dependency patch is in place.

Update js-yaml to 4.3.1; the existing gray-matter patch keeps front matter parsing compatible.

Reviewed By: cstollmeta

Differential Revision: D115515664


