### PR TITLE
Clamp the asin argument in quaternionToXYZEuler (#1630)

### DIFF
--- a/pymomentum/tensor_momentum/tensor_quaternion.cpp
+++ b/pymomentum/tensor_momentum/tensor_quaternion.cpp
@@ -21,6 +21,8 @@
 #endif
 #include <Eigen/Core>
 
+#include <limits>
+
 namespace pymomentum {
 
 using torch::autograd::AutogradContext;
@@ -212,13 +214,23 @@ at::Tensor quaternionInverse(at::Tensor q) {
 
 at::Tensor quaternionToXYZEuler(at::Tensor q) {
   checkQuaternion(q);
+
+  // The asin argument is analytically exactly +/-1 at the gimbal singularity, so rounding tips it
+  // out of domain and returns NaN. Clamp short of the endpoints rather than to them: asin's
+  // derivative is unbounded there. eps is 8 ULP of the tensor's own dtype so float64 is not held
+  // to float32's far looser bound. Reduced-precision dtypes fall back to the float32 value, which
+  // is below their own ULP; this conversion is not usable at that precision regardless.
+  const double kEulerEps = 8.0 *
+      (q.scalar_type() == at::kDouble ? std::numeric_limits<double>::epsilon()
+                                      : std::numeric_limits<float>::epsilon());
+
   at::Tensor qx = q.select(-1, 0);
   at::Tensor qy = q.select(-1, 1);
   at::Tensor qz = q.select(-1, 2);
   at::Tensor qw = q.select(-1, 3);
 
   at::Tensor rx = at::atan2(2 * (qw * qx + qy * qz), 1 - 2 * (sqr(qx) + sqr(qy)));
-  at::Tensor ry = at::asin(2 * (qw * qy - qz * qx));
+  at::Tensor ry = at::asin(at::clamp(2 * (qw * qy - qz * qx), -1.0 + kEulerEps, 1.0 - kEulerEps));
   at::Tensor rz = at::atan2(2 * (qw * qz + qx * qy), 1 - 2 * (sqr(qy) + sqr(qz)));
   return at::stack({rx, ry, rz}, -1);
 }

--- a/pymomentum/test/test_diff_geometry.py
+++ b/pymomentum/test/test_diff_geometry.py
@@ -12,6 +12,7 @@ This file contains all torch-dependent tests migrated from test_geometry.py and 
 These tests verify that differentiable operations work correctly with PyTorch autograd.
 """
 
+import itertools
 import math
 import unittest
 
@@ -439,6 +440,78 @@ class TestDiffGeometry(unittest.TestCase):
                 pym_skel_state.to_matrix(skel_state2),
             )
         )
+
+    def _assert_gimbal_singularity_finite(
+        self,
+        # pyre-ignore[2]: pymomentum Character has no stub in this test module
+        character,
+        dtype: torch.dtype,
+        sign: float,
+        label: str,
+    ) -> None:
+        """One (dtype, sign) case of the gimbal-singularity guard.
+
+        The conversion is applied to inv(pre_rotation) * local_rotation, so simply rotating the
+        joint by 90 degrees does not reach the singularity. Use the root, whose local rotation
+        equals its global one, and pre-multiply by its pre-rotation so the conversion receives
+        exactly R_y(+/-90).
+        """
+        n_joints = character.skeleton.size
+        pre = character.skeleton.joints[0].pre_rotation  # (x, y, z, w)
+        pre_q = torch.tensor(
+            [float(pre[0]), float(pre[1]), float(pre[2]), float(pre[3])], dtype=dtype
+        )
+        h = math.sqrt(2.0) / 2.0  # sin(45) == cos(45)
+        r_y = torch.tensor([0.0, sign * h, 0.0, h], dtype=dtype)
+
+        rot = torch.zeros(1, n_joints, 4, dtype=dtype)
+        rot[..., 3] = 1.0  # identity for every joint
+        rot[0, 0, :] = pym_quaternion.multiply(pre_q, r_y)
+        skel_state = torch.cat(
+            [
+                torch.zeros(1, n_joints, 3, dtype=dtype),
+                rot,
+                torch.ones(1, n_joints, 1, dtype=dtype),
+            ],
+            dim=-1,
+        )
+
+        joint_params = pym_diff_geometry.skeleton_state_to_joint_parameters(
+            character, skel_state
+        )
+        self.assertTrue(
+            torch.isfinite(joint_params).all(),
+            f"non-finite joint parameters at the {label} gimbal singularity ({dtype}): "
+            f"{int(torch.isnan(joint_params).sum())} NaN, "
+            f"{int(torch.isinf(joint_params).sum())} Inf",
+        )
+
+        # The clamp must not distort a legitimate rotation: this angle is exactly +/-pi/2 at the
+        # singularity and should come back essentially unchanged. Tolerance is per-dtype since the
+        # clamp truncates 1.381e-03 rad in float32 but 5.96e-08 in float64. The signed comparison
+        # keeps +90 and -90 distinct, and trips if the construction stops reaching the singularity.
+        middle_euler = joint_params.view(1, n_joints, 7)[0, 0, 4]
+        self.assertAlmostEqual(
+            float(middle_euler),
+            sign * math.pi / 2,
+            delta=4e-3 if dtype == torch.float32 else 1e-6,
+            msg=f"{label} ({dtype}) no longer reaches the gimbal singularity, "
+            f"so it cannot detect the NaN",
+        )
+
+    def test_skeleton_state_to_joint_parameters_gimbal_singularity(self) -> None:
+        # At a +/-90 degree middle Euler angle the asin argument is analytically exactly +/-1, so
+        # rounding can push it out of domain and return NaN. In float64 even a plain 90 degree
+        # rotation about Y does it: 2 * (cos45 * sin45) == 1.0000000000000002.
+        #
+        # Both dtypes and both signs are covered: the clamp bounds are symmetric and its epsilon
+        # is chosen per dtype, so a change to either could regress a case the other misses.
+        character = pym_test_utils.create_test_character()
+        for dtype, (sign, label) in itertools.product(
+            (torch.float64, torch.float32), ((1.0, "+90"), (-1.0, "-90"))
+        ):
+            with self.subTest(dtype=str(dtype), rotation=label):
+                self._assert_gimbal_singularity_finite(character, dtype, sign, label)
 
     def test_typePromotion(self) -> None:
         # Verify that float/double promotion is working.


### PR DESCRIPTION
Summary:

`quaternionToXYZEuler` computed the middle Euler angle as `asin(2 * (qw*qy - qz*qx))` with no
domain guard. At a gimbal singularity that argument is analytically exactly +/-1, so any rounding
pushes it outside `[-1, 1]` and `asin` returns NaN.

This is not an exotic input. In float64 a plain 90 degree rotation about Y triggers it:

```
q = (0, sin45, 0, cos45)
2 * (qw*qy - qz*qx) = 1.0000000000000002     # exceeds 1.0 by 2.22e-16
asin(...) -> NaN
```

A single NaN here is unusually destructive, because callers feed these joint parameters into a
linear solve. One non-finite element spreads across the whole batch, and the IK solver then
rejects every parameter set in it rather than the one bad row.

The fix clamps the argument, stopping short of +/-1 rather than at it because `asin` has unbounded
derivative at the endpoints. Both existing implementations of this same function already clamp
this way: `backend/torch_quaternion.py:quaternion_to_xyz_euler` and `quaternion_np.py`.

## What the clamp costs

The clamp is applied in the *sine* domain, where `asin` is near-vertical, so it also truncates
arguments that were legitimately in domain:

```
asin(1 - eps) = pi/2 - sqrt(2 * eps)   approximately
```

Anything in `(1 - eps, 1]` therefore returns an angle short of +/-pi/2, and clamped inputs get
exactly zero gradient rather than a very large one. Both are deliberate: the alternatives at the
singularity are a NaN value and a NaN gradient.

## Why the epsilon is dtype-scaled

A single flat epsilon has to be sized for the least precise dtype, which makes it far more
conservative than float64 needs. `eps` is therefore 8 ULP of the tensor's own dtype:

| epsilon | angular truncation |
|---|---|
| flat 1e-6 | 1.414e-03 rad (0.081 deg), both dtypes |
| 8 ULP float32 = 9.54e-07 | 1.381e-03 rad (0.079 deg) |
| 8 ULP float64 = 1.78e-15 | 5.96e-08 rad (0.0000034 deg) |

float32 keeps essentially the 1e-6 the Python implementations use, which it genuinely needs --
overflows of order 6e-08 have been observed at that precision. float64 tightens by nine orders of
magnitude, against a worst case of 2.22e-16 from the rounding shown above. Both bounds still cover
their respective overflows, and the accuracy cost near 90 degrees effectively disappears in
float64.

Only float32 and float64 are distinguished. Reduced-precision dtypes fall back to the float32
bound, which is below one ULP for them, so the clamp degenerates to clamping at +/-1 -- still
NaN-free, but without margin. That is intentional rather than an oversight: at bfloat16's ULP even
a single-ULP guard costs several degrees of angle, so this conversion is not usable at that
precision whatever epsilon is chosen.

Reviewed By: cstollmeta

Differential Revision: D116487834


