### PR TITLE
Run scheduled Pixi lockfile updates monthly

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 5 * * FRI # Runs at 05:00, on every Friday
+    - cron: '0 5 1 * *' # Runs at 05:00 UTC on the first day of each month
 
 jobs:
   pixi-update:


### PR DESCRIPTION
## Summary

Move the scheduled Pixi lockfile refresh from weekly to monthly. The workflow opened 42 lockfile PRs over the past year; this should remove roughly 30 routine review and full-CI cycles annually.

The manual trigger remains available for releases, security updates, and other urgent refreshes.

## Validation

- Parsed the workflow and verified both `workflow_dispatch` and the monthly `0 5 1 * *` schedule.
- `git diff --check`