### PR TITLE
Make sequence solver batch test deterministic

### DIFF
--- a/momentum/test/character_sequence_solver/solver_test.cpp
+++ b/momentum/test/character_sequence_solver/solver_test.cpp
@@ -399,9 +399,9 @@ TYPED_TEST(SequenceSolverTest, CompareCholeskyPerFrameOnlyAcrossBatchesAndIterat
   universalParams.set(4);
   universalParams.set(7);
 
-  const auto workerCount = dispenso::globalThreadPool().numThreads();
-  ASSERT_GE(workerCount, 0);
-  const size_t nFrames = std::max<size_t>(4, static_cast<size_t>(workerCount) + 2);
+  constexpr size_t kWorkerCount = 1;
+  // One pool worker plus the caller processes four one-frame chunks in two batches.
+  constexpr size_t nFrames = 2 * (kWorkerCount + 1);
   MultiPoseTestProblem<T> problem(this->rng, character, nFrames, universalParams);
 
   const auto populateSolverFunction = [&](SequenceSolverFunctionT<T>& result) {
@@ -443,7 +443,16 @@ TYPED_TEST(SequenceSolverTest, CompareCholeskyPerFrameOnlyAcrossBatchesAndIterat
 
   SequenceCholeskySolverT<T> solverCholesky(solverOptionsCholesky, &sequenceSolverFunctionCholesky);
   Eigen::VectorX<T> parametersCholesky = parametersInit;
-  solverCholesky.solve(parametersCholesky);
+  auto& threadPool = dispenso::globalThreadPool();
+  const auto originalWorkerCount = threadPool.numThreads();
+  threadPool.resize(kWorkerCount);
+  try {
+    solverCholesky.solve(parametersCholesky);
+  } catch (...) {
+    threadPool.resize(originalWorkerCount);
+    throw;
+  }
+  threadPool.resize(originalWorkerCount);
   const T errCholesky = sequenceSolverFunctionCholesky.getError(parametersCholesky);
 
   EXPECT_NEAR(errQr, errCholesky, Eps<T>(5e-5f, 1e-8));


### PR DESCRIPTION
Summary:
## Motivation
The multi-batch comparison test scaled its frame count with the available thread-pool workers. This changed the generated numerical problem across machines and could push equivalent QR and Cholesky solutions beyond a fixed tolerance even when solver behavior was unchanged.

## This diff
Makes the test workload deterministic while retaining coverage of multiple batches and solver iterations.

- **Fixed workload:** Run the Cholesky solve with one pool worker and four frames, producing two batches of one-frame chunks.
- **State restoration:** Restore the original pool size after the solve, including when an exception is thrown, so later tests see unchanged process state.

Differential Revision: D119520172


