### PR TITLE
Keep pure-Python Torch helpers in pymomentum-core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,9 +194,10 @@ Studio project.
 - GitHub Actions workflows live in `.github/workflows/`. Keep platform matrices
   intentional and use existing workflow patterns before adding new mechanisms.
 - Wheel builds have three layered variants:
-  - `core` - NumPy/native modules without PyTorch.
-  - `cpu` - Torch helpers and C++ extensions for CPU PyTorch; depends on core.
-  - `gpu` - Torch helpers and C++ extensions for CUDA PyTorch; depends on core.
+  - `core` - NumPy/native modules and pure-Python Torch helpers, without a
+    required PyTorch installation.
+  - `cpu` - C++ extensions for CPU PyTorch; depends on core.
+  - `gpu` - C++ extensions for CUDA PyTorch; depends on core.
 - Build and test wheel variants with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ conda install -c conda-forge momentum-cpp
 
 Install PyPI wheels -- these are experimental ⚠️
 ```bash
-# Install the NumPy/native core without PyTorch
+# Install the NumPy/native core and pure-Python Torch helpers without installing PyTorch
 pip install pymomentum-core
+
+# Install the core and PyTorch for pure-Python Torch helpers
+pip install "pymomentum-core[torch]"
 
 # Install core package with optional visualization helpers
 pip install "pymomentum-core[viser,rerun]"
 
-# Add diff_geometry, Torch helpers, and differentiable solvers for CPU PyTorch
+# Add diff_geometry and differentiable solvers for CPU PyTorch
 pip install pymomentum-cpu
 
 # Install full package including diff_geometry and differentiable solver modules, linked against CUDA PyTorch
@@ -66,11 +69,11 @@ pip install pymomentum-gpu
 The same layered packages are available from conda-forge. `pymomentum` remains a
 compatibility package that installs the CPU or GPU stack selected by the solver.
 
-The `pymomentum-core` package owns the NumPy/native modules `geometry`,
-`solver2`, `marker_tracking`, `axel`, `camera`, and `renderer`. It does not
-install PyTorch. `pymomentum-cpu` and `pymomentum-gpu` are mutually exclusive
-add-ons: each installs the Torch helpers plus `diff_geometry` and `solver`, and
-depends on a compatible `pymomentum-core` release.
+The `pymomentum-core` package owns the NumPy/native modules and pure-Python
+Torch helpers, including `pymomentum.torch.character`. PyTorch is optional and
+is installed by the `torch` extra. `pymomentum-cpu` and `pymomentum-gpu` are
+mutually exclusive add-ons: each installs the compiled `diff_geometry` and
+`solver` modules and depends on a compatible `pymomentum-core` release.
 
 > ⚠️ **PyPI support is experimental.** For the most stable experience, we recommend using Conda or Pixi.
 

--- a/momentum/website/docs_python/01_user_guide/01_getting_started.md
+++ b/momentum/website/docs_python/01_user_guide/01_getting_started.md
@@ -29,7 +29,7 @@ Choose your preferred installation method based on your workflow. **We recommend
 pixi add pymomentum
 
 # Explicit backend selection
-pixi add pymomentum-core # NumPy/native modules, no PyTorch
+pixi add pymomentum-core # NumPy/native modules and optional pure-Python Torch helpers
 pixi add pymomentum-cpu  # CPU-only
 pixi add pymomentum-gpu  # GPU (CUDA) support
 ```
@@ -45,7 +45,7 @@ pixi add pymomentum-gpu  # GPU (CUDA) support
 conda install -c conda-forge pymomentum
 
 # Explicit backend selection
-conda install -c conda-forge pymomentum-core # NumPy/native modules, no PyTorch
+conda install -c conda-forge pymomentum-core # NumPy/native modules and optional pure-Python Torch helpers
 conda install -c conda-forge pymomentum-cpu  # CPU-only
 conda install -c conda-forge pymomentum-gpu  # GPU (CUDA) support
 ```
@@ -72,18 +72,22 @@ For the most stable and well-tested installation experience, we recommend using 
 
 ```bash
 # Using uv (preferred over pip)
-uv add pymomentum-core  # NumPy/native modules, no PyTorch
+uv add pymomentum-core          # Core without installing PyTorch
+uv add "pymomentum-core[torch]" # Core with pure-Python Torch helpers enabled
 uv add pymomentum-cpu   # CPU version
 uv add pymomentum-gpu   # GPU version (requires CUDA)
 
 # Alternative: Using pip
 pip install pymomentum-core
+pip install "pymomentum-core[torch]" # Include PyTorch for the pure-Python helpers
 pip install pymomentum-cpu
 pip install pymomentum-gpu
 ```
 
-The CPU and GPU distributions are add-ons that install a compatible
-`pymomentum-core`; do not install both add-ons in the same environment.
+Core includes the pure-Python Torch helpers but does not install PyTorch unless
+the `torch` extra is selected. The CPU and GPU distributions add the compiled
+Torch extensions and install a compatible `pymomentum-core`; do not install
+both add-ons in the same environment.
 
 **Browse packages:** [pymomentum-core](https://pypi.org/project/pymomentum-core/), [pymomentum-cpu](https://pypi.org/project/pymomentum-cpu/), [pymomentum-gpu](https://pypi.org/project/pymomentum-gpu/)
 

--- a/momentum/website/docs_python/03_developer_guide/03_pypi_publishing.md
+++ b/momentum/website/docs_python/03_developer_guide/03_pypi_publishing.md
@@ -118,8 +118,9 @@ PYMOMENTUM_VARIANT=cpu pixi run -e py312 wheel_test
 ```
 
 Core and add-on wheels use separate CMake install components. The core wheel
-owns all NumPy/native modules; CPU and GPU wheels own only Torch-backed modules
-and require the matching core release series.
+owns all NumPy/native modules and pure-Python Torch helpers; CPU and GPU wheels
+own only the compiled Torch extensions and require the matching core release
+series.
 
 ## CI Workflow
 

--- a/pymomentum/CMakeLists.txt
+++ b/pymomentum/CMakeLists.txt
@@ -363,7 +363,6 @@ mt_python_binding(
 mt_python_library(
   NAME quaternion
   PYMOMENTUM_SOURCES_VARS quaternion_sources
-  COMPONENT pymomentum_torch
 )
 
 mt_python_library(
@@ -374,7 +373,6 @@ mt_python_library(
 mt_python_library(
   NAME skel_state
   PYMOMENTUM_SOURCES_VARS skel_state_sources
-  COMPONENT pymomentum_torch
 )
 
 mt_python_library(
@@ -385,21 +383,18 @@ mt_python_library(
 mt_python_library(
   NAME trs
   PYMOMENTUM_SOURCES_VARS trs_sources
-  COMPONENT pymomentum_torch
 )
 
 mt_python_library(
   NAME backend
   PYMOMENTUM_SOURCES_VARS backend_common_sources backend_torch_core_sources backend_torch_sources backend_triton_sources
   PRESERVE_DIRECTORY_STRUCTURE
-  COMPONENT pymomentum_torch
 )
 
 mt_python_library(
   NAME torch
   PYMOMENTUM_SOURCES_VARS gpu_character_sources
   PRESERVE_DIRECTORY_STRUCTURE
-  COMPONENT pymomentum_torch
 )
 
 mt_python_library(

--- a/pyproject-pypi.toml.j2
+++ b/pyproject-pypi.toml.j2
@@ -123,7 +123,7 @@ keywords = [
     "motion-capture",
     "character-animation",
     "robotics",
-{% if build_torch_extensions %}
+{% if build_torch_extensions or tag == "core" %}
     "torch",
 {% endif %}
 ]
@@ -149,7 +149,7 @@ dependencies = [
 {% if tag == "core" %}
     "numpy>=1.20.0",
 {% else %}
-    # The add-on contributes only Torch-backed modules to the core namespace.
+    # The add-on contributes only compiled Torch extensions to the core namespace.
     "pymomentum-core>={{ core_version_min }},<{{ core_version_max }}",
 {% if tag != "gpu" %}
     # PyTorch version constraints - platform and Python version specific
@@ -176,6 +176,7 @@ dependencies = [
 # Opt-in extras. Visualization stacks are large and have transitive deps
 # users may not want; keep them out of the default install.
 [project.optional-dependencies]
+torch = ["torch>=1.13"]
 rerun = ["rerun-sdk>=0.23.3,<0.34"]
 viser = ["viser>=1.0.24,<2"]
 {% endif %}

--- a/scripts/generate_pyproject.py
+++ b/scripts/generate_pyproject.py
@@ -129,7 +129,7 @@ def main():
         {
             "tag": "core",
             "distribution_name": "pymomentum-core",
-            "description_suffix": "core package without PyTorch",
+            "description_suffix": "core package without PyTorch C++ extensions",
             "build_torch_extensions": False,
             "wheel_libs_dir": "pymomentum_core.libs",
             "install_component": "pymomentum_core",

--- a/scripts/test_generate_pyproject.py
+++ b/scripts/test_generate_pyproject.py
@@ -48,6 +48,9 @@ class GeneratePyprojectTest(unittest.TestCase):
         core = generated["core"]
         self.assertEqual(core["project"]["dependencies"], ["numpy>=1.20.0"])
         self.assertEqual(
+            core["project"]["optional-dependencies"]["torch"], ["torch>=1.13"]
+        )
+        self.assertEqual(
             core["tool"]["scikit-build"]["install"]["components"],
             ["pymomentum_core"],
         )

--- a/scripts/test_wheel.py
+++ b/scripts/test_wheel.py
@@ -107,27 +107,40 @@ def check_wheel_contents(
     if any("geometry_test_utils" in name for name in names):
         raise RuntimeError(f"{wheel_file.name} contains test-only bindings")
 
-    torch_paths = {
+    pure_torch_paths = {
+        "pymomentum/backend/selection.py",
         "pymomentum/quaternion.py",
         "pymomentum/skel_state.py",
+        "pymomentum/torch/character.py",
         "pymomentum/trs.py",
     }
     if wheel_type == "core":
+        missing = sorted(pure_torch_paths - package_files)
+        if missing:
+            raise RuntimeError(f"core wheel is missing Torch helpers: {missing}")
         unexpected = sorted(
             name
             for name in package_files
-            if name in torch_paths
-            or name.startswith("pymomentum/backend/")
-            or name.startswith("pymomentum/torch/")
-            or name.startswith("pymomentum/diff_geometry.")
+            if name.startswith("pymomentum/diff_geometry.")
             or name.startswith("pymomentum/solver.")
         )
         if unexpected:
-            raise RuntimeError(f"core wheel contains Torch add-on files: {unexpected}")
+            raise RuntimeError(
+                f"core wheel contains compiled Torch extensions: {unexpected}"
+            )
         return
 
     if core_wheel is None:
         raise RuntimeError("CPU/GPU wheel tests require the matching core wheel")
+    unexpected = sorted(
+        name
+        for name in package_files
+        if name in pure_torch_paths
+        or name.startswith("pymomentum/backend/")
+        or name.startswith("pymomentum/torch/")
+    )
+    if unexpected:
+        raise RuntimeError(f"{wheel_type} wheel contains core files: {unexpected}")
     with zipfile.ZipFile(core_wheel) as archive:
         core_files = {
             name
@@ -158,7 +171,7 @@ def get_import_test_script(
 ) -> str:
     """Return the Python smoke test script for a wheel type."""
     torch_extensions = has_torch_extensions(wheel_type)
-    torch_runtime = has_torch_extensions(wheel_type)
+    torch_runtime = not expect_no_torch
     lines = [
         "import importlib.util",
         "import os",
@@ -197,16 +210,21 @@ def get_import_test_script(
             "    import pymomentum.renderer as renderer",
         ]
     )
-    if torch_extensions:
+    if torch_runtime:
         lines.extend(
             [
                 "    import pymomentum.backend as backend",
-                "    import pymomentum.diff_geometry as diff_geometry",
                 "    import pymomentum.quaternion as quaternion",
                 "    import pymomentum.skel_state as skel_state",
-                "    import pymomentum.solver as solver",
                 "    import pymomentum.torch.character as torch_character",
                 "    import pymomentum.trs as trs",
+            ]
+        )
+    if torch_extensions:
+        lines.extend(
+            [
+                "    import pymomentum.diff_geometry as diff_geometry",
+                "    import pymomentum.solver as solver",
             ]
         )
         if wheel_type == "gpu" and require_cuda:
@@ -219,8 +237,14 @@ def get_import_test_script(
     else:
         if wheel_type == "core":
             if expect_no_torch:
-                lines.append(
-                    '    assert importlib.util.find_spec("torch") is None, "pymomentum-core must not install PyTorch"'
+                lines.extend(
+                    [
+                        '    assert importlib.util.find_spec("torch") is None, "pymomentum-core must not install PyTorch"',
+                        '    assert importlib.util.find_spec("pymomentum.quaternion") is not None',
+                        '    assert importlib.util.find_spec("pymomentum.skel_state") is not None',
+                        '    assert importlib.util.find_spec("pymomentum.torch.character") is not None',
+                        '    assert importlib.util.find_spec("pymomentum.trs") is not None',
+                    ]
                 )
             lines.extend(
                 [
@@ -232,8 +256,6 @@ def get_import_test_script(
             [
                 '    assert importlib.util.find_spec("pymomentum.diff_geometry") is None, "pymomentum-core must not expose pymomentum.diff_geometry"',
                 '    assert importlib.util.find_spec("pymomentum.solver") is None, "pymomentum-core must not expose pymomentum.solver"',
-                '    assert importlib.util.find_spec("pymomentum.torch") is None, "pymomentum-core must not expose pymomentum.torch"',
-                '    assert importlib.util.find_spec("pymomentum.quaternion") is None, "pymomentum-core must not expose torch-backed helpers"',
             ]
         )
     lines.extend(
@@ -376,7 +398,7 @@ def run_import_tests(
         env.pop(name, None)
     # Keep the checkout's namespace-package directories out of wheel import checks.
     with tempfile.TemporaryDirectory() as tmpdir:
-        if has_torch_extensions(wheel_type):
+        if not expect_no_torch:
             result = subprocess.run(
                 [
                     python_exe,
@@ -514,6 +536,26 @@ def test_in_container(
             "/tmp/test_venv/bin/python -I /tmp/test_wheel_imports.py",
         ]
     )
+    if wheel_type == "core":
+        core_with_torch_script = get_import_test_script("core")
+        container_lines.extend(
+            [
+                "",
+                'echo "Installing optional PyTorch dependency..."',
+                '$PYTHON -m uv pip install --python /tmp/test_venv/bin/python "torch>=2.8.0,<2.9" --index-url '
+                + get_torch_index("core"),
+                "$PYTHON -m uv pip check --python /tmp/test_venv/bin/python",
+                "cat >/tmp/test_core_torch_after_pymomentum.py <<'PYTEST'",
+                *torch_after_pymomentum_script.rstrip().splitlines(),
+                "PYTEST",
+                "/tmp/test_venv/bin/python -I /tmp/test_core_torch_after_pymomentum.py",
+                'echo "Testing pure-Python Torch helpers..."',
+                "cat >/tmp/test_core_with_torch.py <<'PYTEST'",
+                *core_with_torch_script.rstrip().splitlines(),
+                "PYTEST",
+                "/tmp/test_venv/bin/python -I /tmp/test_core_with_torch.py",
+            ]
+        )
     if core_wheel is not None:
         core_import_script = get_import_test_script("core")
         container_lines.extend(
@@ -658,8 +700,38 @@ def test_locally_with_uv(
             require_triton,
             expect_no_torch=wheel_type == "core",
         )
-        if returncode != 0 or core_wheel is None:
+        if returncode != 0:
             return returncode
+
+        if wheel_type == "core":
+            torch_index = get_torch_index("core")
+            print(f"Installing optional torch dependency from {torch_index}...")
+            result = subprocess.run(
+                [
+                    uv_path,
+                    "pip",
+                    "install",
+                    "--python",
+                    python_exe,
+                    "torch>=2.8.0,<2.9",
+                    "--index-url",
+                    torch_index,
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if result.returncode != 0:
+                print(
+                    f"[FAIL] Failed to install optional torch: {result.stderr}",
+                    file=sys.stderr,
+                )
+                return result.returncode
+            return run_import_tests(python_exe, "core")
+
+        if core_wheel is None:
+            return 0
 
         print(f"Uninstalling {DIST_NAME_BY_TYPE[wheel_type]} and retesting core...")
         result = subprocess.run(


### PR DESCRIPTION
## Summary

MHR uses `pymomentum.geometry` together with the pure-Python `pymomentum.torch.character` path, but it does not need the ABI-coupled `diff_geometry` or `solver` extensions. Keep the pure-Python Torch helpers in `pymomentum-core` so consumers can supply their own PyTorch installation without selecting a CPU or CUDA add-on.

The CPU and GPU distributions continue to contain only the compiled Torch extensions and depend on the matching core release. Core still installs without PyTorch by default; `pymomentum-core[torch]` is provided for users who want the helper dependency installed automatically.

This builds on the additive wheel variants introduced in #1650 and provides the lightweight package boundary needed by facebookresearch/MHR#40.

## Checklist:

- [x] Adheres to the [style guidelines](https://facebookresearch.github.io/momentum/docs/developer_guide/style_guide)
- [x] Codebase formatted by running `pixi run lint`

## Test Plan

Built separate core and CPU wheels and installed them in clean Python 3.12 environments. Core geometry worked without PyTorch; after adding PyTorch, the pure helper modules imported successfully. The CPU add-on contained no duplicate helper files, and uninstalling it left core usable.

With the core wheel and CPU PyTorch installed, MHR 1.0.1 loaded the released LOD 6 assets and completed a forward and backward pass.
