### PR TITLE
FbxBuilder: write user-defined properties on animated meshes

### DIFF
--- a/momentum/io/fbx/fbx_builder.cpp
+++ b/momentum/io/fbx/fbx_builder.cpp
@@ -278,11 +278,48 @@ void FbxBuilder::addMotionWithJointParams(
       true); // skipActiveJointParamCheck = true
 }
 
+namespace {
+
+// Writes each entry as a user-defined FBX property. The eUserDefined flag is what
+// makes DCC tools treat these as the object's custom attributes; without it they
+// are stored but not surfaced on import.
+void writeUserProperties(::fbxsdk::FbxNode* node, const FbxUserProperties& userProperties) {
+  for (const auto& entry : userProperties) {
+    const std::string& propertyName = entry.first;
+    const FbxUserPropertyValue& value = entry.second;
+    std::visit(
+        [&](const auto& typedValue) {
+          using T = std::decay_t<decltype(typedValue)>;
+          ::fbxsdk::FbxDataType dataType;
+          if constexpr (std::is_same_v<T, bool>) {
+            dataType = ::fbxsdk::FbxBoolDT;
+          } else if constexpr (std::is_same_v<T, int>) {
+            dataType = ::fbxsdk::FbxIntDT;
+          } else if constexpr (std::is_same_v<T, float>) {
+            dataType = ::fbxsdk::FbxFloatDT;
+          } else {
+            dataType = ::fbxsdk::FbxStringDT;
+          }
+          auto property = ::fbxsdk::FbxProperty::Create(node, dataType, propertyName.c_str());
+          property.ModifyFlag(::fbxsdk::FbxPropertyFlags::eUserDefined, true);
+          if constexpr (std::is_same_v<T, std::string>) {
+            property.Set(::fbxsdk::FbxString(typedValue.c_str()));
+          } else {
+            property.Set(typedValue);
+          }
+        },
+        value);
+  }
+}
+
+} // namespace
+
 void FbxBuilder::addAnimatedMesh(
     const Character& character,
     const std::string& name,
     float fps,
-    const MatrixXf& jointParams) {
+    const MatrixXf& jointParams,
+    const FbxUserProperties& userProperties) {
   MT_THROW_IF(character.mesh == nullptr, "Character has no mesh");
   addAnimatedMesh(
       *character.mesh,
@@ -290,7 +327,8 @@ void FbxBuilder::addAnimatedMesh(
       fps,
       jointParams,
       character.skeleton.joints.empty() ? Vector3f::Zero()
-                                        : character.skeleton.joints[0].translationOffset);
+                                        : character.skeleton.joints[0].translationOffset,
+      userProperties);
 }
 
 void FbxBuilder::addAnimatedMesh(
@@ -298,7 +336,8 @@ void FbxBuilder::addAnimatedMesh(
     const std::string& name,
     float fps,
     const MatrixXf& jointParams,
-    const Vector3f& translationOffset) {
+    const Vector3f& translationOffset,
+    const FbxUserProperties& userProperties) {
   MT_THROW_IF(!impl_, "FbxBuilder has been moved from or already saved");
   MT_THROW_IF(!impl_->scene, "FBX scene is null");
   MT_THROW_IF(jointParams.cols() == 0, "jointParams is empty");
@@ -331,6 +370,8 @@ void FbxBuilder::addAnimatedMesh(
     }
     writeTextureUVIndicesToFbxMesh(mesh, lMesh, uvType);
   }
+
+  writeUserProperties(meshNode, userProperties);
 
   root->AddChild(meshNode);
 
@@ -476,7 +517,12 @@ void FbxBuilder::addMotionWithJointParams(const Character&, float, const MatrixX
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 
-void FbxBuilder::addAnimatedMesh(const Character&, const std::string&, float, const MatrixXf&) {
+void FbxBuilder::addAnimatedMesh(
+    const Character&,
+    const std::string&,
+    float,
+    const MatrixXf&,
+    const FbxUserProperties&) {
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 
@@ -485,7 +531,8 @@ void FbxBuilder::addAnimatedMesh(
     const std::string&,
     float,
     const MatrixXf&,
-    const Vector3f&) {
+    const Vector3f&,
+    const FbxUserProperties&) {
   MT_THROW("FbxBuilder requires the Autodesk FBX SDK.");
 }
 

--- a/momentum/io/fbx/fbx_builder.h
+++ b/momentum/io/fbx/fbx_builder.h
@@ -14,9 +14,22 @@
 #include <momentum/math/mesh.h>
 #include <momentum/math/types.h>
 
+#include <map>
 #include <span>
+#include <string>
+#include <variant>
 
 namespace momentum {
+
+/// Value of a user-defined FBX property.
+using FbxUserPropertyValue = std::variant<bool, int, float, std::string>;
+
+/// User-defined FBX properties, keyed by property name.
+///
+/// These are written to a node as user-defined properties, which is how DCC
+/// tools surface them as an object's "custom attributes". Note this is unrelated
+/// to the FBX SDK's `FbxNodeAttribute`, which is the geometry attached to a node.
+using FbxUserProperties = std::map<std::string, FbxUserPropertyValue>;
 
 /// Builder class for creating FBX files with multiple characters and animations.
 ///
@@ -108,11 +121,14 @@ class FbxBuilder final {
   /// @param name Name for the mesh node.
   /// @param fps Animation frame rate in frames per second.
   /// @param jointParams Joint parameters matrix with shape (nFrames x nJointParams).
+  /// @param userProperties User-defined properties to write onto the mesh node,
+  ///   surfaced by DCC tools as the object's custom attributes.
   void addAnimatedMesh(
       const Character& character,
       const std::string& name,
       float fps,
-      const MatrixXf& jointParams);
+      const MatrixXf& jointParams,
+      const FbxUserProperties& userProperties = {});
 
   /// Add an animated mesh from a Mesh object (no Character needed).
   ///
@@ -127,12 +143,15 @@ class FbxBuilder final {
   /// @param jointParams Joint parameters matrix with shape (nFrames x nJointParams).
   /// @param translationOffset Rest-pose translation offset added to the
   ///   translation channels (defaults to zero).
+  /// @param userProperties User-defined properties to write onto the mesh node,
+  ///   surfaced by DCC tools as the object's custom attributes.
   void addAnimatedMesh(
       const Mesh& mesh,
       const std::string& name,
       float fps,
       const MatrixXf& jointParams,
-      const Vector3f& translationOffset = Vector3f::Zero());
+      const Vector3f& translationOffset = Vector3f::Zero(),
+      const FbxUserProperties& userProperties = {});
 
   /// Add a marker sequence to the scene.
   ///

--- a/pymomentum/geometry/fbx_builder_pybind.cpp
+++ b/pymomentum/geometry/fbx_builder_pybind.cpp
@@ -125,12 +125,13 @@ This is useful for rigid bodies or characters with simple parameterization.
              const mm::Character& character,
              const std::string& name,
              float fps,
-             const std::optional<Eigen::MatrixXf>& jointParams) {
+             const std::optional<Eigen::MatrixXf>& jointParams,
+             const mm::FbxUserProperties& userProperties) {
             mm::MatrixXf transposedJointParams;
             if (jointParams.has_value() && jointParams->size() > 0) {
               transposedJointParams = jointParams->transpose();
             }
-            builder.addAnimatedMesh(character, name, fps, transposedJointParams);
+            builder.addAnimatedMesh(character, name, fps, transposedJointParams, userProperties);
           },
           R"(Add an animated mesh (no skeleton) to the scene.
 
@@ -141,11 +142,15 @@ as a simple animated mesh without any skeleton hierarchy.
 :param character: The character providing the mesh geometry.
 :param name: Name for the mesh node.
 :param fps: Animation frame rate in frames per second.
-:param joint_params: Joint parameters matrix with shape (nFrames, nJointParams).)",
+:param joint_params: Joint parameters matrix with shape (nFrames, nJointParams).
+:param user_properties: Mapping of name to bool/int/float/str, written onto the
+    mesh node as user-defined FBX properties. DCC tools surface these as the
+    object's custom attributes.)",
           py::arg("character"),
           py::arg("name"),
           py::arg("fps") = 120.0f,
-          py::arg("joint_params") = std::nullopt)
+          py::arg("joint_params") = std::nullopt,
+          py::arg("user_properties") = mm::FbxUserProperties{})
       .def(
           "add_animated_mesh",
           [](mm::FbxBuilder& builder,
@@ -153,7 +158,8 @@ as a simple animated mesh without any skeleton hierarchy.
              const std::string& name,
              float fps,
              const std::optional<Eigen::MatrixXf>& jointParams,
-             const std::optional<Eigen::Vector3f>& translationOffset) {
+             const std::optional<Eigen::Vector3f>& translationOffset,
+             const mm::FbxUserProperties& userProperties) {
             mm::MatrixXf transposedJointParams;
             if (jointParams.has_value() && jointParams->size() > 0) {
               transposedJointParams = jointParams->transpose();
@@ -163,7 +169,8 @@ as a simple animated mesh without any skeleton hierarchy.
                 name,
                 fps,
                 transposedJointParams,
-                translationOffset.value_or(Eigen::Vector3f::Zero()));
+                translationOffset.value_or(Eigen::Vector3f::Zero()),
+                userProperties);
           },
           R"(Add an animated mesh from a Mesh object (no Character needed).
 
@@ -175,12 +182,16 @@ parameters. Only the root transform (first 7 joint params) is used.
 :param fps: Animation frame rate in frames per second.
 :param joint_params: Joint parameters matrix with shape (nFrames, nJointParams).
 :param translation_offset: Rest-pose translation offset added to the translation
-    channels (defaults to zero).)",
+    channels (defaults to zero).
+:param user_properties: Mapping of name to bool/int/float/str, written onto the
+    mesh node as user-defined FBX properties. DCC tools surface these as the
+    object's custom attributes.)",
           py::arg("mesh"),
           py::arg("name"),
           py::arg("fps") = 120.0f,
           py::arg("joint_params") = std::nullopt,
-          py::arg("translation_offset") = std::nullopt)
+          py::arg("translation_offset") = std::nullopt,
+          py::arg("user_properties") = mm::FbxUserProperties{})
       .def(
           "add_marker_sequence",
           [](mm::FbxBuilder& builder,

--- a/pymomentum/test/test_fbx.py
+++ b/pymomentum/test/test_fbx.py
@@ -397,6 +397,60 @@ class TestFBX(unittest.TestCase):
             # Should have 3 frames total (sparse support)
             self.assertEqual(len(loaded_sequence.frames), nFrames)
 
+    def _save_animated_mesh(
+        self, path: str, user_properties: dict[str, bool | int | float | str]
+    ) -> bytes:
+        """Write a one-object FBX via add_animated_mesh and return its raw bytes."""
+        builder = pym_geometry.FbxBuilder()
+        builder.add_animated_mesh(
+            self.character,
+            name="prop",
+            fps=60,
+            joint_params=self.joint_params,
+            user_properties=user_properties,
+        )
+        builder.save(path)
+        with open(path, "rb") as f:
+            return f.read()
+
+    def test_animated_mesh_user_properties(self) -> None:
+        if not pym_geometry.is_fbxsdk_available():
+            return
+
+        with tempfile.NamedTemporaryFile(suffix=".fbx") as temp_file:
+            data = self._save_animated_mesh(
+                temp_file.name,
+                {
+                    "HOI": 1,
+                    "category_id": 433,
+                    "held": True,
+                    "mass": 0.25,
+                    "category_label": "screwdriver",
+                },
+            )
+            for token in (b"HOI", b"category_label", b"screwdriver", b"held", b"mass"):
+                self.assertIn(token, data)
+
+            # Each property record is: name, type, subtype, flags, value. The flags
+            # field must be the length-prefixed string "U" (user-defined), or DCC
+            # tools store the property without surfacing it as a custom attribute.
+            user_defined_flag = b"S\x01\x00\x00\x00U"
+            label_at = data.index(b"category_label")
+            self.assertIn(user_defined_flag, data[label_at : label_at + 96])
+
+            # Ints round-trip as ints rather than being stringified: the record for
+            # category_id ends in an "I" marker followed by 433 little-endian.
+            id_at = data.index(b"category_id")
+            self.assertIn(
+                user_defined_flag + b"I" + (433).to_bytes(4, "little"),
+                data[id_at : id_at + 96],
+            )
+
+        with tempfile.NamedTemporaryFile(suffix=".fbx") as temp_file:
+            # Passing no properties must not invent any.
+            bare = self._save_animated_mesh(temp_file.name, {})
+            self.assertNotIn(b"category_label", bare)
+
     def test_load_markers_empty_file(self) -> None:
         if not pym_geometry.is_fbxsdk_available():
             return


### PR DESCRIPTION
Summary:
`FbxBuilder` had no way to attach arbitrary metadata to an exported object. It writes a
few fixed properties of its own (`metadata`, `RigName`, `Col_Type`), but a caller with
per-object metadata -- a category, an identifier, a classification flag -- had nowhere to
put it, so that information was lost on export.

Add an optional `FbxUserProperties` argument to both `addAnimatedMesh` overloads: a map
of name to `bool`/`int`/`float`/`string`, written onto the mesh node. Each property is
created with the matching FBX data type, so integers stay integers rather than being
stringified, and is flagged `eUserDefined`. That flag is what makes a DCC treat a
property as an object's custom attribute rather than internal bookkeeping; without it a
property is stored but not surfaced on import.

Named `FbxUserProperties` rather than something built on "attribute" because the FBX SDK
already uses `FbxNodeAttribute` for the geometry attached to a node, and reusing that
word here would mislead. The Python docstrings mention "custom attributes" so the
binding is still discoverable from the DCC-facing terminology.

Exposed in Python as a `user_properties` keyword on both `add_animated_mesh` overloads.
Existing callers are unaffected: the argument defaults to empty and no properties are
written when it is.

Note for future work: momentum's own pre-existing properties are created without the
`eUserDefined` flag. This change does not alter them, but that is a plausible
explanation if any of them have been observed not to appear as custom attributes after
import.

Differential Revision: D115120571


