### PR TITLE
Factor sequence LDLT diagonal blocks in place

### DIFF
--- a/momentum/character_sequence_solver/sequence_cholesky_solver.cpp
+++ b/momentum/character_sequence_solver/sequence_cholesky_solver.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <deque>
 #include <limits>
 #include <memory>
 #include <span>
@@ -729,6 +730,8 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> solveCommonNormalEquationsOnly(
 using BlockFactorScalar = double;
 using BlockFactorMatrixType = Eigen::Matrix<BlockFactorScalar, Eigen::Dynamic, Eigen::Dynamic>;
 using BlockFactorVectorType = Eigen::Matrix<BlockFactorScalar, Eigen::Dynamic, 1>;
+using BlockFactorRefType = Eigen::Ref<BlockFactorMatrixType>;
+using BlockDiagonalLdlt = Eigen::LDLT<BlockFactorRefType>;
 
 struct BlockLdltFactors {
   Eigen::Index blockSize = 0;
@@ -738,7 +741,7 @@ struct BlockLdltFactors {
   // The block-tridiagonal fast path never needs the unfactored diagonal blocks after their
   // LDLT decompositions have been computed.  Wider bands use them when updating later blocks.
   BlockFactorMatrixType diagonalFactors;
-  std::vector<Eigen::LDLT<BlockFactorMatrixType>> diagonalLdltFactors;
+  std::deque<BlockDiagonalLdlt> diagonalLdltFactors;
 
   auto lowerFactor(Eigen::Index iBlock, Eigen::Index jBlock) {
     MT_CHECK(iBlock >= jBlock);
@@ -760,7 +763,7 @@ struct BlockLdltFactors {
 };
 
 template <typename T>
-BlockLdltFactors factorBlockNormalEquations(
+std::unique_ptr<BlockLdltFactors> factorBlockNormalEquations(
     NormalEquationBlock<T>& hessian,
     Eigen::Index blockSize) {
   const Eigen::Index nBand = hessian.nBand();
@@ -777,14 +780,13 @@ BlockLdltFactors factorBlockNormalEquations(
     lowerFactors = packedBand.template cast<BlockFactorScalar>();
   }
 
-  BlockLdltFactors factors{
-      .blockSize = blockSize,
-      .nBlocks = nBlocks,
-      .bandwidthBlocks = bandwidthBlocks,
-      .lowerFactors = std::move(lowerFactors),
-      .diagonalFactors = bandwidthBlocks > 2 ? BlockFactorMatrixType::Zero(nBand, blockSize)
-                                             : BlockFactorMatrixType(),
-      .diagonalLdltFactors = std::vector<Eigen::LDLT<BlockFactorMatrixType>>(nBlocks)};
+  auto factors = std::make_unique<BlockLdltFactors>();
+  factors->blockSize = blockSize;
+  factors->nBlocks = nBlocks;
+  factors->bandwidthBlocks = bandwidthBlocks;
+  factors->lowerFactors = std::move(lowerFactors);
+  factors->diagonalFactors =
+      bandwidthBlocks > 2 ? BlockFactorMatrixType::Zero(nBand, blockSize) : BlockFactorMatrixType();
 
   BlockFactorMatrixType previousDiagonalUpdate;
   if (bandwidthBlocks == 2) {
@@ -792,7 +794,7 @@ BlockLdltFactors factorBlockNormalEquations(
   }
 
   for (Eigen::Index iBlock = 0; iBlock < nBlocks; ++iBlock) {
-    BlockFactorMatrixType diagonal = factors.lowerFactor(iBlock, iBlock);
+    BlockFactorMatrixType diagonal = factors->lowerFactor(iBlock, iBlock);
     const Eigen::Index kStart = std::max<Eigen::Index>(0, iBlock - bandwidthBlocks + 1);
     if (bandwidthBlocks == 2 && iBlock > 0) {
       // For block-tridiagonal systems, L_ik * D_k * L_ik^T is equivalent to
@@ -800,37 +802,39 @@ BlockLdltFactors factorBlockNormalEquations(
       diagonal -= previousDiagonalUpdate;
     } else {
       for (Eigen::Index kBlock = kStart; kBlock < iBlock; ++kBlock) {
-        const auto& lik = factors.lowerFactor(iBlock, kBlock);
-        diagonal.noalias() -= lik * factors.diagonalFactor(kBlock) * lik.transpose();
+        const auto& lik = factors->lowerFactor(iBlock, kBlock);
+        diagonal.noalias() -= lik * factors->diagonalFactor(kBlock) * lik.transpose();
       }
     }
 
-    factors.diagonalLdltFactors.at(static_cast<size_t>(iBlock)).compute(diagonal);
-    if (factors.diagonalLdltFactors.at(static_cast<size_t>(iBlock)).info() != Eigen::Success) {
+    if (bandwidthBlocks > 2) {
+      factors->diagonalFactor(iBlock) = diagonal;
+    }
+    auto diagonalBlock = factors->lowerFactor(iBlock, iBlock);
+    diagonalBlock = diagonal;
+    factors->diagonalLdltFactors.emplace_back(diagonalBlock);
+    const auto& diagonalLdlt = factors->diagonalLdltFactors.back();
+    if (diagonalLdlt.info() != Eigen::Success) {
       MT_THROW("Block banded LDLT factorization failed at block {}", iBlock);
     }
-    if (bandwidthBlocks > 2) {
-      factors.diagonalFactor(iBlock) = diagonal;
-    }
-    factors.lowerFactor(iBlock, iBlock).setIdentity();
 
     const Eigen::Index jEnd = std::min(nBlocks, iBlock + bandwidthBlocks);
     for (Eigen::Index jBlock = iBlock + 1; jBlock < jEnd; ++jBlock) {
-      BlockFactorMatrixType value = factors.lowerFactor(jBlock, iBlock);
+      BlockFactorMatrixType value = factors->lowerFactor(jBlock, iBlock);
       const auto kStartCur = std::max<Eigen::Index>({0, jBlock - bandwidthBlocks + 1, kStart});
       for (Eigen::Index kBlock = kStartCur; kBlock < iBlock; ++kBlock) {
-        value.noalias() -= factors.lowerFactor(jBlock, kBlock) * factors.diagonalFactor(kBlock) *
-            factors.lowerFactor(iBlock, kBlock).transpose();
+        value.noalias() -= factors->lowerFactor(jBlock, kBlock) * factors->diagonalFactor(kBlock) *
+            factors->lowerFactor(iBlock, kBlock).transpose();
       }
 
       const BlockFactorMatrixType lowerFactor =
-          factors.diagonalLdltFactors.at(static_cast<size_t>(iBlock))
+          factors->diagonalLdltFactors.at(static_cast<size_t>(iBlock))
               .solve(value.transpose())
               .transpose();
       if (bandwidthBlocks == 2) {
         previousDiagonalUpdate.noalias() = lowerFactor * value.transpose();
       }
-      factors.lowerFactor(jBlock, iBlock) = lowerFactor;
+      factors->lowerFactor(jBlock, iBlock) = lowerFactor;
     }
   }
 
@@ -927,7 +931,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> solveNormalEquationsBlock(
   MT_CHECK(blockSize > 0);
   MT_CHECK(nBand % blockSize == 0);
 
-  const BlockLdltFactors factors = factorBlockNormalEquations(hessian, blockSize);
+  const auto factors = factorBlockNormalEquations(hessian, blockSize);
 
   BlockFactorVectorType zBand = hessian.rhs().head(nBand).template cast<BlockFactorScalar>();
   BlockFactorMatrixType e = BlockFactorMatrixType::Zero(nBand, nCommon);
@@ -935,13 +939,13 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> solveNormalEquationsBlock(
     e = hessian.common().topRows(nBand).template cast<BlockFactorScalar>();
   }
 
-  applyBlockForwardSubstitution(factors, zBand, e);
+  applyBlockForwardSubstitution(*factors, zBand, e);
 
   BlockFactorVectorType result = BlockFactorVectorType::Zero(nBand + nCommon);
   if (nCommon > 0) {
     BlockFactorMatrixType dInvE = e;
     BlockFactorVectorType dInvZ = zBand;
-    applyBlockDiagonalInverse(factors, dInvZ, dInvE);
+    applyBlockDiagonalInverse(*factors, dInvZ, dInvE);
     result.tail(nCommon) = solveCommonBlock(hessian, e, dInvE, dInvZ);
   }
 
@@ -949,7 +953,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> solveNormalEquationsBlock(
   if (nCommon > 0) {
     bandRhs.noalias() -= e * result.tail(nCommon);
   }
-  result.head(nBand) = solveBlockBandVariables(factors, bandRhs);
+  result.head(nBand) = solveBlockBandVariables(*factors, bandRhs);
 
   return result.template cast<T>();
 }

--- a/momentum/character_sequence_solver/sequence_cholesky_solver.cpp
+++ b/momentum/character_sequence_solver/sequence_cholesky_solver.cpp
@@ -20,6 +20,7 @@
 #include "momentum/common/progress_bar.h"
 
 #include <dispenso/parallel_for.h>
+#include <dispenso/thread_pool.h>
 
 #include <Eigen/Cholesky>
 
@@ -145,6 +146,11 @@ class NormalEquationBlock {
 
   [[nodiscard]] const VectorType& rhs() const {
     return rhs_;
+  }
+
+  MatrixType takeBlockBand() {
+    MT_CHECK(hasBlockBand());
+    return std::move(blockBand_);
   }
 
   auto blockBandBlock(Eigen::Index iBlock, Eigen::Index jBlock) {
@@ -724,40 +730,13 @@ using BlockFactorScalar = double;
 using BlockFactorMatrixType = Eigen::Matrix<BlockFactorScalar, Eigen::Dynamic, Eigen::Dynamic>;
 using BlockFactorVectorType = Eigen::Matrix<BlockFactorScalar, Eigen::Dynamic, 1>;
 
-template <typename T>
-BlockFactorMatrixType getBlockNormalEquation(
-    const NormalEquationBlock<T>& hessian,
-    Eigen::Index blockSize,
-    Eigen::Index iBlock,
-    Eigen::Index jBlock) {
-  if (hessian.hasBlockBand()) {
-    return hessian.blockBandBlock(iBlock, jBlock).template cast<BlockFactorScalar>();
-  }
-
-  BlockFactorMatrixType result = BlockFactorMatrixType::Zero(blockSize, blockSize);
-  const Eigen::Index iOffset = iBlock * blockSize;
-  const Eigen::Index jOffset = jBlock * blockSize;
-  for (Eigen::Index i = 0; i < blockSize; ++i) {
-    for (Eigen::Index j = 0; j < blockSize; ++j) {
-      const Eigen::Index iGlobal = iOffset + i;
-      const Eigen::Index jGlobal = jOffset + j;
-      if (iGlobal <= jGlobal) {
-        if (jGlobal - iGlobal < hessian.bandwidth()) {
-          result(i, j) = hessian.bandEntry(iGlobal, jGlobal);
-        }
-      } else if (iGlobal - jGlobal < hessian.bandwidth()) {
-        result(i, j) = hessian.bandEntry(jGlobal, iGlobal);
-      }
-    }
-  }
-  return result;
-}
-
 struct BlockLdltFactors {
   Eigen::Index blockSize = 0;
   Eigen::Index nBlocks = 0;
   Eigen::Index bandwidthBlocks = 0;
   BlockFactorMatrixType lowerFactors;
+  // The block-tridiagonal fast path never needs the unfactored diagonal blocks after their
+  // LDLT decompositions have been computed.  Wider bands use them when updating later blocks.
   BlockFactorMatrixType diagonalFactors;
   std::vector<Eigen::LDLT<BlockFactorMatrixType>> diagonalLdltFactors;
 
@@ -782,27 +761,43 @@ struct BlockLdltFactors {
 
 template <typename T>
 BlockLdltFactors factorBlockNormalEquations(
-    const NormalEquationBlock<T>& hessian,
+    NormalEquationBlock<T>& hessian,
     Eigen::Index blockSize) {
   const Eigen::Index nBand = hessian.nBand();
   const Eigen::Index nBlocks = nBand / blockSize;
   const Eigen::Index bandwidthBlocks = hessian.blockBandwidth();
+
+  // The normal-equation band and the lower factor have the same packed layout. Consume the
+  // former so both full matrices are not resident throughout factorization.
+  BlockFactorMatrixType lowerFactors;
+  if constexpr (std::is_same_v<T, BlockFactorScalar>) {
+    lowerFactors = hessian.takeBlockBand();
+  } else {
+    const auto packedBand = hessian.takeBlockBand();
+    lowerFactors = packedBand.template cast<BlockFactorScalar>();
+  }
+
   BlockLdltFactors factors{
       .blockSize = blockSize,
       .nBlocks = nBlocks,
       .bandwidthBlocks = bandwidthBlocks,
-      .lowerFactors = BlockFactorMatrixType::Zero(nBlocks * blockSize, bandwidthBlocks * blockSize),
-      .diagonalFactors = BlockFactorMatrixType::Zero(nBand, blockSize),
+      .lowerFactors = std::move(lowerFactors),
+      .diagonalFactors = bandwidthBlocks > 2 ? BlockFactorMatrixType::Zero(nBand, blockSize)
+                                             : BlockFactorMatrixType(),
       .diagonalLdltFactors = std::vector<Eigen::LDLT<BlockFactorMatrixType>>(nBlocks)};
 
+  BlockFactorMatrixType previousDiagonalUpdate;
+  if (bandwidthBlocks == 2) {
+    previousDiagonalUpdate = BlockFactorMatrixType::Zero(blockSize, blockSize);
+  }
+
   for (Eigen::Index iBlock = 0; iBlock < nBlocks; ++iBlock) {
-    auto diagonal = getBlockNormalEquation(hessian, blockSize, iBlock, iBlock);
+    BlockFactorMatrixType diagonal = factors.lowerFactor(iBlock, iBlock);
     const Eigen::Index kStart = std::max<Eigen::Index>(0, iBlock - bandwidthBlocks + 1);
     if (bandwidthBlocks == 2 && iBlock > 0) {
       // For block-tridiagonal systems, L_ik * D_k * L_ik^T is equivalent to
-      // L_ik * A_ik^T and saves one dense block multiply per frame.
-      diagonal.noalias() -= factors.lowerFactor(iBlock, iBlock - 1) *
-          getBlockNormalEquation(hessian, blockSize, iBlock, iBlock - 1).transpose();
+      // L_ik * A_ik^T. Carry that update forward because A_ik shares storage with L_ik.
+      diagonal -= previousDiagonalUpdate;
     } else {
       for (Eigen::Index kBlock = kStart; kBlock < iBlock; ++kBlock) {
         const auto& lik = factors.lowerFactor(iBlock, kBlock);
@@ -814,22 +809,28 @@ BlockLdltFactors factorBlockNormalEquations(
     if (factors.diagonalLdltFactors.at(static_cast<size_t>(iBlock)).info() != Eigen::Success) {
       MT_THROW("Block banded LDLT factorization failed at block {}", iBlock);
     }
-    factors.diagonalFactor(iBlock) = diagonal;
+    if (bandwidthBlocks > 2) {
+      factors.diagonalFactor(iBlock) = diagonal;
+    }
     factors.lowerFactor(iBlock, iBlock).setIdentity();
 
     const Eigen::Index jEnd = std::min(nBlocks, iBlock + bandwidthBlocks);
     for (Eigen::Index jBlock = iBlock + 1; jBlock < jEnd; ++jBlock) {
-      auto value = getBlockNormalEquation(hessian, blockSize, jBlock, iBlock);
+      BlockFactorMatrixType value = factors.lowerFactor(jBlock, iBlock);
       const auto kStartCur = std::max<Eigen::Index>({0, jBlock - bandwidthBlocks + 1, kStart});
       for (Eigen::Index kBlock = kStartCur; kBlock < iBlock; ++kBlock) {
         value.noalias() -= factors.lowerFactor(jBlock, kBlock) * factors.diagonalFactor(kBlock) *
             factors.lowerFactor(iBlock, kBlock).transpose();
       }
 
-      factors.lowerFactor(jBlock, iBlock) =
+      const BlockFactorMatrixType lowerFactor =
           factors.diagonalLdltFactors.at(static_cast<size_t>(iBlock))
               .solve(value.transpose())
               .transpose();
+      if (bandwidthBlocks == 2) {
+        previousDiagonalUpdate.noalias() = lowerFactor * value.transpose();
+      }
+      factors.lowerFactor(jBlock, iBlock) = lowerFactor;
     }
   }
 
@@ -919,7 +920,7 @@ BlockFactorVectorType solveBlockBandVariables(
 
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> solveNormalEquationsBlock(
-    const NormalEquationBlock<T>& hessian,
+    NormalEquationBlock<T>& hessian,
     Eigen::Index blockSize) {
   const Eigen::Index nBand = hessian.nBand();
   const Eigen::Index nCommon = hessian.nCommon();
@@ -954,10 +955,8 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> solveNormalEquationsBlock(
 }
 
 template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, 1> solveNormalEquations(
-    const NormalEquationBlock<T>& hessian,
-    Eigen::Index blockSize,
-    bool useBlockLdlt) {
+Eigen::Matrix<T, Eigen::Dynamic, 1>
+solveNormalEquations(NormalEquationBlock<T>& hessian, Eigen::Index blockSize, bool useBlockLdlt) {
   if (!useBlockLdlt || hessian.nBand() == 0 || blockSize <= 1 || hessian.nBand() % blockSize != 0 ||
       hessian.bandwidth() % blockSize != 0 || !hessian.hasBlockBand()) {
     return solveNormalEquationsScalarLdlt(hessian);
@@ -1047,23 +1046,6 @@ void SequenceCholeskySolverT<T>::doIterationWithNormalEquationScalar() {
 
   const size_t chunkSize = std::max<size_t>(1, chunkSize_);
   const size_t nChunks = (fn.getNumFrames() + chunkSize - 1) / chunkSize;
-  std::vector<AccumulationResult<T, NormalEquationScalar>> chunkResults(nChunks);
-
-  if (this->multithreaded_) {
-    dispenso::parallel_for(size_t(0), nChunks, [&](size_t iChunk) {
-      const size_t chunkStart = iChunk * chunkSize;
-      const size_t chunkEnd = std::min(fn.getNumFrames(), chunkStart + chunkSize);
-      chunkResults[iChunk] = processChunk<T, NormalEquationScalar>(
-          &fn, chunkStart, chunkEnd, this->bandwidth_, targetRowsPerJtJChunk_);
-    });
-  } else {
-    for (size_t iChunk = 0; iChunk < nChunks; ++iChunk) {
-      const size_t chunkStart = iChunk * chunkSize;
-      const size_t chunkEnd = std::min(fn.getNumFrames(), chunkStart + chunkSize);
-      chunkResults[iChunk] = processChunk<T, NormalEquationScalar>(
-          &fn, chunkStart, chunkEnd, this->bandwidth_, targetRowsPerJtJChunk_);
-    }
-  }
 
   std::unique_ptr<ProgressBar> progress;
   if (this->progressBar_) {
@@ -1073,11 +1055,40 @@ void SequenceCholeskySolverT<T>::doIterationWithNormalEquationScalar() {
   }
 
   this->error_ = 0;
-  for (auto& result : chunkResults) {
+  const auto mergeChunkResult = [&](AccumulationResult<T, NormalEquationScalar>& result) {
     globalHessian.mergeBlock(*result.normalEquations);
     this->error_ += result.error;
     if (progress) {
       progress->increment(result.nFunctions);
+    }
+    result.normalEquations.reset();
+  };
+
+  if (this->multithreaded_) {
+    const auto workerCount = dispenso::globalThreadPool().numThreads();
+    const size_t chunksPerBatch =
+        std::min(nChunks, workerCount > 0 ? static_cast<size_t>(workerCount + 1) : size_t(1));
+    std::vector<AccumulationResult<T, NormalEquationScalar>> chunkResults(chunksPerBatch);
+    for (size_t batchStart = 0; batchStart < nChunks; batchStart += chunksPerBatch) {
+      const size_t batchSize = std::min(chunksPerBatch, nChunks - batchStart);
+      dispenso::parallel_for(size_t(0), batchSize, [&](size_t iResult) {
+        const size_t iChunk = batchStart + iResult;
+        const size_t chunkStart = iChunk * chunkSize;
+        const size_t chunkEnd = std::min(fn.getNumFrames(), chunkStart + chunkSize);
+        chunkResults[iResult] = processChunk<T, NormalEquationScalar>(
+            &fn, chunkStart, chunkEnd, this->bandwidth_, targetRowsPerJtJChunk_);
+      });
+      for (size_t iResult = 0; iResult < batchSize; ++iResult) {
+        mergeChunkResult(chunkResults[iResult]);
+      }
+    }
+  } else {
+    for (size_t iChunk = 0; iChunk < nChunks; ++iChunk) {
+      const size_t chunkStart = iChunk * chunkSize;
+      const size_t chunkEnd = std::min(fn.getNumFrames(), chunkStart + chunkSize);
+      auto result = processChunk<T, NormalEquationScalar>(
+          &fn, chunkStart, chunkEnd, this->bandwidth_, targetRowsPerJtJChunk_);
+      mergeChunkResult(result);
     }
   }
 

--- a/momentum/test/character_sequence_solver/solver_test.cpp
+++ b/momentum/test/character_sequence_solver/solver_test.cpp
@@ -28,6 +28,8 @@
 #include "momentum/test/character/character_helpers.h"
 #include "momentum/test/solver/solver_test_helpers.h"
 
+#include <dispenso/thread_pool.h>
+
 #include <gtest/gtest.h>
 
 #include <chrono>
@@ -369,6 +371,68 @@ TYPED_TEST(SequenceSolverTest, CompareCholesky) {
   solverOptionsCholesky.regularization = solverOptionsQr.regularization;
   solverOptionsCholesky.multithreaded = false;
   solverOptionsCholesky.chunkSize = 1;
+
+  const Eigen::VectorX<T> parametersInit = sequenceSolverFunctionQr.getJoinedParameterVector();
+
+  SequenceSolverT<T> solverQr(solverOptionsQr, &sequenceSolverFunctionQr);
+  Eigen::VectorX<T> parametersQr = parametersInit;
+  solverQr.solve(parametersQr);
+  const T errQr = sequenceSolverFunctionQr.getError(parametersQr);
+
+  SequenceCholeskySolverT<T> solverCholesky(solverOptionsCholesky, &sequenceSolverFunctionCholesky);
+  Eigen::VectorX<T> parametersCholesky = parametersInit;
+  solverCholesky.solve(parametersCholesky);
+  const T errCholesky = sequenceSolverFunctionCholesky.getError(parametersCholesky);
+
+  EXPECT_NEAR(errQr, errCholesky, Eps<T>(5e-5f, 1e-8));
+  EXPECT_NEAR((parametersQr - parametersCholesky).norm(), T(0), Eps<T>(1e-4f, 1e-8));
+}
+
+TYPED_TEST(SequenceSolverTest, CompareCholeskyPerFrameOnlyAcrossBatchesAndIterations) {
+  using T = typename TestFixture::Type;
+
+  const Character character = createTestCharacter();
+  ParameterTransformT<T> castedCharacterParameterTransform = character.parameterTransform.cast<T>();
+
+  ParameterSet universalParams;
+  universalParams.set(2);
+  universalParams.set(4);
+  universalParams.set(7);
+
+  const auto workerCount = dispenso::globalThreadPool().numThreads();
+  ASSERT_GE(workerCount, 0);
+  const size_t nFrames = std::max<size_t>(4, static_cast<size_t>(workerCount) + 2);
+  MultiPoseTestProblem<T> problem(this->rng, character, nFrames, universalParams);
+
+  const auto populateSolverFunction = [&](SequenceSolverFunctionT<T>& result) {
+    for (size_t iFrame = 0; iFrame < nFrames; ++iFrame) {
+      result.addErrorFunction(iFrame, problem.positionErrors[iFrame]);
+      result.addErrorFunction(iFrame, problem.orientErrors[iFrame]);
+    }
+  };
+
+  SequenceSolverFunctionT<T> sequenceSolverFunctionQr(
+      character, castedCharacterParameterTransform, problem.universalParams, nFrames);
+  populateSolverFunction(sequenceSolverFunctionQr);
+  SequenceSolverFunctionT<T> sequenceSolverFunctionCholesky(
+      character, castedCharacterParameterTransform, problem.universalParams, nFrames);
+  populateSolverFunction(sequenceSolverFunctionCholesky);
+
+  auto solverOptionsQr = SequenceSolverOptions();
+  solverOptionsQr.minIterations = 2;
+  solverOptionsQr.maxIterations = 2;
+  solverOptionsQr.threshold = 0.0f;
+  solverOptionsQr.regularization = 0.37f;
+  solverOptionsQr.multithreaded = false;
+
+  auto solverOptionsCholesky = SequenceCholeskySolverOptions();
+  solverOptionsCholesky.minIterations = solverOptionsQr.minIterations;
+  solverOptionsCholesky.maxIterations = solverOptionsQr.maxIterations;
+  solverOptionsCholesky.threshold = solverOptionsQr.threshold;
+  solverOptionsCholesky.regularization = solverOptionsQr.regularization;
+  solverOptionsCholesky.multithreaded = true;
+  solverOptionsCholesky.chunkSize = 1;
+  solverOptionsCholesky.useDoublePrecisionNormalEquations = true;
 
   const Eigen::VectorX<T> parametersInit = sequenceSolverFunctionQr.getJoinedParameterVector();
 


### PR DESCRIPTION
Summary:
Store each Eigen LDLT factorization directly in the corresponding diagonal block of the packed band matrix. This removes the per-frame dense matrix owned by Eigen while retaining only the small pivot and workspace vectors. Keep the factor container at a stable address so its Eigen Ref objects remain valid.

Add coverage for bandwidth-one solves spanning multiple accumulation batches and multiple solver iterations.

Differential Revision: D117939931


