### PR TITLE
Add an OBJ loader that reads texture coordinates (#1649)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,6 +648,15 @@ mt_library(
 )
 
 mt_library(
+  NAME io_obj
+  HEADERS_VARS io_obj_public_headers
+  SOURCES_VARS io_obj_sources
+  PUBLIC_LINK_LIBRARIES
+    character
+    io_common
+)
+
+mt_library(
   NAME io_motion
   HEADERS_VARS io_motion_public_headers
   SOURCES_VARS io_motion_sources
@@ -692,6 +701,7 @@ mt_library(
     io_common
     io_legacy_json
     io_marker
+    io_obj
     io_motion
     io_shape
     ${io_usd_library}
@@ -1000,6 +1010,14 @@ if(MOMENTUM_BUILD_TESTING)
       io_test_helper
     ENV
       "TEST_RESOURCES_PATH=${CMAKE_SOURCE_DIR}/momentum/test/resources"
+  )
+
+  mt_test(
+    NAME io_obj_test
+    SOURCES_VARS io_obj_test_sources
+    LINK_LIBRARIES
+      io_obj
+      io_test_helper
   )
 
   mt_test(

--- a/cmake/build_variables.bzl
+++ b/cmake/build_variables.bzl
@@ -692,6 +692,18 @@ io_legacy_json_test_sources = [
     "test/io/io_legacy_json_test.cpp",
 ]
 
+io_obj_public_headers = [
+    "io/obj/obj_io.h",
+]
+
+io_obj_sources = [
+    "io/obj/obj_io.cpp",
+]
+
+io_obj_test_sources = [
+    "test/io/io_obj_test.cpp",
+]
+
 io_bvh_public_headers = [
     "io/bvh/bvh_io.h",
 ]

--- a/momentum/io/obj/obj_io.cpp
+++ b/momentum/io/obj/obj_io.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/obj/obj_io.h"
+
+#include "momentum/common/exception.h"
+#include "momentum/common/log.h"
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace momentum {
+
+namespace {
+
+/// One face corner. ``texcoord`` is -1 when the corner carries no `vt` index.
+struct Corner {
+  int32_t vertex = -1;
+  int32_t texcoord = -1;
+};
+
+/// Parse an OBJ index, reporting the offending token and line the way the rest of the
+/// parser does. `std::stoll` alone throws a bare std exception naming neither.
+///
+/// `int64_t` rather than `long`, which is 32 bits on LLP64 (Windows/MSVC) and would
+/// truncate the `count` cast in resolveIndex below.
+int64_t parseIndex(const std::string& field, const char* what, size_t lineNumber) {
+  size_t consumed = 0;
+  int64_t value = 0;
+  try {
+    value = std::stoll(field, &consumed);
+  } catch (const std::exception&) {
+    MT_THROW("OBJ line {}: {} index '{}' is not a valid integer", lineNumber, what, field);
+  }
+  MT_THROW_IF(
+      consumed != field.size(),
+      "OBJ line {}: {} index '{}' has trailing characters",
+      lineNumber,
+      what,
+      field);
+  return value;
+}
+
+/// Resolve a 1-based OBJ index, where a negative value counts back from the end of what has
+/// been read so far -- which is why this can only be done while parsing, not afterwards.
+int32_t resolveIndex(int64_t raw, size_t count, const char* what, size_t lineNumber) {
+  MT_THROW_IF(
+      raw == 0, "OBJ line {}: {} index 0 is invalid, OBJ indices are 1-based", lineNumber, what);
+  const int64_t resolved = (raw > 0) ? (raw - 1) : (static_cast<int64_t>(count) + raw);
+  MT_THROW_IF(
+      resolved < 0 || resolved >= static_cast<int64_t>(count),
+      "OBJ line {}: {} index {} is out of range, {} have been read",
+      lineNumber,
+      what,
+      raw,
+      count);
+  return static_cast<int32_t>(resolved);
+}
+
+/// Parse one whitespace-delimited face corner: `v`, `v/vt`, `v//vn` or `v/vt/vn`.
+Corner
+parseCorner(const std::string& token, size_t numVertices, size_t numTexcoords, size_t lineNumber) {
+  const size_t firstSlash = token.find('/');
+  const std::string vertexField = token.substr(0, firstSlash);
+  MT_THROW_IF(
+      vertexField.empty(), "OBJ line {}: face corner '{}' has no vertex index", lineNumber, token);
+
+  Corner corner;
+  corner.vertex = resolveIndex(
+      parseIndex(vertexField, "vertex", lineNumber), numVertices, "vertex", lineNumber);
+
+  if (firstSlash != std::string::npos) {
+    const size_t secondSlash = token.find('/', firstSlash + 1);
+    const std::string texcoordField = (secondSlash == std::string::npos)
+        ? token.substr(firstSlash + 1)
+        : token.substr(firstSlash + 1, secondSlash - firstSlash - 1);
+    // Empty means the `v//vn` form: a normal index but no texture coordinate.
+    if (!texcoordField.empty()) {
+      corner.texcoord = resolveIndex(
+          parseIndex(texcoordField, "texture coordinate", lineNumber),
+          numTexcoords,
+          "texture coordinate",
+          lineNumber);
+    }
+  }
+  return corner;
+}
+
+uint8_t toByteColor(float v) {
+  return static_cast<uint8_t>(std::lround(std::clamp(v, 0.0f, 1.0f) * 255.0f));
+}
+
+Mesh parseObj(std::istream& stream) {
+  Mesh mesh;
+  std::vector<Eigen::Vector2f> texcoords;
+  std::vector<Eigen::Vector3i> texcoordFaces;
+  std::vector<Corner> corners;
+
+  // Texture coordinates are kept only if *every* face has them, since texcoord_faces has to
+  // stay index-aligned with faces.
+  bool allFacesTextured = true;
+  bool anyFaceTextured = false;
+
+  std::string line;
+  size_t lineNumber = 0;
+  while (std::getline(stream, line)) {
+    ++lineNumber;
+    if (const size_t comment = line.find('#'); comment != std::string::npos) {
+      line.resize(comment);
+    }
+
+    std::istringstream fields(line);
+    std::string token;
+    if (!(fields >> token)) {
+      continue;
+    }
+
+    if (token == "v") {
+      std::vector<float> values;
+      float value = 0.0f;
+      while (fields >> value) {
+        values.push_back(value);
+      }
+      MT_THROW_IF(
+          values.size() < 3,
+          "OBJ line {}: vertex needs at least 3 coordinates, got {}",
+          lineNumber,
+          values.size());
+      mesh.vertices.emplace_back(values[0], values[1], values[2]);
+      // `v x y z r g b` -- the six-float form carries a vertex colour. Four floats is the
+      // rational `w` form instead, whose weight momentum has nowhere to put.
+      if (values.size() >= 6) {
+        mesh.colors.emplace_back(
+            toByteColor(values[3]), toByteColor(values[4]), toByteColor(values[5]));
+      }
+    } else if (token == "vt") {
+      float u = 0.0f;
+      float v = 0.0f;
+      MT_THROW_IF(
+          !(fields >> u >> v),
+          "OBJ line {}: texture coordinate needs at least two floats",
+          lineNumber);
+      texcoords.emplace_back(u, v);
+    } else if (token == "f") {
+      corners.clear();
+      std::string cornerToken;
+      while (fields >> cornerToken) {
+        corners.push_back(
+            parseCorner(cornerToken, mesh.vertices.size(), texcoords.size(), lineNumber));
+      }
+      if (corners.size() < 3) {
+        MT_LOGW("OBJ line {}: skipping face with {} corners", lineNumber, corners.size());
+        continue;
+      }
+
+      const bool textured =
+          std::ranges::all_of(corners, [](const Corner& c) { return c.texcoord >= 0; });
+      anyFaceTextured |= textured;
+      allFacesTextured &= textured;
+
+      mesh.polyFaceSizes.push_back(static_cast<uint32_t>(corners.size()));
+      for (const Corner& c : corners) {
+        mesh.polyFaces.push_back(static_cast<uint32_t>(c.vertex));
+        if (textured) {
+          mesh.polyTexcoordFaces.push_back(static_cast<uint32_t>(c.texcoord));
+        }
+      }
+
+      for (size_t i = 2; i < corners.size(); ++i) {
+        mesh.faces.emplace_back(corners[0].vertex, corners[i - 1].vertex, corners[i].vertex);
+        if (textured) {
+          texcoordFaces.emplace_back(
+              corners[0].texcoord, corners[i - 1].texcoord, corners[i].texcoord);
+        }
+      }
+    }
+    // `vn`, `g`, `o`, `s`, `usemtl` and `mtllib` are deliberately ignored; see the header.
+  }
+
+  MT_THROW_IF(mesh.vertices.empty(), "OBJ file contains no vertices");
+  MT_THROW_IF(mesh.faces.empty(), "OBJ file contains no faces");
+
+  if (anyFaceTextured && allFacesTextured) {
+    mesh.texcoords = std::move(texcoords);
+    mesh.texcoord_faces = std::move(texcoordFaces);
+  } else {
+    if (anyFaceTextured) {
+      MT_LOGW(
+          "OBJ file texture-maps only some of its {} faces; loading it untextured",
+          mesh.faces.size());
+    }
+    mesh.polyTexcoordFaces.clear();
+  }
+
+  if (mesh.colors.size() != mesh.vertices.size()) {
+    if (!mesh.colors.empty()) {
+      MT_LOGW(
+          "OBJ file gives colours for {} of {} vertices; discarding them",
+          mesh.colors.size(),
+          mesh.vertices.size());
+    }
+    mesh.colors.assign(mesh.vertices.size(), Vector3b::Constant(255));
+  }
+  mesh.confidence.assign(mesh.vertices.size(), 1.0f);
+  mesh.updateNormals();
+  return mesh;
+}
+
+} // namespace
+
+Mesh loadObj(const filesystem::path& filepath) {
+  std::ifstream file(filepath);
+  MT_THROW_IF(!file.is_open(), "Failed to open OBJ file: {}", filepath.string());
+  return parseObj(file);
+}
+
+Mesh loadObj(std::span<const std::byte> bytes) {
+  std::istringstream stream(std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size()));
+  return parseObj(stream);
+}
+
+} // namespace momentum

--- a/momentum/io/obj/obj_io.h
+++ b/momentum/io/obj/obj_io.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <momentum/common/filesystem.h>
+#include <momentum/math/mesh.h>
+
+#include <span>
+
+namespace momentum {
+
+/// Loads a mesh from a Wavefront OBJ file.
+///
+/// Reads positions (`v`), texture coordinates (`vt`) and faces (`f`), accepting all four
+/// OBJ face-corner forms (`v`, `v/vt`, `v//vn`, `v/vt/vn`) and both positive and negative
+/// (relative) indices. Polygons are fan-triangulated into @ref Mesh::faces, and the
+/// original topology is preserved in @ref Mesh::polyFaces and @ref Mesh::polyFaceSizes.
+///
+/// Texture coordinates are indexed per face corner, which is OBJ's own layout, so they map
+/// directly onto @ref Mesh::texcoords and @ref Mesh::texcoord_faces. They are kept only if
+/// every face carries a complete set of `vt` indices; a file that texture-maps some faces
+/// and not others is loaded untextured, because @ref Mesh::texcoord_faces has to align
+/// one-to-one with @ref Mesh::faces.
+///
+/// Vertex normals are recomputed from the geometry rather than read from `vn`: @ref Mesh
+/// stores one normal per vertex, while OBJ indexes them per face corner, so honouring `vn`
+/// in general would mean splitting vertices. This matches how the FBX and glTF loaders
+/// treat normals.
+///
+/// Vertex colours are read from the six-float `v x y z r g b` form some exporters emit, and
+/// default to white otherwise.
+///
+/// Material, group, object and smoothing directives (`mtllib`, `usemtl`, `g`, `o`, `s`) are
+/// ignored, so the whole file loads as one mesh.
+///
+/// @param[in] filepath Path to the OBJ file.
+/// @return The loaded mesh.
+/// @throws std::runtime_error if the file cannot be opened, an index is out of range, or the
+///     file contains no geometry.
+[[nodiscard]] Mesh loadObj(const filesystem::path& filepath);
+
+/// Loads a mesh from an in-memory OBJ file.
+///
+/// @param[in] bytes Buffer holding the OBJ file contents.
+/// @return The loaded mesh.
+/// @throws std::runtime_error under the same conditions as the path overload.
+[[nodiscard]] Mesh loadObj(std::span<const std::byte> bytes);
+
+} // namespace momentum

--- a/momentum/test/io/io_obj_test.cpp
+++ b/momentum/test/io/io_obj_test.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "momentum/io/obj/obj_io.h"
+#include "momentum/test/io/io_helpers.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+
+using namespace momentum;
+
+namespace {
+
+/// Write `contents` to a temporary .obj and load it.
+Mesh loadFromText(const std::string& name, const std::string& contents) {
+  const TemporaryFile file = temporaryFile(name, "obj");
+  {
+    std::ofstream out(file.path());
+    out << contents;
+  }
+  return loadObj(file.path());
+}
+
+// Two triangles sharing an edge, each corner with its own texture coordinate.
+constexpr const char* kQuadAsTriangles = R"(# comment line
+v 0 0 0
+v 1 0 0
+v 1 1 0
+v 0 1 0
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+f 1/1 2/2 3/3
+f 1/1 3/3 4/4
+)";
+
+} // namespace
+
+TEST(IoObjTest, ReadsPositionsFacesAndTexcoords) {
+  const Mesh mesh = loadFromText("obj_basic", kQuadAsTriangles);
+
+  EXPECT_EQ(mesh.vertices.size(), 4);
+  EXPECT_EQ(mesh.faces.size(), 2);
+  EXPECT_EQ(mesh.texcoords.size(), 4);
+  // texcoord_faces must stay index-aligned with faces or downstream indexing breaks.
+  EXPECT_EQ(mesh.texcoord_faces.size(), mesh.faces.size());
+
+  EXPECT_EQ(mesh.vertices[2], Eigen::Vector3f(1.0f, 1.0f, 0.0f));
+  // OBJ indices are 1-based; the loader must rebase them to 0.
+  EXPECT_EQ(mesh.faces[1], Eigen::Vector3i(0, 2, 3));
+  EXPECT_EQ(mesh.texcoord_faces[1], Eigen::Vector3i(0, 2, 3));
+  EXPECT_EQ(mesh.texcoords[3], Eigen::Vector2f(0.0f, 1.0f));
+
+  // Per-vertex arrays the rest of momentum assumes are populated.
+  EXPECT_EQ(mesh.normals.size(), mesh.vertices.size());
+  EXPECT_EQ(mesh.colors.size(), mesh.vertices.size());
+}
+
+TEST(IoObjTest, FanTriangulatesPolygonsAndKeepsOriginalTopology) {
+  const Mesh mesh = loadFromText(
+      "obj_quad",
+      "v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\nv 2 0 0\n"
+      "f 1 2 3 4\n"
+      "f 2 5 3\n");
+
+  // A quad fans into 2 triangles, plus the standalone triangle.
+  EXPECT_EQ(mesh.faces.size(), 3);
+  EXPECT_EQ(mesh.faces[0], Eigen::Vector3i(0, 1, 2));
+  EXPECT_EQ(mesh.faces[1], Eigen::Vector3i(0, 2, 3));
+
+  // The un-triangulated topology is preserved alongside it.
+  const std::vector<uint32_t> expectedSizes{4, 3};
+  EXPECT_EQ(mesh.polyFaceSizes, expectedSizes);
+  const std::vector<uint32_t> expectedPolyFaces{0, 1, 2, 3, 1, 4, 2};
+  EXPECT_EQ(mesh.polyFaces, expectedPolyFaces);
+}
+
+TEST(IoObjTest, AcceptsEveryCornerFormAndNegativeIndices) {
+  // `v//vn` carries a normal but no texture coordinate, and -1 means "the vertex most
+  // recently read", so both faces below address the same three vertices.
+  const Mesh mesh = loadFromText(
+      "obj_forms",
+      "v 0 0 0\nv 1 0 0\nv 1 1 0\n"
+      "vn 0 0 1\n"
+      "f 1 2 3\n"
+      "f 1//1 2//1 3//1\n"
+      "f -3 -2 -1\n");
+
+  EXPECT_EQ(mesh.faces.size(), 3);
+  for (const auto& face : mesh.faces) {
+    EXPECT_EQ(face, Eigen::Vector3i(0, 1, 2));
+  }
+  // No face carried a vt index, so the mesh is untextured rather than partly textured.
+  EXPECT_TRUE(mesh.texcoords.empty());
+  EXPECT_TRUE(mesh.texcoord_faces.empty());
+}
+
+TEST(IoObjTest, DropsTexcoordsWhenOnlySomeFacesHaveThem) {
+  // texcoord_faces cannot be partially populated, so a mixed file loads untextured.
+  const Mesh mesh = loadFromText(
+      "obj_mixed",
+      "v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\n"
+      "vt 0 0\nvt 1 0\nvt 1 1\n"
+      "f 1/1 2/2 3/3\n"
+      "f 1 3 4\n");
+
+  EXPECT_EQ(mesh.faces.size(), 2);
+  EXPECT_TRUE(mesh.texcoords.empty());
+  EXPECT_TRUE(mesh.texcoord_faces.empty());
+}
+
+TEST(IoObjTest, ReadsVertexColorsFromTheSixFloatForm) {
+  const Mesh mesh = loadFromText(
+      "obj_colors",
+      "v 0 0 0 1 0 0\nv 1 0 0 0 1 0\nv 1 1 0 0 0 1\n"
+      "f 1 2 3\n");
+
+  ASSERT_EQ(mesh.colors.size(), 3);
+  EXPECT_EQ(mesh.colors[0], Vector3b(255, 0, 0));
+  EXPECT_EQ(mesh.colors[2], Vector3b(0, 0, 255));
+}
+
+TEST(IoObjTest, RejectsOutOfRangeAndEmptyFiles) {
+  EXPECT_THROW(loadFromText("obj_oor", "v 0 0 0\nv 1 0 0\nv 1 1 0\nf 1 2 9\n"), std::runtime_error);
+  EXPECT_THROW(loadFromText("obj_novertex", "# nothing here\n"), std::runtime_error);
+  EXPECT_THROW(loadFromText("obj_noface", "v 0 0 0\nv 1 0 0\n"), std::runtime_error);
+}
+
+TEST(IoObjTest, ReportsTheLineAndTokenForAMalformedIndex) {
+  // std::stoll alone throws a bare std::invalid_argument naming neither the line
+  // nor the token, unlike every other diagnostic this parser emits.
+  const auto expectMentions =
+      [](const std::string& name, const std::string& text, const std::string& needle) {
+        try {
+          loadFromText(name, text);
+          FAIL() << "expected a throw for " << name;
+        } catch (const std::runtime_error& e) {
+          const std::string what = e.what();
+          EXPECT_NE(what.find("line 4"), std::string::npos) << what;
+          EXPECT_NE(what.find(needle), std::string::npos) << what;
+        }
+      };
+  const std::string prefix = "v 0 0 0\nv 1 0 0\nv 1 1 0\n";
+  expectMentions("obj_bad_vertex_index", prefix + "f abc 2 3\n", "abc");
+  expectMentions("obj_bad_texcoord_index", prefix + "f 1/xy 2 3\n", "xy");
+  expectMentions("obj_trailing_chars", prefix + "f 1x 2 3\n", "1x");
+}
+
+TEST(IoObjTest, RejectsAMalformedTextureCoordinate) {
+  // A short or non-numeric vt used to fall through as (0, 0), silently corrupting
+  // UVs rather than failing the way a malformed vertex or face does.
+  EXPECT_THROW(loadFromText("obj_vt_short", "v 0 0 0\nvt 0.5\nf 1 1 1\n"), std::runtime_error);
+  EXPECT_THROW(
+      loadFromText("obj_vt_nonnumeric", "v 0 0 0\nvt foo bar\nf 1 1 1\n"), std::runtime_error);
+}
+
+TEST(IoObjTest, RecomputesNormalsRatherThanReadingThem) {
+  // Normals come from updateNormals(), not from vn: a Mesh stores one normal per
+  // vertex while OBJ indexes them per face corner, so the file's values are junk
+  // here and must not survive.
+  const Mesh mesh = loadFromText(
+      "obj_vn",
+      "v 0 0 0\nv 1 0 0\nv 0 1 0\n"
+      "vn 1 0 0\nvn 1 0 0\nvn 1 0 0\n"
+      "f 1//1 2//2 3//3\n");
+  ASSERT_EQ(mesh.normals.size(), 3);
+  // The triangle lies in z=0, so a geometric normal is +/-Z, never the +X in the file.
+  for (const auto& n : mesh.normals) {
+    EXPECT_NEAR(std::abs(n.z()), 1.0f, 1e-5f) << n.transpose();
+    EXPECT_NEAR(n.x(), 0.0f, 1e-5f) << n.transpose();
+  }
+}
+
+TEST(IoObjTest, LoadsFromMemoryIdenticallyToDisk) {
+  const Mesh fromDisk = loadFromText("obj_mem", kQuadAsTriangles);
+  const std::string text(kQuadAsTriangles);
+  const Mesh fromMemory = loadObj(std::as_bytes(std::span<const char>(text.data(), text.size())));
+
+  ASSERT_EQ(fromMemory.vertices.size(), fromDisk.vertices.size());
+  EXPECT_EQ(fromMemory.faces, fromDisk.faces);
+  EXPECT_EQ(fromMemory.texcoord_faces, fromDisk.texcoord_faces);
+}

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -221,6 +221,7 @@ mt_python_binding(
     io_gltf
     io_legacy_json
     io_marker
+    io_obj
     io_shape
     io_skeleton
     io_urdf

--- a/pymomentum/geometry/geometry_pybind.cpp
+++ b/pymomentum/geometry/geometry_pybind.cpp
@@ -46,6 +46,7 @@
 #include <momentum/io/gltf/gltf_io.h>
 #include <momentum/io/legacy_json/legacy_json_io.h>
 #include <momentum/io/marker/coordinate_system.h>
+#include <momentum/io/obj/obj_io.h>
 #include <momentum/io/shape/blend_shape_io.h>
 #include <momentum/io/skeleton/locator_io.h>
 #include <momentum/math/intersection.h>
@@ -961,6 +962,23 @@ you will likely want to retarget the parameters using the :meth:`mapParameters` 
 :return: a tuple [motionData, motionParameterNames, identityData, identityParameterNames]. Does NOT include the character or FPS.
       )",
       py::arg("gltf_filename"));
+
+  m.def(
+      "load_obj",
+      [](const std::string& path) { return mm::loadObj(path); },
+      R"(Load a mesh from a Wavefront OBJ file.
+
+Reads positions, texture coordinates and faces. Polygons are fan-triangulated, with the
+original topology kept in the mesh's polygon arrays. Texture coordinates are kept only if
+every face has them, since they must stay index-aligned with the triangulated faces.
+
+Normals are recomputed from the geometry rather than read from the file, because a Mesh
+stores one normal per vertex while OBJ indexes them per face corner.
+
+:param path: Path to a .obj file.
+:return: The loaded Mesh.
+      )",
+      py::arg("path"));
 
   // loadMarkersFromFile(path, mainSubjectOnly)
   // TODO(T138941756): Expose the loadMarker and loadMarkersForMainSubject


### PR DESCRIPTION
Summary:

momentum could not load a Wavefront OBJ except through `loadObjMesh` in the URDF
module, which reads positions and faces only -- it takes the substring before the
first `/` in each face corner and discards the `vt` and `vn` indices. That is
enough to place a URDF collision or visual mesh, but it means an OBJ cannot be
used anywhere a textured mesh is wanted.

This adds `io/obj` as a first-class loader:

- positions, texture coordinates and faces, accepting all four face-corner forms
  (`v`, `v/vt`, `v//vn`, `v/vt/vn`) and both positive and negative indices
- polygons are fan-triangulated into `faces`, with the original topology kept in
  `polyFaces` / `polyFaceSizes` / `polyTexcoordFaces`
- texture coordinates map straight onto `texcoords` / `texcoord_faces`, since OBJ
  already indexes them per face corner
- vertex colours from the six-float `v x y z r g b` form
- out-of-range and zero indices are diagnosed with the offending line number
  rather than producing a silently corrupt mesh

Two deliberate restrictions, both documented on the API:

Texture coordinates are kept only when *every* face carries a complete set of
`vt` indices. `texcoord_faces` has to stay index-aligned with `faces`, so a file
that texture-maps only some of its faces cannot be represented and is loaded
untextured with a warning, rather than half-mapped.

Normals are recomputed from the geometry rather than read from `vn`. A `Mesh`
holds one normal per vertex while OBJ indexes them per face corner, so honouring
`vn` in general would require splitting vertices. The FBX and glTF loaders
already recompute, so this is consistent.

`loadObjMesh` in `io/urdf` is left alone; folding it into this loader is a
follow-up, and doing it here would mix a URDF behaviour change into a new-API
diff.

Also exposes `load_obj` in pymomentum.

Differential Revision: D118681429


